### PR TITLE
Version Bump - 4.5.1b

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -1132,7 +1132,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -1174,7 +1174,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -1317,7 +1317,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 38;
+				CURRENT_PROJECT_VERSION = 39;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;


### PR DESCRIPTION
This pull request increments the project version number in the Xcode project file. This is a routine update to reflect a new build or release.

* Increased the `CURRENT_PROJECT_VERSION` from 38 to 39 in three locations within the `PlayolaRadio.xcodeproj/project.pbxproj` file. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1135-R1135) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1177-R1177) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1320-R1320)