### PR TITLE
Add Alert To Screen -- Failure to Grab JSON

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -179,11 +179,11 @@
 			children = (
 				D339E55A2BFD0CE200B9E35B /* Dependencies */,
 				D3536A392BFA6520006942D6 /* Extensions */,
-				D3536A042BFA4F49006942D6 /* PlayolaRadioApp.swift */,
 				D339E55B2BFD0CEE00B9E35B /* Views */,
 				D3536A082BFA4F4A006942D6 /* Assets.xcassets */,
 				D3536A0A2BFA4F4A006942D6 /* Preview Content */,
 				D3536A312BFA64AB006942D6 /* Models.swift */,
+				D3536A042BFA4F49006942D6 /* PlayolaRadioApp.swift */,
 			);
 			path = PlayolaRadio;
 			sourceTree = "<group>";

--- a/PlayolaRadio/Views/Pages/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPageTests.swift
@@ -103,6 +103,7 @@ final class StationListPageTests: XCTestCase {
 
     await store.receive(\.stationsListResponseReceived.failure) {
       $0.isLoadingStationLists = false
+      $0.alert = .stationListLoadFailure
     }
 
     await monitorStationStoreTask.cancel()


### PR DESCRIPTION
Adds an Alert to the StationList screen if the JSON request results in an error.  This shows how to display an alert message.