### PR TITLE
fix: copy real secrets in setup-conductor instead of example file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,9 @@ release-staging:
 	bundle exec fastlane release_staging
 
 # Set up workspace for Conductor agents
+ORIGINAL_REPO := $(HOME)/playola/playola-radio-ios
 setup-conductor:
 	@for f in Secrets Secrets-Development Secrets-Local Secrets-Staging; do \
 		test -f PlayolaRadio/Config/$$f.xcconfig \
-			|| cp PlayolaRadio/Config/Secrets-Example.xcconfig PlayolaRadio/Config/$$f.xcconfig; \
+			|| cp $(ORIGINAL_REPO)/PlayolaRadio/Config/$$f.xcconfig PlayolaRadio/Config/$$f.xcconfig; \
 	done

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+ORIGINAL_REPO := $(HOME)/playola/playola-radio-ios
+
 .PHONY: lint format format-check release bump-build release-production release-staging setup-conductor
 
 # Run SwiftLint (strict mode to match CI)
@@ -35,8 +37,8 @@ release-staging:
 	bundle exec fastlane release_staging
 
 # Set up workspace for Conductor agents
-ORIGINAL_REPO := $(HOME)/playola/playola-radio-ios
 setup-conductor:
+	@test -d $(ORIGINAL_REPO) || (echo "ERROR: Original repo not found at $(ORIGINAL_REPO). Set ORIGINAL_REPO to the correct path." && exit 1)
 	@for f in Secrets Secrets-Development Secrets-Local Secrets-Staging; do \
 		test -f PlayolaRadio/Config/$$f.xcconfig \
 			|| cp $(ORIGINAL_REPO)/PlayolaRadio/Config/$$f.xcconfig PlayolaRadio/Config/$$f.xcconfig; \


### PR DESCRIPTION
## Summary
Copy each environment's actual secrets file (Secrets, Secrets-Development, Secrets-Local, Secrets-Staging) from the original repo instead of copying the example file for all of them.

This fixes the setup-conductor target to properly initialize the workspace with real credentials.

## Test plan
- [x] Makefile syntax verified
- [x] Variable substitution tested
- [x] Tests not affected (infrastructure only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)