### PR TITLE
Convert All Tests to XCTest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ fastlane/report.xml
 
 # Claude generated files
 claude-files/
+
+DerivedData/

--- a/PlayolaRadio/Views/Pages/AboutPage/AboutPageTests.swift
+++ b/PlayolaRadio/Views/Pages/AboutPage/AboutPageTests.swift
@@ -6,105 +6,90 @@
 //
 
 import Sharing
-import Testing
+import XCTest
 
 @testable import PlayolaRadio
 
 @MainActor
-struct AboutPageTests {
-  @Test("Tapping the icon 10 times changes the defaults and displays an alert")
-  func testTurnsOnTheSecretStations() {
+final class AboutPageTests: XCTestCase {
+  func testPlayolaIcon_TurnsOnTheSecretStations() {
     let aboutPage = AboutPageModel()
-    #expect(aboutPage.showSecretStations == false)
+    XCTAssertFalse(aboutPage.showSecretStations)
     aboutPage.handlePlayolaIconTapped10Times()
-    #expect(aboutPage.showSecretStations == true)
-    #expect(aboutPage.presentedAlert == .secretStationsTurnedOnAlert)
+    XCTAssertTrue(aboutPage.showSecretStations)
+    XCTAssertEqual(aboutPage.presentedAlert, .secretStationsTurnedOnAlert)
   }
 
-  @Test("Tapping the icon 10 times changes the defaults and displays an alert")
-  func testTurnsOffTheSecretStations() {
+  func testPlayolaIcon_TurnsOffTheSecretStations() {
     @Shared(.showSecretStations) var showSecretStations = true
     let aboutPage = AboutPageModel()
-    #expect(aboutPage.showSecretStations == true)
+    XCTAssertTrue(aboutPage.showSecretStations)
     aboutPage.handlePlayolaIconTapped10Times()
-    #expect(aboutPage.showSecretStations == false)
-    #expect(aboutPage.presentedAlert == .secretStationsHiddenAlert)
+    XCTAssertFalse(aboutPage.showSecretStations)
+    XCTAssertEqual(aboutPage.presentedAlert, .secretStationsHiddenAlert)
   }
 
-  @Test("Correctly sets canSendEmail when true")
-  func testCorrectlySetsCanSendEmailWhenTrue() async {
+  func testViewAppeared_CorrectlySetsCanSendEmailWhenTrue() async {
     let aboutPage = AboutPageModel(mailService: MailServiceMock(shouldBeAbleToSendEmail: true))
     await aboutPage.viewAppeared()
-    #expect(aboutPage.canSendEmail == true)
+    XCTAssertTrue(aboutPage.canSendEmail)
   }
 
-  @Test("Correctly sets canSendEmail when false")
-  func testCorrectlySetsCanSendEmailWhenFalse() async {
+  func testViewAppeared_CorrectlySetsCanSendEmailWhenFalse() async {
     let aboutPage = AboutPageModel(mailService: MailServiceMock(shouldBeAbleToSendEmail: false))
     await aboutPage.viewAppeared()
-    #expect(aboutPage.canSendEmail == false)
+    XCTAssertFalse(aboutPage.canSendEmail)
   }
 
-  @MainActor
-  @Suite("Feedback Button")
-  struct FeedbackTests {
-    @Test("Correctly sets canSendEmail when false")
-    func testCorrectlySetsCanSendEmailWhenFalse() async {
-      let aboutPage = AboutPageModel(mailService: MailServiceMock(shouldBeAbleToSendEmail: false))
-      await aboutPage.viewAppeared()
-      #expect(aboutPage.canSendEmail == false)
-    }
+  // MARK: - Feedback Button Tests
 
-    @Test("Shows Feedback Email when MailComposer is available")
-    func testShowsFeedbackEmailWhenMailComposerIsAvailable() async {
-      let aboutPage = AboutPageModel(canSendEmail: true)
-      aboutPage.feedbackButtonTapped()
-      #expect(aboutPage.isShowingMailComposer == true)
-    }
-
-    @Test("Shows Feedback Email when MailComposer is unavailable but url can be created")
-    func testShowsFeedbackEmailWhenMailComposerIsUnavavailable() async {
-      let mailServiceMock = MailServiceMock(canCreateUrl: true)
-      let aboutPage = AboutPageModel(canSendEmail: false, mailService: mailServiceMock)
-      aboutPage.feedbackButtonTapped()
-      #expect(mailServiceMock.receivedEmail == "feedback@playola.fm")
-      #expect(mailServiceMock.receivedSubject == "What I Think About Playola")
-    }
-
-    @Test("Shows Alert when no mail program could be opened")
-    func testShowsFeedbackEmailWhenMailCannotBeOpened() async {
-      let mailServiceMock = MailServiceMock(canCreateUrl: false)
-      let aboutPage = AboutPageModel(canSendEmail: false, mailService: mailServiceMock)
-      aboutPage.feedbackButtonTapped()
-      #expect(aboutPage.presentedAlert == .cannotOpenMailAlert)
-    }
+  func testFeedbackButton_CorrectlySetsCanSendEmailWhenFalse() async {
+    let aboutPage = AboutPageModel(mailService: MailServiceMock(shouldBeAbleToSendEmail: false))
+    await aboutPage.viewAppeared()
+    XCTAssertFalse(aboutPage.canSendEmail)
   }
 
-  @MainActor
-  @Suite("WaitlistButton")
-  struct WaitlistButtonTests {
-    @Test("Shows Feedback Email when MailComposer is available")
-    func testShowsFeedbackEmailWhenMailComposerIsAvailable() async {
-      let aboutPage = AboutPageModel(canSendEmail: true)
-      aboutPage.waitingListButtonTapped()
-      #expect(aboutPage.isShowingMailComposer == true)
-    }
+  func testFeedbackButton_ShowsFeedbackEmailWhenMailComposerIsAvailable() async {
+    let aboutPage = AboutPageModel(canSendEmail: true)
+    aboutPage.feedbackButtonTapped()
+    XCTAssertTrue(aboutPage.isShowingMailComposer)
+  }
 
-    @Test("Shows Feedback Email when MailComposer is unavailable but url can be created")
-    func testShowsFeedbackEmailWhenMailComposerIsUnavavailable() async {
-      let mailServiceMock = MailServiceMock(canCreateUrl: true)
-      let aboutPage = AboutPageModel(canSendEmail: false, mailService: mailServiceMock)
-      aboutPage.waitingListButtonTapped()
-      #expect(mailServiceMock.receivedEmail == "waitlist@playola.fm")
-      #expect(mailServiceMock.receivedSubject == "Add Me To The Waitlist")
-    }
+  func testFeedbackButton_ShowsFeedbackEmailWhenMailComposerIsUnavailable() async {
+    let mailServiceMock = MailServiceMock(canCreateUrl: true)
+    let aboutPage = AboutPageModel(canSendEmail: false, mailService: mailServiceMock)
+    aboutPage.feedbackButtonTapped()
+    XCTAssertEqual(mailServiceMock.receivedEmail, "feedback@playola.fm")
+    XCTAssertEqual(mailServiceMock.receivedSubject, "What I Think About Playola")
+  }
 
-    @Test("Shows Alert when no mail program could be opened")
-    func testShowsFeedbackEmailWhenMailCannotBeOpened() async {
-      let mailServiceMock = MailServiceMock(canCreateUrl: false)
-      let aboutPage = AboutPageModel(canSendEmail: false, mailService: mailServiceMock)
-      aboutPage.waitingListButtonTapped()
-      #expect(aboutPage.presentedAlert == .cannotOpenMailAlert)
-    }
+  func testFeedbackButton_ShowsAlertWhenMailCannotBeOpened() async {
+    let mailServiceMock = MailServiceMock(canCreateUrl: false)
+    let aboutPage = AboutPageModel(canSendEmail: false, mailService: mailServiceMock)
+    aboutPage.feedbackButtonTapped()
+    XCTAssertEqual(aboutPage.presentedAlert, .cannotOpenMailAlert)
+  }
+
+  // MARK: - Waitlist Button Tests
+
+  func testWaitlistButton_ShowsFeedbackEmailWhenMailComposerIsAvailable() async {
+    let aboutPage = AboutPageModel(canSendEmail: true)
+    aboutPage.waitingListButtonTapped()
+    XCTAssertTrue(aboutPage.isShowingMailComposer)
+  }
+
+  func testWaitlistButton_ShowsFeedbackEmailWhenMailComposerIsUnavailable() async {
+    let mailServiceMock = MailServiceMock(canCreateUrl: true)
+    let aboutPage = AboutPageModel(canSendEmail: false, mailService: mailServiceMock)
+    aboutPage.waitingListButtonTapped()
+    XCTAssertEqual(mailServiceMock.receivedEmail, "waitlist@playola.fm")
+    XCTAssertEqual(mailServiceMock.receivedSubject, "Add Me To The Waitlist")
+  }
+
+  func testWaitlistButton_ShowsAlertWhenMailCannotBeOpened() async {
+    let mailServiceMock = MailServiceMock(canCreateUrl: false)
+    let aboutPage = AboutPageModel(canSendEmail: false, mailService: mailServiceMock)
+    aboutPage.waitingListButtonTapped()
+    XCTAssertEqual(aboutPage.presentedAlert, .cannotOpenMailAlert)
   }
 }

--- a/PlayolaRadio/Views/Pages/NowPlayingPage/NowPlayingPageTests.swift
+++ b/PlayolaRadio/Views/Pages/NowPlayingPage/NowPlayingPageTests.swift
@@ -6,63 +6,69 @@
 //
 
 import FRadioPlayer
-import Testing
+import XCTest
 
 @testable import PlayolaRadio
 
 @MainActor
-struct NowPlayingPageTests {
-  @Suite("viewAppeared")
-  struct ViewAppearedTests {
-    @Test("Populates correctly when loading")
-    @MainActor func testNowPlayingPopulatesCorrectlyWhenLoading() {
-      //  let player = URLStreamPlayerMock()
-      //  player.state = URLStreamPlayer.State(playbackState: .playing, playerStatus: .loading, currentStation: .mock)
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(playbackStatus: .loading(.mock))
-      let nowPlayingPage = NowPlayingPageModel(stationPlayer: playerMock)
-      nowPlayingPage.viewAppeared()
-      #expect(nowPlayingPage.navigationBarTitle == "Bri Bagwell's Banned Radio")
-      #expect(nowPlayingPage.nowPlayingArtist == "Station Loading...")
-      #expect(nowPlayingPage.nowPlayingTitle == "Bri Bagwell's Banned Radio")
-    }
+final class NowPlayingPageTests: XCTestCase {
+  // MARK: - viewAppeared Tests
 
-    @Test("Populates correctly when something is playing")
-    @MainActor func testNowPlayingPopulatesCorrectlyWhenSomethingIsPlaying() {
-      let station = RadioStation.mock
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .playing(station),
-        artistPlaying: "Rachel Loy",
-        titlePlaying: "Selfie"
-      )
-      let nowPlayingPage = NowPlayingPageModel(stationPlayer: playerMock)
-      nowPlayingPage.viewAppeared()
-      #expect(nowPlayingPage.navigationBarTitle == "Bri Bagwell's Banned Radio")
-      #expect(nowPlayingPage.nowPlayingArtist == "Rachel Loy")
-      #expect(nowPlayingPage.nowPlayingTitle == "Selfie")
+  func testViewAppeared_PopulatesCorrectlyWhenLoading() {
+    let mockStation = RadioStation.mock
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(playbackStatus: .loading(mockStation))
+    let nowPlayingPage = NowPlayingPageModel(stationPlayer: playerMock)
+    nowPlayingPage.viewAppeared()
+
+    let expectedTitle = "\(mockStation.name) \(mockStation.desc)"
+    XCTAssertEqual(nowPlayingPage.navigationBarTitle, expectedTitle)
+    XCTAssertEqual(nowPlayingPage.nowPlayingArtist, "Station Loading...")
+    XCTAssertEqual(nowPlayingPage.nowPlayingTitle, expectedTitle)
+  }
+
+  func testViewAppeared_PopulatesCorrectlyWhenSomethingIsPlaying() {
+    let mockStation = RadioStation.mock
+    let testArtist = "Rachel Loy"
+    let testTitle = "Selfie"
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .playing(mockStation),
+      artistPlaying: testArtist,
+      titlePlaying: testTitle
+    )
+    let nowPlayingPage = NowPlayingPageModel(stationPlayer: playerMock)
+    nowPlayingPage.viewAppeared()
+
+    let expectedTitle = "\(mockStation.name) \(mockStation.desc)"
+    XCTAssertEqual(nowPlayingPage.navigationBarTitle, expectedTitle)
+    XCTAssertEqual(nowPlayingPage.nowPlayingArtist, testArtist)
+    XCTAssertEqual(nowPlayingPage.nowPlayingTitle, testTitle)
+  }
+
+  // MARK: - About Display Tests
+
+  func testAboutDisplay_TappingAboutButtonDisplaysAboutPageAsSheet() {
+    let nowPlayingPage = NowPlayingPageModel()
+    XCTAssertNil(nowPlayingPage.presentedSheet)
+    nowPlayingPage.aboutButtonTapped()
+    if case .about = nowPlayingPage.presentedSheet {
+      // Success - sheet is presented
+    } else {
+      XCTFail("Expected about sheet to be presented")
     }
   }
 
-  @Suite("About Display")
-  struct AboutDisplay {
-    @Test("Tapping about button displays about as a sheet")
-    @MainActor func testTappingAboutButtonDisplaysAboutPageAsSheet() {
-      let nowPlayingPage = NowPlayingPageModel()
-      #expect(nowPlayingPage.presentedSheet == nil)
-      nowPlayingPage.aboutButtonTapped()
-      #expect(nowPlayingPage.presentedSheet ~= .about(AboutPageModel()))
-    }
-
-    @Test("Can be dismissed")
-    @MainActor func testTappingAboutButtonDismissWorks() {
-      let nowPlayingPage = NowPlayingPageModel(
-        presentedSheet: .about(AboutPageModel()))
-      nowPlayingPage.dismissAboutSheetButtonTapped()
-      #expect(nowPlayingPage.presentedSheet == nil)
-    }
+  func testAboutDisplay_CanBeDismissed() {
+    let nowPlayingPage = NowPlayingPageModel(
+      presentedSheet: .about(AboutPageModel()))
+    nowPlayingPage.dismissAboutSheetButtonTapped()
+    XCTAssertNil(nowPlayingPage.presentedSheet)
   }
 
-  @Test("Info Button Tapped")
-  func testInfoButtonPushesInfoOntoTheNavigationStack() {}
+  // MARK: - Info Button Tests
+
+  func testInfoButtonTapped_PushesInfoOntoTheNavigationStack() {
+    // TODO: Implement test
+  }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -8,285 +8,253 @@
 import FRadioPlayer
 import Foundation
 import PlayolaPlayer
-import Testing
+import XCTest
 
 @testable import PlayolaRadio
 
 @MainActor
-struct PlayerPageTests {
-  // MARK: - viewAppeared
-  @Suite("viewAppeared")
-  struct ViewAppearedTests {
+final class PlayerPageTests: XCTestCase {
+  // MARK: - viewAppeared Tests
 
-    @Test("Populates correctly when loading (no progress)")
-    @MainActor
-    func testPopulatesCorrectlyWhenLoadingNoProgress() {
-      let station = RadioStation.mock
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .loading(station)  // no progress
-      )
+  func testViewAppeared_PopulatesCorrectlyWhenLoadingNoProgress() {
+    let station = RadioStation.mock
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .loading(station)  // no progress
+    )
 
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
 
-      #expect(model.primaryNavBarTitle == station.name)
-      #expect(model.secondaryNavBarTitle == station.desc)
-      #expect(model.nowPlayingText == "Station Loading...")
-      #expect(model.playolaAudioBlockPlaying == nil)
-    }
-
-    @Test("Populates correctly when loading (with progress)")
-    @MainActor
-    func testPopulatesCorrectlyWhenLoadingWithProgress() {
-      let station = RadioStation.mock
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .loading(station, 0.42)
-      )
-
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
-
-      #expect(model.primaryNavBarTitle == station.name)
-      #expect(model.secondaryNavBarTitle == station.desc)
-      #expect(model.nowPlayingText == "Station Loading...")
-      #expect(model.loadingPercentage == 0.42)
-      #expect(model.playolaAudioBlockPlaying == nil)
-    }
-
-    @Test("Populates correctly when something is playing")
-    @MainActor
-    func testPopulatesCorrectlyWhenSomethingIsPlaying() {
-      let station = RadioStation.mock
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .playing(station),
-        artistPlaying: "Rachel Loy",
-        titlePlaying: "Selfie"
-      )
-
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
-
-      #expect(model.nowPlayingText == "Selfie - Rachel Loy")
-      #expect(model.stationArtUrl == URL(string: station.imageURL))
-      #expect(model.playolaAudioBlockPlaying == nil)  // No AudioBlock in this test
-    }
-
-    @Test("Populates correctly when something is playing with AudioBlock")
-    @MainActor
-    func testPopulatesCorrectlyWhenSomethingIsPlayingWithAudioBlock() {
-      let station = RadioStation.mock
-      let audioBlock = AudioBlock.mock
-      let spin = Spin.mockWith(audioBlock: audioBlock)
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .playing(station),
-        artistPlaying: "Rachel Loy",
-        titlePlaying: "Selfie",
-        playolaSpinPlaying: spin
-      )
-
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
-
-      #expect(model.nowPlayingText == "Selfie - Rachel Loy")
-      #expect(model.stationArtUrl == URL(string: station.imageURL))
-      #expect(model.playolaAudioBlockPlaying == audioBlock)
-    }
-
-    @Test("Populates relatedText prioritizing the AudioBlock's transcript")
-    @MainActor
-    func testPopulatesRelatedTextPrioritizingTheAudioBlockTranscription() {
-      let station = RadioStation.mock
-      let transcription = "This is the transcription"
-      let audioBlock = AudioBlock.mockWith(transcription: transcription)
-
-      let relatedTexts = [
-        RelatedText(title: "title1", body: "body1"),
-        RelatedText(title: "title2", body: "body2"),
-      ]
-      let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .playing(station),
-        artistPlaying: "Rachel Loy",
-        titlePlaying: "Selfie",
-        playolaSpinPlaying: spin
-      )
-
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
-
-      #expect(model.relatedText?.title == "Why I chose this song")
-      #expect(model.relatedText?.body == transcription)
-      #expect(model.playolaAudioBlockPlaying == audioBlock)
-    }
-
-    @Test("Populates relatedText when it exists but transcription does not.")
-    @MainActor
-    func testPopulatesRelatedTextWhenRelatedTextButNoTranscription() {
-      let station = RadioStation.mock
-      let audioBlock = AudioBlock.mockWith(transcription: nil)
-
-      let relatedTexts = [
-        RelatedText(title: "title1", body: "body1"),
-        RelatedText(title: "title2", body: "body2"),
-      ]
-      let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .playing(station),
-        artistPlaying: "Rachel Loy",
-        titlePlaying: "Selfie",
-        playolaSpinPlaying: spin
-      )
-
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
-
-      #expect(model.relatedText != nil)
-      // randomly picks one.
-      #expect(model.relatedText == relatedTexts[0] || model.relatedText == relatedTexts[1])
-      #expect(model.playolaAudioBlockPlaying == audioBlock)
-    }
-
-    @Test("Populates correctly when stopped")
-    @MainActor
-    func testPopulatesCorrectlyWhenStopped() {
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .stopped
-      )
-
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
-
-      #expect(model.nowPlayingText == "")
-      #expect(model.albumArtUrl == nil)
-      #expect(model.playolaAudioBlockPlaying == nil)
-    }
-
-    @Test("Populates correctly when error")
-    @MainActor
-    func testPopulatesCorrectlyWhenError() {
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .error
-      )
-
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
-
-      #expect(model.nowPlayingText == "Error Playing Station")
-      #expect(model.primaryNavBarTitle == "")
-      #expect(model.secondaryNavBarTitle == "")
-      #expect(model.albumArtUrl == nil)
-      #expect(model.playolaAudioBlockPlaying == nil)
-    }
-
-    @Test("Populates correctly when starting new station")
-    @MainActor
-    func testPopulatesCorrectlyWhenStartingNewStation() {
-      let station = RadioStation.mock
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .startingNewStation(station)
-      )
-
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
-
-      #expect(model.primaryNavBarTitle == station.name)
-      #expect(model.secondaryNavBarTitle == station.desc)
-      #expect(model.nowPlayingText == "")
-      #expect(model.playolaAudioBlockPlaying == nil)
-    }
-
-    @Test("Populates correctly when starting new station with AudioBlock")
-    @MainActor
-    func testPopulatesCorrectlyWhenStartingNewStationWithAudioBlock() {
-      let station = RadioStation.mock
-      let audioBlock = AudioBlock.mock
-      let spin = Spin.mockWith(audioBlock: audioBlock)
-      let playerMock = StationPlayerMock()
-      playerMock.state = StationPlayer.State(
-        playbackStatus: .startingNewStation(station),
-        playolaSpinPlaying: spin
-      )
-
-      let model = PlayerPageModel(stationPlayer: playerMock)
-      model.viewAppeared()
-
-      #expect(model.primaryNavBarTitle == station.name)
-      #expect(model.secondaryNavBarTitle == station.desc)
-      #expect(model.nowPlayingText == "")
-      #expect(model.playolaAudioBlockPlaying == audioBlock)
-    }
+    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    XCTAssertEqual(model.secondaryNavBarTitle, station.desc)
+    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
+    XCTAssertNil(model.playolaAudioBlockPlaying)
   }
 
-  // MARK: - playPauseButtonTapped
-  @Suite("playPauseButtonTapped")
-  struct PlayPauseButtonTappedTests {
+  func testViewAppeared_PopulatesCorrectlyWhenLoadingWithProgress() {
+    let station = RadioStation.mock
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .loading(station, 0.42)
+    )
 
-    @Test("Stops the stream when something is playing")
-    @MainActor
-    func testStopsWhenPlaying() {
-      let station = RadioStation.mock
-      let spy = StationPlayerMock()
-      spy.state = StationPlayer.State(
-        playbackStatus: .playing(station)
-      )
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
 
-      let model = PlayerPageModel(stationPlayer: spy)
-      model.viewAppeared()
-      #expect(spy.stopCalledCount == 0)
-      model.playPauseButtonTapped()
+    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    XCTAssertEqual(model.secondaryNavBarTitle, station.desc)
+    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
+    XCTAssertEqual(model.loadingPercentage, 0.42)
+    XCTAssertNil(model.playolaAudioBlockPlaying)
+  }
 
-      #expect(spy.stopCalledCount == 1)
-      #expect(spy.callsToPlay.count == 0)
-    }
+  func testViewAppeared_PopulatesCorrectlyWhenSomethingIsPlaying() {
+    let station = RadioStation.mock
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .playing(station),
+      artistPlaying: "Rachel Loy",
+      titlePlaying: "Selfie"
+    )
 
-    @Test("Plays the previously-playing station when stopped")
-    @MainActor
-    func testPlaysWhenStopped() {
-      let station = RadioStation.mock
-      let spy = StationPlayerMock()
-      spy.state = StationPlayer.State(
-        playbackStatus: .playing(station)
-      )
-      let model = PlayerPageModel(stationPlayer: spy)
-      model.viewAppeared()
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
 
-      spy.state = StationPlayer.State(
-        playbackStatus: .stopped
-      )
+    XCTAssertEqual(model.nowPlayingText, "Selfie - Rachel Loy")
+    XCTAssertEqual(model.stationArtUrl, URL(string: station.imageURL))
+    XCTAssertNil(model.playolaAudioBlockPlaying)  // No AudioBlock in this test
+  }
 
-      model.playPauseButtonTapped()
+  func testViewAppeared_PopulatesCorrectlyWhenSomethingIsPlayingWithAudioBlock() {
+    let station = RadioStation.mock
+    let audioBlock = AudioBlock.mock
+    let spin = Spin.mockWith(audioBlock: audioBlock)
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .playing(station),
+      artistPlaying: "Rachel Loy",
+      titlePlaying: "Selfie",
+      playolaSpinPlaying: spin
+    )
 
-      #expect(spy.callsToPlay.count == 1)
-      #expect(spy.callsToPlay[0] == station)
-      #expect(spy.stopCalledCount == 0)
-    }
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
 
-    @Test("Dismisses the player when stop button is pressed during playback")
-    @MainActor
-    func testDismissesWhenStopButtonPressed() {
-      let station = RadioStation.mock
-      let spy = StationPlayerMock()
-      spy.state = StationPlayer.State(
-        playbackStatus: .playing(station)
-      )
+    XCTAssertEqual(model.nowPlayingText, "Selfie - Rachel Loy")
+    XCTAssertEqual(model.stationArtUrl, URL(string: station.imageURL))
+    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+  }
 
-      var dismissCalled = false
-      let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
-      model.viewAppeared()
+  func testViewAppeared_PopulatesRelatedTextPrioritizingTheAudioBlockTranscription() {
+    let station = RadioStation.mock
+    let transcription = "This is the transcription"
+    let audioBlock = AudioBlock.mockWith(transcription: transcription)
 
-      model.playPauseButtonTapped()
+    let relatedTexts = [
+      RelatedText(title: "title1", body: "body1"),
+      RelatedText(title: "title2", body: "body2"),
+    ]
+    let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .playing(station),
+      artistPlaying: "Rachel Loy",
+      titlePlaying: "Selfie",
+      playolaSpinPlaying: spin
+    )
 
-      #expect(spy.stopCalledCount == 1)
-      #expect(dismissCalled == true)
-    }
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
+
+    XCTAssertEqual(model.relatedText?.title, "Why I chose this song")
+    XCTAssertEqual(model.relatedText?.body, transcription)
+    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+  }
+
+  func testViewAppeared_PopulatesRelatedTextWhenRelatedTextButNoTranscription() {
+    let station = RadioStation.mock
+    let audioBlock = AudioBlock.mockWith(transcription: nil)
+
+    let relatedTexts = [
+      RelatedText(title: "title1", body: "body1"),
+      RelatedText(title: "title2", body: "body2"),
+    ]
+    let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .playing(station),
+      artistPlaying: "Rachel Loy",
+      titlePlaying: "Selfie",
+      playolaSpinPlaying: spin
+    )
+
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
+
+    XCTAssertNotNil(model.relatedText)
+    // randomly picks one.
+    XCTAssertTrue(model.relatedText == relatedTexts[0] || model.relatedText == relatedTexts[1])
+    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+  }
+
+  func testViewAppeared_PopulatesCorrectlyWhenStopped() {
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .stopped
+    )
+
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
+
+    XCTAssertEqual(model.nowPlayingText, "")
+    XCTAssertNil(model.albumArtUrl)
+    XCTAssertNil(model.playolaAudioBlockPlaying)
+  }
+
+  func testViewAppeared_PopulatesCorrectlyWhenError() {
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .error
+    )
+
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
+
+    XCTAssertEqual(model.nowPlayingText, "Error Playing Station")
+    XCTAssertEqual(model.primaryNavBarTitle, "")
+    XCTAssertEqual(model.secondaryNavBarTitle, "")
+    XCTAssertNil(model.albumArtUrl)
+    XCTAssertNil(model.playolaAudioBlockPlaying)
+  }
+
+  func testViewAppeared_PopulatesCorrectlyWhenStartingNewStation() {
+    let station = RadioStation.mock
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .startingNewStation(station)
+    )
+
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
+
+    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    XCTAssertEqual(model.secondaryNavBarTitle, station.desc)
+    XCTAssertEqual(model.nowPlayingText, "")
+    XCTAssertNil(model.playolaAudioBlockPlaying)
+  }
+
+  func testViewAppeared_PopulatesCorrectlyWhenStartingNewStationWithAudioBlock() {
+    let station = RadioStation.mock
+    let audioBlock = AudioBlock.mock
+    let spin = Spin.mockWith(audioBlock: audioBlock)
+    let playerMock = StationPlayerMock()
+    playerMock.state = StationPlayer.State(
+      playbackStatus: .startingNewStation(station),
+      playolaSpinPlaying: spin
+    )
+
+    let model = PlayerPageModel(stationPlayer: playerMock)
+    model.viewAppeared()
+
+    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    XCTAssertEqual(model.secondaryNavBarTitle, station.desc)
+    XCTAssertEqual(model.nowPlayingText, "")
+    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+  }
+
+  // MARK: - playPauseButtonTapped Tests
+
+  func testPlayPauseButtonTapped_StopsWhenPlaying() {
+    let station = RadioStation.mock
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(
+      playbackStatus: .playing(station)
+    )
+
+    let model = PlayerPageModel(stationPlayer: spy)
+    model.viewAppeared()
+    XCTAssertEqual(spy.stopCalledCount, 0)
+    model.playPauseButtonTapped()
+
+    XCTAssertEqual(spy.stopCalledCount, 1)
+    XCTAssertEqual(spy.callsToPlay.count, 0)
+  }
+
+  func testPlayPauseButtonTapped_PlaysWhenStopped() {
+    let station = RadioStation.mock
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(
+      playbackStatus: .playing(station)
+    )
+    let model = PlayerPageModel(stationPlayer: spy)
+    model.viewAppeared()
+
+    spy.state = StationPlayer.State(
+      playbackStatus: .stopped
+    )
+
+    model.playPauseButtonTapped()
+
+    XCTAssertEqual(spy.callsToPlay.count, 1)
+    XCTAssertEqual(spy.callsToPlay[0], station)
+    XCTAssertEqual(spy.stopCalledCount, 0)
+  }
+
+  func testPlayPauseButtonTapped_DismissesWhenStopButtonPressed() {
+    let station = RadioStation.mock
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(
+      playbackStatus: .playing(station)
+    )
+
+    var dismissCalled = false
+    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    model.viewAppeared()
+
+    model.playPauseButtonTapped()
+
+    XCTAssertEqual(spy.stopCalledCount, 1)
+    XCTAssertTrue(dismissCalled)
   }
 }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -6,30 +6,44 @@
 //
 
 import AuthenticationServices
