### PR TITLE
Remove API Singleton

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -26,3 +26,6 @@ type_body_length:
   warning: 1000
   error: 1000
 
+file_length:
+  warning: 1000
+  error: 1000

--- a/PlayolaRadio/Dependencies/API.swift
+++ b/PlayolaRadio/Dependencies/API.swift
@@ -17,14 +17,14 @@ import Sharing
 @DependencyClient
 struct APIClient {
   var getStations: () async throws -> IdentifiedArrayOf<StationList> = { [] }
-  var signInViaApple: (String, String, String, String?) async -> Void = { _, _, _, _ in }
-  var revokeAppleCredentials: (String) async -> Void = { _ in }
-  var signInViaGoogle: (String) async -> Void = { _ in }
+  var signInViaApple: (String, String, String, String?) async throws -> String = { _, _, _, _ in ""
+  }
+  var revokeAppleCredentials: (String) async throws -> Void = { _ in }
+  var signInViaGoogle: (String) async throws -> String = { _ in "" }
 }
 
 extension APIClient: DependencyKey {
   static let liveValue: Self = {
-    let coordinator = APICoordinator.shared
     return Self(
       getStations: {
         let url = "\(Config.shared.baseUrl.absoluteString)/v1/developer/stationLists"
@@ -36,18 +36,54 @@ extension APIClient: DependencyKey {
         return IdentifiedArray(uniqueElements: stationLists)
       },
       signInViaApple: { identityToken, email, authCode, displayName in
-        await coordinator.signInViaApple(
-          identityToken: identityToken,
-          email: email,
-          authCode: authCode,
-          displayName: displayName
-        )
+        var parameters: [String: Any] = [
+          "identityToken": identityToken,
+          "authCode": authCode,
+          "email": email,
+        ]
+        if let displayName {
+          parameters["displayName"] = displayName
+        }
+        let response = try await AF.request(
+          "\(Config.shared.baseUrl.absoluteString)/v1/auth/apple/mobile/signup",
+          method: .post,
+          parameters: parameters,
+          encoding: JSONEncoding.default
+        ).serializingDecodable(LoginResponse.self).value
+
+        return response.playolaToken
       },
       revokeAppleCredentials: { appleUserId in
-        await coordinator.revokeAppleCredentials(appleUserId: appleUserId)
+        let parameters: [String: Any] = ["appleUserId": appleUserId]
+        _ = try await AF.request(
+          "\(Config.shared.baseUrl.absoluteString)/v1/auth/apple/revoke",
+          method: .put,
+          parameters: parameters,
+          encoding: JSONEncoding.default
+        )
+        .validate(statusCode: 200..<300)
+        .serializingData()
+        .value
+
+        AuthService.shared.signOut()
+        AuthService.shared.clearAppleUser()
       },
       signInViaGoogle: { code in
-        await coordinator.signInViaGoogle(code: code)
+        let parameters: [String: Any] = [
+          "code": code,
+          "originatesFromIOS": true,
+        ]
+
+        let response = try await AF.request(
+          "\(Config.shared.baseUrl.absoluteString)/v1/auth/google/signin",
+          method: .post,
+          parameters: parameters,
+          encoding: JSONEncoding.default
+        )
+        .validate(statusCode: 200..<300)
+        .serializingDecodable(LoginResponse.self).value
+
+        return response.playolaToken
       }
     )
   }()
@@ -62,83 +98,6 @@ extension DependencyValues {
     get { self[APIClient.self] }
     set { self[APIClient.self] = newValue }
   }
-}
-
-// MARK: - API Coordinator (Internal Implementation)
-
-@MainActor
-private class APICoordinator {
-  static let shared = APICoordinator()
-
-  @Shared(.auth) var auth: Auth
-
-  func signInViaApple(
-    identityToken: String,
-    email: String,
-    authCode: String,
-    displayName: String?
-  ) async {
-    var parameters: [String: Any] = [
-      "identityToken": identityToken,
-      "authCode": authCode,
-      "email": email,
-    ]
-    if let displayName {
-      parameters["displayName"] = displayName
-    }
-    AF.request(
-      "\(Config.shared.baseUrl.absoluteString)/v1/auth/apple/mobile/signup",
-      method: .post,
-      parameters: parameters,
-      encoding: JSONEncoding.default
-    ).responseDecodable(of: LoginResponse.self) { response in
-      switch response.result {
-      case let .success(loginResponse):
-        self.$auth.withLock { $0 = Auth(jwtToken: loginResponse.playolaToken) }
-      case let .failure(error):
-        print("Failure to log in: \(error)")
-      }
-    }
-  }
-
-  func revokeAppleCredentials(appleUserId: String) async {
-    let parameters: [String: Any] = ["appleUserId": appleUserId]
-    AF.request(
-      "\(Config.shared.baseUrl.absoluteString)/v1/auth/apple/revoke",
-      method: .put,
-      parameters: parameters,
-      encoding: JSONEncoding.default
-    )
-    .validate(statusCode: 200..<300)
-    .response { _ in
-      AuthService.shared.signOut()
-      AuthService.shared.clearAppleUser()
-    }
-  }
-
-  func signInViaGoogle(code: String) async {
-    let parameters: [String: Any] = [
-      "code": code,
-      "originatesFromIOS": true,
-    ]
-
-    AF.request(
-      "\(Config.shared.baseUrl.absoluteString)/v1/auth/google/signin",
-      method: .post,
-      parameters: parameters,
-      encoding: JSONEncoding.default
-    )
-    .validate(statusCode: 200..<300)
-    .responseDecodable(of: LoginResponse.self) { response in
-      switch response.result {
-      case let .success(loginResponse):
-        self.$auth.withLock { $0 = Auth(jwtToken: loginResponse.playolaToken) }
-      case let .failure(error):
-        print("Failure to log in: \(error)")
-      }
-    }
-  }
-
 }
 
 struct LoginResponse: Decodable {

--- a/PlayolaRadio/Dependencies/API.swift
+++ b/PlayolaRadio/Dependencies/API.swift
@@ -23,7 +23,7 @@ struct APIClient {
   var signInViaGoogle: (String) async throws -> String = { _ in "" }
 }
 
-extension APIClient: DependencyKey {
+extension APIClient: DependencyKey, Sendable {
   static let liveValue: Self = {
     return Self(
       getStations: {
@@ -36,7 +36,7 @@ extension APIClient: DependencyKey {
         return IdentifiedArray(uniqueElements: stationLists)
       },
       signInViaApple: { identityToken, email, authCode, displayName in
-        var parameters: [String: Any] = [
+        var parameters: [String: String] = [
           "identityToken": identityToken,
           "authCode": authCode,
           "email": email,
@@ -54,7 +54,7 @@ extension APIClient: DependencyKey {
         return response.playolaToken
       },
       revokeAppleCredentials: { appleUserId in
-        let parameters: [String: Any] = ["appleUserId": appleUserId]
+        let parameters: [String: String] = ["appleUserId": appleUserId]
         _ = try await AF.request(
           "\(Config.shared.baseUrl.absoluteString)/v1/auth/apple/revoke",
           method: .put,
@@ -69,7 +69,7 @@ extension APIClient: DependencyKey {
         AuthService.shared.clearAppleUser()
       },
       signInViaGoogle: { code in
-        let parameters: [String: Any] = [
+        let parameters: [String: Sendable] = [
           "code": code,
           "originatesFromIOS": true,
         ]

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -17,8 +17,9 @@ class MainContainerModel: ViewModel {
 
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored var stationPlayer: StationPlayer!
+  @ObservationIgnored @Shared(.stationLists) var stationLists
 
-  @ObservationIgnored @Shared(.stationListsLoaded) var stationListsLoaded: Bool
+  @ObservationIgnored @Shared(.stationListsLoaded) var stationListsLoaded: Bool = false
 
   enum ActiveTab {
     case home
@@ -50,6 +51,7 @@ class MainContainerModel: ViewModel {
 
   init(stationPlayer: StationPlayer? = nil) {
     self.stationPlayer = stationPlayer ?? .shared
+    super.init()
   }
 
   func viewAppeared() async {
@@ -57,7 +59,9 @@ class MainContainerModel: ViewModel {
     guard !stationListsLoaded else { return }
 
     do {
-      try await api.getStations()
+      let retrievedStationsLists = try await api.getStations()
+      self.$stationLists.withLock { $0 = retrievedStationsLists }
+      self.$stationListsLoaded.withLock { $0 = true }
     } catch {
       presentedAlert = .errorLoadingStations
     }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -56,7 +56,7 @@ final class MainContainerTests: XCTestCase {
 
   func testViewAppeared_CorrectlyRetrievesStationListsWhenApiIsSuccessful() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
-    @Shared(.stationLists) var stationLists = StationList.mocks
+    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     var getStationsCallCount = 0
 
     let mainContainerModel = withDependencies {
@@ -70,11 +70,13 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.viewAppeared()
     XCTAssertEqual(getStationsCallCount, 1)
+    XCTAssertEqual(stationLists, StationList.mocks)
+    XCTAssertTrue(stationListsLoaded)
   }
 
   func testViewAppeared_DisplaysAnErrorAlertOnApiError() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
-    @Shared(.stationLists) var stationLists = StationList.mocks
+    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     struct TestError: Error {}
 
     let mainContainerModel = withDependencies {
@@ -87,6 +89,24 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.viewAppeared()
     XCTAssertEqual(mainContainerModel.presentedAlert, .errorLoadingStations)
+    XCTAssertFalse(stationListsLoaded)
+  }
+
+  func testViewAppeared_ExitsEarlyWhenStationListsAlreadyLoaded() async {
+    @Shared(.stationListsLoaded) var stationListsLoaded = true
+    var getStationsCallCount = 0
+
+    let mainContainerModel = withDependencies {
+      $0.api.getStations = {
+        getStationsCallCount += 1
+        return StationList.mocks
+      }
+    } operation: {
+      MainContainerModel()
+    }
+
+    await mainContainerModel.viewAppeared()
+    XCTAssertEqual(getStationsCallCount, 0)
   }
 
   // MARK: - Small Player Properties Tests

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -6,6 +6,8 @@
 //
 
 import AuthenticationServices
+import Dependencies
+import Sharing
 import XCTest
 
 @testable import PlayolaRadio


### PR DESCRIPTION
Convert the API Singleton to an APIClient and push all handling for auth and stationsLists into the MainContainer.

This pull request refactors the API client and its usage across the codebase to improve error handling, simplify the implementation, and enhance test coverage. Key changes include replacing the `APICoordinator` with direct API calls using `Alamofire`, updating method signatures to return values or throw errors, and modifying dependent components to align with the new API client structure.

### API Client Refactor:
* Removed the `APICoordinator` class and replaced it with direct API calls using `Alamofire` for methods like `getStations`, `signInViaApple`, `revokeAppleCredentials`, and `signInViaGoogle`. These methods now return values or throw errors, improving error handling and simplifying the implementation. (`PlayolaRadio/Dependencies/API.swift`, [PlayolaRadio/Dependencies/API.swiftL20-R99](diffhunk://#diff-c77827c58497c0a41fcf9e0f0b14722aa3da817f05887ccbd822c203b5a42a98L20-R99))
* Added the `Sendable` conformance to `APIClient` for better concurrency support. (`PlayolaRadio/Dependencies/API.swift`, [PlayolaRadio/Dependencies/API.swiftL20-R99](diffhunk://#diff-c77827c58497c0a41fcf9e0f0b14722aa3da817f05887ccbd822c203b5a42a98L20-R99))

### ViewModel Updates:
* Updated `MainContainerModel` to fetch station lists directly via the refactored `APIClient`. Added logic to handle station list loading status and store the retrieved data in shared state. (`PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift`, [[1]](diffhunk://#diff-3cc1b6ca679353600c570ab3081f064836c15cebb1737aa91702de9d018b7e9eR20-R22) [[2]](diffhunk://#diff-3cc1b6ca679353600c570ab3081f064836c15cebb1737aa91702de9d018b7e9eR54-R64)
* Modified `SignInPageModel` to handle errors during Apple and Google sign-in and update the authentication state upon successful login. (`PlayolaRadio/Views/Pages/SignInPage/SignInPage.swift`, [[1]](diffhunk://#diff-04bf419bf2b87ad3ac98ec2b541fec13eb63b07db61a9e9cccea8b188e0e1e4cL61-R71) [[2]](diffhunk://#diff-04bf419bf2b87ad3ac98ec2b541fec13eb63b07db61a9e9cccea8b188e0e1e4cL91-R102)

### Test Updates:
* Enhanced test coverage for `MainContainerModel` to verify station list retrieval, error handling, and early exit when data is already loaded. (`PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift`, [[1]](diffhunk://#diff-256ba44113c8ae96fa146df99f5f826d1a29d38249df9ffc60579b6a500e6c91L59-R59) [[2]](diffhunk://#diff-256ba44113c8ae96fa146df99f5f826d1a29d38249df9ffc60579b6a500e6c91R73-R79) [[3]](diffhunk://#diff-256ba44113c8ae96fa146df99f5f826d1a29d38249df9ffc60579b6a500e6c91R92-R109)
* Added dependencies import in `SignInPageTests` to support testing with the refactored API client. (`PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift`, [PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swiftR9-R10](diffhunk://#diff-1b44003ba913c5358e79fc2c5fecd107e6fa3c86ee5a13124713c3de255e4355R9-R10))