### PR TITLE
Visual Tweaks

### DIFF
--- a/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
@@ -30,6 +30,7 @@ struct HomePageView: View {
           HomePageStationList(stations: model.forYouStations) {
             model.handleStationTapped($0)
           }
+          .padding(.top, -48)
         }
         .padding(.horizontal, 24)
         .scrollIndicators(.hidden)

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
@@ -22,7 +22,7 @@ struct StationCardView: View {
 
   var body: some View {
     Button(action: { onRadioStationSelected(station) }) {
-      HStack(spacing: 0) {
+      HStack(spacing: 2) {
         AsyncImage(url: URL(string: station.imageURL )) { image in
           image
             .resizable()
@@ -34,19 +34,19 @@ struct StationCardView: View {
         .clipped()
         
         // Right side - Text content
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 6) {
           Text(station.name)
-            .font(.custom("Inter-Regular", size: 12))
+            .font(.custom(FontNames.Inter_500_Medium, size: 12))
             .foregroundColor(Color(hex: "#C7C7C7"))
-          
+            .padding(.top, 10)
+
           Text(station.desc)
-            .font(.custom("SpaceGrotesk-Light_Bold", size: 16))
+            .font(.custom(FontNames.Inter_500_Medium, size: 16))
             .fontWeight(.bold)
             .foregroundColor(.white)
-            .padding(.bottom, 4)
           
           Text(station.longDesc)
-            .font(.custom("Inter-Regular", size: 14))
+            .font(.custom(FontNames.Inter_400_Regular, size: 12))
             .foregroundColor(Color(hex: "#C7C7C7"))
             .lineLimit(nil)
             .lineSpacing(4)
@@ -59,6 +59,7 @@ struct StationCardView: View {
       }
       .background(Color(white: 0.15))
       .cornerRadius(6)
+      .multilineTextAlignment(.leading)
     }
   }
 }
@@ -84,7 +85,6 @@ struct HomePageStationList: View {
       }
     }
     .padding(.vertical, 20)
-    .background(Color.black)
   }
 }
 


### PR DESCRIPTION
This pull request introduces UI refinements to the `HomePageView` and its associated components in the `PlayolaRadio` app. The changes focus on improving layout spacing, typography consistency, and visual alignment across the `StationCardView` and `HomePageStationList` components.

### Layout and Spacing Adjustments:
* Added a negative top padding to the `HomePageStationList` within `HomePageView` to adjust vertical spacing. (`PlayolaRadio/Views/Pages/HomePage/HomePageView.swift`, [PlayolaRadio/Views/Pages/HomePage/HomePageView.swiftR33](diffhunk://#diff-2ffdbb75655f9b167714fc152bc343697a64a910fa189bee27889d01412e39c2R33))
* Increased horizontal spacing in the `HStack` of `StationCardView` from `0` to `2` for better content separation. (`PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift`, [PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swiftL25-R25](diffhunk://#diff-54fccd9d57ab23fcc794bb7e3072adf6add10abbdf300c05c75e428cd6045e39L25-R25))
* Reduced vertical spacing in the `VStack` of `StationCardView` from `8` to `6` and added a top padding to the station name for improved alignment. (`PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift`, [PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swiftL37-R49](diffhunk://#diff-54fccd9d57ab23fcc794bb7e3072adf6add10abbdf300c05c75e428cd6045e39L37-R49))

### Typography and Styling Updates:
* Updated font definitions in `StationCardView` to use constants from `FontNames` for better maintainability and consistency:
  - Changed the station name and description fonts to `Inter_500_Medium`.
  - Adjusted the long description font to `Inter_400_Regular` with a smaller size. (`PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift`, [PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swiftL37-R49](diffhunk://#diff-54fccd9d57ab23fcc794bb7e3072adf6add10abbdf300c05c75e428cd6045e39L37-R49))

### Visual Enhancements:
* Added `.multilineTextAlignment(.leading)` to `StationCardView` for consistent text alignment across multiline content. (`PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift`, [PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swiftR62](diffhunk://#diff-54fccd9d57ab23fcc794bb7e3072adf6add10abbdf300c05c75e428cd6045e39R62))
* Removed the black background from `HomePageStationList` to align with the overall design aesthetic. (`PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift`, [PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swiftL87](diffhunk://#diff-54fccd9d57ab23fcc794bb7e3072adf6add10abbdf300c05c75e428cd6045e39L87))