### PR TITLE
Add Station Replay from Lock Screen

### DIFF
--- a/PlayolaRadio/Core/Audio/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/Audio/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -6,6 +6,7 @@
 //
 
 import Dependencies
+import MediaPlayer
 import XCTest
 
 @testable import PlayolaRadio


### PR DESCRIPTION
This pull request refines the handling of remote playback commands and inactivity in the `NowPlayingUpdater` class, and updates related tests. The main focus is on improving how the play command works when playback is stopped, simplifying command setup, and making the inactivity timer more accessible.

**Remote Command Handling Improvements:**

* The play command now only restarts the last played station if playback is currently stopped, and returns `.commandFailed` otherwise. This prevents unintended behavior when playback is already active.
* Removed custom handling for the pause command, focusing only on play and stop commands for remote control events.

**Inactivity Timer and State Management:**

* Made `startInactivityTimer` public to allow external triggering, increasing flexibility for managing inactivity.
* No longer clears the `lastPlayedStation` when the inactivity timer fires and remote control is released, preserving station history for future playback.

**Testing Updates:**

* Added `MediaPlayer` import to `NowPlayingUpdaterTests.swift` to support new remote command logic in tests.