### PR TITLE
Bugfix: Adjust for AudioBlock property type updates

### DIFF
--- a/PlayolaRadio/Dependencies/StationPlayer.swift
+++ b/PlayolaRadio/Dependencies/StationPlayer.swift
@@ -96,7 +96,7 @@ class StationPlayer: ObservableObject {
       state = .init(playbackStatus: .playing(currentStation!),
                     artistPlaying: nowPlaying.artist,
                     titlePlaying: nowPlaying.title,
-                    albumArtworkUrl: nowPlaying.imageUrl != nil ? URL(string: nowPlaying.imageUrl!) : nil)
+                    albumArtworkUrl: nowPlaying.imageUrl)
     case .none:
       state = .init(playbackStatus: .error)
     }


### PR DESCRIPTION
This pull request makes a small change to the `StationPlayer` class in the `PlayolaRadio/Dependencies/StationPlayer.swift` file. The change simplifies the assignment of the `albumArtworkUrl` property by directly using `nowPlaying.imageUrl` without converting it to a `URL` object.