### PR TITLE
Reactivity - Bump PlayolaRadio Library to 0.6.0

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -1315,7 +1315,7 @@
 			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.5.1;
+				minimumVersion = 0.6.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
This offloads the volume analysis and some other functions to the background thread, increasing responsiveness.

This pull request updates the minimum version requirement for a Swift package dependency in the `PlayolaRadio.xcodeproj` project file.

* [`PlayolaRadio.xcodeproj/project.pbxproj`](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1318-R1318): Updated the `minimumVersion` of a Swift package dependency from `0.5.1` to `0.6.0` to ensure compatibility with the latest features or fixes.