### PR TITLE
CarPlay Improvements

### DIFF
--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -37,8 +37,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
   var trackingService = TrackingService.shared
 
   private var isTransitioningToNowPlaying = false
-
-  // dependency injection
+  
   var stationPlayer: StationPlayer { StationPlayer.shared }
 
   override init() {
@@ -109,13 +108,10 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
   ) {
     self.interfaceController = nil
 
-    // Cancel all observers
     for observer in observers {
       observer.cancel()
     }
     observers.removeAll()
-
-    // Clear image cache when disconnecting to free memory
     CPListItem.clearImageCache()
   }
 
@@ -172,14 +168,8 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
   }
 
   private func setupNowPlayingTemplate() {
-    // Ensure NowPlayingUpdater is active for CarPlay
     _ = NowPlayingUpdater.shared
-
-    // The shared CPNowPlayingTemplate automatically displays content from MPNowPlayingInfoCenter,
-    // which is managed by our NowPlayingUpdater service
   }
-
-  // MARK: - Error Handling
 
   private func observePlaybackErrors() {
     stationPlayer.$state
@@ -190,13 +180,10 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
         case .error:
           self.handlePlaybackError()
         case .loading, .startingNewStation:
-          // Station is loading - implement best practice navigation
           self.handleStationLoading()
         case .playing:
-          // Successfully playing
           break
         case .stopped:
-          // Station is stopped - remove now playing template
           self.handleStationStopped()
         default:
           break

--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -37,7 +37,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
   var trackingService = TrackingService.shared
 
   private var isTransitioningToNowPlaying = false
-  
+
   var stationPlayer: StationPlayer { StationPlayer.shared }
 
   override init() {

--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -147,7 +147,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
     if interfaceController.templates.contains(CPNowPlayingTemplate.shared) {
       print("Now playing template in stack, popping to it")
       interfaceController.pop(to: CPNowPlayingTemplate.shared, animated: animated) {
-        success, error in
+        _, error in
         if let error = error {
           print("Error popping to now playing template: \(error)")
         } else {
@@ -157,7 +157,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
     } else {
       print("Pushing now playing template to stack")
       interfaceController.pushTemplate(CPNowPlayingTemplate.shared, animated: animated) {
-        success, error in
+        _, error in
         if let error = error {
           print("Error pushing now playing template: \(error)")
         } else {
@@ -198,7 +198,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
     // 1) Dismiss any alerts
     if let presentedTemplate = interfaceController.presentedTemplate {
       print("Dismissing presented template: \(presentedTemplate)")
-      interfaceController.dismissTemplate(animated: true) { success, error in
+      interfaceController.dismissTemplate(animated: true) { _, error in
         if let error = error {
           print("Error dismissing template: \(error)")
         }
@@ -214,7 +214,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
     // 3) If there is a nowplaying template on the stack, pop to it
     if interfaceController.templates.contains(CPNowPlayingTemplate.shared) {
       print("Now playing template in stack, popping to it")
-      interfaceController.pop(to: CPNowPlayingTemplate.shared, animated: true) { success, error in
+      interfaceController.pop(to: CPNowPlayingTemplate.shared, animated: true) { _, error in
         if let error = error {
           print("Error popping to now playing template: \(error)")
         } else {
@@ -225,7 +225,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
       // 4) If there is no nowplaying template on the stack, push to it
       print("Pushing now playing template to stack")
       interfaceController.pushTemplate(CPNowPlayingTemplate.shared, animated: true) {
-        success, error in
+        _, error in
         if let error = error {
           print("Error pushing now playing template: \(error)")
         } else {
@@ -241,7 +241,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
     // If Now Playing template is in the stack, remove it by popping back to root
     if interfaceController.templates.contains(CPNowPlayingTemplate.shared) {
       print("Station stopped - removing now playing template from stack")
-      interfaceController.popToRootTemplate(animated: true) { success, error in
+      interfaceController.popToRootTemplate(animated: true) { _, error in
         if let error = error {
           print("Error popping to root after stop: \(error)")
         } else {
@@ -292,7 +292,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
 
     // First dismiss any presented alert
     if interfaceController.presentedTemplate != nil {
-      interfaceController.dismissTemplate(animated: true) { success, error in
+      interfaceController.dismissTemplate(animated: true) { _, error in
         if let error = error {
           print("Error dismissing template: \(error)")
         }
@@ -301,7 +301,7 @@ class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSc
 
     // If we're not already at the root, pop to it
     if interfaceController.templates.count > 1 {
-      interfaceController.popToRootTemplate(animated: true) { success, error in
+      interfaceController.popToRootTemplate(animated: true) { _, error in
         if let error = error {
           print("Error popping to root: \(error)")
         }

--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -10,7 +10,8 @@ import FRadioPlayer
 import IdentifiedCollections
 import Sharing
 
-class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+@MainActor
+class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSceneDelegate {
   private func tabImage(_ identifier: String) -> UIImage? {
     switch identifier {
     case StationList.KnownIDs.artistList.rawValue:
@@ -35,16 +36,20 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
 
   var trackingService = TrackingService.shared
 
+  private var isTransitioningToNowPlaying = false
+
   // dependency injection
   var stationPlayer: StationPlayer { StationPlayer.shared }
 
   override init() {
     super.init()
     setupNowPlayingTemplate()
+    observePlaybackErrors()
   }
 
   private func playStation(_ station: RadioStation?) {
     guard let station else { return }
+
     stationPlayer.play(station: station)
     showNowPlayingTemplate()
   }
@@ -103,35 +108,232 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     didDisconnectInterfaceController interfaceController: CPInterfaceController
   ) {
     self.interfaceController = nil
+
+    // Cancel all observers
     for observer in observers {
       observer.cancel()
     }
+    observers.removeAll()
+
+    // Clear image cache when disconnecting to free memory
+    CPListItem.clearImageCache()
   }
 
   private func showNowPlayingTemplate(animated: Bool = true) {
-    guard interfaceController?.topTemplate != CPNowPlayingTemplate.shared else { return }
+    guard let interfaceController = interfaceController else {
+      print("No interface controller available")
+      return
+    }
 
-    if interfaceController?.templates.contains(CPNowPlayingTemplate.shared) == true {
-      interfaceController?.pop(to: CPNowPlayingTemplate.shared, animated: animated, completion: nil)
+    // Prevent overlapping transitions
+    guard !isTransitioningToNowPlaying else {
+      print("Already transitioning to now playing, ignoring")
+      return
+    }
+
+    defer { isTransitioningToNowPlaying = false }
+    isTransitioningToNowPlaying = true
+
+    print("showNowPlayingTemplate called")
+    print("Current top template: \(interfaceController.topTemplate)")
+    print("Templates in stack: \(interfaceController.templates.count)")
+    print(
+      "Now playing template in stack: \(interfaceController.templates.contains(CPNowPlayingTemplate.shared))"
+    )
+
+    // Don't do anything if already showing
+    if interfaceController.topTemplate == CPNowPlayingTemplate.shared {
+      print("Already showing now playing template, returning")
+      return
+    }
+
+    // Check if it's already in the stack
+    if interfaceController.templates.contains(CPNowPlayingTemplate.shared) {
+      print("Now playing template in stack, popping to it")
+      interfaceController.pop(to: CPNowPlayingTemplate.shared, animated: animated) {
+        success, error in
+        if let error = error {
+          print("Error popping to now playing template: \(error)")
+        } else {
+          print("Successfully popped to now playing template")
+        }
+      }
     } else {
-      interfaceController?.pushTemplate(
-        CPNowPlayingTemplate.shared, animated: animated, completion: nil)
+      print("Pushing now playing template to stack")
+      interfaceController.pushTemplate(CPNowPlayingTemplate.shared, animated: animated) {
+        success, error in
+        if let error = error {
+          print("Error pushing now playing template: \(error)")
+        } else {
+          print("Successfully pushed now playing template")
+        }
+      }
     }
   }
 
   private func setupNowPlayingTemplate() {
-    // Setup now playing template configuration
+    // Ensure NowPlayingUpdater is active for CarPlay
+    _ = NowPlayingUpdater.shared
+
+    // The shared CPNowPlayingTemplate automatically displays content from MPNowPlayingInfoCenter,
+    // which is managed by our NowPlayingUpdater service
+  }
+
+  // MARK: - Error Handling
+
+  private func observePlaybackErrors() {
+    stationPlayer.$state
+      .sink { [weak self] state in
+        guard let self = self else { return }
+
+        switch state.playbackStatus {
+        case .error:
+          self.handlePlaybackError()
+        case .loading, .startingNewStation:
+          // Station is loading - implement best practice navigation
+          self.handleStationLoading()
+        case .playing:
+          // Successfully playing
+          break
+        case .stopped:
+          // Station is stopped - remove now playing template
+          self.handleStationStopped()
+        default:
+          break
+        }
+      }
+      .store(in: &observers)
+  }
+
+  private func handleStationLoading() {
+    guard let interfaceController = interfaceController else { return }
+
+    // 1) Dismiss any alerts
+    if let presentedTemplate = interfaceController.presentedTemplate {
+      print("Dismissing presented template: \(presentedTemplate)")
+      interfaceController.dismissTemplate(animated: true) { success, error in
+        if let error = error {
+          print("Error dismissing template: \(error)")
+        }
+      }
+    }
+
+    // 2) If the now playing template is showing, do nothing
+    if interfaceController.topTemplate == CPNowPlayingTemplate.shared {
+      print("Now playing template already showing, no action needed")
+      return
+    }
+
+    // 3) If there is a nowplaying template on the stack, pop to it
+    if interfaceController.templates.contains(CPNowPlayingTemplate.shared) {
+      print("Now playing template in stack, popping to it")
+      interfaceController.pop(to: CPNowPlayingTemplate.shared, animated: true) { success, error in
+        if let error = error {
+          print("Error popping to now playing template: \(error)")
+        } else {
+          print("Successfully popped to now playing template")
+        }
+      }
+    } else {
+      // 4) If there is no nowplaying template on the stack, push to it
+      print("Pushing now playing template to stack")
+      interfaceController.pushTemplate(CPNowPlayingTemplate.shared, animated: true) {
+        success, error in
+        if let error = error {
+          print("Error pushing now playing template: \(error)")
+        } else {
+          print("Successfully pushed now playing template")
+        }
+      }
+    }
+  }
+
+  private func handleStationStopped() {
+    guard let interfaceController = interfaceController else { return }
+
+    // If Now Playing template is in the stack, remove it by popping back to root
+    if interfaceController.templates.contains(CPNowPlayingTemplate.shared) {
+      print("Station stopped - removing now playing template from stack")
+      interfaceController.popToRootTemplate(animated: true) { success, error in
+        if let error = error {
+          print("Error popping to root after stop: \(error)")
+        } else {
+          print("Successfully removed now playing template after stop")
+        }
+      }
+    } else {
+      print("Station stopped - now playing template not in stack")
+    }
+  }
+
+  private func handlePlaybackError() {
+    guard let interfaceController = interfaceController else { return }
+
+    // Don't show multiple error alerts
+    if interfaceController.presentedTemplate is CPAlertTemplate {
+      return
+    }
+
+    // Create title with station name for context
+    let titleVariants: [String]
+    if let station = stationPlayer.currentStation {
+      titleVariants = ["Unable to Connect to \(station.name)"]
+    } else {
+      titleVariants = ["Unable to Connect"]
+    }
+
+    // Create alert with single action
+    let alert = CPAlertTemplate(
+      titleVariants: titleVariants,
+      actions: [
+        CPAlertAction(title: "Choose Another Station", style: .default) { [weak self] _ in
+          self?.popToStationList()
+        }
+      ]
+    )
+
+    // Present alert
+    interfaceController.presentTemplate(alert, animated: true) { success, error in
+      if !success {
+        print("Failed to present error alert: \(error?.localizedDescription ?? "Unknown error")")
+      }
+    }
+  }
+
+  private func popToStationList() {
+    guard let interfaceController = interfaceController else { return }
+
+    // First dismiss any presented alert
+    if interfaceController.presentedTemplate != nil {
+      interfaceController.dismissTemplate(animated: true) { success, error in
+        if let error = error {
+          print("Error dismissing template: \(error)")
+        }
+      }
+    }
+
+    // If we're not already at the root, pop to it
+    if interfaceController.templates.count > 1 {
+      interfaceController.popToRootTemplate(animated: true) { success, error in
+        if let error = error {
+          print("Error popping to root: \(error)")
+        }
+      }
+    }
   }
 
   /// Creates a CPListItem from a RadioStation
   /// - Parameter station: The radio station to convert
   /// - Returns: A configured CPListItem
   public func cPListItemFrom(station: RadioStation) -> CPListItem {
+    // Use a default placeholder image for better UX
+    let placeholder = UIImage(systemName: "radio") ?? UIImage()
+
     let listItem = CPListItem(
       text: station.name,
       detailText: station.desc,
       remoteImageUrl: URL(string: station.imageURL),
-      placeholder: nil
+      placeholder: placeholder
     )
     listItem.handler = { _, completion in
       self.stationPlayer.play(station: station)
@@ -141,13 +343,13 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
   }
 }
 
-extension CarPlaySceneDelegate: CPTabBarTemplateDelegate {
+extension CarPlaySceneDelegate: @preconcurrency CPTabBarTemplateDelegate {
   func tabBarTemplate(_ tabBarTemplate: CPTabBarTemplate, didSelect selectedTemplate: CPTemplate) {
     // Handle tab selection
   }
 }
 
-extension CarPlaySceneDelegate: CPInterfaceControllerDelegate {
+extension CarPlaySceneDelegate: @preconcurrency CPInterfaceControllerDelegate {
   func templateWillAppear(_ aTemplate: CPTemplate, animated: Bool) {
     // Handle template will appear
   }

--- a/PlayolaRadio/Extensions/CPListItem+InitWithRemoteUrl.swift
+++ b/PlayolaRadio/Extensions/CPListItem+InitWithRemoteUrl.swift
@@ -4,10 +4,96 @@
 //
 //  Created by Brian D Keane on 1/20/25.
 //
-import CarPlay
+@preconcurrency import CarPlay
+import Foundation
+import UIKit
+
+// MARK: - Image Loader Actor
+
+/// Thread-safe image loader for CarPlay
+actor CarPlayImageLoader {
+  static let shared = CarPlayImageLoader()
+
+  private let cache = NSCache<NSURL, UIImage>()
+  private var activeTasks: [URL: Task<UIImage?, Never>] = [:]
+
+  private let urlSession: URLSession = {
+    let config = URLSessionConfiguration.default
+    config.timeoutIntervalForRequest = 10.0
+    config.requestCachePolicy = .returnCacheDataElseLoad
+    config.urlCache = URLCache(
+      memoryCapacity: 10 * 1024 * 1024,  // 10 MB
+      diskCapacity: 50 * 1024 * 1024,  // 50 MB
+      diskPath: "carplay_images"
+    )
+    return URLSession(configuration: config)
+  }()
+
+  init() {
+    cache.countLimit = 100
+    cache.totalCostLimit = 50 * 1024 * 1024  // 50 MB
+  }
+
+  func loadImage(from url: URL) async -> UIImage? {
+    // Check cache first
+    if let cachedImage = cache.object(forKey: url as NSURL) {
+      return cachedImage
+    }
+
+    // Check if there's already a task loading this URL
+    if let existingTask = activeTasks[url] {
+      return await existingTask.value
+    }
+
+    // Create new loading task
+    let task = Task { () -> UIImage? in
+      do {
+        let (data, _) = try await urlSession.data(from: url)
+        guard let image = UIImage(data: data) else {
+          print("CarPlay image loading failed: Invalid image data from \(url)")
+          return nil
+        }
+
+        // Cache the image
+        cache.setObject(image, forKey: url as NSURL)
+        return image
+      } catch {
+        if (error as NSError).code != NSURLErrorCancelled {
+          print("CarPlay image loading error for \(url): \(error.localizedDescription)")
+        }
+        return nil
+      }
+    }
+
+    // Store the task
+    activeTasks[url] = task
+
+    // Clean up when done
+    let result = await task.value
+    activeTasks[url] = nil
+
+    return result
+  }
+
+  func cancelLoading(for url: URL) {
+    activeTasks[url]?.cancel()
+    activeTasks[url] = nil
+  }
+
+  func clearCache() {
+    cache.removeAllObjects()
+    for task in activeTasks.values {
+      task.cancel()
+    }
+    activeTasks.removeAll()
+  }
+}
+
+// MARK: - CPListItem Extension
 
 extension CPListItem {
   private static let identifierUserInfoKey = "CPListItem.Identifier"
+  private static let imageURLUserInfoKey = "CPListItem.ImageURL"
 
   public convenience init(
     text: String?,
@@ -17,21 +103,46 @@ extension CPListItem {
   ) {
     self.init(text: text, detailText: detailText, image: placeholder)
 
-    if let remoteImageUrl {
-      let dataTask = URLSession.shared.dataTask(with: remoteImageUrl) { [weak self] data, _, _ in
-        if let data, let image = UIImage(data: data) {
-          DispatchQueue.main.async { [weak self] in
-            self?.setImage(image)
-          }
-        } else {
-          print("Error downlaoding image")
-        }
-      }
-      dataTask.resume()
-    }
+    guard let remoteImageUrl else { return }
 
-    var identifier: String? {
-      (userInfo as? [String: Any])?[Self.identifierUserInfoKey] as? String
+    // Store URL in userInfo for later cancellation
+    var info = (userInfo as? [String: Any]) ?? [:]
+    info[Self.imageURLUserInfoKey] = remoteImageUrl
+    userInfo = info
+
+    // Load image asynchronously
+    Task { @MainActor in
+      if let image = await CarPlayImageLoader.shared.loadImage(from: remoteImageUrl) {
+        self.setImage(image)
+      }
+    }
+  }
+
+  // MARK: - Identifier Support
+
+  var identifier: String? {
+    (userInfo as? [String: Any])?[Self.identifierUserInfoKey] as? String
+  }
+
+  // MARK: - Image Management
+
+  /// Cancel image loading for this item
+  public func cancelImageLoading() {
+    guard let url = (userInfo as? [String: Any])?[Self.imageURLUserInfoKey] as? URL else { return }
+
+    Task {
+      await CarPlayImageLoader.shared.cancelLoading(for: url)
+    }
+  }
+}
+
+// MARK: - Cache Management
+
+extension CPListItem {
+  /// Clear all cached images
+  public static func clearImageCache() {
+    Task {
+      await CarPlayImageLoader.shared.clearCache()
     }
   }
 }

--- a/PlayolaRadio/Services/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Services/NowPlayingUpdater.swift
@@ -207,7 +207,7 @@ class NowPlayingUpdater {
       MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
     nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(
       boundsSize: image.size,
-      requestHandler: { size in
+      requestHandler: { _ in
         return image
       })
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo

--- a/PlayolaRadio/Services/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Services/NowPlayingUpdater.swift
@@ -55,9 +55,11 @@ class NowPlayingUpdater {
   private var lastPlayedStation: RadioStation?
   private var currentArtworkURL: String?
   private func updateNowPlaying(with stationPlayerState: StationPlayer.State) {
-    print("🎵 NowPlayingUpdater: updateNowPlaying called with status: \(stationPlayerState.playbackStatus)")
+    print(
+      "🎵 NowPlayingUpdater: updateNowPlaying called with status: \(stationPlayerState.playbackStatus)"
+    )
     print("🎵 Current station: \(stationPlayer.currentStation?.name ?? "nil")")
-    
+
     guard let currentStation = stationPlayer.currentStation else {
       print("🎵 No current station - clearing now playing info")
       clearNowPlayingInfo()
@@ -68,13 +70,14 @@ class NowPlayingUpdater {
     var nowPlayingInfo = buildNowPlayingInfo(for: stationPlayerState, station: currentStation)
     updatePlaybackState(for: stationPlayerState.playbackStatus)
     setPlaybackRate(for: stationPlayerState.playbackStatus, in: &nowPlayingInfo)
-    
+
     // Handle artwork based on playback status
     switch stationPlayerState.playbackStatus {
     case .loading, .stopped:
       // For loading/stopped states, preserve existing artwork if available, otherwise load new
       if let existingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo,
-         let existingArtwork = existingInfo[MPMediaItemPropertyArtwork] {
+        let existingArtwork = existingInfo[MPMediaItemPropertyArtwork]
+      {
         nowPlayingInfo[MPMediaItemPropertyArtwork] = existingArtwork
       } else {
         // Only load if we don't already have this station's artwork
@@ -85,7 +88,8 @@ class NowPlayingUpdater {
     case .playing:
       // Preserve existing artwork
       if let existingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo,
-         let existingArtwork = existingInfo[MPMediaItemPropertyArtwork] {
+        let existingArtwork = existingInfo[MPMediaItemPropertyArtwork]
+      {
         nowPlayingInfo[MPMediaItemPropertyArtwork] = existingArtwork
       }
     default:
@@ -186,10 +190,10 @@ class NowPlayingUpdater {
     if currentArtworkURL == station.imageURL {
       return
     }
-    
+
     // For CarPlay/Lock Screen: always use station image, ignore album artwork
     station.getImage { image in
-      Task { 
+      Task {
         self.updateNowPlayingImage(image)
         await MainActor.run {
           self.currentArtworkURL = station.imageURL


### PR DESCRIPTION
This pull request introduces several updates to improve CarPlay integration, enhance playback error handling, and optimize image management within the PlayolaRadio app. The most significant changes include adding thread-safe image loading with caching, improving the handling of playback states and errors, and refining the `NowPlayingUpdater` logic to better manage artwork and playback information.

### CarPlay integration improvements:
* Added `@MainActor` and `@preconcurrency` annotations to `CarPlaySceneDelegate` and related extensions for better concurrency handling. (`PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift`, [[1]](diffhunk://#diff-8599ac9b814f11548cd14c4fc36f43809d80bf18705a4ba46edcbc89ce59fb02L13-R14) [[2]](diffhunk://#diff-8599ac9b814f11548cd14c4fc36f43809d80bf18705a4ba46edcbc89ce59fb02L144-R339)
* Introduced new methods to manage CarPlay templates, ensuring smoother transitions and handling playback errors (e.g., `observePlaybackErrors`, `handlePlaybackError`, `handleStationLoading`, `handleStationStopped`). (`PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift`, [[1]](diffhunk://#diff-8599ac9b814f11548cd14c4fc36f43809d80bf18705a4ba46edcbc89ce59fb02L38-R51) [[2]](diffhunk://#diff-8599ac9b814f11548cd14c4fc36f43809d80bf18705a4ba46edcbc89ce59fb02R110-R323)

### Image management enhancements:
* Implemented a thread-safe `CarPlayImageLoader` actor with caching for efficient image loading and management. (`PlayolaRadio/Extensions/CPListItem+InitWithRemoteUrl.swift`, [PlayolaRadio/Extensions/CPListItem+InitWithRemoteUrl.swiftL7-R96](diffhunk://#diff-d199b3ef2888f59de096136447adf77c3ca5b33dbf79fb23a8f92456f3aac3bbL7-R96))
* Updated the `CPListItem` initializer to use the new image loader and added methods for canceling image loading and clearing the cache. (`PlayolaRadio/Extensions/CPListItem+InitWithRemoteUrl.swift`, [PlayolaRadio/Extensions/CPListItem+InitWithRemoteUrl.swiftL20-R146](diffhunk://#diff-d199b3ef2888f59de096136447adf77c3ca5b33dbf79fb23a8f92456f3aac3bbL20-R146))

### Playback state and error handling:
* Enhanced `NowPlayingUpdater` to preserve or update artwork based on playback status, avoid redundant artwork loading, and clear playback information when necessary. (`PlayolaRadio/Services/NowPlayingUpdater.swift`, [[1]](diffhunk://#diff-f9f2e4ad6a63405fe22901e7b7d9327598d2888bdebd65c1dcf04269a6ab950aR56-R64) [[2]](diffhunk://#diff-f9f2e4ad6a63405fe22901e7b7d9327598d2888bdebd65c1dcf04269a6ab950aR73-R106) [[3]](diffhunk://#diff-f9f2e4ad6a63405fe22901e7b7d9327598d2888bdebd65c1dcf04269a6ab950aL156-R200)
* Improved error handling during playback by presenting alerts and managing transitions in CarPlay templates. (`PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift`, [PlayolaRadio/CarPlay/CarPlaySceneDelegate.swiftR110-R323](diffhunk://#diff-8599ac9b814f11548cd14c4fc36f43809d80bf18705a4ba46edcbc89ce59fb02R110-R323))

### Code simplifications and logging:
* Added detailed debug logging to trace playback state updates and CarPlay template actions. (`PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift`, [[1]](diffhunk://#diff-8599ac9b814f11548cd14c4fc36f43809d80bf18705a4ba46edcbc89ce59fb02R110-R323); `PlayolaRadio/Services/NowPlayingUpdater.swift`, [[2]](diffhunk://#diff-f9f2e4ad6a63405fe22901e7b7d9327598d2888bdebd65c1dcf04269a6ab950aR56-R64)
* Simplified artwork handling logic in `NowPlayingUpdater` to prioritize station images over album artwork. (`PlayolaRadio/Services/NowPlayingUpdater.swift`, [[1]](diffhunk://#diff-f9f2e4ad6a63405fe22901e7b7d9327598d2888bdebd65c1dcf04269a6ab950aL156-R200) [[2]](diffhunk://#diff-f9f2e4ad6a63405fe22901e7b7d9327598d2888bdebd65c1dcf04269a6ab950aL170-R211)