-import Testing
+import XCTest
 
 @testable import PlayolaRadio
 
 @MainActor
-struct SignInPageTests {
+final class SignInPageTests: XCTestCase {
   // TODO: Add these tests
-  @Test("Correctly adds scope to an apple sign in request")
-  func testCorrectlyAddsScopeToTheAppleSignInRequest() {
+  func testSignInWithApple_CorrectlyAddsScopeToTheAppleSignInRequest() {
     let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
     let model = SignInPageModel()
     model.signInWithAppleButtonTapped(request: request)
-    #expect(request.requestedScopes == [.email, .fullName])
+    XCTAssertEqual(request.requestedScopes, [.email, .fullName])
   }
 
   // TODO: Create these tests:
-  @Suite("signInWithAppleCompleted()")
-  struct SignInWithAppleCompleted {
-    // @Test("Can handle decoding error on appleIDCredential")
-    // @Test("Stores appleSignInInfo if the email was received")
-    // @Test("Notifies the user if there was no email cached and none provided")
-    // @Test("Provides the results to the API")
-  }
+  // MARK: - signInWithAppleCompleted() Tests
 
-  // @Suite("SignInWithGoogle")
-  // @Test("LogOutButtonTapped()")
+  // func testSignInWithAppleCompleted_CanHandleDecodingErrorOnAppleIDCredential() {
+  //   // TODO: Implement test
+  // }
+
+  // func testSignInWithAppleCompleted_StoresAppleSignInInfoIfEmailWasReceived() {
+  //   // TODO: Implement test
+  // }
+
+  // func testSignInWithAppleCompleted_NotifiesUserIfNoEmailCachedAndNoneProvided() {
+  //   // TODO: Implement test
+  // }
+
+  // func testSignInWithAppleCompleted_ProvidesResultsToAPI() {
+  //   // TODO: Implement test
+  // }
+
+  // MARK: - SignInWithGoogle Tests
+  // TODO: Implement Google sign in tests
+
+  // MARK: - LogOutButtonTapped Tests
+  // func testLogOutButtonTapped() {
+  //   // TODO: Implement test
+  // }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -7,133 +7,111 @@
 
 import IdentifiedCollections
 import Sharing
-import Testing
+import XCTest
 
 @testable import PlayolaRadio
 
-enum StationListPageTests {
-  // -------------------------------------------------------------
-  // MARK: - View Appeared
-  // -------------------------------------------------------------
-  @MainActor @Suite("ViewAppeared")
-  struct ViewAppeared {
-    @Test(
-      "Populates stationListsForDisplay, segmentTitles & selectedSegment based on initial shared stationLists"
-    )
-    func testPopulatesFromInitialSharedStationLists() async {
-      @Shared(.stationLists) var stationLists = StationList.mocks
-      let expectedVisibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
-      let model = StationListModel()
-      await model.viewAppeared()
-      #expect(model.stationListsForDisplay == expectedVisibleLists)
-      #expect(model.segmentTitles == ["All"] + expectedVisibleLists.map { $0.title })
-      #expect(model.selectedSegment == "All")
-    }
+@MainActor
+final class StationListPageTests: XCTestCase {
+  // MARK: - View Appeared Tests
+
+  func testViewAppeared_PopulatesFromInitialSharedStationLists() async {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    let expectedVisibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
+    let model = StationListModel()
+    await model.viewAppeared()
+    XCTAssertEqual(model.stationListsForDisplay, expectedVisibleLists)
+    XCTAssertEqual(model.segmentTitles, ["All"] + expectedVisibleLists.map { $0.title })
+    XCTAssertEqual(model.selectedSegment, "All")
   }
 
-  // -------------------------------------------------------------
-  // MARK: - Segment Selection
-  // -------------------------------------------------------------
-  @MainActor @Suite("SegmentSelection")
-  struct SegmentSelection {
-    @Test("Filters stationListsForDisplay when a segment is selected")
-    func testFiltersWhenSegmentSelected() async {
-      @Shared(.stationLists) var stationLists = StationList.mocks
-      let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
-      guard let firstList = visibleLists.first else {
-        #expect(true, "StationList.mocks should have at least one non-development list")
-        return
-      }
-      let model = StationListModel()
-      await model.viewAppeared()
-      model.segmentSelected(firstList.title)
-      #expect(model.selectedSegment == firstList.title)
-      #expect(model.stationListsForDisplay == [firstList])
+  // MARK: - Segment Selection Tests
+
+  func testSegmentSelection_FiltersWhenSegmentSelected() async {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
+    guard let firstList = visibleLists.first else {
+      XCTFail("StationList.mocks should have at least one non-development list")
+      return
     }
+    let model = StationListModel()
+    await model.viewAppeared()
+    model.segmentSelected(firstList.title)
+    XCTAssertEqual(model.selectedSegment, firstList.title)
+    XCTAssertEqual(model.stationListsForDisplay, [firstList])
   }
 
-  // -------------------------------------------------------------
-  // MARK: - Shared stationLists Updates
-  // -------------------------------------------------------------
-  @MainActor @Suite("SharedStationListsUpdates")
-  struct SharedStationListsUpdates {
-    @Test("Keeps selected segment when updated lists still contain that segment")
-    func testKeepsSelectedSegmentWhenStillPresent() async {
-      @Shared(.stationLists) var stationLists = StationList.mocks
-      let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
-      guard let targetList = visibleLists.first else {
-        #expect(true, "StationList.mocks should have at least one non-development list")
-        return
-      }
+  // MARK: - Shared stationLists Updates Tests
 
-      let model = StationListModel()
-      await model.viewAppeared()
-      model.segmentSelected(targetList.title)
-
-      // mutate shared lists but keep a list with the same title
-      $stationLists.withLock { lists in
-        lists = IdentifiedArray(
-          uniqueElements: [
-            StationList(
-              id: targetList.id,
-              title: targetList.title,
-              stations: targetList.stations.reversed()
-            )
-          ]
-        )
-      }
-
-      #expect(model.selectedSegment == targetList.title)
-      #expect(model.stationListsForDisplay.count == 1)
-      #expect(model.stationListsForDisplay.first?.title == targetList.title)
+  func testSharedStationListsUpdates_KeepsSelectedSegmentWhenStillPresent() async {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
+    guard let targetList = visibleLists.first else {
+      XCTFail("StationList.mocks should have at least one non-development list")
+      return
     }
 
-    @Test("Resets selected segment to All when updated lists no longer contain the segment")
-    func testResetsSelectedSegmentWhenSegmentMissing() async {
-      @Shared(.stationLists) var stationLists = StationList.mocks
-      let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
-      guard let targetList = visibleLists.first else {
-        #expect(true, "StationList.mocks should have at least one non-development list")
-        return
-      }
+    let model = StationListModel()
+    await model.viewAppeared()
+    model.segmentSelected(targetList.title)
 
-      let model = StationListModel()
-      await model.viewAppeared()
-      model.segmentSelected(targetList.title)
-
-      // mutate shared lists and remove the previously selected segment
-      $stationLists.withLock { lists in
-        lists = IdentifiedArray(
-          uniqueElements:
-            visibleLists
-            .filter { $0.id != targetList.id }
-            .map { StationList(id: $0.id, title: $0.title, stations: $0.stations) }
-        )
-      }
-
-      let expectedVisibleAfterUpdate = stationLists.filter {
-        $0.id != StationList.inDevelopmentListId
-      }
-      #expect(model.selectedSegment == "All")
-      #expect(model.stationListsForDisplay == expectedVisibleAfterUpdate)
+    // mutate shared lists but keep a list with the same title
+    $stationLists.withLock { lists in
+      lists = IdentifiedArray(
+        uniqueElements: [
+          StationList(
+            id: targetList.id,
+            title: targetList.title,
+            stations: targetList.stations.reversed()
+          )
+        ]
+      )
     }
+
+    XCTAssertEqual(model.selectedSegment, targetList.title)
+    XCTAssertEqual(model.stationListsForDisplay.count, 1)
+    XCTAssertEqual(model.stationListsForDisplay.first?.title, targetList.title)
   }
 
-  // -------------------------------------------------------------
-  // MARK: - Player interaction
-  // -------------------------------------------------------------
-  @MainActor @Suite("PlayerInteraction")
-  struct StationPlayerInteraction {
-    @Test("Plays a station when it is tapped")
-    func testPlaysAStationWhenItIsTapped() {
-      let stationPlayerMock: StationPlayerMock = .mockStoppedPlayer()
-      let station: RadioStation = .mock
-
-      let stationListModel = StationListModel(stationPlayer: stationPlayerMock)
-      stationListModel.stationSelected(station)
-
-      #expect(stationPlayerMock.callsToPlay.count == 1)
-      #expect(stationPlayerMock.callsToPlay.first?.id == station.id)
+  func testSharedStationListsUpdates_ResetsSelectedSegmentWhenSegmentMissing() async {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
+    guard let targetList = visibleLists.first else {
+      XCTFail("StationList.mocks should have at least one non-development list")
+      return
     }
+
+    let model = StationListModel()
+    await model.viewAppeared()
+    model.segmentSelected(targetList.title)
+
+    // mutate shared lists and remove the previously selected segment
+    $stationLists.withLock { lists in
+      lists = IdentifiedArray(
+        uniqueElements:
+          visibleLists
+          .filter { $0.id != targetList.id }
+          .map { StationList(id: $0.id, title: $0.title, stations: $0.stations) }
+      )
+    }
+
+    let expectedVisibleAfterUpdate = stationLists.filter {
+      $0.id != StationList.inDevelopmentListId
+    }
+    XCTAssertEqual(model.selectedSegment, "All")
+    XCTAssertEqual(model.stationListsForDisplay, expectedVisibleAfterUpdate)
+  }
+
+  // MARK: - Player Interaction Tests
+
+  func testPlayerInteraction_PlaysAStationWhenItIsTapped() {
+    let stationPlayerMock: StationPlayerMock = .mockStoppedPlayer()
+    let station: RadioStation = .mock
+
+    let stationListModel = StationListModel(stationPlayer: stationPlayerMock)
+    stationListModel.stationSelected(station)
+
+    XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
+    XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, station.id)
   }
 }


### PR DESCRIPTION
The @MainActor issue was too much to deal with.  Xcode constantly crashing.  Going to revert for now and revisit after Swift Testing 1.0 is released.

This pull request refactors test files across multiple components in the PlayolaRadio project to improve consistency and readability. Key changes include replacing `Testing` with `XCTest`, converting test structures to `final class` format, and updating assertions to use XCTest methods like `XCTAssertEqual` and `XCTAssertNil`. Additionally, test organization has been improved with clearer naming conventions and `// MARK:` comments.

### Test Framework Update:
* Replaced `Testing` with `XCTest` in all test files to standardize the testing framework. (`[[1]](diffhunk://#diff-fbbb9312a9fd5ad35d60022638667db1803fb0677dd9fdaf7a1624c3d9bb7865L12-R20)`, `[[2]](diffhunk://#diff-2673e64908797f5fc64d02b04ce178bd6da0fadf8fc732bbd156ac885f342126L9-R93)`, `[[3]](diffhunk://#diff-94878e6776a43ac57df09b0b1e3efa09ac0fdbe4c5c33828b03b752f11b2d085L10-R42)`, `[[4]](diffhunk://#diff-256ba44113c8ae96fa146df99f5f826d1a29d38249df9ffc60579b6a500e6c91L12-R17)`)

### Structural Changes:
* Converted test structures from `struct` or `enum` to `final class` format for compatibility with XCTest. (`[[1]](diffhunk://#diff-fbbb9312a9fd5ad35d60022638667db1803fb0677dd9fdaf7a1624c3d9bb7865L12-R20)`, `[[2]](diffhunk://#diff-2673e64908797f5fc64d02b04ce178bd6da0fadf8fc732bbd156ac885f342126L9-R93)`, `[[3]](diffhunk://#diff-94878e6776a43ac57df09b0b1e3efa09ac0fdbe4c5c33828b03b752f11b2d085L10-R42)`, `[[4]](diffhunk://#diff-256ba44113c8ae96fa146df99f5f826d1a29d38249df9ffc60579b6a500e6c91L12-R17)`)

### Assertion Updates:
* Replaced `#expect` assertions with XCTest methods like `XCTAssertEqual`, `XCTAssertNil`, `XCTAssertTrue`, and `XCTAssertFalse` for improved clarity and functionality. (`[[1]](diffhunk://#diff-fbbb9312a9fd5ad35d60022638667db1803fb0677dd9fdaf7a1624c3d9bb7865L54-R153)`, `[[2]](diffhunk://#diff-2673e64908797f5fc64d02b04ce178bd6da0fadf8fc732bbd156ac885f342126L9-R93)`, `[[3]](diffhunk://#diff-94878e6776a43ac57df09b0b1e3efa09ac0fdbe4c5c33828b03b752f11b2d085L56-R113)`)

### Test Organization:
* Added `// MARK:` comments to group related tests and improve readability. (`[[1]](diffhunk://#diff-fbbb9312a9fd5ad35d60022638667db1803fb0677dd9fdaf7a1624c3d9bb7865L54-R153)`, `[[2]](diffhunk://#diff-2673e64908797f5fc64d02b04ce178bd6da0fadf8fc732bbd156ac885f342126L9-R93)`, `[[3]](diffhunk://#diff-94878e6776a43ac57df09b0b1e3efa09ac0fdbe4c5c33828b03b752f11b2d085L56-R113)`)

### Naming Conventions:
* Updated test method names to follow a consistent and descriptive format, such as `testGetCurrentToken_ReturnsNilWhenUserNotLoggedIn` and `testFeedbackButton_ShowsAlertWhenMailCannotBeOpened`. (`[[1]](diffhunk://#diff-fbbb9312a9fd5ad35d60022638667db1803fb0677dd9fdaf7a1624c3d9bb7865L54-R153)`, `[[2]](diffhunk://#diff-2673e64908797f5fc64d02b04ce178bd6da0fadf8fc732bbd156ac885f342126L9-R93)`, `[[3]](diffhunk://#diff-94878e6776a43ac57df09b0b1e3efa09ac0fdbe4c5c33828b03b752f11b2d085L56-R113)`)