### PR TITLE
fix: guard Sentry import/init with #if canImport

### DIFF
--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -10,11 +10,14 @@ import GoogleSignIn
 import GoogleSignInSwift
 import SDWebImage
 import SDWebImageSVGCoder
-import Sentry
 import Sharing
 import SwiftUI
 import UIKit
 import UserNotifications
+
+#if canImport(Sentry)
+  import Sentry
+#endif
 
 extension Notification.Name {
   static let refreshSupportMessages = Notification.Name("refreshSupportMessages")
@@ -28,17 +31,19 @@ class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDele
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
-    SentrySDK.start { options in
-      options.dsn =
-        "https://c024cbc3afc46a4539e4cd73ea4f32c0@o4511043985801216.ingest.us.sentry.io/4511043987898368"
-      options.sendDefaultPii = false
-      options.tracesSampleRate = 0.1
-      options.configureProfiling = {
-        $0.sessionSampleRate = 0.1
-        $0.lifecycle = .trace
+    #if canImport(Sentry)
+      SentrySDK.start { options in
+        options.dsn =
+          "https://c024cbc3afc46a4539e4cd73ea4f32c0@o4511043985801216.ingest.us.sentry.io/4511043987898368"
+        options.sendDefaultPii = false
+        options.tracesSampleRate = 0.1
+        options.configureProfiling = {
+          $0.sessionSampleRate = 0.1
+          $0.lifecycle = .trace
+        }
+        options.experimental.enableLogs = true
       }
-      options.experimental.enableLogs = true
-    }
+    #endif
 
     UNUserNotificationCenter.current().delegate = self
     return true


### PR DESCRIPTION
## Summary
- Wraps `import Sentry` and `SentrySDK.start` in `#if canImport(Sentry)` guards so builds without the Sentry package (e.g. Staging) compile successfully

## Test plan
- [x] Build succeeds for iOS target
- [ ] Staging build compiles without Sentry

🤖 Generated with [Claude Code](https://claude.com/claude-code)