### PR TITLE
Plug Player Into New UX

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -89,6 +89,7 @@
 		D3CE19032D3C825C0091B888 /* PlayolaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D3CE19022D3C825C0091B888 /* PlayolaPlayer */; };
 		D3CE19052D3CA6180091B888 /* SharedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CE19042D3CA6150091B888 /* SharedUserDefaults.swift */; };
 		D3D6CE5F2D5ECED50059BDCA /* UrlStreamListeningSessionReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D6CE5E2D5ECECB0059BDCA /* UrlStreamListeningSessionReporter.swift */; };
+		D3FA612A2E00584200E9DF49 /* PlayerPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA61292E00583F00E9DF49 /* PlayerPageModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -179,6 +180,7 @@
 		D3B662C22D4272ED00975D2F /* Secrets-Local.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-Local.xcconfig"; sourceTree = "<group>"; };
 		D3CE19042D3CA6150091B888 /* SharedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedUserDefaults.swift; sourceTree = "<group>"; };
 		D3D6CE5E2D5ECECB0059BDCA /* UrlStreamListeningSessionReporter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UrlStreamListeningSessionReporter.swift; sourceTree = "<group>"; };
+		D3FA61292E00583F00E9DF49 /* PlayerPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPageModel.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -303,7 +305,6 @@
 			children = (
 				D31CD5222DFBA1EC009B9780 /* ViewModel.swift */,
 				D34D5C372D71062E00148048 /* SideMenuView */,
-				D3137DCE2D3AA1E10070033A /* PlayolaSheet.swift */,
 				D3137DBA2D3976550070033A /* PlayolaAlert.swift */,
 				D339E55F2BFD0FD800B9E35B /* AirPlayView.swift */,
 				D339E5612BFD0FD800B9E35B /* NowPlayingEqAnimation.swift */,
@@ -389,6 +390,7 @@
 				D3536A372BFA6520006942D6 /* Color+Hex.swift */,
 				D3536A382BFA6520006942D6 /* UIImage+Cache.swift */,
 				D339E56E2BFD306600B9E35B /* FRadioPlayerMetadata+Equatable.swift */,
+				D3137DCE2D3AA1E10070033A /* PlayolaSheet.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -466,6 +468,7 @@
 		D37257CE2DFB4358001BC6F9 /* PlayerPage */ = {
 			isa = PBXGroup;
 			children = (
+				D3FA61292E00583F00E9DF49 /* PlayerPageModel.swift */,
 				D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */,
 			);
 			path = PlayerPage;
@@ -640,6 +643,7 @@
 				D339E57E2BFD750700B9E35B /* MailService.swift in Sources */,
 				D339E56F2BFD306600B9E35B /* FRadioPlayerMetadata+Equatable.swift in Sources */,
 				D3137DCF2D3AA1E40070033A /* PlayolaSheet.swift in Sources */,
+				D3FA612A2E00584200E9DF49 /* PlayerPageModel.swift in Sources */,
 				D31C43A82D3C19640021AAE4 /* StationPlayer.swift in Sources */,
 				D339E5642BFD0FD800B9E35B /* StationListCellView.swift in Sources */,
 				D37257D02DFB4368001BC6F9 /* PlayerPage.swift in Sources */,

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -75,9 +75,12 @@
 		D37257CC2DFA3F83001BC6F9 /* FontNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */; };
 		D37257D02DFB4368001BC6F9 /* PlayerPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */; };
 		D38031352E00AFD20011DD64 /* PlayerPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38031332E00AD9F0011DD64 /* PlayerPageTests.swift */; };
+		D382671C2E00C1460006BAC2 /* SmallPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D382671B2E00C13E0006BAC2 /* SmallPlayer.swift */; };
 		D3A2761E2D43C747006055AF /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761D2D43C747006055AF /* GoogleSignIn */; };
 		D3A276202D43C747006055AF /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761F2D43C747006055AF /* GoogleSignInSwift */; };
 		D3A276692D49628C006055AF /* UIApplication+keyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A276682D496282006055AF /* UIApplication+keyWindow.swift */; };
+		D3AACEEB2E0111F800DFAA24 /* SmallPlayerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3AACEEA2E0111F500DFAA24 /* SmallPlayerModel.swift */; };
+		D3AACEED2E0111FE00DFAA24 /* SmallPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3AACEEC2E0111FB00DFAA24 /* SmallPlayerTests.swift */; };
 		D3B662682D3F58E700975D2F /* FRadioPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D3B662672D3F58E700975D2F /* FRadioPlayer */; };
 		D3B6626A2D40103C00975D2F /* SignInPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B662692D40103800975D2F /* SignInPage.swift */; };
 		D3B6626D2D4016C200975D2F /* NavigationCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B6626C2D4016BF00975D2F /* NavigationCoordinator.swift */; };
@@ -173,7 +176,10 @@
 		D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontNames.swift; sourceTree = "<group>"; };
 		D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPage.swift; sourceTree = "<group>"; };
 		D38031332E00AD9F0011DD64 /* PlayerPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPageTests.swift; sourceTree = "<group>"; };
+		D382671B2E00C13E0006BAC2 /* SmallPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallPlayer.swift; sourceTree = "<group>"; };
 		D3A276682D496282006055AF /* UIApplication+keyWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+keyWindow.swift"; sourceTree = "<group>"; };
+		D3AACEEA2E0111F500DFAA24 /* SmallPlayerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallPlayerModel.swift; sourceTree = "<group>"; };
+		D3AACEEC2E0111FB00DFAA24 /* SmallPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallPlayerTests.swift; sourceTree = "<group>"; };
 		D3B662692D40103800975D2F /* SignInPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPage.swift; sourceTree = "<group>"; };
 		D3B6626C2D4016BF00975D2F /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
 		D3B662712D41618500975D2F /* AppleSignInInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleSignInInfo.swift; sourceTree = "<group>"; };
@@ -305,6 +311,7 @@
 		D339E55D2BFD0FC200B9E35B /* Components */ = {
 			isa = PBXGroup;
 			children = (
+				D3AACEE92E0111E600DFAA24 /* SmallPlayer */,
 				D31CD5222DFBA1EC009B9780 /* ViewModel.swift */,
 				D34D5C372D71062E00148048 /* SideMenuView */,
 				D3137DBA2D3976550070033A /* PlayolaAlert.swift */,
@@ -477,6 +484,16 @@
 			path = PlayerPage;
 			sourceTree = "<group>";
 		};
+		D3AACEE92E0111E600DFAA24 /* SmallPlayer */ = {
+			isa = PBXGroup;
+			children = (
+				D3AACEEC2E0111FB00DFAA24 /* SmallPlayerTests.swift */,
+				D3AACEEA2E0111F500DFAA24 /* SmallPlayerModel.swift */,
+				D382671B2E00C13E0006BAC2 /* SmallPlayer.swift */,
+			);
+			path = SmallPlayer;
+			sourceTree = "<group>";
+		};
 		D3B6626B2D4016B900975D2F /* Services */ = {
 			isa = PBXGroup;
 			children = (
@@ -627,6 +644,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D3AACEEB2E0111F800DFAA24 /* SmallPlayerModel.swift in Sources */,
 				D3D6CE5F2D5ECED50059BDCA /* UrlStreamListeningSessionReporter.swift in Sources */,
 				D37257B02DF88BB7001BC6F9 /* HomePageView.swift in Sources */,
 				D35673C62D3E91BD00E4E926 /* MainSceneDelegate.swift in Sources */,
@@ -657,6 +675,7 @@
 				D339E5762BFD419400B9E35B /* AboutPage.swift in Sources */,
 				D3137DD22D3ABB520070033A /* GenericNowPlaying.swift in Sources */,
 				D3361FE42D6E980000A859FF /* SideMenuView.swift in Sources */,
+				D3AACEED2E0111FE00DFAA24 /* SmallPlayerTests.swift in Sources */,
 				D3536A3C2BFA6520006942D6 /* UIImage+Cache.swift in Sources */,
 				D37257C42DF8F885001BC6F9 /* circleBackground.swift in Sources */,
 				D3B6626D2D4016C200975D2F /* NavigationCoordinator.swift in Sources */,
@@ -675,6 +694,7 @@
 				D339E5672BFD10AE00B9E35B /* StationListPage.swift in Sources */,
 				D37257C92DFA247D001BC6F9 /* MainContainer.swift in Sources */,
 				D339E5692BFD1C0800B9E35B /* API.swift in Sources */,
+				D382671C2E00C1460006BAC2 /* SmallPlayer.swift in Sources */,
 				D35673B42D3DC6D100E4E926 /* TrackingService.swift in Sources */,
 				D3536A052BFA4F49006942D6 /* PlayolaRadioApp.swift in Sources */,
 			);

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -74,6 +74,7 @@
 		D37257C92DFA247D001BC6F9 /* MainContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C82DFA247A001BC6F9 /* MainContainer.swift */; };
 		D37257CC2DFA3F83001BC6F9 /* FontNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */; };
 		D37257D02DFB4368001BC6F9 /* PlayerPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */; };
