### PR TITLE
Update PlayolaPlayer to 0.9.0 (Fade and Scheduling Improvements)

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -1489,7 +1489,7 @@
 			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.8.2;
+				minimumVersion = 0.9.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
This pull request updates the minimum required version of the `PlayolaPlayer` Swift package dependency in the Xcode project configuration. This change ensures that the project uses at least version 0.9.0 of `PlayolaPlayer`, which may include important updates or fixes.

* Increased the minimum required version of the `PlayolaPlayer` Swift package from `0.8.2` to `0.9.0` in `PlayolaRadio.xcodeproj/project.pbxproj`.