### PR TITLE
Bugfix: Apple Sign In Bug

### DIFF
--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -60,9 +60,9 @@ class SignInPageModel: ViewModel {
     }
   }
 
-  func signInWithAppleButtonTapped(request: ASAuthorizationAppleIDRequest) async {
+  func signInWithAppleButtonTapped(request: ASAuthorizationAppleIDRequest) {
     request.requestedScopes = [.email, .fullName]
-    await analytics.track(.signInStarted(method: .apple))
+    Task { await analytics.track(.signInStarted(method: .apple)) }
   }
 
   func signInWithAppleCompleted(result: Result<ASAuthorization, any Error>) {
@@ -93,6 +93,7 @@ class SignInPageModel: ViewModel {
 
       guard let email = appleIDCredential.email ?? appleSignInInfo?.email else {
         print("Error trying to sign in -- no email ever.")
+        Task { await analytics.track(.signInFailed(method: .apple, error: "No email ever.")) }
         return
       }
       Task {

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -59,9 +59,7 @@ struct SignInPage: View {
           // Auth buttons
           VStack(spacing: 16) {
             SignInWithAppleButton(.signIn) { request in
-              Task {
-                await model.signInWithAppleButtonTapped(request: request)
-              }
+              model.signInWithAppleButtonTapped(request: request)
             } onCompletion: { result in
               model.signInWithAppleCompleted(result: result)
             }


### PR DESCRIPTION
Scope was being set async.

This pull request refactors the Apple sign-in flow in the sign-in page, focusing on simplifying the handling of asynchronous analytics tracking and improving error logging. The changes ensure that analytics events are tracked without requiring the calling code to be asynchronous, and add tracking for failed sign-in attempts due to missing email information.

Apple Sign-In Flow Refactor:

* Changed `signInWithAppleButtonTapped` in `SignInPageModel` to be synchronous and internally launch analytics tracking asynchronously, simplifying its usage from the view layer (`SignInPageView.swift`). [[1]](diffhunk://#diff-23979c71fbf7d370eb24f0ec39c7afec109fba5d4be26ff6af25a9cdecb88a73L63-R65) [[2]](diffhunk://#diff-f7ebe63e24da352193cd0320c3063d02337ce7fdbb78478e98d243919848881fL62-R62)

Error Handling and Analytics:

* Added analytics tracking for failed Apple sign-in attempts when no email is provided, improving visibility into sign-in errors.