### PR TITLE
fix: split library requests into pending and fulfilled subsections

### DIFF
--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageModel.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageModel.swift
@@ -68,8 +68,16 @@ class LibraryPageModel: ViewModel {
     return letters.sorted()
   }
 
-  var activeRequests: [StationLibraryRequest] {
-    libraryRequests.filter { $0.status != .dismissed }
+  var pendingRequests: [StationLibraryRequest] {
+    libraryRequests.filter { $0.status == .pending }
+  }
+
+  var fulfilledRequests: [StationLibraryRequest] {
+    libraryRequests.filter { $0.status == .completed }
+  }
+
+  var hasActiveRequests: Bool {
+    !pendingRequests.isEmpty || !fulfilledRequests.isEmpty
   }
 
   var emptyStateMessage: String {
@@ -80,11 +88,12 @@ class LibraryPageModel: ViewModel {
     "SONGS (\(filteredSongs.count))"
   }
 
-  let requestsSectionHeader = "PENDING REQUESTS"
+  let requestsSectionHeader = "REQUESTS"
+  let pendingSubsectionHeader = "Pending"
+  let fulfilledSubsectionHeader = "Added to Library"
   let dismissButtonText = "DISMISS"
   let cancelButtonText = "CANCEL"
   let pendingRemovalText = "Pending Removal"
-  let waitingStatusText = "Waiting"
   let searchPrompt = "Search songs"
 
   // MARK: - User Actions

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
@@ -190,9 +190,9 @@ final class LibraryPageTests: XCTestCase {
     }
   }
 
-  // MARK: - Active Requests Tests
+  // MARK: - Request Filtering Tests
 
-  func testActiveRequestsExcludesDismissed() async {
+  func testPendingRequestsReturnsOnlyPendingRequests() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .pending),
       StationLibraryRequest.mockWith(id: "request-2", status: .completed),
@@ -200,10 +200,52 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertEqual(model.activeRequests.count, 2)
-      XCTAssertTrue(model.activeRequests.contains { $0.id == "request-1" })
-      XCTAssertTrue(model.activeRequests.contains { $0.id == "request-2" })
-      XCTAssertFalse(model.activeRequests.contains { $0.id == "request-3" })
+      XCTAssertEqual(model.pendingRequests.count, 1)
+      XCTAssertEqual(model.pendingRequests[0].id, "request-1")
+    }
+  }
+
+  func testFulfilledRequestsReturnsOnlyCompletedRequests() async {
+    let mockRequests = [
+      StationLibraryRequest.mockWith(id: "request-1", status: .pending),
+      StationLibraryRequest.mockWith(id: "request-2", status: .completed),
+      StationLibraryRequest.mockWith(id: "request-3", status: .dismissed),
+    ]
+
+    await withLoadedModel(requests: mockRequests) { model in
+      XCTAssertEqual(model.fulfilledRequests.count, 1)
+      XCTAssertEqual(model.fulfilledRequests[0].id, "request-2")
+    }
+  }
+
+  func testHasActiveRequestsReturnsTrueWhenPendingExists() async {
+    let mockRequests = [
+      StationLibraryRequest.mockWith(id: "request-1", status: .pending)
+    ]
+
+    await withLoadedModel(requests: mockRequests) { model in
+      XCTAssertTrue(model.hasActiveRequests)
+    }
+  }
+
+  func testHasActiveRequestsReturnsTrueWhenFulfilledExists() async {
+    let mockRequests = [
+      StationLibraryRequest.mockWith(id: "request-1", status: .completed)
+    ]
+
+    await withLoadedModel(requests: mockRequests) { model in
+      XCTAssertTrue(model.hasActiveRequests)
+    }
+  }
+
+  func testHasActiveRequestsReturnsFalseWhenAllDismissed() async {
+    let mockRequests = [
+      StationLibraryRequest.mockWith(id: "request-1", status: .dismissed),
+      StationLibraryRequest.mockWith(id: "request-2", status: .dismissed),
+    ]
+
+    await withLoadedModel(requests: mockRequests) { model in
+      XCTAssertFalse(model.hasActiveRequests)
     }
   }
 
@@ -334,9 +376,9 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertEqual(model.activeRequests.count, 1)
+        XCTAssertEqual(model.fulfilledRequests.count, 1)
         await model.dismissRequestButtonTapped(mockRequest)
