### PR TITLE
Bugfixes: Compressed Subtitle when Keyboard is Showing and NowPlayingUpdater Initialization

### DIFF
--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -15,6 +15,12 @@ struct ContentView: View {
   @Dependency(\.analytics) var analytics
   @State private var hasTrackedAppOpen = false
 
+  init() {
+    // Ensure StationPlayer and NowPlayingUpdater are initialized early
+    _ = StationPlayer.shared
+    _ = NowPlayingUpdater.shared
+  }
+
   var body: some View {
     Group {
       if auth.isLoggedIn {

--- a/PlayolaRadio/Views/Pages/InvitationCodePage/InvitationCodePageView.swift
+++ b/PlayolaRadio/Views/Pages/InvitationCodePage/InvitationCodePageView.swift
@@ -38,6 +38,8 @@ struct InvitationCodePageView: View {
             .multilineTextAlignment(.center)
             .lineSpacing(2)
             .padding(.horizontal, 38)
+            // don't compress vertically when keyboard is showing
+            .fixedSize(horizontal: false, vertical: true)
         }
       }
 


### PR DESCRIPTION
This pull request introduces improvements to app initialization and user interface layout. The most significant change ensures that key singleton components are initialized early in the app lifecycle, which can help prevent issues related to late initialization. Additionally, a UI tweak has been made to improve text layout when the keyboard is displayed.

App initialization:

* Added an `init()` method to `ContentView` that proactively initializes the `StationPlayer` and `NowPlayingUpdater` singletons to ensure they are ready when needed.

User interface enhancement:

* Updated the text view in `InvitationCodePageView` to use `.fixedSize(horizontal: false, vertical: true)`, preventing vertical compression of text when the keyboard appears.