### PR TITLE
Bump PlayolaPlayer to 0.6.2

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -1315,7 +1315,7 @@
 			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.6.1;
+				minimumVersion = 0.6.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
This pull request includes a minor update to the minimum required version of the `PlayolaPlayer` Swift package in the `PlayolaRadio.xcodeproj/project.pbxproj` file. The minimum version has been incremented from `0.6.1` to `0.6.2`.