### PR TITLE
Remove Landscape Orientation

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -977,7 +977,8 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1017,7 +1018,8 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1158,7 +1160,8 @@
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen.storyboard;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait";
-				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = UIInterfaceOrientationPortrait;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = UIInterfaceOrientationPortrait;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
This pull request updates the supported interface orientations for both iPad and iPhone in the `PlayolaRadio.xcodeproj/project.pbxproj` configuration. The main change restricts the app to portrait mode only on both device types, removing support for landscape and upside-down orientations.

Interface orientation settings:

* Restricted `INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad` to only `UIInterfaceOrientationPortrait`, removing landscape and upside-down support. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L980-R981) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1020-R1022) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1161-R1164)
* Added `INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone` with value `UIInterfaceOrientationPortrait`, ensuring iPhone devices also only support portrait orientation. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L980-R981) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1020-R1022) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1161-R1164)