### PR TITLE
Dismiss Player Returning from Background Without Audio

### DIFF
--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -9,6 +9,7 @@ import SwiftUI
 
 struct PlayerPage: View {
   @Environment(\.dismiss) private var dismiss
+  @Environment(\.scenePhase) var scenePhase
   @Bindable var model: PlayerPageModel
 
   var body: some View {
@@ -144,7 +145,9 @@ struct PlayerPage: View {
       //            Spacer()
     }
     .background(Color.black)
-    .onAppear { model.viewAppeared() }
+    .onChange(of: scenePhase) { _, newValue in
+      model.scenePhaseChanged(newPhase: newValue)
+    }
   }
 }
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -134,12 +134,19 @@ class PlayerPageModel: ViewModel {
     self.onDismiss = onDismiss
   }
 
-  func viewAppeared() {
-    // No longer needed - all properties are computed from nowPlaying
-  }
-
   func playPauseButtonTapped() {
     stationPlayer.stop()
     onDismiss?()
+  }
+
+  func scenePhaseChanged(newPhase: ScenePhase) {
+    if newPhase == .active {
+      switch stationPlayer.state.playbackStatus {
+      case .stopped, .error:
+        onDismiss?()
+      default:
+        break
+      }
+    }
   }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -27,7 +27,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertEqual(model.primaryNavBarTitle, station.name)
     XCTAssertEqual(model.secondaryNavBarTitle, station.desc)
@@ -45,7 +44,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertEqual(model.primaryNavBarTitle, station.name)
     XCTAssertEqual(model.secondaryNavBarTitle, station.desc)
@@ -66,7 +64,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertEqual(model.nowPlayingText, "Selfie - Rachel Loy")
     XCTAssertEqual(model.stationArtUrl, URL(string: station.imageURL))
@@ -88,7 +85,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertEqual(model.nowPlayingText, "Selfie - Rachel Loy")
     XCTAssertEqual(model.stationArtUrl, URL(string: station.imageURL))
@@ -116,7 +112,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertEqual(model.relatedText?.title, "Why I chose this song")
     XCTAssertEqual(model.relatedText?.body, transcription)
@@ -143,7 +138,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertNotNil(model.relatedText)
     // randomly picks one.
@@ -159,7 +153,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertEqual(model.nowPlayingText, "")
     XCTAssertNil(model.albumArtUrl)
@@ -174,7 +167,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertEqual(model.nowPlayingText, "Error Playing Station")
     XCTAssertEqual(model.primaryNavBarTitle, "")
@@ -193,7 +185,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertEqual(model.primaryNavBarTitle, station.name)
     XCTAssertEqual(model.secondaryNavBarTitle, station.desc)
@@ -215,7 +206,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     XCTAssertEqual(model.primaryNavBarTitle, station.name)
     XCTAssertEqual(model.secondaryNavBarTitle, station.desc)
@@ -244,7 +234,6 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: playerMock)
-    model.viewAppeared()
 
     // Get the first relatedText result
     let firstResult = model.relatedText
@@ -271,7 +260,7 @@ final class PlayerPageTests: XCTestCase {
     )
 
     let model = PlayerPageModel(stationPlayer: spy)
-    model.viewAppeared()
+
     XCTAssertEqual(spy.stopCalledCount, 0)
     model.playPauseButtonTapped()
 
