### PR TITLE
UrlStreamListeningSessionReporter

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -68,6 +68,7 @@
 		D3BEE95D2D49A3BD00469CDC /* Testing in Frameworks */ = {isa = PBXBuildFile; productRef = D3BEE95C2D49A3BD00469CDC /* Testing */; };
 		D3CE19032D3C825C0091B888 /* PlayolaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D3CE19022D3C825C0091B888 /* PlayolaPlayer */; };
 		D3CE19052D3CA6180091B888 /* SharedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CE19042D3CA6150091B888 /* SharedUserDefaults.swift */; };
+		D3D6CE5F2D5ECED50059BDCA /* UrlStreamListeningSessionReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D6CE5E2D5ECECB0059BDCA /* UrlStreamListeningSessionReporter.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -137,6 +138,7 @@
 		D3B662752D41B0C700975D2F /* SignInPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPageTests.swift; sourceTree = "<group>"; };
 		D3B662C22D4272ED00975D2F /* Secrets-Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-Local.xcconfig"; sourceTree = "<group>"; };
 		D3CE19042D3CA6150091B888 /* SharedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedUserDefaults.swift; sourceTree = "<group>"; };
+		D3D6CE5E2D5ECECB0059BDCA /* UrlStreamListeningSessionReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlStreamListeningSessionReporter.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -221,6 +223,7 @@
 			isa = PBXGroup;
 			children = (
 				D35673B32D3DC6CE00E4E926 /* TrackingService.swift */,
+				D3D6CE5E2D5ECECB0059BDCA /* UrlStreamListeningSessionReporter.swift */,
 				D31C43A72D3C195B0021AAE4 /* StationPlayer.swift */,
 				D339E5682BFD1C0800B9E35B /* API.swift */,
 				D339E56C2BFD2FAB00B9E35B /* URLStreamPlayer.swift */,
@@ -498,6 +501,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D3D6CE5F2D5ECED50059BDCA /* UrlStreamListeningSessionReporter.swift in Sources */,
 				D35673C62D3E91BD00E4E926 /* MainSceneDelegate.swift in Sources */,
 				D35673B22D3DC59300E4E926 /* RadioStation.swift in Sources */,
 				D35673BA2D3DC9EE00E4E926 /* Config.swift in Sources */,