-        XCTAssertEqual(model.activeRequests.count, 0)
+        XCTAssertEqual(model.fulfilledRequests.count, 0)
       }
     )
   }

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
@@ -107,50 +107,31 @@ struct LibraryPageView: View {
   }
 
   private var pendingRequestsSubsection: some View {
-    Group {
-      Text(model.pendingSubsectionHeader)
-        .font(.custom(FontNames.Inter_500_Medium, size: 11))
-        .foregroundColor(.playolaGray)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.horizontal, 12)
-        .padding(.vertical, 4)
-        .listRowInsets(EdgeInsets())
-        .listRowSeparator(.hidden)
-        .listRowBackground(Color.clear)
-
-      ForEach(model.pendingRequests) { request in
-        LibraryRequestRow(
-          request: request,
-          typeLabel: model.requestTypeLabel(for: request),
-          typeColor: model.requestTypeColor(for: request),
-          statusLabel: model.requestStatusLabel(for: request),
-          canDismiss: model.canDismissRequest(request),
-          canCancel: model.canCancelRequest(request),
-          showCheckmark: false,
-          dismissButtonText: model.dismissButtonText,
-          cancelButtonText: model.cancelButtonText,
-          onDismiss: {
-            Task {
-              await model.dismissRequestButtonTapped(request)
-            }
-          },
-          onCancel: {
-            Task {
-              await model.cancelRequestButtonTapped(request)
-            }
-          }
-        )
-        .id("request-\(request.id)")
-        .listRowInsets(EdgeInsets())
-        .listRowSeparator(.hidden)
-        .listRowBackground(Color.clear)
-      }
-    }
+    requestsSubsection(
+      header: model.pendingSubsectionHeader,
+      requests: model.pendingRequests,
+      showCheckmark: false,
+      rowOpacity: 1.0
+    )
   }
 
   private var fulfilledRequestsSubsection: some View {
+    requestsSubsection(
+      header: model.fulfilledSubsectionHeader,
+      requests: model.fulfilledRequests,
+      showCheckmark: true,
+      rowOpacity: 0.7
+    )
+  }
+
+  private func requestsSubsection(
+    header: String,
+    requests: [StationLibraryRequest],
+    showCheckmark: Bool,
+    rowOpacity: Double
+  ) -> some View {
     Group {
-      Text(model.fulfilledSubsectionHeader)
+      Text(header)
         .font(.custom(FontNames.Inter_500_Medium, size: 11))
         .foregroundColor(.playolaGray)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -160,7 +141,7 @@ struct LibraryPageView: View {
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
 
-      ForEach(model.fulfilledRequests) { request in
+      ForEach(requests) { request in
         LibraryRequestRow(
           request: request,
           typeLabel: model.requestTypeLabel(for: request),
@@ -168,7 +149,7 @@ struct LibraryPageView: View {
           statusLabel: model.requestStatusLabel(for: request),
           canDismiss: model.canDismissRequest(request),
           canCancel: model.canCancelRequest(request),
-          showCheckmark: true,
+          showCheckmark: showCheckmark,
           dismissButtonText: model.dismissButtonText,
           cancelButtonText: model.cancelButtonText,
           onDismiss: {
@@ -186,7 +167,7 @@ struct LibraryPageView: View {
         .listRowInsets(EdgeInsets())
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
-        .opacity(0.7)
+        .opacity(rowOpacity)
       }
     }
   }
@@ -414,7 +395,7 @@ struct LibraryRequestRow: View {
           Image(systemName: "checkmark.circle.fill")
             .font(.system(size: 14))
             .foregroundColor(.green)
-            .background(Circle().fill(Color.black).frame(width: 12, height: 12))
+            .background(Circle().fill(Color.black).frame(width: 16, height: 16))
             .offset(x: 2, y: 2)
         }
       }

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
@@ -67,7 +67,7 @@ struct LibraryPageView: View {
   private var songListView: some View {
     ScrollViewReader { proxy in
       List {
-        if !model.activeRequests.isEmpty {
+        if model.hasActiveRequests {
           requestsSection
         }
 
@@ -95,7 +95,30 @@ struct LibraryPageView: View {
 
   private var requestsSection: some View {
     Section {
-      ForEach(model.activeRequests) { request in
+      if !model.pendingRequests.isEmpty {
+        pendingRequestsSubsection
+      }
+      if !model.fulfilledRequests.isEmpty {
+        fulfilledRequestsSubsection
+      }
+    } header: {
+      SectionHeader(title: model.requestsSectionHeader)
+    }
+  }
+
+  private var pendingRequestsSubsection: some View {
+    Group {
+      Text(model.pendingSubsectionHeader)
+        .font(.custom(FontNames.Inter_500_Medium, size: 11))
+        .foregroundColor(.playolaGray)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .listRowInsets(EdgeInsets())
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
+
+      ForEach(model.pendingRequests) { request in
         LibraryRequestRow(
           request: request,
           typeLabel: model.requestTypeLabel(for: request),
@@ -103,6 +126,7 @@ struct LibraryPageView: View {
           statusLabel: model.requestStatusLabel(for: request),
           canDismiss: model.canDismissRequest(request),
           canCancel: model.canCancelRequest(request),
+          showCheckmark: false,
           dismissButtonText: model.dismissButtonText,
           cancelButtonText: model.cancelButtonText,
           onDismiss: {
@@ -121,8 +145,49 @@ struct LibraryPageView: View {
         .listRowSeparator(.hidden)
         .listRowBackground(Color.clear)
       }
-    } header: {
-      SectionHeader(title: model.requestsSectionHeader)
+    }
+  }
+
+  private var fulfilledRequestsSubsection: some View {
+    Group {
+      Text(model.fulfilledSubsectionHeader)
+        .font(.custom(FontNames.Inter_500_Medium, size: 11))
+        .foregroundColor(.playolaGray)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 12)
+        .padding(.vertical, 4)
+        .listRowInsets(EdgeInsets())
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
+
+      ForEach(model.fulfilledRequests) { request in
+        LibraryRequestRow(
+          request: request,
+          typeLabel: model.requestTypeLabel(for: request),
+          typeColor: model.requestTypeColor(for: request),
+          statusLabel: model.requestStatusLabel(for: request),
+          canDismiss: model.canDismissRequest(request),
+          canCancel: model.canCancelRequest(request),
+          showCheckmark: true,
+          dismissButtonText: model.dismissButtonText,
+          cancelButtonText: model.cancelButtonText,
+          onDismiss: {
+            Task {
+              await model.dismissRequestButtonTapped(request)
+            }
+          },
+          onCancel: {
+            Task {
+              await model.cancelRequestButtonTapped(request)
+            }
+          }
+        )
+        .id("request-\(request.id)")
+        .listRowInsets(EdgeInsets())
+        .listRowSeparator(.hidden)
+        .listRowBackground(Color.clear)
+        .opacity(0.7)
+      }
     }
   }
 
@@ -320,6 +385,7 @@ struct LibraryRequestRow: View {
   let statusLabel: String
   let canDismiss: Bool
   let canCancel: Bool
+  var showCheckmark: Bool = false
   let dismissButtonText: String
   let cancelButtonText: String
   let onDismiss: () -> Void
@@ -327,20 +393,30 @@ struct LibraryRequestRow: View {
 
   var body: some View {
     HStack(spacing: 12) {
-      if let imageUrl = request.imageUrl {
-        WebImage(url: imageUrl)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 45, height: 45)
-          .clipped()
-      } else {
-        RoundedRectangle(cornerRadius: 4)
-          .fill(Color(hex: "#666666"))
-          .frame(width: 45, height: 45)
-          .overlay(
-            Image(systemName: "music.note")
-              .foregroundColor(Color(hex: "#999999"))
-          )
+      ZStack(alignment: .bottomTrailing) {
+        if let imageUrl = request.imageUrl {
+          WebImage(url: imageUrl)
+            .resizable()
+            .aspectRatio(contentMode: .fill)
+            .frame(width: 45, height: 45)
+            .clipped()
+        } else {
+          RoundedRectangle(cornerRadius: 4)
+            .fill(Color(hex: "#666666"))
+            .frame(width: 45, height: 45)
+            .overlay(
+              Image(systemName: "music.note")
+                .foregroundColor(Color(hex: "#999999"))
+            )
+        }
+
+        if showCheckmark {
+          Image(systemName: "checkmark.circle.fill")
+            .font(.system(size: 14))
+            .foregroundColor(.green)
+            .background(Circle().fill(Color.black).frame(width: 12, height: 12))
+            .offset(x: 2, y: 2)
+        }
       }
 
       VStack(alignment: .leading, spacing: 2) {


### PR DESCRIPTION
## Summary
- Completed library requests were incorrectly shown under "PENDING REQUESTS", confusing station owners into thinking requests hadn't been fulfilled
- Split the requests section into "Pending" and "Added to Library" subsections with distinct visual treatment
- Fulfilled requests show a green checkmark on album art and reduced opacity to deprioritize them
- Replaced single `activeRequests` filter with `pendingRequests`, `fulfilledRequests`, and `hasActiveRequests` computed properties
- Added 5 focused tests replacing the single `testActiveRequestsExcludesDismissed` test

## Test plan
- [x] All 58 LibraryPageTests pass (0 failures)
- [ ] Verify pending requests appear under "Pending" subsection
- [ ] Verify completed requests appear under "Added to Library" with green checkmark and reduced opacity
- [ ] Verify dismissed requests are hidden from both subsections
- [ ] Verify dismiss button still works on fulfilled requests