### PR TITLE
Bugfix: Keyboard Blocks Input Label on InvitationCodePage

### DIFF
--- a/PlayolaRadio/Views/Pages/InvitationCodePage/InvitationCodePageView.swift
+++ b/PlayolaRadio/Views/Pages/InvitationCodePage/InvitationCodePageView.swift
@@ -10,6 +10,9 @@ import SwiftUI
 struct InvitationCodePageView: View {
   @Bindable var model: InvitationCodePageModel
 
+  // Keyboard focus for the single text field
+  @FocusState private var isInputFocused: Bool
+
   var body: some View {
     VStack(spacing: 0) {
 
@@ -36,7 +39,6 @@ struct InvitationCodePageView: View {
             .lineSpacing(2)
             .padding(.horizontal, 38)
         }
-        //        .padding(.horizontal, 38)
       }
 
       // Form section
@@ -58,6 +60,11 @@ struct InvitationCodePageView: View {
               .autocapitalization(.allCharacters)
               .disableAutocorrection(true)
               .frame(minHeight: 48)
+              .focused($isInputFocused)  // ← bind focus to enable dismissals
+              .submitLabel(.send)
+              .onSubmit {
+                Task { await model.actionButtonTapped() }
+              }
 
             // Error message
             if let errorMessage = model.errorMessage {
@@ -79,9 +86,7 @@ struct InvitationCodePageView: View {
         // Action button
         Button(
           action: {
-            Task {
-              await model.actionButtonTapped()
-            }
+            Task { await model.actionButtonTapped() }
           },
           label: {
             HStack {
@@ -109,9 +114,7 @@ struct InvitationCodePageView: View {
           // Join waitlist button
           Button(
             action: {
-              Task {
-                await model.changeModeButtonTapped()
-              }
+              Task { await model.changeModeButtonTapped() }
             },
             label: {
               HStack {
@@ -141,6 +144,33 @@ struct InvitationCodePageView: View {
       Spacer()
     }
     .background(Color(hex: "#130000"))
+
+    // 1) Tap anywhere outside the field to dismiss keyboard
+    .contentShape(Rectangle())
+    .onTapGesture {
+      isInputFocused = false
+    }
+
+    // 2) Drag down anywhere to dismiss (simple, non-interactive)
+    .simultaneousGesture(
+      DragGesture(minimumDistance: 10)
+        .onEnded { value in
+          if value.translation.height > 30 { isInputFocused = false }
+        }
+    )
+
+    // 3) Keyboard toolbar "Hide" button
+    .toolbar {
+      ToolbarItemGroup(placement: .keyboard) {
+        Spacer()
+        Button {
+          isInputFocused = false
+        } label: {
+          Image(systemName: "keyboard.chevron.compact.down")
+          Text("Hide")
+        }
+      }
+    }
     .sheet(isPresented: $model.showingShareSheet) {
       ShareSheet(items: [
         "https://apps.apple.com/us/app/playola-radio/id6480465361",


### PR DESCRIPTION
This pull request enhances the user experience on the `InvitationCodePageView` by improving keyboard management for the invitation code input field. The most significant changes introduce multiple intuitive ways for users to dismiss the keyboard, streamline action handling, and tidy up the code.

**Keyboard management improvements:**

* Added a `@FocusState` property `isInputFocused` to track and control keyboard focus for the invitation code text field.
* Enabled keyboard dismissal by tapping outside the text field, dragging down, or using a custom "Hide" button in the keyboard toolbar.
* Bound the text field's focus state and updated the `.submitLabel` to `.send`, triggering the action when the user submits from the keyboard.

**Code simplification and cleanup:**

* Streamlined action button and join waitlist button handlers by removing unnecessary multi-line `Task` blocks. [[1]](diffhunk://#diff-0286142c6400b78b11afe84516169c94ead2809b794eac0832cdc0df322a9acaL82-R89) [[2]](diffhunk://#diff-0286142c6400b78b11afe84516169c94ead2809b794eac0832cdc0df322a9acaL112-R117)
* Removed commented-out padding code to keep the layout clean.