--- a/PlayolaRadio/Dependencies/URLStreamPlayer.swift
+++ b/PlayolaRadio/Dependencies/URLStreamPlayer.swift
@@ -12,6 +12,7 @@ import MediaPlayer
 import UIKit
 
 public class URLStreamPlayer: ObservableObject {
+  var urlStreamReporter: UrlStreamListeningSessionReporter? = nil
     struct State: Sendable, Equatable {
         static func == (lhs: URLStreamPlayer.State, rhs: URLStreamPlayer.State) -> Bool {
             lhs.playerStatus == rhs.playerStatus &&
@@ -26,7 +27,11 @@ public class URLStreamPlayer: ObservableObject {
         var nowPlaying: FRadioPlayer.Metadata?
     }
 
-    @Published var state: URLStreamPlayer.State = State(playbackState: .stopped, playerStatus: nil, currentStation: nil, nowPlaying: nil)
+    @Published var state: URLStreamPlayer.State = State(
+      playbackState: .stopped,
+      playerStatus: nil,
+      currentStation: nil,
+      nowPlaying: nil)
 
     @Published var albumArtworkURL: URL?
 
@@ -42,6 +47,9 @@ public class URLStreamPlayer: ObservableObject {
 
     init() {
         addObserverToPlayer()
+      Task {
+        self.urlStreamReporter = await UrlStreamListeningSessionReporter(urlStreamPlayer: self)
+      }
     }
 
     func addObserverToPlayer() {

--- a/PlayolaRadio/Dependencies/UrlStreamListeningSessionReporter.swift
+++ b/PlayolaRadio/Dependencies/UrlStreamListeningSessionReporter.swift
@@ -1,0 +1,133 @@
+//
+//  UrlStreamListeningSessionReporter.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 2/13/25.
+//
+import Combine
+import UIKit
+import PlayolaPlayer
+
+@MainActor
+public class UrlStreamListeningSessionReporter {
+  var deviceId: String? {
+    return UIDevice.current.identifierForVendor?.uuidString
+  }
+  var timer: Timer?
+  let basicToken = "aW9zQXBwOnNwb3RpZnlTdWNrc0FCaWcx" // TODO: De-hard-code this
+  var disposeBag = Set<AnyCancellable>()
+  weak var urlStreamPlayer: URLStreamPlayer?
+  var currentListeningSessionID: String?
+  var lastSendStreamUrl: String?
+
+  init(urlStreamPlayer: URLStreamPlayer) {
+    self.urlStreamPlayer = urlStreamPlayer
+
+    urlStreamPlayer.$state.sink { state in
+      if let stationUrl = urlStreamPlayer.currentStation?.streamURL {
+        if stationUrl != self.lastSendStreamUrl {
+          self.lastSendStreamUrl = stationUrl
+          self.reportOrExtendListeningSession(stationUrl)
+          self.startPeriodicNotifications()
+        }
+      } else {
+        guard self.lastSendStreamUrl != nil else { return }
+        self.lastSendStreamUrl = nil
+        self.endListeningSession()
+        self.stopPeriodicNotifications()
+      }
+    }.store(in: &disposeBag)
+  }
+
+  public func endListeningSession() {
+    guard let deviceId else {
+      print("Cannot send listeningSession -- missing identifier")
+      return
+    }
+    let url = URL(string: "https://admin-api.playola.fm/v1/listeningSessions/end")!
+    let requestBody = [ "deviceId": deviceId]
+
+    guard let jsonData = try? JSONEncoder().encode(requestBody) else {
+      print("Error: unable to encode request body to JSON for end listeningSession")
+      return
+    }
+
+    var request = createPostRequest(url: url, jsonData: jsonData)
+    // Create a URLSession task to send the request
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+      if let error = error {
+        print("Error: \(error.localizedDescription)")
+        return
+      }
+
+      if let httpResponse = response as? HTTPURLResponse {
+        print("Response Status Code: \(httpResponse.statusCode)")
+      }
+
+      if let data = data, let responseString = String(data: data, encoding: .utf8) {
+        print("Response Data: \(responseString)")
+      }
+    }
+    task.resume()
+  }
+
+  public func reportOrExtendListeningSession(_ stationUrl: String) {
+    let url = URL(string: "https://admin-api.playola.fm/v1/listeningSessions")!
+
+    // Create an instance of the Codable struct
+    let requestBody = [
+      "deviceId": deviceId,
+      "stationUrl": stationUrl
+      ]
+
+    // Convert the Codable struct to JSON data
+    guard let jsonData = try? JSONEncoder().encode(requestBody) else {
+      print("Error: Unable to encode request body to JSON")
+      return
+    }
+
+    // Create the request
+    var request = createPostRequest(url: url, jsonData: jsonData)
+
+    // Create a URLSession task to send the request
+    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+      if let error = error {
+        print("Error: \(error.localizedDescription)")
+        return
+      }
+
+      if let httpResponse = response as? HTTPURLResponse {
+        print("Response Status Code: \(httpResponse.statusCode)")
+      }
+
+      if let data = data, let responseString = String(data: data, encoding: .utf8) {
+        print("Response Data: \(responseString)")
+      }
+    }
+    task.resume()
+  }
+
+  private func startPeriodicNotifications() {
+    self.timer = Timer.scheduledTimer(withTimeInterval: 10.0, repeats: true, block: { [weak self] timer in
+      guard let self else { return }
+      guard let stationUrl = self.urlStreamPlayer?.currentStation?.streamURL else {
+        print("Error -- stationId should exist")
+        return
+      }
+      self.reportOrExtendListeningSession(stationUrl)
+    })
+  }
+
+  private func stopPeriodicNotifications() {
+    self.timer?.invalidate()
+  }
+
+  private func createPostRequest(url: URL, jsonData: Data) -> URLRequest {
+    var request = URLRequest(url: url)
+    request.httpMethod = "POST"
+    request.httpBody = jsonData
+    request.addValue("Basic \(basicToken)", forHTTPHeaderField: "Authorization")
+    request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+    return request
+  }
+}


### PR DESCRIPTION
This pull request introduces a new feature to the `PlayolaRadio` project by adding a `UrlStreamListeningSessionReporter` class and integrating it into the `URLStreamPlayer`. The changes primarily involve updating the project configuration and implementing the new class for reporting listening sessions.

### New Feature Implementation:

* **Project Configuration Updates:**
  * Added `UrlStreamListeningSessionReporter.swift` to the `PBXBuildFile`, `PBXFileReference`, `PBXGroup`, and `PBXSourcesBuildPhase` sections in the `PlayolaRadio.xcodeproj/project.pbxproj` file. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R71) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R141) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R226) [[4]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R504)

* **Integration with `URLStreamPlayer`:**
  * Declared a new optional property `urlStreamReporter` in the `URLStreamPlayer` class.
  * Updated the initialization of `URLStreamPlayer` to asynchronously create an instance of `UrlStreamListeningSessionReporter`.

* **Implementation of `UrlStreamListeningSessionReporter`:**
  * Added a new class `UrlStreamListeningSessionReporter` to handle the reporting of listening sessions, including methods for starting and ending sessions, and periodic notifications.