### PR TITLE
Bump PlayolaPlayer (0.9.2 for reset fades)

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -1489,7 +1489,7 @@
 			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 0.9.1;
+				minimumVersion = 0.9.2;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
This pull request updates the minimum required version of the `PlayolaPlayer` Swift package dependency in the `PlayolaRadio.xcodeproj/project.pbxproj` file. This ensures the project uses at least version 0.9.2 of the package, which may include important bug fixes or new features.

* Dependency update:
  * Increased the minimum required version of the `PlayolaPlayer` Swift package from 0.9.1 to 0.9.2 in `PlayolaRadio.xcodeproj/project.pbxproj`.