### PR TITLE
Navigation for StationDetailPage

### DIFF
--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -40,9 +40,6 @@ struct AppReducer {
     Reduce { state, action in
       switch action {
 
-      case let .element(id: _, action: .nowPlaying(.delegate(.pushStationDetailOntoNavStack(station)))):
-
-
       case .stationListReducer(.delegate(.pushNowPlayingOntoNavStack)):
         state.path.append(.nowPlaying(NowPlayingReducer.State()))
         return .none
@@ -57,8 +54,16 @@ struct AppReducer {
       case .nowPlayingReducer(_):
         return .none
 
-      case .path:
-        return .none
+      case let .path(action):
+        switch action {
+        case let .element(id: _, action: .nowPlaying(.delegate(.pushStationDetailOntoNavStack(station)))):
+          state.path.append(.stationDetail(StationDetailReducer.State(station: station)))
+          return .none
+
+        default:
+          return .none
+        }
+
       }
     }
     .forEach(\.path, action: \.path)

--- a/PlayolaRadio/Views/Pages/NowPlayingPage.swift
+++ b/PlayolaRadio/Views/Pages/NowPlayingPage.swift
@@ -43,7 +43,8 @@ struct NowPlayingReducer {
       case pushStationDetailOntoNavStack(RadioStation)
     }
   }
-
+  
+  @Dependency(\.dismiss) var dismiss
   @Dependency(\.stationPlayer) var stationPlayer
 
   var body: some ReducerOf<Self> {
@@ -75,7 +76,9 @@ struct NowPlayingReducer {
 
       case .playButtonTapped:
         stationPlayer.stopStation()
-        return .none
+        return .run { _ in
+          await self.dismiss()
+        }
 
       case .playolaIconTapped:
         state.destination = .add(AboutPageReducer.State())
@@ -114,18 +117,20 @@ struct NowPlayingPage: View {
 
   var body: some View {
     ZStack {
-      Color.black
+      Image("background")
+        .resizable()
         .edgesIgnoringSafeArea(.all)
 
       VStack {
-        AsyncImage(url: store.albumArtworkURL)
-        { result in
-          result.image?
+        AsyncImage(url: store.albumArtworkURL) { image in
+          image
             .resizable()
             .scaledToFill()
-            .frame(width: 274, height: 274)
             .padding(.top, 35)
+        } placeholder: {
+          Image("AppIcon")
         }
+        .frame(width: 274, height: 274)
 
         HStack(spacing: 12) {
 //              Image("btn-previous")

--- a/PlayolaRadio/Views/Pages/NowPlayingPageTests.swift
+++ b/PlayolaRadio/Views/Pages/NowPlayingPageTests.swift
@@ -125,6 +125,7 @@ final class NowPlayingPageTests: XCTestCase {
     await monitorStationStoreTask.cancel()
   }
 
-  // TODO: Test that stop is called on stationPlayer on .playButtonTapped action
+  // TODO: Test that stop is called on stationPlayer and dimsiss() is called on .playButtonTapped action
+
 }
 

--- a/PlayolaRadio/Views/Pages/StationDetailPage.swift
+++ b/PlayolaRadio/Views/Pages/StationDetailPage.swift
@@ -17,11 +17,19 @@ struct StationDetailReducer {
   }
 
   enum Action {
+    case dismissButtonTapped
   }
+
+  @Dependency(\.dismiss) var dismiss
 
   var body: some ReducerOf<Self> {
     Reduce { state, action in
-      return .none
+      switch action {
+      case .dismissButtonTapped:
+        return .run { _ in
+          await self.dismiss()
+        }
+      }
     }
   }
 }
@@ -61,7 +69,7 @@ struct StationDetailPage: View {
 
         Spacer()
 
-        Button(action: {}) {
+        Button(action: { store.send(.dismissButtonTapped) }) {
           Text("Okay")
             .frame(maxWidth: .infinity)
         }
@@ -70,6 +78,7 @@ struct StationDetailPage: View {
       }
       .padding()
     }
+    .foregroundStyle(.white)
   }
 }
 
@@ -78,7 +87,6 @@ struct StationDetailPage: View {
     StationDetailPage(store: Store(initialState: StationDetailReducer.State(station: .mock), reducer: {
       StationDetailReducer()
     }))
-    .foregroundStyle(.white)
   }
 
 }


### PR DESCRIPTION
This PR makes navigation work with the StationDetailView page.  It relies on [this example](https://github.com/pointfreeco/episode-code-samples/blob/main/0264-observable-architecture-pt6/swift-composable-architecture/Examples/CaseStudies/SwiftUICaseStudies/03-NavigationStack.swift) from the Composable Architecture repo.