### PR TITLE
Toast

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -7,6 +7,11 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		D302576B2E63423D00F4228B /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
+		D302576D2E63428800F4228B /* ToastClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576C2E63428700F4228B /* ToastClient.swift */; };
+		D30257712E6342B400F4228B /* ToastModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257702E6342B200F4228B /* ToastModifier.swift */; };
+		D30257732E6342BA00F4228B /* ToastPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257722E6342B800F4228B /* ToastPreview.swift */; };
+		D30257762E6342C900F4228B /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257752E6342C600F4228B /* ToastView.swift */; };
 		D3137DBB2D3976580070033A /* PlayolaAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBA2D3976550070033A /* PlayolaAlert.swift */; };
 		D3137DC02D39818E0070033A /* MailServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBF2D3981880070033A /* MailServiceMock.swift */; };
 		D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DC12D39B4FC0070033A /* StationListPageTests.swift */; };
@@ -127,6 +132,11 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		D302576A2E63423B00F4228B /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
+		D302576C2E63428700F4228B /* ToastClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastClient.swift; sourceTree = "<group>"; };
+		D30257702E6342B200F4228B /* ToastModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastModifier.swift; sourceTree = "<group>"; };
+		D30257722E6342B800F4228B /* ToastPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastPreview.swift; sourceTree = "<group>"; };
+		D30257752E6342C600F4228B /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
 		D3137DBA2D3976550070033A /* PlayolaAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaAlert.swift; sourceTree = "<group>"; };
 		D3137DBF2D3981880070033A /* MailServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailServiceMock.swift; sourceTree = "<group>"; };
 		D3137DC12D39B4FC0070033A /* StationListPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPageTests.swift; sourceTree = "<group>"; };
@@ -258,6 +268,24 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		D302576E2E63429000F4228B /* Toast */ = {
+			isa = PBXGroup;
+			children = (
+				D302576C2E63428700F4228B /* ToastClient.swift */,
+			);
+			path = Toast;
+			sourceTree = "<group>";
+		};
+		D302576F2E6342AC00F4228B /* Toast */ = {
+			isa = PBXGroup;
+			children = (
+				D30257752E6342C600F4228B /* ToastView.swift */,
+				D30257722E6342B800F4228B /* ToastPreview.swift */,
+				D30257702E6342B200F4228B /* ToastModifier.swift */,
+			);
+			path = Toast;
+			sourceTree = "<group>";
+		};
 		D3137DBE2D3981750070033A /* Mocks */ = {
 			isa = PBXGroup;
 			children = (
@@ -283,6 +311,7 @@
 		D3137DD02D3ABB490070033A /* Models */ = {
 			isa = PBXGroup;
 			children = (
+				D302576A2E63423B00F4228B /* Toast.swift */,
 				D3FE88832E37EF24009AE7B7 /* PrizeTier.swift */,
 				D3B744CC2E368D790042A427 /* Prize.swift */,
 				D3B744B32E2FECC80042A427 /* LocalListeningSession.swift */,
@@ -324,6 +353,7 @@
 		D339E55D2BFD0FC200B9E35B /* Reusable Components */ = {
 			isa = PBXGroup;
 			children = (
+				D302576F2E6342AC00F4228B /* Toast */,
 				D37257C22DF8F875001BC6F9 /* SwiftUI Modifiers */,
 				D3B744C62E3139860042A427 /* ListeningTimeTile */,
 				D31CD5222DFBA1EC009B9780 /* ViewModel.swift */,
@@ -488,6 +518,7 @@
 		D378CCD12E58C37D00497A4A /* Core */ = {
 			isa = PBXGroup;
 			children = (
+				D302576E2E63429000F4228B /* Toast */,
 				D378CCD22E58C38D00497A4A /* Analytics */,
 				D378CCD32E58C3B100497A4A /* API */,
 				D378CCD42E58C3DC00497A4A /* Audio */,
@@ -804,8 +835,10 @@
 				D35673B22D3DC59300E4E926 /* RadioStation.swift in Sources */,
 				D3B744C22E31317B0042A427 /* RewardsPageView.swift in Sources */,
 				D37257B22DF88BC1001BC6F9 /* HomePageModel.swift in Sources */,
+				D30257732E6342BA00F4228B /* ToastPreview.swift in Sources */,
 				D35673BA2D3DC9EE00E4E926 /* Config.swift in Sources */,
 				D3B744B72E2FED940042A427 /* ListeningTracker.swift in Sources */,
+				D30257712E6342B400F4228B /* ToastModifier.swift in Sources */,
 				D31CD5232DFBA1F2009B9780 /* ViewModel.swift in Sources */,
 				D3B6626A2D40103C00975D2F /* SignInPageView.swift in Sources */,
 				D3536A3B2BFA6520006942D6 /* Color+Hex.swift in Sources */,
@@ -817,6 +850,7 @@
 				D35673C32D3E872600E4E926 /* CPListItem+InitWithRemoteUrl.swift in Sources */,
 				D3B744AD2E2FCD930042A427 /* MainContainerModel.swift in Sources */,
 				D39591172E39932600720CF8 /* ContactPageModel.swift in Sources */,
+				D302576B2E63423D00F4228B /* Toast.swift in Sources */,
 				D339E57E2BFD750700B9E35B /* MailService.swift in Sources */,
 				D339E56F2BFD306600B9E35B /* FRadioPlayerMetadata+Equatable.swift in Sources */,
 				D3FE88842E37EF29009AE7B7 /* PrizeTier.swift in Sources */,
@@ -843,6 +877,7 @@
 				D3B6626D2D4016C200975D2F /* NavigationCoordinator.swift in Sources */,
 				D378CCD02E57947800497A4A /* ShareSheet.swift in Sources */,
 				D3B744C02E3131730042A427 /* RewardsPageModel.swift in Sources */,
+				D302576D2E63428800F4228B /* ToastClient.swift in Sources */,
 				D3B744B02E2FE6FB0042A427 /* RewardsProfile.swift in Sources */,
 				D3137DD42D3AC9BE0070033A /* EnumTypeEquatableProtocol.swift in Sources */,
 				D3A08A3A2E53A788002468E0 /* InvitationCodePageView.swift in Sources */,
@@ -858,6 +893,7 @@
 				D339E56D2BFD2FAB00B9E35B /* URLStreamPlayer.swift in Sources */,
 				D339E5672BFD10AE00B9E35B /* StationListPage.swift in Sources */,
 				D37257C92DFA247D001BC6F9 /* MainContainer.swift in Sources */,
+				D30257762E6342C900F4228B /* ToastView.swift in Sources */,
 				D339E5692BFD1C0800B9E35B /* APIClient.swift in Sources */,
 				D382671C2E00C1460006BAC2 /* SmallPlayer.swift in Sources */,
 				D3536A052BFA4F49006942D6 /* PlayolaRadioApp.swift in Sources */,

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		D30257712E6342B400F4228B /* ToastModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257702E6342B200F4228B /* ToastModifier.swift */; };
 		D30257732E6342BA00F4228B /* ToastPreview.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257722E6342B800F4228B /* ToastPreview.swift */; };
 		D30257762E6342C900F4228B /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257752E6342C600F4228B /* ToastView.swift */; };
+		D30257792E634A2600F4228B /* ToastClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257772E634A1C00F4228B /* ToastClientTests.swift */; };
 		D3137DBB2D3976580070033A /* PlayolaAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBA2D3976550070033A /* PlayolaAlert.swift */; };
 		D3137DC02D39818E0070033A /* MailServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBF2D3981880070033A /* MailServiceMock.swift */; };
 		D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DC12D39B4FC0070033A /* StationListPageTests.swift */; };
@@ -137,6 +138,7 @@
 		D30257702E6342B200F4228B /* ToastModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastModifier.swift; sourceTree = "<group>"; };
 		D30257722E6342B800F4228B /* ToastPreview.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastPreview.swift; sourceTree = "<group>"; };
 		D30257752E6342C600F4228B /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
+		D30257772E634A1C00F4228B /* ToastClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastClientTests.swift; sourceTree = "<group>"; };
 		D3137DBA2D3976550070033A /* PlayolaAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaAlert.swift; sourceTree = "<group>"; };
 		D3137DBF2D3981880070033A /* MailServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailServiceMock.swift; sourceTree = "<group>"; };
 		D3137DC12D39B4FC0070033A /* StationListPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPageTests.swift; sourceTree = "<group>"; };
@@ -271,6 +273,7 @@
 		D302576E2E63429000F4228B /* Toast */ = {
 			isa = PBXGroup;
 			children = (
+				D30257772E634A1C00F4228B /* ToastClientTests.swift */,
 				D302576C2E63428700F4228B /* ToastClient.swift */,
 			);
 			path = Toast;
@@ -908,6 +911,7 @@
 			files = (
 				D38031352E00AFD20011DD64 /* PlayerPageTests.swift in Sources */,
 				D3137DC02D39818E0070033A /* MailServiceMock.swift in Sources */,
+				D30257792E634A2600F4228B /* ToastClientTests.swift in Sources */,
 				D3137DC62D39BEE00070033A /* URLStreamPlayerMock.swift in Sources */,
 				D3B744CB2E313B230042A427 /* ListeningTimeTileTests.swift in Sources */,
 				D3B744C52E31318A0042A427 /* RewardsPageTests.swift in Sources */,

--- a/PlayolaRadio/Core/Toast/ToastClient.swift
+++ b/PlayolaRadio/Core/Toast/ToastClient.swift
@@ -1,0 +1,6 @@
+//
+//  ToastClient.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/30/25.
+//

--- a/PlayolaRadio/Core/Toast/ToastClient.swift
+++ b/PlayolaRadio/Core/Toast/ToastClient.swift
@@ -4,3 +4,78 @@
 //
 //  Created by Brian D Keane on 8/30/25.
 //
+
+import ComposableArchitecture
+import Dependencies
+import Foundation
+
+@DependencyClient
+public struct ToastClient {
+  public var show: @Sendable (PlayolaToast) async -> Void
+  public var currentToast: @Sendable () async -> PlayolaToast?
+  public var dismiss: @Sendable () async -> Void
+}
+
+extension ToastClient: DependencyKey {
+  public static var liveValue: ToastClient {
+    let toastState = ToastState()
+
+    return ToastClient(
+      show: { toast in
+        await toastState.show(toast)
+      },
+      currentToast: {
+        await toastState.currentToast
+      },
+      dismiss: {
+        await toastState.dismiss()
+      }
+    )
+  }
+}
+
+private actor ToastState {
+  private(set) var currentToast: PlayolaToast?
+  private var toastQueue: [PlayolaToast] = []
+  private var dismissTask: Task<Void, Never>?
+  @Dependency(\.continuousClock) var clock
+
+  func show(_ toast: PlayolaToast) {
+    toastQueue.append(toast)
+    if currentToast == nil {
+      Task {
+        await showNext()
+      }
+    }
+  }
+
+  func dismiss() {
+    dismissTask?.cancel()
+    dismissTask = nil
+    currentToast = nil
+    Task {
+      await showNext()
+    }
+  }
+
+  private func showNext() async {
+    guard currentToast == nil, !toastQueue.isEmpty else { return }
+
+    let toast = toastQueue.removeFirst()
+    currentToast = toast
+
+    dismissTask = Task {
+      try? await clock.sleep(for: .seconds(toast.duration))
+      guard !Task.isCancelled else { return }
+      currentToast = nil
+      await showNext()
+    }
+  }
+}
+
+extension DependencyValues {
+  public var toast: ToastClient {
+    get { self[ToastClient.self] }
+    set { self[ToastClient.self] = newValue }
+  }
+}

--- a/PlayolaRadio/Core/Toast/ToastClientTests.swift
+++ b/PlayolaRadio/Core/Toast/ToastClientTests.swift
@@ -1,0 +1,340 @@
+//
+//  ToastClientTests.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/30/25.
+//
+
+import Dependencies
+import XCTest
+
+@testable import PlayolaRadio
+
+@MainActor
+final class ToastClientTests: XCTestCase {
+
+  // MARK: - Basic Show/Dismiss
+
+  func testShow_SetsCurrentToast() async {
+    await withDependencies {
+      $0.continuousClock = TestClock()
+    } operation: {
+      let toast = PlayolaToast(
+        message: "Test message",
+        buttonTitle: "OK"
+      )
+
+      let client = ToastClient.liveValue
+
+      await client.show(toast)
+
+      let currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "Test message")
+      XCTAssertEqual(currentToast?.buttonTitle, "OK")
+    }
+  }
+
+  func testDismiss_ClearsCurrentToast() async {
+    await withDependencies {
+      $0.continuousClock = TestClock()
+    } operation: {
+      let toast = PlayolaToast(
+        message: "Test message",
+        buttonTitle: "OK"
+      )
+
+      let client = ToastClient.liveValue
+
+      await client.show(toast)
+      let currentToast = await client.currentToast()
+      XCTAssertNotNil(currentToast)
+
+      await client.dismiss()
+
+      let dismissedToast = await client.currentToast()
+      XCTAssertNil(dismissedToast)
+    }
+  }
+
+  // MARK: - Queue Management
+
+  func testShow_QueuesMultipleToasts() async {
+    await withDependencies {
+      $0.continuousClock = TestClock()
+    } operation: {
+      let toast1 = PlayolaToast(
+        message: "First toast",
+        buttonTitle: "OK"
+      )
+      let toast2 = PlayolaToast(
+        message: "Second toast",
+        buttonTitle: "OK"
+      )
+
+      let client = ToastClient.liveValue
+
+      await client.show(toast1)
+      await client.show(toast2)
+
+      let currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "First toast")
+
+      await client.dismiss()
+
+      let nextToast = await client.currentToast()
+      XCTAssertEqual(nextToast?.message, "Second toast")
+    }
+  }
+
+  func testQueue_ShowsToastsInOrder() async {
+    await withDependencies {
+      $0.continuousClock = TestClock()
+    } operation: {
+      let toast1 = PlayolaToast(message: "First", buttonTitle: "OK")
+      let toast2 = PlayolaToast(message: "Second", buttonTitle: "OK")
+      let toast3 = PlayolaToast(message: "Third", buttonTitle: "OK")
+
+      let client = ToastClient.liveValue
+
+      await client.show(toast1)
+      await client.show(toast2)
+      await client.show(toast3)
+
+      var currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "First")
+
+      await client.dismiss()
+      currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "Second")
+
+      await client.dismiss()
+      currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "Third")
+
+      await client.dismiss()
+      currentToast = await client.currentToast()
+      XCTAssertNil(currentToast)
+    }
+  }
+
+  // MARK: - Auto-dismiss
+
+  func testAutoDismiss_AfterSpecifiedDuration() async {
+    let clock = TestClock()
+
+    await withDependencies {
+      $0.continuousClock = clock
+    } operation: {
+      let toast = PlayolaToast(
+        message: "Test message",
+        buttonTitle: "OK",
+        duration: 2.0
+      )
+
+      let client = ToastClient.liveValue
+
+      await client.show(toast)
+
+      var currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "Test message")
+
+      await clock.advance(by: .seconds(1.0))
+      currentToast = await client.currentToast()
+      XCTAssertNotNil(currentToast)
+
+      await clock.advance(by: .seconds(1.5))
+      currentToast = await client.currentToast()
+      XCTAssertNil(currentToast)
+    }
+  }
+
+  func testAutoDismiss_ShowsNextToastInQueue() async {
+    let clock = TestClock()
+
+    await withDependencies {
+      $0.continuousClock = clock
+    } operation: {
+      let toast1 = PlayolaToast(
+        message: "First toast",
+        buttonTitle: "OK",
+        duration: 1.0
+      )
+      let toast2 = PlayolaToast(
+        message: "Second toast",
+        buttonTitle: "OK",
+        duration: 2.0
+      )
+
+      let client = ToastClient.liveValue
+
+      await client.show(toast1)
+      await client.show(toast2)
+
+      var currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "First toast")
+
+      await clock.advance(by: .seconds(1.5))
+
+      currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "Second toast")
+    }
+  }
+
+  // MARK: - Manual Dismiss
+
+  func testManualDismiss_CancelsAutoDismissTimer() async {
+    let clock = TestClock()
+
+    await withDependencies {
+      $0.continuousClock = clock
+    } operation: {
+      let toast = PlayolaToast(
+        message: "Test toast",
+        buttonTitle: "OK",
+        duration: 3.0
+      )
+
+      let client = ToastClient.liveValue
+
+      await client.show(toast)
+
+      var currentToast = await client.currentToast()
+      XCTAssertNotNil(currentToast)
+
+      await client.dismiss()
+
+      currentToast = await client.currentToast()
+      XCTAssertNil(currentToast)
+
+      // Ensure timer was cancelled - toast shouldn't resurrect
+      await clock.advance(by: .seconds(5.0))
+      currentToast = await client.currentToast()
+      XCTAssertNil(currentToast)
+    }
+  }
+
+  func testManualDismiss_ShowsNextToastInQueue() async {
+    await withDependencies {
+      $0.continuousClock = TestClock()
+    } operation: {
+      let toast1 = PlayolaToast(
+        message: "First toast",
+        buttonTitle: "OK",
+        duration: 5.0  // Long duration to ensure we dismiss manually
+      )
+      let toast2 = PlayolaToast(
+        message: "Second toast",
+        buttonTitle: "OK"
+      )
+
+      let client = ToastClient.liveValue
+
+      await client.show(toast1)
+      await client.show(toast2)
+
+      var currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "First toast")
+
+      await client.dismiss()
+
+      currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "Second toast")
+    }
+  }
+
+  // MARK: - Concurrent Access
+
+  func testConcurrentShow_SafelyQueuesAllToasts() async {
+    await withDependencies {
+      $0.continuousClock = TestClock()
+    } operation: {
+      let toast1 = PlayolaToast(message: "Toast 1", buttonTitle: "OK")
+      let toast2 = PlayolaToast(message: "Toast 2", buttonTitle: "OK")
+      let toast3 = PlayolaToast(message: "Toast 3", buttonTitle: "OK")
+
+      let client = ToastClient.liveValue
+
+      async let show1 = client.show(toast1)
+      async let show2 = client.show(toast2)
+      async let show3 = client.show(toast3)
+
+      await show1
+      await show2
+      await show3
+
+      let currentToast = await client.currentToast()
+      XCTAssertNotNil(currentToast)
+      XCTAssertTrue(
+        ["Toast 1", "Toast 2", "Toast 3"].contains(currentToast?.message)
+      )
+
+      await client.dismiss()
+      let secondToast = await client.currentToast()
+      XCTAssertNotNil(secondToast)
+
+      await client.dismiss()
+      let thirdToast = await client.currentToast()
+      XCTAssertNotNil(thirdToast)
+
+      await client.dismiss()
+      let finalToast = await client.currentToast()
+      XCTAssertNil(finalToast)
+    }
+  }
+
+  // MARK: - Toast Actions
+
+  func testToastAction_ExecutesWhenInvoked() async {
+    await withDependencies {
+      $0.continuousClock = TestClock()
+    } operation: {
+      var actionExecuted = false
+
+      let toast = PlayolaToast(
+        message: "Test",
+        buttonTitle: "OK",
+        action: {
+          actionExecuted = true
+        }
+      )
+
+      toast.action?()
+
+      XCTAssertTrue(actionExecuted)
+    }
+  }
+
+  // MARK: - Edge Cases
+
+  func testDismiss_WhenNoCurrentToast_DoesNothing() async {
+    await withDependencies {
+      $0.continuousClock = TestClock()
+    } operation: {
+      let client = ToastClient.liveValue
+
+      await client.dismiss()
+
+      let currentToast = await client.currentToast()
+      XCTAssertNil(currentToast)
+    }
+  }
+
+  func testShow_WithZeroDuration_StillShowsToast() async {
+    await withDependencies {
+      $0.continuousClock = TestClock()
+    } operation: {
+      let toast = PlayolaToast(
+        message: "Zero duration",
+        buttonTitle: "OK",
+        duration: 0.0
+      )
+
+      let client = ToastClient.liveValue
+
+      await client.show(toast)
+
+      let currentToast = await client.currentToast()
+      XCTAssertEqual(currentToast?.message, "Zero duration")
+    }
+  }
+}

