### PR TITLE
UX Cleanup

### DIFF
--- a/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
@@ -95,11 +95,11 @@ struct PrizeTierRow: View {
             .foregroundColor(.white)
             .fixedSize(horizontal: true, vertical: false)
         }
-        .frame(minWidth: 150, alignment: .trailing)
+        .frame(maxWidth: .infinity, alignment: .leading)
       }
     }
     .padding(.vertical, 12)
-    .padding(.horizontal, 16)
+    .padding(.horizontal, 20)
     .background(Color.black)
     .cornerRadius(12)
   }

--- a/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageView.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageView.swift
@@ -64,7 +64,6 @@ struct RewardsPageView: View {
           }
           .background(Color(white: 0.08))
           .cornerRadius(12)
-          .padding(.horizontal, 20)
         }
       }
       .padding(.top, 20)

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -105,7 +105,7 @@ private struct StationRowView: View {
 
   var body: some View {
     Button(action: action) {
-      HStack(spacing: 12) {
+      HStack(spacing: 16) {
         if let url = URL(string: station.imageURL) {
           AsyncImage(url: url) { image in
             image

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -115,6 +115,7 @@ private struct StationRowView: View {
             Color(white: 0.2)
           }
           .frame(width: 64, height: 64)
+          .clipped()
           .cornerRadius(6)
         }
 

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -49,7 +49,7 @@ struct SmallPlayer: View {
   var body: some View {
     VStack(spacing: 0) {
       // Player bar
-      HStack(spacing: 12) {
+      HStack(spacing: 16) {
         // Artwork
         AsyncImage(url: artworkURL) { phase in
           switch phase {

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -61,8 +61,8 @@ struct SmallPlayer: View {
             Color.gray.opacity(0.3)
           }
         }
-        .frame(width: 48, height: 48)
-        .padding(.leading, 16)
+        .frame(width: 64, height: 64)
+        .clipped()
         .clipShape(RoundedRectangle(cornerRadius: 6))
 
         // Title & subtitle
@@ -106,7 +106,7 @@ struct SmallPlayer: View {
         )
         .padding(.trailing, 24)
       }
-      .padding(.horizontal, 12)
+      .padding(.horizontal)
       .padding(.vertical, 8)
       .background(Color.black.opacity(0.85))
 


### PR DESCRIPTION
* Line up stationplayer with station list
* Line up prize tiers

This pull request introduces layout adjustments to the rewards page components to improve visual alignment and spacing. The most important changes are focused on enhancing the appearance and consistency of prize tier rows and the overall rewards page.

**Layout and Alignment Improvements:**

* Updated the frame of the `PrizeTierRow` to use `maxWidth: .infinity` and `alignment: .leading` for better horizontal alignment and responsiveness.
* Increased horizontal padding in `PrizeTierRow` from 16 to 20 for improved spacing.

**Rewards Page Container Adjustment:**

* Removed the redundant horizontal padding from the rewards page container to avoid double spacing and ensure consistent margins.