### PR TITLE
Migrate to StreamingStationPlayer (PlayolaPlayer 0.15.0)

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -1615,7 +1615,7 @@
 			);
 			mainGroup = D35369F82BFA4F49006942D6;
 			packageReferences = (
-				D3CE19012D3C825C0091B888 /* XCRemoteSwiftPackageReference "PlayolaPlayer" */,
+				D3CE19012D3C825C0091B888 /* XCRemoteSwiftPackageReference "playola-player-swift" */,
 				D35673B52D3DC6EC00E4E926 /* XCRemoteSwiftPackageReference "mixpanel-swift" */,
 				D3B662662D3F58E700975D2F /* XCRemoteSwiftPackageReference "FRadioPlayer" */,
 				D3B6626E2D40352500975D2F /* XCRemoteSwiftPackageReference "Alamofire" */,
@@ -2640,12 +2640,12 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
-		D30F00382E8592F0007BCC73 /* XCRemoteSwiftPackageReference "PlayolaPlayer" */ = {
+		D30F00382E8592F0007BCC73 /* XCRemoteSwiftPackageReference "playola-player-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
+			repositoryURL = "https://github.com/playola-radio/playola-player-swift";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.10.0;
+				minimumVersion = 0.15.0;
 			};
 		};
 		D30F003A2E8592F0007BCC73 /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {
@@ -2792,12 +2792,12 @@
 				version = 0.10.0;
 			};
 		};
-		D3CE19012D3C825C0091B888 /* XCRemoteSwiftPackageReference "PlayolaPlayer" */ = {
+		D3CE19012D3C825C0091B888 /* XCRemoteSwiftPackageReference "playola-player-swift" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
+			repositoryURL = "https://github.com/playola-radio/playola-player-swift";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.14.0;
+				minimumVersion = 0.15.0;
 			};
 		};
 		9E0939D453C04700B9C51BBD /* XCRemoteSwiftPackageReference "sentry-cocoa" */ = {
@@ -2817,7 +2817,7 @@
 		};
 		D30F00372E8592F0007BCC73 /* PlayolaPlayer */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = D30F00382E8592F0007BCC73 /* XCRemoteSwiftPackageReference "PlayolaPlayer" */;
+			package = D30F00382E8592F0007BCC73 /* XCRemoteSwiftPackageReference "playola-player-swift" */;
 			productName = PlayolaPlayer;
 		};
 		D30F00392E8592F0007BCC73 /* Mixpanel */ = {
@@ -2951,7 +2951,7 @@
 		};
 		D3CE19022D3C825C0091B888 /* PlayolaPlayer */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = D3CE19012D3C825C0091B888 /* XCRemoteSwiftPackageReference "PlayolaPlayer" */;
+			package = D3CE19012D3C825C0091B888 /* XCRemoteSwiftPackageReference "playola-player-swift" */;
 			productName = PlayolaPlayer;
 		};
 		0B6E1320AC744E9FAEC2F50F /* Sentry */ = {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -77,18 +77,14 @@ class NowPlayingUpdater {
   private var sessionStartTime: Date?
   private var lastPlaybackStatus: StationPlayer.PlaybackStatus = .stopped
   private func updateNowPlaying(with stationPlayerState: StationPlayer.State) {
-    print(
-      "🎵 NowPlayingUpdater: updateNowPlaying called with status: \(stationPlayerState.playbackStatus)"
-    )
-    print("🎵 Current station: \(stationPlayer.currentStation?.name ?? "nil")")
-
     guard let currentStation = stationPlayer.currentStation else {
-      print("🎵 No current station - clearing now playing info")
       clearNowPlayingInfo()
       return
     }
 
     lastPlayedStation = currentStation
+    updateSharedNowPlaying(with: stationPlayerState, station: currentStation)
+
     var nowPlayingInfo = buildNowPlayingInfo(
       for: stationPlayerState,
       station: currentStation
@@ -125,10 +121,12 @@ class NowPlayingUpdater {
   }
 
   private func clearNowPlayingInfo() {
-    print("🧹 Clearing now playing info")
     MPNowPlayingInfoCenter.default().playbackState = .stopped
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     currentArtworkURL = nil
+    $nowPlaying.withLock {
+      $0 = NowPlaying(playbackStatus: .stopped)
+    }
   }
 
   private func buildNowPlayingInfo(
@@ -143,8 +141,8 @@ class NowPlayingUpdater {
     switch state.playbackStatus {
     case .playing:
       populatePlayingInfo(&nowPlayingInfo, state: state, station: station)
-    case .loading(_, let progress):
-      populateLoadingInfo(&nowPlayingInfo, station: station, progress: progress)
+    case .loading:
+      populateLoadingInfo(&nowPlayingInfo, station: station)
     case .stopped:
       populateStoppedInfo(&nowPlayingInfo, state: state)
     case .startingNewStation:
@@ -223,16 +221,10 @@ class NowPlayingUpdater {
 
   private func populateLoadingInfo(
     _ info: inout [String: Any],
-    station: AnyStation,
-    progress: Float?
+    station: AnyStation
   ) {
     info[MPMediaItemPropertyTitle] = "Loading \(station.name)..."
     info[MPMediaItemPropertyArtist] = station.name
-
-    if let progress = progress {
-      info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = Double(progress * 100)
-      info[MPMediaItemPropertyPlaybackDuration] = 100.0
-    }
   }
 
   private func populateStoppedInfo(
@@ -309,133 +301,23 @@ class NowPlayingUpdater {
       self.updateNowPlaying(with: state)
     }.store(in: &disposeBag)
     setupRemoteControlCenter()
-    setupSharedStateObservation()
   }
 
   // MARK: - Shared State Management
 
-  private func setupSharedStateObservation() {
-    // Observe StreamingStationPlayer state changes
-    stationPlayer.playolaStationPlayer.$state
-      .sink { [weak self] playolaState in
-        self?.processPlayolaStationPlayerState(playolaState)
-      }
-      .store(in: &disposeBag)
-
-    // Observe URLStreamPlayer state changes
-    URLStreamPlayer.shared.$state
-      .sink { [weak self] urlStreamState in
-        self?.processUrlStreamStateChanged(urlStreamState)
-      }
-      .store(in: &disposeBag)
-  }
-
-  // MARK: - State Processing Methods (duplicated from StationPlayer)
-
-  func processPlayolaStationPlayerState(
-    _ playolaState: StreamingStationPlayer.State?
+  private func updateSharedNowPlaying(
+    with state: StationPlayer.State,
+    station: AnyStation
   ) {
-    switch playolaState {
-    case .idle:
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: nil,
-          playbackStatus: .stopped
-        )
-      }
-    case .loading:
-      guard let currentStation = stationPlayer.currentStation else { return }
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: currentStation,
-          playbackStatus: .loading(currentStation)
-        )
-      }
-    case .playing(let nowPlayingData):
-      if let currentStation = stationPlayer.currentStation {
-        $nowPlaying.withLock {
-          $0 = NowPlaying(
-            artistPlaying: nowPlayingData.audioBlock.artist,
-            titlePlaying: nowPlayingData.audioBlock.title,
-            albumArtworkUrl: nowPlayingData.audioBlock.imageUrl,
-            playolaSpinPlaying: nowPlayingData,
-            currentStation: currentStation,
-            playbackStatus: .playing(currentStation)
-          )
-        }
-      }
-    case .none:
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: nil,
-          playbackStatus: .error
-        )
-      }
-    }
-  }
-
-  private func processUrlStreamStateChanged(
-    _ urlStreamPlayerState: URLStreamPlayer.State
-  ) {
-    switch urlStreamPlayerState.playerStatus {
-    case .loading:
-      guard let currentStation = stationPlayer.currentStation else { return }
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: currentStation,
-          playbackStatus: .loading(currentStation)
-        )
-      }
-    case .loadingFinished, .readyToPlay:
-      guard let currentStation = stationPlayer.currentStation else { return }
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: urlStreamPlayerState.nowPlaying?.artistName,
-          titlePlaying: urlStreamPlayerState.nowPlaying?.trackName,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: currentStation,
-          playbackStatus: .playing(currentStation)
-        )
-      }
-    case .error:
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: nil,
-          playbackStatus: .error
-        )
-      }
-    case .urlNotSet, .none:
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: nil,
-          playbackStatus: .stopped
-        )
-      }
+    $nowPlaying.withLock {
+      $0 = NowPlaying(
+        artistPlaying: state.artistPlaying,
+        titlePlaying: state.titlePlaying,
+        albumArtworkUrl: state.albumArtworkUrl,
+        playolaSpinPlaying: state.playolaSpinPlaying,
+        currentStation: station,
+        playbackStatus: state.playbackStatus
+      )
     }
   }
 

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -315,8 +315,8 @@ class NowPlayingUpdater {
   // MARK: - Shared State Management
 
   private func setupSharedStateObservation() {
-    // Observe PlayolaStationPlayer state changes
-    PlayolaStationPlayer.shared.$state
+    // Observe StreamingStationPlayer state changes
+    stationPlayer.playolaStationPlayer.$state
       .sink { [weak self] playolaState in
         self?.processPlayolaStationPlayerState(playolaState)
       }
@@ -333,7 +333,7 @@ class NowPlayingUpdater {
   // MARK: - State Processing Methods (duplicated from StationPlayer)
 
   func processPlayolaStationPlayerState(
-    _ playolaState: PlayolaStationPlayer.State?
+    _ playolaState: StreamingStationPlayer.State?
   ) {
     switch playolaState {
     case .idle:
@@ -347,7 +347,7 @@ class NowPlayingUpdater {
           playbackStatus: .stopped
         )
       }
-    case .loading(let progress):
+    case .loading:
       guard let currentStation = stationPlayer.currentStation else { return }
       $nowPlaying.withLock {
         $0 = NowPlaying(
@@ -356,7 +356,7 @@ class NowPlayingUpdater {
           albumArtworkUrl: nil,
           playolaSpinPlaying: nil,
           currentStation: currentStation,
-          playbackStatus: .loading(currentStation, progress)
+          playbackStatus: .loading(currentStation)
         )
       }
     case .playing(let nowPlayingData):

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -59,14 +59,14 @@ class StationPlayer: ObservableObject {
   // MARK: Dependencies
 
   var urlStreamPlayer: URLStreamPlayer
-  var playolaStationPlayer: PlayolaStationPlayer
+  var playolaStationPlayer: StreamingStationPlayer
 
   init(
     urlStreamPlayer: URLStreamPlayer? = nil,
-    playolaStationPlayer: PlayolaStationPlayer? = nil
+    playolaStationPlayer: StreamingStationPlayer? = nil
   ) {
     self.urlStreamPlayer = urlStreamPlayer ?? .shared
-    self.playolaStationPlayer = playolaStationPlayer ?? .shared
+    self.playolaStationPlayer = playolaStationPlayer ?? StreamingStationPlayer()
 
     self.urlStreamPlayer.$state.sink(receiveValue: { state in
       self.processUrlStreamStateChanged(state)
@@ -166,7 +166,7 @@ class StationPlayer: ObservableObject {
   }
 
   func processPlayolaStationPlayerState(
-    _ playolaState: PlayolaStationPlayer.State?
+    _ playolaState: StreamingStationPlayer.State?
   ) {
     switch playolaState {
     case .idle:
@@ -177,10 +177,10 @@ class StationPlayer: ObservableObject {
         albumArtworkUrl: nil,
         playolaSpinPlaying: nil
       )
-    case .loading(let progress):
+    case .loading:
       guard let currentStation else { return }
       state = .init(
-        playbackStatus: .loading(currentStation, progress),
+        playbackStatus: .loading(currentStation),
         artistPlaying: nil,
         titlePlaying: nil,
         albumArtworkUrl: nil,

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -24,7 +24,7 @@ class StationPlayer: ObservableObject {
     case startingNewStation(AnyStation)
     case playing(AnyStation)
     case stopped
-    case loading(AnyStation, Float? = nil)
+    case loading(AnyStation)
     case error
   }
 
@@ -47,7 +47,7 @@ class StationPlayer: ObservableObject {
       return station
     case .playing(let station):
       return station
-    case .loading(let station, _):
+    case .loading(let station):
       return station
     case .error, .stopped:
       return nil

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -90,8 +90,8 @@ class PlayerPageModel: ViewModel {
 
   var loadingPercentage: Float {
     switch nowPlaying?.playbackStatus {
-    case .loading(_, let progress):
-      return progress ?? 0.0
+    case .loading:
+      return 0.0
     case .startingNewStation:
       return 0.0
     default:

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -34,10 +34,10 @@ final class PlayerPageTests: XCTestCase {
     XCTAssertNil(model.playolaAudioBlockPlaying)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenLoadingWithProgress() {
+  func testViewAppeared_PopulatesCorrectlyWhenLoadingShowsZeroProgress() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
-      station: station, status: .loading(station, 0.42))
+      station: station, status: .loading(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
     XCTAssertEqual(model.primaryNavBarTitle, station.name)
@@ -47,7 +47,7 @@ final class PlayerPageTests: XCTestCase {
       XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
     }
     XCTAssertEqual(model.nowPlayingText, "Station Loading...")
-    XCTAssertEqual(model.loadingPercentage, 0.42)
+    XCTAssertEqual(model.loadingPercentage, 0.0)
     XCTAssertNil(model.playolaAudioBlockPlaying)
   }
 

--- a/PlayolaRadioTests/Mocks/StationPlayerMock.swift
+++ b/PlayolaRadioTests/Mocks/StationPlayerMock.swift
@@ -13,7 +13,7 @@ class StationPlayerMock: StationPlayer {
   var stopCalledCount = 0
   override init(
     urlStreamPlayer _: URLStreamPlayer? = nil,
-    playolaStationPlayer _: PlayolaStationPlayer? = nil
+    playolaStationPlayer _: StreamingStationPlayer? = nil
   ) {
     super.init(urlStreamPlayer: URLStreamPlayerMock())
   }


### PR DESCRIPTION
## Summary
- Switch PlayolaPlayer package from `briankeane/PlayolaPlayer` to `playola-radio/playola-player-swift` at 0.15.0
- Replace `PlayolaStationPlayer` (download-first) with `StreamingStationPlayer` (stream-first) for faster audio startup
- Update NowPlayingUpdater to observe the player instance instead of the removed singleton

## Test plan
- [ ] Build succeeds with no compiler errors
- [ ] All existing tests pass
- [ ] Play a Playola station — audio starts streaming immediately
- [ ] Verify lock screen shows correct now playing info
- [ ] Verify CarPlay controls work (play/stop/seek)