--- a/PlayolaRadio/Models/Toast.swift
+++ b/PlayolaRadio/Models/Toast.swift
@@ -7,14 +7,14 @@
 
 import Foundation
 
-struct PlayolaToast: Identifiable {
-  let id = UUID()
-  let message: String
-  let buttonTitle: String
-  let duration: TimeInterval
-  let action: (() -> Void)?
+public struct PlayolaToast: Identifiable {
+  public let id = UUID()
+  public let message: String
+  public let buttonTitle: String
+  public let duration: TimeInterval
+  public let action: (() -> Void)?
 
-  init(
+  public init(
     message: String,
     buttonTitle: String,
     duration: TimeInterval = 3.0,
@@ -28,7 +28,7 @@ struct PlayolaToast: Identifiable {
 }
 
 extension PlayolaToast: Equatable {
-  static func == (lhs: PlayolaToast, rhs: PlayolaToast) -> Bool {
+  public static func == (lhs: PlayolaToast, rhs: PlayolaToast) -> Bool {
     lhs.id == rhs.id
   }
 }

--- a/PlayolaRadio/Models/Toast.swift
+++ b/PlayolaRadio/Models/Toast.swift
@@ -1,0 +1,34 @@
+//
+//  Toast.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/30/25.
+//
+
+import Foundation
+
+struct PlayolaToast: Identifiable {
+  let id = UUID()
+  let message: String
+  let buttonTitle: String
+  let duration: TimeInterval
+  let action: (() -> Void)?
+
+  init(
+    message: String,
+    buttonTitle: String,
+    duration: TimeInterval = 3.0,
+    action: (() -> Void)? = nil
+  ) {
+    self.message = message
+    self.buttonTitle = buttonTitle
+    self.duration = duration
+    self.action = action
+  }
+}
+
+extension PlayolaToast: Equatable {
+  static func == (lhs: PlayolaToast, rhs: PlayolaToast) -> Bool {
+    lhs.id == rhs.id
+  }
+}

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -21,6 +21,7 @@ class HomePageModel: ViewModel {
   @ObservationIgnored @Shared(.auth) var auth: Auth
   @ObservationIgnored @Shared(.activeTab) var activeTab
   @ObservationIgnored @Dependency(\.analytics) var analytics
+  @ObservationIgnored @Dependency(\.toast) var toast
 
   @ObservationIgnored var stationPlayer: StationPlayer
 
@@ -73,5 +74,19 @@ class HomePageModel: ViewModel {
         entryPoint: "home_recommendations"
       ))
     stationPlayer.play(station: station)
+  }
+
+  func testShowToast() {
+    Task {
+      await toast.show(
+        PlayolaToast(
+          message: "Added to Liked Songs",
+          buttonTitle: "View all",
+          action: {
+            print("View all tapped!")
+          }
+        )
+      )
+    }
   }
 }

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
@@ -29,6 +29,15 @@ struct HomePageView: View {
 
           ListeningTimeTile(model: model.listeningTimeTileModel)
 
+          // Temporary test button for toast
+          Button("Test Toast") {
+            model.testShowToast()
+          }
+          .padding()
+          .background(Color.white)
+          .foregroundColor(.black)
+          .cornerRadius(8)
+
           HomePageStationList(stations: model.forYouStations) { station in
             Task { await model.handleStationTapped(station) }
           }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -84,6 +84,15 @@ struct MainContainer: View {
         }
       }
     )
+    .overlay(alignment: .bottom) {
+      if let toast = model.presentedToast {
+        ToastView(toast: toast)
+          .padding(.horizontal, 20)
+          .padding(.bottom, 0)
+          .transition(.move(edge: .bottom).combined(with: .opacity))
+      }
+    }
+    .animation(.easeInOut(duration: 0.3), value: model.presentedToast)
     .onAppear { Task { await model.viewAppeared() } }
 
   }

--- a/PlayolaRadio/Views/Reusable Components/Toast/ToastModifier.swift
+++ b/PlayolaRadio/Views/Reusable Components/Toast/ToastModifier.swift
@@ -1,0 +1,7 @@
+//
+//  ToastModifier.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/30/25.
+//
+

--- a/PlayolaRadio/Views/Reusable Components/Toast/ToastPreview.swift
+++ b/PlayolaRadio/Views/Reusable Components/Toast/ToastPreview.swift
@@ -1,0 +1,7 @@
+//
+//  ToastPreview.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/30/25.
+//
+

--- a/PlayolaRadio/Views/Reusable Components/Toast/ToastView.swift
+++ b/PlayolaRadio/Views/Reusable Components/Toast/ToastView.swift
@@ -1,0 +1,69 @@
+//
+//  ToastView.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/30/25.
+//
+
+import SwiftUI
+
+struct ToastView: View {
+    let toast: PlayolaToast
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            Text(toast.message)
+                .font(.custom("Inter", size: 16))
+                .fontWeight(.medium)
+                .foregroundColor(.black)
+                .lineLimit(1)
+                .padding(.vertical, 14)
+                .padding(.leading, 16)
+            
+            Spacer()
+            
+            Button(action: {
+                toast.action?()
+            }) {
+                Text(toast.buttonTitle)
+                    .font(.custom("Inter", size: 16))
+                    .fontWeight(.semibold)
+                    .foregroundColor(Color(hex: "#EF6962"))
+                    .padding(.vertical, 12)
+                    .padding(.trailing, 16)
+            }
+        }
+        .frame(maxWidth: .infinity)
+        .background(Color.white)
+        .cornerRadius(8)
+        .shadow(color: Color.black.opacity(0.15), radius: 10, x: 0, y: 5)
+    }
+}
+
+#Preview {
+    ZStack {
+        Color.black
+            .ignoresSafeArea()
+        
+        VStack(spacing: 20) {
+            ToastView(toast: PlayolaToast(
+                message: "Added to Liked Songs",
+                buttonTitle: "View all",
+                action: { print("View all tapped") }
+            ))
+            
+            ToastView(toast: PlayolaToast(
+                message: "Song removed",
+                buttonTitle: "Undo",
+                action: { print("Undo tapped") }
+            ))
+            
+            ToastView(toast: PlayolaToast(
+                message: "Network error",
+                buttonTitle: "Retry",
+                action: { print("Retry tapped") }
+            ))
+        }
+        .padding(.horizontal, 26)
+    }
+}

