### PR TITLE
Contact Page Texts

### DIFF
--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -84,6 +84,14 @@ struct LoggedInUser: Codable {
       profileImageUrl: profileImageUrl, role: role)
   }
 
+  var fullName: String {
+    var constructedName = firstName
+    if let lastName {
+      constructedName += " \(lastName)"
+    }
+    return constructedName
+  }
+
   private static func generateJWT(
     id: String, firstName: String, lastName: String? = nil, email: String, profileImageUrl: String?,
     role: String

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -19,6 +19,14 @@ class ContactPageModel: ViewModel {
   var mainContainerNavigationCoordinator
   var editProfilePageModel: EditProfilePageModel = EditProfilePageModel()
 
+  var name: String {
+    return auth.currentUser?.fullName ?? "Anonymous"
+  }
+
+  var email: String {
+    return auth.currentUser?.email ?? "Unknown"
+  }
+
   init(
     stationPlayer: StationPlayer? = nil
   ) {

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -48,4 +48,50 @@ final class ContactPageTests: XCTestCase {
     XCTAssertNil(auth.currentUser)
     XCTAssertNil(auth.jwt)
   }
+
+  func testNameDisplay_ReturnsFullNameWhenLoggedIn() {
+    let loggedInUser = LoggedInUser(
+      id: "123",
+      firstName: "Jane",
+      lastName: "Smith",
+      email: "jane@example.com",
+      role: "user"
+    )
+    @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
+
+    let model = ContactPageModel()
+
+    XCTAssertEqual(model.name, "Jane Smith")
+  }
+
+  func testNameDisplay_ReturnsAnonymousWhenNotLoggedIn() {
+    @Shared(.auth) var auth = Auth()
+
+    let model = ContactPageModel()
+
+    XCTAssertEqual(model.name, "Anonymous")
+  }
+
+  func testEmailDisplay_ReturnsEmailWhenLoggedIn() {
+    let loggedInUser = LoggedInUser(
+      id: "456",
+      firstName: "Bob",
+      lastName: "Johnson",
+      email: "bob@test.com",
+      role: "admin"
+    )
+    @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
+
+    let model = ContactPageModel()
+
+    XCTAssertEqual(model.email, "bob@test.com")
+  }
+
+  func testEmailDisplay_ReturnsUnknownWhenNotLoggedIn() {
+    @Shared(.auth) var auth = Auth()
+
+    let model = ContactPageModel()
+
+    XCTAssertEqual(model.email, "Unknown")
+  }
 }

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
@@ -42,11 +42,11 @@ struct ContactPageView: View {
 
               // Name and Email
               VStack(spacing: 4) {
-                Text("Brian Keane")
+                Text(model.name)
                   .font(.custom(FontNames.Inter_500_Medium, size: 20))
                   .foregroundColor(.white)
 
-                Text(verbatim: "briank@gmail.com")
+                Text(verbatim: model.email)
                   .font(.custom(FontNames.Inter_400_Regular, size: 14))
                   .foregroundColor(Color(hex: "#BABABA"))
 


### PR DESCRIPTION
This pull request introduces enhancements to the `ContactPage` functionality by dynamically displaying user information based on authentication state. Key changes include adding a computed property for a user's full name, updating the `ContactPageModel` to handle user details, modifying the `ContactPageView` to display dynamic data, and adding unit tests to ensure correctness.

### Enhancements to user information handling:

* [`PlayolaRadio/Models/LoggedInUser.swift`](diffhunk://#diff-f7c2cc31df5e8f4a87af7d9e52b2ac6f0e05abd947ef8891585055c8bf65f648R87-R94): Added a `fullName` computed property to construct a user's full name from `firstName` and `lastName`, defaulting to only `firstName` if `lastName` is absent.

* [`PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift`](diffhunk://#diff-a1ff4a7885a75abb527c272aa7256eee1ee9f25810e0ec17f98ac0cd316c0e03R22-R29): Added `name` and `email` computed properties to fetch the current user's full name and email, defaulting to "Anonymous" and "Unknown" respectively when no user is logged in.

### Updates to the `ContactPageView`:

* [`PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift`](diffhunk://#diff-41324b6c7d08afff54b2154673e3823f340865b570d87ae05655b7990c84d3ebL45-R49): Updated the view to display dynamic `name` and `email` values from the `ContactPageModel` instead of hardcoded placeholders.

### Unit tests for new functionality:

* [`PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift`](diffhunk://#diff-42d4e83330c04121a256ec45ec7bc92465e40a5434efafa8f6a1d0ca18873671R51-R96): Added tests to verify the behavior of `name` and `email` properties in both logged-in and logged-out scenarios, ensuring the correct values are displayed.