@@ -290,7 +279,6 @@ final class PlayerPageTests: XCTestCase {
 
     var dismissCalled = false
     let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
-    model.viewAppeared()
 
     model.playPauseButtonTapped()
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -297,4 +297,93 @@ final class PlayerPageTests: XCTestCase {
     XCTAssertEqual(spy.stopCalledCount, 1)
     XCTAssertTrue(dismissCalled)
   }
+
+  // MARK: - scenePhaseChanged Tests
+
+  func testScenePhaseChanged_DismissesWhenActiveAndPlayerStopped() {
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(playbackStatus: .stopped)
+
+    var dismissCalled = false
+    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+
+    model.scenePhaseChanged(newPhase: .active)
+
+    XCTAssertTrue(dismissCalled)
+  }
+
+  func testScenePhaseChanged_DismissesWhenActiveAndPlayerError() {
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(playbackStatus: .error)
+
+    var dismissCalled = false
+    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+
+    model.scenePhaseChanged(newPhase: .active)
+
+    XCTAssertTrue(dismissCalled)
+  }
+
+  func testScenePhaseChanged_DoesNotDismissWhenActiveAndPlayerPlaying() {
+    let station = RadioStation.mock
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(playbackStatus: .playing(station))
+
+    var dismissCalled = false
+    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+
+    model.scenePhaseChanged(newPhase: .active)
+
+    XCTAssertFalse(dismissCalled)
+  }
+
+  func testScenePhaseChanged_DoesNotDismissWhenActiveAndPlayerLoading() {
+    let station = RadioStation.mock
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(playbackStatus: .loading(station))
+
+    var dismissCalled = false
+    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+
+    model.scenePhaseChanged(newPhase: .active)
+
+    XCTAssertFalse(dismissCalled)
+  }
+
+  func testScenePhaseChanged_DoesNotDismissWhenActiveAndPlayerStartingNewStation() {
+    let station = RadioStation.mock
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(playbackStatus: .startingNewStation(station))
+
+    var dismissCalled = false
+    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+
+    model.scenePhaseChanged(newPhase: .active)
+
+    XCTAssertFalse(dismissCalled)
+  }
+
+  func testScenePhaseChanged_DoesNotDismissWhenBackgroundPhase() {
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(playbackStatus: .stopped)
+
+    var dismissCalled = false
+    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+
+    model.scenePhaseChanged(newPhase: .background)
+
+    XCTAssertFalse(dismissCalled)
+  }
+
+  func testScenePhaseChanged_DoesNotDismissWhenInactivePhase() {
+    let spy = StationPlayerMock()
+    spy.state = StationPlayer.State(playbackStatus: .stopped)
+
+    var dismissCalled = false
+    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+
+    model.scenePhaseChanged(newPhase: .inactive)
+
+    XCTAssertFalse(dismissCalled)
+  }
 }


### PR DESCRIPTION
This pull request introduces changes to handle `scenePhase` updates in the `PlayerPage` view and its associated model, improving the app's response to lifecycle events. It also includes new test cases to ensure the behavior is robust and well-tested.

### Enhancements to lifecycle handling:

* [`PlayerPage.swift`](diffhunk://#diff-f575e81eea962cd9096d10b351b82e18859941b884cfb18f7cf56a9954313341R12): Added an `@Environment` property for `scenePhase` and replaced the `.onAppear` modifier with `.onChange` to handle `scenePhase` updates. This ensures the view reacts appropriately to changes in the app's lifecycle. [[1]](diffhunk://#diff-f575e81eea962cd9096d10b351b82e18859941b884cfb18f7cf56a9954313341R12) [[2]](diffhunk://#diff-f575e81eea962cd9096d10b351b82e18859941b884cfb18f7cf56a9954313341L147-R150)

* [`PlayerPageModel.swift`](diffhunk://#diff-18266a15f83ef5cdd31b76d2a5ba946e37e47cf7288a1104391da7c0b617ef7eL137-R151): Removed the unused `viewAppeared` method and added a new `scenePhaseChanged` method to handle `scenePhase` updates. The method dismisses the view if the app becomes active and the player is stopped or in an error state.

### Testing improvements:

* [`PlayerPageTests.swift`](diffhunk://#diff-ba76417e4801c3d5f6af92b64d411645f55f5c27f0e581dfdcb59354397e40b2R300-R388): Added comprehensive test cases for the `scenePhaseChanged` method to verify that the view dismisses correctly based on the player's state and the app's lifecycle phase. These tests include scenarios for active, background, and inactive phases, as well as different playback statuses.