### PR TITLE
Update PlayolaPlayer Library for Station Loading Deadlock Fix

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -1315,7 +1315,7 @@
 			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.6.0;
+				minimumVersion = 0.6.1;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
This pull request includes a minor update to the `PlayolaRadio.xcodeproj` file to ensure compatibility with a newer version of a dependency.

Dependency update:

* Updated the `minimumVersion` of a remote Swift package in `PlayolaRadio.xcodeproj` from `0.6.0` to `0.6.1` to use the latest compatible version.