+		D38031352E00AFD20011DD64 /* PlayerPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D38031332E00AD9F0011DD64 /* PlayerPageTests.swift */; };
 		D3A2761E2D43C747006055AF /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761D2D43C747006055AF /* GoogleSignIn */; };
 		D3A276202D43C747006055AF /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761F2D43C747006055AF /* GoogleSignInSwift */; };
 		D3A276692D49628C006055AF /* UIApplication+keyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A276682D496282006055AF /* UIApplication+keyWindow.swift */; };
@@ -171,6 +172,7 @@
 		D37257C82DFA247A001BC6F9 /* MainContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContainer.swift; sourceTree = "<group>"; };
 		D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontNames.swift; sourceTree = "<group>"; };
 		D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPage.swift; sourceTree = "<group>"; };
+		D38031332E00AD9F0011DD64 /* PlayerPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPageTests.swift; sourceTree = "<group>"; };
 		D3A276682D496282006055AF /* UIApplication+keyWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+keyWindow.swift"; sourceTree = "<group>"; };
 		D3B662692D40103800975D2F /* SignInPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPage.swift; sourceTree = "<group>"; };
 		D3B6626C2D4016BF00975D2F /* NavigationCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationCoordinator.swift; sourceTree = "<group>"; };
@@ -468,6 +470,7 @@
 		D37257CE2DFB4358001BC6F9 /* PlayerPage */ = {
 			isa = PBXGroup;
 			children = (
+				D38031332E00AD9F0011DD64 /* PlayerPageTests.swift */,
 				D3FA61292E00583F00E9DF49 /* PlayerPageModel.swift */,
 				D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */,
 			);
@@ -682,6 +685,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D3137DC42D39B5E60070033A /* APIMock.swift in Sources */,
+				D38031352E00AFD20011DD64 /* PlayerPageTests.swift in Sources */,
 				D3137DC02D39818E0070033A /* MailServiceMock.swift in Sources */,
 				D3137DC62D39BEE00070033A /* URLStreamPlayerMock.swift in Sources */,
 				D31C43AA2D3C39110021AAE4 /* StationPlayerMock.swift in Sources */,

--- a/PlayolaRadio/Dependencies/StationPlayer.swift
+++ b/PlayolaRadio/Dependencies/StationPlayer.swift
@@ -13,6 +13,7 @@ import PlayolaPlayer
 class StationPlayer: ObservableObject {
   var disposeBag: Set<AnyCancellable> = Set()
   enum PlaybackStatus {
+    case startingNewStation(RadioStation)
     case playing(RadioStation)
     case stopped
     case loading(RadioStation, Float? = nil)
@@ -30,6 +31,8 @@ class StationPlayer: ObservableObject {
   
   public var currentStation: RadioStation? {
     switch state.playbackStatus {
+    case let .startingNewStation(radioStation):
+      return radioStation
     case let .playing(radioStation):
       return radioStation
     case let .loading(radioStation, _):
@@ -70,6 +73,7 @@ class StationPlayer: ObservableObject {
   public func play(station: RadioStation) {
     guard currentStation != station else { return }
     stop()
+    state = State(playbackStatus: .startingNewStation(station))
     state = State(playbackStatus: .loading(station))
     if let _ = station.streamURL {
       urlStreamPlayer.set(station: station)

--- a/PlayolaRadio/Dependencies/StationPlayer.swift
+++ b/PlayolaRadio/Dependencies/StationPlayer.swift
@@ -97,10 +97,13 @@ class StationPlayer: ObservableObject {
       guard let currentStation else { return }
       state = .init(playbackStatus: .loading(currentStation, progress), titlePlaying: nil, albumArtworkUrl: nil)
     case let .playing(nowPlaying):
-      state = .init(playbackStatus: .playing(currentStation!),
-                    artistPlaying: nowPlaying.artist,
-                    titlePlaying: nowPlaying.title,
-                    albumArtworkUrl: nowPlaying.imageUrl)
+      if let currentStation {
+        state = .init(playbackStatus: .playing(currentStation),
+                      artistPlaying: nowPlaying.artist,
+                      titlePlaying: nowPlaying.title,
+                      albumArtworkUrl: nowPlaying.imageUrl)
+      }
+
     case .none:
       state = .init(playbackStatus: .error)
     }

--- a/PlayolaRadio/Extensions/PlayolaSheet.swift
+++ b/PlayolaRadio/Extensions/PlayolaSheet.swift
@@ -6,9 +6,10 @@
 //
 
 enum PlayolaSheet: Hashable, Identifiable, Equatable {
-    var id: Self {
-        self
-    }
-
-    case about(AboutPageModel)
+  var id: Self {
+    self
+  }
+  
+  case about(AboutPageModel)
+  case player(PlayerPageModel)
 }

--- a/PlayolaRadio/Views/Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Components/SmallPlayer/SmallPlayer.swift
@@ -1,0 +1,85 @@
+//
+//  SmallPlayer.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 6/16/25.
+//
+
+import SwiftUI
+import Foundation
+
+struct SmallPlayer: View {
+  var mainTitle: String
+  var secondaryTitle: String
+  var artworkURL: URL
+  var onStopButtonTapped: () -> Void
+
+   // MARK: - Body
+   var body: some View {
+       VStack(spacing: 0) {
+           // Player bar
+           HStack(spacing: 12) {
+               // Artwork
+               AsyncImage(url: artworkURL) { phase in
+                   switch phase {
+                   case .success(let image):
+                       image
+                           .resizable()
+                           .scaledToFill()
+                   default:
+                       Color.gray.opacity(0.3)
+                   }
+               }
+               .frame(width: 48, height: 48)
+               .padding(.leading, 16)
+               .clipShape(RoundedRectangle(cornerRadius: 6))
+
+               // Title & subtitle
+               VStack(alignment: .leading, spacing: 4) {
+                   Text(mainTitle)
+                   .font(.custom(FontNames.Inter_500_Medium, size: 16))
+                       .foregroundColor(.white)
+                 Text(secondaryTitle)
+                   .font(.custom(FontNames.Inter_400_Regular, size: 14))
+                       .foregroundColor(.gray)
+               }
+               .padding(.vertical, 12)
+
+               Spacer()
+
+               // Play / pause button
+               Button(action: {}) {
+                   Image(systemName: "stop.fill")
+                       .foregroundColor(.black)
+                       .frame(width: 34, height: 34)
+                       .background(.white)
+                       .clipShape(Circle())
+               }
+               .padding(.trailing, 24)
+           }
+           .padding(.horizontal, 12)
+           .padding(.vertical, 8)
+           .background(Color.black.opacity(0.85))
+
+           // Progress bar
+           GeometryReader { geo in
+               Rectangle()
+                   .fill(Color.red)
+                   .frame(width: geo.size.width)
+                   .frame(maxHeight: 2, alignment: .leading)
+                   .allowsHitTesting(false)
+           }
+           .frame(height: 2)
+       }
+   }
+}
+
+struct SmallPlayer_Previews: PreviewProvider {
+    static var previews: some View {
+      SmallPlayer(
+        mainTitle: "Jacob Stelly's",
+        secondaryTitle: "Moondog Radio",
+        artworkURL: URL(string: "https://playola-static.s3.amazonaws.com/station-images/Jacob-Stelly-1-116029.jpg")!,
+        onStopButtonTapped: {})
+    }
+}

--- a/PlayolaRadio/Views/Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Components/SmallPlayer/SmallPlayer.swift
@@ -47,8 +47,7 @@ struct SmallPlayer: View {
 
                Spacer()
 
-               // Play / pause button
-               Button(action: {}) {
+               Button(action: onStopButtonTapped) {
                    Image(systemName: "stop.fill")
                        .foregroundColor(.black)
                        .frame(width: 34, height: 34)

--- a/PlayolaRadio/Views/Components/SmallPlayer/SmallPlayerModel.swift
+++ b/PlayolaRadio/Views/Components/SmallPlayer/SmallPlayerModel.swift
@@ -1,0 +1,7 @@
+//
+//  SmallPlayerModel.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 6/16/25.
+//
+

--- a/PlayolaRadio/Views/Components/SmallPlayer/SmallPlayerTests.swift
+++ b/PlayolaRadio/Views/Components/SmallPlayer/SmallPlayerTests.swift
@@ -1,0 +1,8 @@
+//
+//  SmallPlayerTests.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 6/16/25.
+//
+
+

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -18,11 +18,16 @@ class HomePageModel: ViewModel {
   @ObservationIgnored @Shared(.stationListsLoaded) var stationListsLoaded: Bool
   @ObservationIgnored @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
 
+  @ObservationIgnored var stationPlayer: StationPlayer
+
   var forYouStations: IdentifiedArrayOf<RadioStation> = []
   var presentedAlert: PlayolaAlert? = nil
 
+  init(stationPlayer: StationPlayer? = nil) {
+    self.stationPlayer = stationPlayer ?? .shared
+  }
+
   // MARK: Actions
-  
   func viewAppeared() async {
     $stationLists.publisher
       .sink { lists in
@@ -35,5 +40,9 @@ class HomePageModel: ViewModel {
   func handlePlayolaIconTapped10Times() {
     $showSecretStations.withLock { $0 = !$0 }
     presentedAlert = showSecretStations ? .secretStationsTurnedOnAlert : .secretStationsHiddenAlert
+  }
+
+  func handleStationTapped(_ station: RadioStation) {
+    stationPlayer.play(station: station)
   }
 }

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -64,4 +64,19 @@ enum HomePageTests {
       #expect(homePage.presentedAlert == .secretStationsHiddenAlert)
     }
   }
+
+  @MainActor @Suite("PlayerInteraction")
+  struct StationPlayerInteraction {
+    @Test("Plays a station when it is tapped")
+    func testPlaysAStationWhenItIsTapped() {
+      let stationPlayerMock: StationPlayerMock = .mockStoppedPlayer()
+      let station: RadioStation = .mock
+
+      let homePageModel = HomePageModel(stationPlayer: stationPlayerMock)
+      homePageModel.handleStationTapped(station)
+
+      #expect(stationPlayerMock.callsToPlay.count == 1)
+      #expect(stationPlayerMock.callsToPlay.first?.id == station.id)
+    }
+  }
 }

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
@@ -27,7 +27,9 @@ struct HomePageView: View {
           HomeIntroSection(
             onIconTapped10Times: model.handlePlayolaIconTapped10Times)
 
-          HomePageStationList(stations: model.forYouStations)
+          HomePageStationList(stations: model.forYouStations) {
+            model.handleStationTapped($0)
+          }
         }
         .padding(.horizontal, 24)
         .scrollIndicators(.hidden)

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
@@ -18,50 +18,54 @@ struct Station: Identifiable {
 
 struct StationCardView: View {
   let station: RadioStation
+  let onRadioStationSelected: (RadioStation) -> Void
 
   var body: some View {
-    HStack(spacing: 0) {
-      AsyncImage(url: URL(string: station.imageURL )) { image in
-        image
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-      } placeholder: {
-        Color(white: 0.3)
+    Button(action: { onRadioStationSelected(station) }) {
+      HStack(spacing: 0) {
+        AsyncImage(url: URL(string: station.imageURL )) { image in
+          image
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+        } placeholder: {
+          Color(white: 0.3)
+        }
+        .frame(width: 160, height: 160)
+        .clipped()
+        
+        // Right side - Text content
+        VStack(alignment: .leading, spacing: 8) {
+          Text(station.name)
+            .font(.custom("Inter-Regular", size: 12))
+            .foregroundColor(Color(hex: "#C7C7C7"))
+          
+          Text(station.desc)
+            .font(.custom("SpaceGrotesk-Light_Bold", size: 16))
+            .fontWeight(.bold)
+            .foregroundColor(.white)
+            .padding(.bottom, 4)
+          
+          Text(station.longDesc)
+            .font(.custom("Inter-Regular", size: 14))
+            .foregroundColor(Color(hex: "#C7C7C7"))
+            .lineLimit(nil)
+            .lineSpacing(4)
+        }
+        .padding(.horizontal, 24)
+        .padding(.bottom, 20)
+        .frame(maxWidth: .infinity,
+               maxHeight: 160,
+               alignment: .leading)
       }
-      .frame(width: 160, height: 160)
-      .clipped()
-
-      // Right side - Text content
-      VStack(alignment: .leading, spacing: 8) {
-        Text(station.name)
-          .font(.custom("Inter-Regular", size: 12))
-          .foregroundColor(Color(hex: "#C7C7C7"))
-
-        Text(station.desc)
-          .font(.custom("SpaceGrotesk-Light_Bold", size: 16))
-          .fontWeight(.bold)
-          .foregroundColor(.white)
-          .padding(.bottom, 4)
-
-        Text(station.longDesc)
-          .font(.custom("Inter-Regular", size: 14))
-          .foregroundColor(Color(hex: "#C7C7C7"))
-          .lineLimit(nil)
-          .lineSpacing(4)
-      }
-      .padding(.horizontal, 24)
-      .padding(.bottom, 20)
-      .frame(maxWidth: .infinity,
-             maxHeight: 160,
-             alignment: .leading)
+      .background(Color(white: 0.15))
+      .cornerRadius(6)
     }
-    .background(Color(white: 0.15))
-    .cornerRadius(6)
   }
 }
 
 struct HomePageStationList: View {
   var stations: IdentifiedArrayOf<RadioStation>
+  var onRadioStationSelected: (RadioStation) -> Void
 
   var body: some View {
     VStack(alignment: .leading) {
@@ -73,7 +77,9 @@ struct HomePageStationList: View {
 
       VStack(spacing: 12) {  // Reduced spacing between cards
         ForEach(stations) { station in
-          StationCardView(station: station)
+          StationCardView(station: station) {
+            onRadioStationSelected($0)
+          }
         }
       }
     }
@@ -84,7 +90,7 @@ struct HomePageStationList: View {
 
 struct HomePageStationList_Previews: PreviewProvider {
   static var previews: some View {
-    HomePageStationList(stations: [.mock])
+    HomePageStationList(stations: [.mock], onRadioStationSelected: { _ in })
       .preferredColorScheme(.dark)
       .padding(.horizontal, 24)
   }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -131,7 +131,7 @@ struct MainContainer: View {
 //                              }
                       }
                   case let .player(playerPageModel):
-                    PlayerPage()
+                    PlayerPage(model: PlayerPageModel())
                   }
               })
         .onAppear { Task { await model.viewAppeared() } }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -31,6 +31,7 @@ class MainContainerModel: ViewModel {
   var presentedSheet: PlayolaSheet? = nil
 
   var homePageModel = HomePageModel()
+  var stationListModel = StationListModel()
 
   init(api: API? = nil, stationPlayer: StationPlayer? = nil) {
     self.api = api ?? API()
@@ -88,7 +89,7 @@ struct MainContainer: View {
                 }
                 .tag(MainContainerModel.ActiveTab.home)
 
-            StationListPage()
+        StationListPage(model: model.stationListModel)
                 .tabItem {
                     Image("RadioStationsTabImage")
                     Text("Radio Stations")

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -33,6 +33,27 @@ class MainContainerModel: ViewModel {
   var homePageModel = HomePageModel()
   var stationListModel = StationListModel()
 
+  var shouldShowSmallPlayer: Bool {
+    switch stationPlayer.state.playbackStatus {
+    case .playing, .loading:
+      return true
+    case .stopped, .error, .startingNewStation:
+      return false
+    }
+  }
+
+  var smallPlayerMainTitle: String {
+    stationPlayer.currentStation?.name ?? ""
+  }
+
+  var smallPlayerSecondaryTitle: String {
+      return stationPlayer.currentStation?.desc ?? ""
+  }
+
+  var smallPlayerArtworkURL: URL {
+    stationPlayer.state.albumArtworkUrl ?? stationPlayer.currentStation?.processedImageURL() ?? URL(string: "https://example.com")!
+  }
+
   init(api: API? = nil, stationPlayer: StationPlayer? = nil) {
     self.api = api ?? API()
     self.stationPlayer = stationPlayer ?? .shared
@@ -64,6 +85,14 @@ class MainContainerModel: ViewModel {
       return
     }
   }
+
+  func onSmallPlayerStopTapped() {
+    stationPlayer.stop()
+  }
+
+  func onSmallPlayerTapped() {
+    self.presentedSheet = .player(PlayerPageModel())
+  }
 }
 
 extension PlayolaAlert {
@@ -80,68 +109,84 @@ extension PlayolaAlert {
 struct MainContainer: View {
   @Bindable var model: MainContainerModel
 
-    var body: some View {
+  var body: some View {
+    VStack(spacing: 0) {
       TabView(selection: $model.selectedTab) {
-        HomePageView(model: model.homePageModel)
-                .tabItem {
-                    Image("HomeTabImage")
-                    Text("Home")
-                }
-                .tag(MainContainerModel.ActiveTab.home)
-
-        StationListPage(model: model.stationListModel)
-                .tabItem {
-                    Image("RadioStationsTabImage")
-                    Text("Radio Stations")
-                }
-                .tag(MainContainerModel.ActiveTab.stationsList)
-
-        HomePageView(model: model.homePageModel) // Temporarily using HomePageView
-                .tabItem {
-                    Image("ProfileTabImage")
-                    Text("Profile")
-                }
-                .tag(MainContainerModel.ActiveTab.profile)
+        TabContentWithSmallPlayer(content: {
+          HomePageView(model: model.homePageModel)
+        })
+        .tabItem {
+          Image("HomeTabImage")
+          Text("Home")
         }
-        .accentColor(.white) // Makes the selected tab icon white
-        .onAppear {
-            let tabBarAppearance = UITabBarAppearance()
-            tabBarAppearance.configureWithOpaqueBackground()
-            tabBarAppearance.backgroundColor = .black
+        .tag(MainContainerModel.ActiveTab.home)
 
-            UITabBar.appearance().standardAppearance = tabBarAppearance
-            UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
-            UITabBar.appearance().unselectedItemTintColor = UIColor(white: 0.7, alpha: 1.0)
+        TabContentWithSmallPlayer(content: {
+          StationListPage(model: model.stationListModel)
+        })
+        .tabItem {
+          Image("RadioStationsTabImage")
+          Text("Radio Stations")
         }
-        .alert(item: $model.presentedAlert) { $0.alert }
-        .sheet(item: $model.presentedSheet, content: { item in
-                  switch item {
-                  case let .about(aboutModel):
-                      NavigationStack {
-                          AboutPage(model: aboutModel)
-//                              .toolbar {
-//                                  ToolbarItem(placement: .confirmationAction) {
-//                                      Button(action: { model.dismissButtonInSheetTapped() }) {
-//                                          Image(systemName: "xmark.circle.fill")
-//                                              .resizable()
-//                                              .frame(width: 32, height: 32)
-//                                              .foregroundColor(.gray)
-//                                              .padding(20)
-//                                      }
-//                                  }
-//                              }
-                      }
-                  case let .player(playerPageModel):
-                    PlayerPage(model: PlayerPageModel())
-                  }
-              })
-        .onAppear { Task { await model.viewAppeared() } }
+        .tag(MainContainerModel.ActiveTab.stationsList)
+
+        TabContentWithSmallPlayer(content: {
+          HomePageView(model: model.homePageModel) // Temporarily using HomePageView
+        })
+        .tabItem {
+          Image("ProfileTabImage")
+          Text("Profile")
+        }
+        .tag(MainContainerModel.ActiveTab.profile)
+      }
+      .accentColor(.white) // Makes the selected tab icon white
+      .onAppear {
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.configureWithOpaqueBackground()
+        tabBarAppearance.backgroundColor = .black
+
+        UITabBar.appearance().standardAppearance = tabBarAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+        UITabBar.appearance().unselectedItemTintColor = UIColor(white: 0.7, alpha: 1.0)
+      }
     }
+    .alert(item: $model.presentedAlert) { $0.alert }
+    .sheet(item: $model.presentedSheet, content: { item in
+      switch item {
+      case let .about(aboutModel):
+        NavigationStack {
+          AboutPage(model: aboutModel)
+        }
+      case let .player(playerPageModel):
+        PlayerPage(model: PlayerPageModel())
+      }
+    })
+    .onAppear { Task { await model.viewAppeared() } }
+  }
+
+  @ViewBuilder
+  private func TabContentWithSmallPlayer<Content: View>(@ViewBuilder content: () -> Content) -> some View {
+    VStack(spacing: 0) {
+      content()
+
+      if model.shouldShowSmallPlayer {
+        SmallPlayer(
+          mainTitle: model.smallPlayerMainTitle,
+          secondaryTitle: model.smallPlayerSecondaryTitle,
+          artworkURL: model.smallPlayerArtworkURL,
+          onStopButtonTapped: model.onSmallPlayerStopTapped
+        )
+        .onTapGesture {
+          model.onSmallPlayerTapped()
+        }
+      }
+    }
+  }
 }
 
 struct MainContainer_Previews: PreviewProvider {
-    static var previews: some View {
-      MainContainer(model: MainContainerModel())
-            .preferredColorScheme(.dark)
-    }
+  static var previews: some View {
+    MainContainer(model: MainContainerModel())
+      .preferredColorScheme(.dark)
+  }
 }

--- a/PlayolaRadio/Views/Pages/NowPlayingPage/NowPlayingPage.swift
+++ b/PlayolaRadio/Views/Pages/NowPlayingPage/NowPlayingPage.swift
@@ -87,6 +87,8 @@ class NowPlayingPageModel: ViewModel {
             nowPlayingTitle = ""
             nowPlayingArtist = "Error Playing Station"
             albumArtUrl = nil
+        default:
+          return
         }
     }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -69,7 +69,7 @@ struct PlayerPage: View {
                 .foregroundColor(.gray)
 
               Text(model.nowPlayingText)
-                .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 24))
+                .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 20))
                 .foregroundColor(.white)
                 .multilineTextAlignment(.center)
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -104,12 +104,12 @@ struct PlayerPage: View {
             .padding(.top, 32)
 
             // Play Button
-            Button(action: {}) {
+            Button(action: { model.playPauseButtonTapped() }) {
               Circle()
                 .fill(Color.white)
                 .frame(width: 80, height: 80)
                 .overlay(
-                  Image(systemName: "stop.fill")
+                  Image(systemName: model.playerButtonImageName.rawValue)
                     .foregroundColor(.black)
                     .font(.system(size: 40))
                 )

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct PlayerPage: View {
     @Environment(\.dismiss) private var dismiss
+  @Bindable var model: PlayerPageModel
 
     var body: some View {
         VStack(spacing: 0) {
@@ -25,10 +26,10 @@ struct PlayerPage: View {
                 Spacer()
 
                 VStack(spacing: 4) {
-                    Text("Jacob Stelly's")
+                  Text(model.primaryNavBarTitle)
                         .font(.custom(FontNames.Inter_500_Medium, size: 20))
                         .foregroundColor(.white)
-                    Text("Moondog Radio")
+                  Text(model.secondaryNavBarTitle)
                         .font(.custom(FontNames.Inter_400_Regular, size: 14))
                         .foregroundColor(Color(hex: "#C7C7C7"))
                 }
@@ -49,7 +50,7 @@ struct PlayerPage: View {
 
 
             // Main Image
-            AsyncImage(url: URL(string: "https://playola-static.s3.amazonaws.com/station-images/Jacob-Stelly-1-116029.jpg")) { image in
+            AsyncImage(url: model.stationArtUrl) { image in
               image
                 .resizable()
                 .aspectRatio(contentMode: .fill)
@@ -67,7 +68,7 @@ struct PlayerPage: View {
                 .font(.custom(FontNames.Inter_500_Medium, size: 12))
                 .foregroundColor(.gray)
 
-              Text("Jacob Stelly - Sweet Irene")
+              Text(model.nowPlayingText)
                 .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 24))
                 .foregroundColor(.white)
 
@@ -142,10 +143,11 @@ struct PlayerPage: View {
 //            Spacer()
         }
         .background(Color.black)
+        .onAppear { model.viewAppeared() }
     }
 }
 
 #Preview {
-    PlayerPage()
+  PlayerPage(model: PlayerPageModel())
         .preferredColorScheme(.dark)
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -71,8 +71,9 @@ struct PlayerPage: View {
               Text(model.nowPlayingText)
                 .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 24))
                 .foregroundColor(.white)
+                .multilineTextAlignment(.center)
 
-              ProgressView(value: 1.0)
+              ProgressView(value: model.loadingPercentage)
                 .progressViewStyle(LinearProgressViewStyle(tint: Color.playolaRed))
                 .cornerRadius(8)
                 .scaleEffect(y: 2, anchor: .center)

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -7,6 +7,8 @@
 
 import SwiftUI
 
+
+
 struct PlayerPage: View {
     @Environment(\.dismiss) private var dismiss
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -21,7 +21,14 @@ class PlayerPageModel: ViewModel {
   // Unused for now
   var albumArtUrl: URL? = nil
   var stationArtUrl: URL? = nil
+  var previouslyPlayingStation: RadioStation? = nil
 
+  enum PlayerButtonImageName: String {
+    case play = "play.fill"
+    case stop = "stop.fill"
+  }
+
+  var playerButtonImageName = PlayerButtonImageName.stop
 
   @ObservationIgnored var stationPlayer: StationPlayer
 
@@ -44,6 +51,8 @@ class PlayerPageModel: ViewModel {
       }
       albumArtUrl = state.albumArtworkUrl
       stationArtUrl = URL(string: radioStation.imageURL)
+      self.playerButtonImageName = .stop
+      self.previouslyPlayingStation = radioStation
     case let .loading(radioStation, progress):
       primaryNavBarTitle = radioStation.name
       secondaryNavBarTitle = radioStation.desc
@@ -53,19 +62,38 @@ class PlayerPageModel: ViewModel {
         nowPlayingText = "Station Loading..."
       }
       albumArtUrl = URL(string: radioStation.imageURL)
+      self.playerButtonImageName = .stop
+      self.previouslyPlayingStation = radioStation
     case .stopped:
       albumArtUrl = nil
       nowPlayingText = ""
+      self.playerButtonImageName = .play
     case .error:
       primaryNavBarTitle = ""
       secondaryNavBarTitle = ""
       nowPlayingText = "Error Playing Station"
       albumArtUrl = nil
+      self.playerButtonImageName = .play
     case let .startingNewStation(radioStation):
       primaryNavBarTitle = radioStation.name
       secondaryNavBarTitle = radioStation.desc
       nowPlayingText = ""
       albumArtUrl = URL(string: radioStation.imageURL)
+      self.previouslyPlayingStation = radioStation
+      self.playerButtonImageName = .stop
+    }
+  }
+
+  func playPauseButtonTapped() {
+    // compared with `!=`.  Use pattern matching instead.
+    switch stationPlayer.state.playbackStatus {
+    case .stopped:
+      // If it’s currently stopped, start playing.
+      if let station = self.previouslyPlayingStation {
+        stationPlayer.play(station: station)
+      }
+    default:
+      stationPlayer.stop()
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -11,5 +11,61 @@ import Combine
 @MainActor
 @Observable
 class PlayerPageModel: ViewModel {
-  
+  var cancellables: Set<AnyCancellable> = []
+
+  // MARK: State
+  var nowPlayingText: String = ""
+  var primaryNavBarTitle: String = ""
+  var secondaryNavBarTitle: String = ""
+
+  // Unused for now
+  var albumArtUrl: URL? = nil
+  var stationArtUrl: URL? = nil
+
+
+  @ObservationIgnored var stationPlayer: StationPlayer
+
+  init(stationPlayer: StationPlayer? = nil) {
+    self.stationPlayer = stationPlayer ?? .shared
+  }
+
+  func viewAppeared() {
+    processNewStationState(stationPlayer.state)
+    stationPlayer.$state.sink { self.processNewStationState($0) }.store(in: &cancellables)
+  }
+
+  func processNewStationState(_ state: StationPlayer.State) {
+    switch state.playbackStatus {
+    case let .playing(radioStation):
+      if let titlePlaying = state.titlePlaying, let artistPlaying = state.artistPlaying {
+        nowPlayingText = "\(titlePlaying) / \(artistPlaying)"
+      } else {
+        nowPlayingText = ""
+      }
+      albumArtUrl = state.albumArtworkUrl
+      stationArtUrl = URL(string: radioStation.imageURL)
+    case let .loading(radioStation, progress):
+      primaryNavBarTitle = radioStation.name
+      secondaryNavBarTitle = radioStation.desc
+      if let progress {
+        nowPlayingText = "Station Loading... \(Int(round(progress * 100)))%"
+      } else {
+        nowPlayingText = "Station Loading..."
+      }
+      albumArtUrl = URL(string: radioStation.imageURL)
+    case .stopped:
+      albumArtUrl = nil
+      nowPlayingText = ""
+    case .error:
+      primaryNavBarTitle = ""
+      secondaryNavBarTitle = ""
+      nowPlayingText = "Error Playing Station"
+      albumArtUrl = nil
+    case let .startingNewStation(radioStation):
+      primaryNavBarTitle = radioStation.name
+      secondaryNavBarTitle = radioStation.desc
+      nowPlayingText = ""
+      albumArtUrl = URL(string: radioStation.imageURL)
+    }
+  }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -48,7 +48,7 @@ class PlayerPageModel: ViewModel {
     switch state.playbackStatus {
     case let .playing(radioStation):
       if let titlePlaying = state.titlePlaying, let artistPlaying = state.artistPlaying {
-        nowPlayingText = "\(titlePlaying) / \(artistPlaying)"
+        nowPlayingText = "\(titlePlaying) - \(artistPlaying)"
       } else {
         nowPlayingText = ""
       }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -17,11 +17,14 @@ class PlayerPageModel: ViewModel {
   var nowPlayingText: String = ""
   var primaryNavBarTitle: String = ""
   var secondaryNavBarTitle: String = ""
+  var stationArtUrl: URL? = nil
+  var previouslyPlayingStation: RadioStation? = nil
+  var loadingPercentage: Float = 1.0
+
 
   // Unused for now
   var albumArtUrl: URL? = nil
-  var stationArtUrl: URL? = nil
-  var previouslyPlayingStation: RadioStation? = nil
+
 
   enum PlayerButtonImageName: String {
     case play = "play.fill"
@@ -53,13 +56,13 @@ class PlayerPageModel: ViewModel {
       stationArtUrl = URL(string: radioStation.imageURL)
       self.playerButtonImageName = .stop
       self.previouslyPlayingStation = radioStation
+      self.loadingPercentage = 1.0
     case let .loading(radioStation, progress):
       primaryNavBarTitle = radioStation.name
       secondaryNavBarTitle = radioStation.desc
+      nowPlayingText = "Station Loading..."
       if let progress {
-        nowPlayingText = "Station Loading... \(Int(round(progress * 100)))%"
-      } else {
-        nowPlayingText = "Station Loading..."
+        self.loadingPercentage = progress
       }
       albumArtUrl = URL(string: radioStation.imageURL)
       self.playerButtonImageName = .stop

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -1,0 +1,15 @@
+//
+//  PlayerPageModel.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 6/16/25.
+//
+
+import SwiftUI
+import Combine
+
+@MainActor
+@Observable
+class PlayerPageModel: ViewModel {
+  
+}

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -15,7 +15,7 @@ struct PlayerPageTests {
   // MARK: - viewAppeared
   @Suite("viewAppeared")
   struct ViewAppearedTests {
-
+    
     @Test("Populates correctly when loading (no progress)")
     @MainActor
     func testPopulatesCorrectlyWhenLoadingNoProgress() {
@@ -24,15 +24,15 @@ struct PlayerPageTests {
       playerMock.state = StationPlayer.State(
         playbackStatus: .loading(station) // no progress
       )
-
+      
       let model = PlayerPageModel(stationPlayer: playerMock)
       model.viewAppeared()
-
+      
       #expect(model.primaryNavBarTitle   == station.name)
       #expect(model.secondaryNavBarTitle == station.desc)
       #expect(model.nowPlayingText       == "Station Loading...")
     }
-
+    
     @Test("Populates correctly when loading (with progress)")
     @MainActor
     func testPopulatesCorrectlyWhenLoadingWithProgress() {
@@ -41,15 +41,15 @@ struct PlayerPageTests {
       playerMock.state = StationPlayer.State(
         playbackStatus: .loading(station, 0.42)   // 42 %
       )
-
+      
       let model = PlayerPageModel(stationPlayer: playerMock)
       model.viewAppeared()
-
+      
       #expect(model.primaryNavBarTitle   == station.name)
       #expect(model.secondaryNavBarTitle == station.desc)
       #expect(model.nowPlayingText       == "Station Loading... 42%")
     }
-
+    
     @Test("Populates correctly when something is playing")
     @MainActor
     func testPopulatesCorrectlyWhenSomethingIsPlaying() {
@@ -60,14 +60,14 @@ struct PlayerPageTests {
         artistPlaying  : "Rachel Loy",
         titlePlaying   : "Selfie"
       )
-
+      
       let model = PlayerPageModel(stationPlayer: playerMock)
       model.viewAppeared()
-
+      
       #expect(model.nowPlayingText     == "Selfie / Rachel Loy")
       #expect(model.stationArtUrl      == URL(string: station.imageURL))
     }
-
+    
     @Test("Populates correctly when stopped")
     @MainActor
     func testPopulatesCorrectlyWhenStopped() {
@@ -75,14 +75,14 @@ struct PlayerPageTests {
       playerMock.state = StationPlayer.State(
         playbackStatus: .stopped
       )
-
+      
       let model = PlayerPageModel(stationPlayer: playerMock)
       model.viewAppeared()
-
+      
       #expect(model.nowPlayingText == "")
       #expect(model.albumArtUrl    == nil)
     }
-
+    
     @Test("Populates correctly when error")
     @MainActor
     func testPopulatesCorrectlyWhenError() {
@@ -90,7 +90,7 @@ struct PlayerPageTests {
       playerMock.state = StationPlayer.State(
         playbackStatus: .error
       )
-
+      
       let model = PlayerPageModel(stationPlayer: playerMock)
       model.viewAppeared()
       
@@ -99,7 +99,7 @@ struct PlayerPageTests {
       #expect(model.secondaryNavBarTitle == "")
       #expect(model.albumArtUrl          == nil)
     }
-
+    
     @Test("Populates correctly when starting new station")
     @MainActor
     func testPopulatesCorrectlyWhenStartingNewStation() {
@@ -108,13 +108,58 @@ struct PlayerPageTests {
       playerMock.state = StationPlayer.State(
         playbackStatus: .startingNewStation(station)
       )
-
+      
       let model = PlayerPageModel(stationPlayer: playerMock)
       model.viewAppeared()
-
+      
       #expect(model.primaryNavBarTitle   == station.name)
       #expect(model.secondaryNavBarTitle == station.desc)
       #expect(model.nowPlayingText       == "")
+    }
+  }
+  
+  // MARK: - playPauseButtonTapped
+  @Suite("playPauseButtonTapped")
+  struct PlayPauseButtonTappedTests {
+    
+    @Test("Stops the stream when something is playing")
+    @MainActor
+    func testStopsWhenPlaying() {
+      let station = RadioStation.mock
+      let spy     = StationPlayerMock()
+      spy.state   = StationPlayer.State(
+        playbackStatus: .playing(station)
+      )
+      
+      let model = PlayerPageModel(stationPlayer: spy)
+      model.viewAppeared()
+      #expect(spy.stopCalledCount == 0)
+      model.playPauseButtonTapped()
+      
+      #expect(spy.stopCalledCount == 1)
+      #expect(spy.callsToPlay.count  == 0)
+    }
+    
+    @Test("Plays the previously-playing station when stopped")
+    @MainActor
+    func testPlaysWhenStopped() {
+      let station = RadioStation.mock
+      let spy     = StationPlayerMock()
+      spy.state = StationPlayer.State(
+        playbackStatus: .playing(station)
+      )
+      let model = PlayerPageModel(stationPlayer: spy)
+      model.viewAppeared()
+      
+      spy.state = StationPlayer.State(
+        playbackStatus: .stopped
+      )
+      
+      model.playPauseButtonTapped()
+      
+      #expect(spy.callsToPlay.count == 1)
+      #expect(spy.callsToPlay[0]  == station)
+      #expect(spy.stopCalledCount == 0)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -65,7 +65,7 @@ struct PlayerPageTests {
       let model = PlayerPageModel(stationPlayer: playerMock)
       model.viewAppeared()
       
-      #expect(model.nowPlayingText     == "Selfie / Rachel Loy")
+      #expect(model.nowPlayingText     == "Selfie - Rachel Loy")
       #expect(model.stationArtUrl      == URL(string: station.imageURL))
     }
     

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -39,7 +39,7 @@ struct PlayerPageTests {
       let station     = RadioStation.mock
       let playerMock  = StationPlayerMock()
       playerMock.state = StationPlayer.State(
-        playbackStatus: .loading(station, 0.42)   // 42 %
+        playbackStatus: .loading(station, 0.42)
       )
       
       let model = PlayerPageModel(stationPlayer: playerMock)
@@ -47,7 +47,8 @@ struct PlayerPageTests {
       
       #expect(model.primaryNavBarTitle   == station.name)
       #expect(model.secondaryNavBarTitle == station.desc)
-      #expect(model.nowPlayingText       == "Station Loading... 42%")
+      #expect(model.nowPlayingText       == "Station Loading...")
+      #expect(model.loadingPercentage == 0.42)
     }
     
     @Test("Populates correctly when something is playing")

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -1,0 +1,120 @@
+//
+//  PlayerPageTests.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 6/16/25.
+//
+
+import FRadioPlayer
+@testable import PlayolaRadio
+import Testing
+import Foundation
+
+@MainActor
+struct PlayerPageTests {
+  // MARK: - viewAppeared
+  @Suite("viewAppeared")
+  struct ViewAppearedTests {
+
+    @Test("Populates correctly when loading (no progress)")
+    @MainActor
+    func testPopulatesCorrectlyWhenLoadingNoProgress() {
+      let station     = RadioStation.mock
+      let playerMock  = StationPlayerMock()
+      playerMock.state = StationPlayer.State(
+        playbackStatus: .loading(station) // no progress
+      )
+
+      let model = PlayerPageModel(stationPlayer: playerMock)
+      model.viewAppeared()
+
+      #expect(model.primaryNavBarTitle   == station.name)
+      #expect(model.secondaryNavBarTitle == station.desc)
+      #expect(model.nowPlayingText       == "Station Loading...")
+    }
+
+    @Test("Populates correctly when loading (with progress)")
+    @MainActor
+    func testPopulatesCorrectlyWhenLoadingWithProgress() {
+      let station     = RadioStation.mock
+      let playerMock  = StationPlayerMock()
+      playerMock.state = StationPlayer.State(
+        playbackStatus: .loading(station, 0.42)   // 42 %
+      )
+
+      let model = PlayerPageModel(stationPlayer: playerMock)
+      model.viewAppeared()
+
+      #expect(model.primaryNavBarTitle   == station.name)
+      #expect(model.secondaryNavBarTitle == station.desc)
+      #expect(model.nowPlayingText       == "Station Loading... 42%")
+    }
+
+    @Test("Populates correctly when something is playing")
+    @MainActor
+    func testPopulatesCorrectlyWhenSomethingIsPlaying() {
+      let station     = RadioStation.mock
+      let playerMock  = StationPlayerMock()
+      playerMock.state = StationPlayer.State(
+        playbackStatus : .playing(station),
+        artistPlaying  : "Rachel Loy",
+        titlePlaying   : "Selfie"
+      )
+
+      let model = PlayerPageModel(stationPlayer: playerMock)
+      model.viewAppeared()
+
+      #expect(model.nowPlayingText     == "Selfie / Rachel Loy")
+      #expect(model.stationArtUrl      == URL(string: station.imageURL))
+    }
+
+    @Test("Populates correctly when stopped")
+    @MainActor
+    func testPopulatesCorrectlyWhenStopped() {
+      let playerMock  = StationPlayerMock()
+      playerMock.state = StationPlayer.State(
+        playbackStatus: .stopped
+      )
+
+      let model = PlayerPageModel(stationPlayer: playerMock)
+      model.viewAppeared()
+
+      #expect(model.nowPlayingText == "")
+      #expect(model.albumArtUrl    == nil)
+    }
+
+    @Test("Populates correctly when error")
+    @MainActor
+    func testPopulatesCorrectlyWhenError() {
+      let playerMock  = StationPlayerMock()
+      playerMock.state = StationPlayer.State(
+        playbackStatus: .error
+      )
+
+      let model = PlayerPageModel(stationPlayer: playerMock)
+      model.viewAppeared()
+      
+      #expect(model.nowPlayingText       == "Error Playing Station")
+      #expect(model.primaryNavBarTitle   == "")
+      #expect(model.secondaryNavBarTitle == "")
+      #expect(model.albumArtUrl          == nil)
+    }
+
+    @Test("Populates correctly when starting new station")
+    @MainActor
+    func testPopulatesCorrectlyWhenStartingNewStation() {
+      let station     = RadioStation.mock
+      let playerMock  = StationPlayerMock()
+      playerMock.state = StationPlayer.State(
+        playbackStatus: .startingNewStation(station)
+      )
+
+      let model = PlayerPageModel(stationPlayer: playerMock)
+      model.viewAppeared()
+
+      #expect(model.primaryNavBarTitle   == station.name)
+      #expect(model.secondaryNavBarTitle == station.desc)
+      #expect(model.nowPlayingText       == "")
+    }
+  }
+}

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -64,6 +64,5 @@ class StationListModel: ViewModel {
 
   func stationSelected(_ station: RadioStation) {
     stationPlayer.play(station: station)
-
   }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -19,10 +19,16 @@ class StationListModel: ViewModel {
   @ObservationIgnored @Shared(.stationListsLoaded) var stationListsLoaded: Bool
   @ObservationIgnored @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
 
+  @ObservationIgnored var stationPlayer: StationPlayer
+
   var stationListsForDisplay: IdentifiedArrayOf<StationList> = []
   var segmentTitles: [String] = ["All"]
   var selectedSegment = "All"
   var presentedAlert: PlayolaAlert? = nil
+
+  init(stationPlayer: StationPlayer? = nil) {
+    self.stationPlayer = stationPlayer ?? .shared
+  }
 
   // MARK: Actions
   func viewAppeared() async {
@@ -35,8 +41,8 @@ class StationListModel: ViewModel {
 
   private func loadStationListsForDisplay(_ rawList: IdentifiedArrayOf<StationList>) {
     let visibleLists = showSecretStations
-      ? rawList
-      : rawList.filter { $0.id != StationList.inDevelopmentListId }
+    ? rawList
+    : rawList.filter { $0.id != StationList.inDevelopmentListId }
 
     segmentTitles = ["All"] + visibleLists.map { $0.title }
 
@@ -54,5 +60,10 @@ class StationListModel: ViewModel {
   func segmentSelected(_ segmentTitle: String) {
     selectedSegment = segmentTitle
     loadStationListsForDisplay(stationLists)
+  }
+
+  func stationSelected(_ station: RadioStation) {
+    stationPlayer.play(station: station)
+
   }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -84,7 +84,9 @@ struct StationListPage: View {
 
         VStack(spacing: 1) {
           ForEach(stations) { station in
-            StationRowView(station: station)
+            StationRowView(station: station, action: {
+              model.stationSelected(station)
+            })
           }
         }
       }
@@ -97,9 +99,10 @@ struct StationListPage: View {
 // ------------------------------------------------------------------
 private struct StationRowView: View {
   let station: RadioStation
+  let action: (() -> Void)
 
   var body: some View {
-    Button(action: {}) {
+    Button(action: action) {
       HStack(spacing: 12) {
         if let url = URL(string: station.imageURL)
         {

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -10,7 +10,7 @@ import IdentifiedCollections
 
 struct StationListPage: View {
   // MARK: - Model
-  @Bindable private var model = StationListModel()
+  @Bindable var model: StationListModel
 
   // MARK: - View
   var body: some View {
@@ -142,7 +142,7 @@ private struct StationRowView: View {
 // ------------------------------------------------------------------
 #Preview {
   NavigationStack {
-    StationListPage()
+    StationListPage(model: StationListModel())
   }
   .preferredColorScheme(.dark)
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -126,7 +126,6 @@ enum StationListPageTests {
 
       #expect(stationPlayerMock.callsToPlay.count == 1)
       #expect(stationPlayerMock.callsToPlay.first?.id == station.id)
-
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -110,4 +110,23 @@ enum StationListPageTests {
       #expect(model.stationListsForDisplay == expectedVisibleAfterUpdate)
     }
   }
+
+  // -------------------------------------------------------------
+  // MARK: - Player interaction
+  // -------------------------------------------------------------
+  @MainActor @Suite("PlayerInteraction")
+  struct StationPlayerInteraction {
+    @Test("Plays a station when it is tapped")
+    func testPlaysAStationWhenItIsTapped() {
+      let stationPlayerMock: StationPlayerMock = .mockStoppedPlayer()
+      let station: RadioStation = .mock
+
+      let stationListModel = StationListModel(stationPlayer: stationPlayerMock)
+      stationListModel.stationSelected(station)
+
+      #expect(stationPlayerMock.callsToPlay.count == 1)
+      #expect(stationPlayerMock.callsToPlay.first?.id == station.id)
+
+    }
+  }
 }


### PR DESCRIPTION
This pull request introduces several updates to the `PlayolaRadio` project, focusing on adding a new `PlayerPage` feature, integrating a `StationPlayer` for enhanced playback management, and improving the modularity of the codebase. Below is a summary of the most important changes, grouped by theme:

### PlayerPage and StationPlayer Integration:
* Added a new `PlayerPage` view and its associated `PlayerPageModel` to manage and display playback details. (`[[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R93)`, `[[2]](diffhunk://#diff-f575e81eea962cd9096d10b351b82e18859941b884cfb18f7cf56a9954313341R10-R14)`, `[[3]](diffhunk://#diff-f575e81eea962cd9096d10b351b82e18859941b884cfb18f7cf56a9954313341L26-R32)`)
* Enhanced `StationPlayer` to include a new `startingNewStation` playback state, allowing smoother transitions when switching stations. (`[[1]](diffhunk://#diff-8cc5af4bb8fb0f3a6ade123a6c0b77bd45a52b845721b6d9fcd7235456ab2f46R16)`, `[[2]](diffhunk://#diff-8cc5af4bb8fb0f3a6ade123a6c0b77bd45a52b845721b6d9fcd7235456ab2f46R34-R35)`, `[[3]](diffhunk://#diff-8cc5af4bb8fb0f3a6ade123a6c0b77bd45a52b845721b6d9fcd7235456ab2f46R76)`, `[[4]](diffhunk://#diff-8cc5af4bb8fb0f3a6ade123a6c0b77bd45a52b845721b6d9fcd7235456ab2f46L96-R106)`)
* Updated `HomePageModel` to handle station taps by triggering playback via the `StationPlayer`. (`[[1]](diffhunk://#diff-03191d1666537add6fec71dc4780976ef85260e650560180ac402b7199947940R21-R30)`, `[[2]](diffhunk://#diff-03191d1666537add6fec71dc4780976ef85260e650560180ac402b7199947940R44-R47)`)

### Navigation and Sheet Presentation:
* Introduced a `presentedSheet` property in `MainContainerModel` to manage the display of modal sheets, such as the new `PlayerPage`. (`[[1]](diffhunk://#diff-3cc1b6ca679353600c570ab3081f064836c15cebb1737aa91702de9d018b7e9eR31-R37)`, `[[2]](diffhunk://#diff-3cc1b6ca679353600c570ab3081f064836c15cebb1737aa91702de9d018b7e9eR116-R136)`)
* Added logic to present the `PlayerPage` when a new station starts playing. (`[PlayolaRadio/Views/Pages/MainContainer/MainContainer.swiftR50-R64](diffhunk://#diff-3cc1b6ca679353600c570ab3081f064836c15cebb1737aa91702de9d018b7e9eR50-R64)`)

### Testing and Code Quality:
* Created unit tests in `HomePageTests` to verify that tapping a station triggers playback correctly. (`[PlayolaRadio/Views/Pages/HomePage/HomePageTests.swiftR67-R81](diffhunk://#diff-94878e6776a43ac57df09b0b1e3efa09ac0fdbe4c5c33828b03b752f11b2d085R67-R81)`)
* Added `PlayerPageTests.swift` to the project for future test coverage of the `PlayerPage`. (`[[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R77)`, `[[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R473-R474)`)

### UI Updates:
* Modified `HomePageStationList` and `StationCardView` to accept a callback for station selection, enabling interaction with the `StationPlayer`. (`[[1]](diffhunk://#diff-54fccd9d57ab23fcc794bb7e3072adf6add10abbdf300c05c75e428cd6045e39R21-R24)`, `[[2]](diffhunk://#diff-54fccd9d57ab23fcc794bb7e3072adf6add10abbdf300c05c75e428cd6045e39R64-R68)`, `[[3]](diffhunk://#diff-54fccd9d57ab23fcc794bb7e3072adf6add10abbdf300c05c75e428cd6045e39L76-R82)`, `[[4]](diffhunk://#diff-54fccd9d57ab23fcc794bb7e3072adf6add10abbdf300c05c75e428cd6045e39L87-R93)`)
* Updated `MainContainer` to include a `.sheet` modifier for presenting modal views. (`[PlayolaRadio/Views/Pages/MainContainer/MainContainer.swiftR116-R136](diffhunk://#diff-3cc1b6ca679353600c570ab3081f064836c15cebb1737aa91702de9d018b7e9eR116-R136)`)

### Project File Updates:
* Added `PlayerPageModel.swift` and `PlayerPageTests.swift` to the Xcode project configuration. (`[[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R93)`, `[[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R473-R474)`, `[[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R649)`, `[[4]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R688)`)
* Reorganized `PlayolaSheet.swift` by renaming and relocating it to the `Extensions` group. (`[[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L306)`, `[[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R395)`)