--- a/PlayolaRadio/Views/Reusable Components/Toast/ToastView.swift
+++ b/PlayolaRadio/Views/Reusable Components/Toast/ToastView.swift
@@ -24,14 +24,14 @@ struct ToastView: View {
             
             Button(action: {
                 toast.action?()
-            }) {
+            }, label: {
                 Text(toast.buttonTitle)
                     .font(.custom("Inter", size: 16))
                     .fontWeight(.semibold)
                     .foregroundColor(Color(hex: "#EF6962"))
                     .padding(.vertical, 12)
                     .padding(.trailing, 16)
-            }
+            })
         }
         .frame(maxWidth: .infinity)
         .background(Color.white)

--- a/PlayolaRadio/Views/Reusable Components/Toast/ToastView.swift
+++ b/PlayolaRadio/Views/Reusable Components/Toast/ToastView.swift
@@ -8,62 +8,71 @@
 import SwiftUI
 
 struct ToastView: View {
-    let toast: PlayolaToast
-    
-    var body: some View {
-        HStack(spacing: 0) {
-            Text(toast.message)
-                .font(.custom("Inter", size: 16))
-                .fontWeight(.medium)
-                .foregroundColor(.black)
-                .lineLimit(1)
-                .padding(.vertical, 14)
-                .padding(.leading, 16)
-            
-            Spacer()
-            
-            Button(action: {
-                toast.action?()
-            }, label: {
-                Text(toast.buttonTitle)
-                    .font(.custom("Inter", size: 16))
-                    .fontWeight(.semibold)
-                    .foregroundColor(Color(hex: "#EF6962"))
-                    .padding(.vertical, 12)
-                    .padding(.trailing, 16)
-            })
+  let toast: PlayolaToast
+
+  var body: some View {
+    HStack(spacing: 0) {
+      Text(toast.message)
+        .font(.custom("Inter", size: 16))
+        .fontWeight(.medium)
+        .foregroundColor(.black)
+        .lineLimit(1)
+        .padding(.vertical, 14)
+        .padding(.leading, 16)
+
+      Spacer()
+
+      Button(
+        action: {
+          toast.action?()
+        },
+        label: {
+          Text(toast.buttonTitle)
+            .font(.custom("Inter", size: 16))
+            .fontWeight(.semibold)
+            .foregroundColor(Color(hex: "#EF6962"))
+            .padding(.vertical, 12)
+            .padding(.trailing, 16)
         }
-        .frame(maxWidth: .infinity)
-        .background(Color.white)
-        .cornerRadius(8)
-        .shadow(color: Color.black.opacity(0.15), radius: 10, x: 0, y: 5)
+      )
     }
+    .frame(maxWidth: .infinity)
+    .background(Color.white)
+    .cornerRadius(8)
+    .shadow(color: Color.black.opacity(0.15), radius: 10, x: 0, y: 5)
+  }
 }
 
 #Preview {
-    ZStack {
-        Color.black
-            .ignoresSafeArea()
-        
-        VStack(spacing: 20) {
-            ToastView(toast: PlayolaToast(
-                message: "Added to Liked Songs",
-                buttonTitle: "View all",
-                action: { print("View all tapped") }
-            ))
-            
-            ToastView(toast: PlayolaToast(
-                message: "Song removed",
-                buttonTitle: "Undo",
-                action: { print("Undo tapped") }
-            ))
-            
-            ToastView(toast: PlayolaToast(
-                message: "Network error",
-                buttonTitle: "Retry",
-                action: { print("Retry tapped") }
-            ))
-        }
-        .padding(.horizontal, 26)
+  ZStack {
+    Color.black
+      .ignoresSafeArea()
+
+    VStack(spacing: 20) {
+      ToastView(
+        toast: PlayolaToast(
+          message: "Added to Liked Songs",
+          buttonTitle: "View all",
+          action: { print("View all tapped") }
+        )
+      )
+
+      ToastView(
+        toast: PlayolaToast(
+          message: "Song removed",
+          buttonTitle: "Undo",
+          action: { print("Undo tapped") }
+        )
+      )
+
+      ToastView(
+        toast: PlayolaToast(
+          message: "Network error",
+          buttonTitle: "Retry",
+          action: { print("Retry tapped") }
+        )
+      )
     }
+    .padding(.horizontal, 26)
+  }
 }


### PR DESCRIPTION
This pull request introduces a new reusable Toast notification system to the app, including its model, client, UI integration, and comprehensive tests. The Toast system allows for easy display, queuing, and dismissal of toast notifications across the app using dependency injection. A temporary test button has also been added to the Home Page for manual testing of the toast feature.

**Toast System Implementation**

* Added `PlayolaToast` model (`Toast.swift`) to represent toast notifications, including fields for message, button title, duration, and an optional action.
* Implemented `ToastClient` as a dependency client, providing async methods to show, dismiss, and query the current toast. It internally manages toast state and a queue, supporting auto-dismiss and manual dismissal.
* Added `ToastClientTests.swift` with thorough unit tests covering toast display, queuing, auto-dismiss, manual dismiss, concurrent access, and edge cases.

**Project Structure & Integration**

* Updated `PlayolaRadio.xcodeproj/project.pbxproj` to add new files and organize them into `Toast` groups under both Core and Reusable Components, ensuring proper visibility and build integration. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R10-R15) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R136-R141) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R273-R291) [[4]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R317) [[5]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R359) [[6]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R524) [[7]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R841-R844) [[8]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R856) [[9]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R883) [[10]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R899) [[11]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R914)

**Home Page Integration**

* Injected the new toast dependency into `HomePageModel` and added a `testShowToast()` helper method to trigger a toast notification. [[1]](diffhunk://#diff-03191d1666537add6fec71dc4780976ef85260e650560180ac402b7199947940R24) [[2]](diffhunk://#diff-03191d1666537add6fec71dc4780976ef85260e650560180ac402b7199947940R78-R91)
* Added a temporary "Test Toast" button to `HomePageView` to manually test the toast notification feature in the UI.