### PR TITLE
Add .greptile config for automated code review

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,106 @@
+{
+  "rules": [
+    {
+      "id": "no-hardcoded-strings-in-views",
+      "rule": "Views must not contain hardcoded user-facing strings. All display text (labels, titles, messages, button text) must come from the Model. Use `Text(model.someProperty)` instead of `Text(\"Some string\")`.",
+      "scope": ["PlayolaRadio/Views/**/*View.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "no-logic-in-views",
+      "rule": "Views must contain zero logic — no conditionals about what text to show, no computed properties, no business logic. Views only bind to Model properties and call Model methods. Move any conditional display logic to a computed property on the Model.",
+      "scope": ["PlayolaRadio/Views/**/*View.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "action-naming-convention",
+      "rule": "User action methods on Models must describe what the user did, not the implementation. Use names like `recordButtonTapped()`, `itemRowTapped(_:)`, `viewAppeared()`. Do NOT use names like `startRecording()`, `toggleExpanded()`, `fetchData()`.",
+      "scope": ["PlayolaRadio/Views/**/*Model.swift"],
+      "severity": "medium"
+    },
+    {
+      "id": "model-must-inherit-viewmodel",
+      "rule": "All page models must be `@MainActor @Observable class SomePageModel: ViewModel`. They must inherit from the `ViewModel` base class and be annotated with both `@MainActor` and `@Observable`.",
+      "scope": ["PlayolaRadio/Views/**/*Model.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "dependency-observation-ignored",
+      "rule": "All `@Dependency` and `@Shared` properties in Models must be marked `@ObservationIgnored` to prevent unnecessary SwiftUI re-renders. Example: `@ObservationIgnored @Dependency(\\.api) var api`.",
+      "scope": ["PlayolaRadio/Views/**/*Model.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "no-task-sleep-in-tests",
+      "rule": "NEVER use `Task.sleep` or `try await Task.sleep` in tests. It makes tests slow and flaky. Use synchronous assertions, test doubles that execute synchronously, or `Task.yield()` with `withMainSerialExecutor`.",
+      "scope": ["PlayolaRadio/**/*Tests.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "shared-state-in-tests",
+      "rule": "In tests, declare `@Shared` locally inside each test method with an initial value: `@Shared(.key) var key = initialValue`. Do NOT use class-level `@Shared` properties or `$shared.withLock` patterns in test setup.",
+      "scope": ["PlayolaRadio/**/*Tests.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "test-class-main-actor",
+      "rule": "All test classes must be annotated with `@MainActor`: `@MainActor final class SomeTests: XCTestCase`.",
+      "scope": ["PlayolaRadio/**/*Tests.swift"],
+      "severity": "medium"
+    },
+    {
+      "id": "use-playola-alert",
+      "rule": "Use `.playolaAlert($model.presentedAlert)` for alerts. Do NOT use SwiftUI's `.alert(item:)` or `.alert(isPresented:)` modifiers directly. All alert definitions should be cases in the `PlayolaAlert` enum.",
+      "scope": ["PlayolaRadio/Views/**/*.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "use-async-await",
+      "rule": "Use async/await for all asynchronous work. Do NOT use completion handlers, callbacks, or Combine publishers for new code.",
+      "scope": ["PlayolaRadio/**/*.swift"],
+      "severity": "medium"
+    },
+    {
+      "id": "navigation-via-coordinator",
+      "rule": "All navigation (push, pop, sheet presentation) must go through the `MainContainerNavigationCoordinator` via `@Shared(.mainContainerNavigationCoordinator)`. Sheets use `PlayolaSheet` enum cases. Do not use SwiftUI's `.sheet` or `NavigationLink` directly.",
+      "scope": ["PlayolaRadio/Views/**/*.swift"],
+      "severity": "medium"
+    },
+    {
+      "id": "identified-array-for-collections",
+      "rule": "Use `IdentifiedArrayOf<T>` from IdentifiedCollections for arrays of identifiable items displayed in lists. This provides O(1) lookup by ID and safer list diffing.",
+      "scope": ["PlayolaRadio/Views/**/*Model.swift"],
+      "severity": "low"
+    },
+    {
+      "id": "tests-colocated",
+      "rule": "Test files must be colocated with the code they test. `SomePageModel.swift` should have `SomePageTests.swift` in the same folder. New Models should have corresponding test files.",
+      "scope": ["PlayolaRadio/Views/**/*.swift"],
+      "severity": "medium"
+    },
+    {
+      "id": "test-naming-camelcase",
+      "rule": "Test method names must use camelCase without underscores. Example: `testOnRecordTappedRequestsPermission`, NOT `test_on_record_tapped_requests_permission`.",
+      "scope": ["PlayolaRadio/**/*Tests.swift"],
+      "severity": "low"
+    },
+    {
+      "id": "shared-state-withlocked-update",
+      "rule": "Update `@Shared` state thread-safely using `$sharedVar.withLock { $0 = newValue }`. Do not assign directly to shared state outside of initialization.",
+      "scope": ["PlayolaRadio/**/*.swift"],
+      "severity": "medium"
+    },
+    {
+      "id": "api-error-handling",
+      "rule": "All API calls must be wrapped in do/catch blocks. Errors should set `presentedAlert` to an appropriate `PlayolaAlert` case with the error's `localizedDescription`. Never silently swallow API errors.",
+      "scope": ["PlayolaRadio/Views/**/*Model.swift"],
+      "severity": "high"
+    },
+    {
+      "id": "loading-state-pattern",
+      "rule": "Use `isLoading = true` with `defer { isLoading = false }` around async operations to ensure loading state is always cleaned up, even on error paths.",
+      "scope": ["PlayolaRadio/Views/**/*Model.swift"],
+      "severity": "low"
+    }
+  ]
+}

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -38,7 +38,7 @@
     },
     {
       "id": "shared-state-in-tests",
-      "rule": "In tests, declare `@Shared` locally inside each test method with an initial value: `@Shared(.key) var key = initialValue`. Do NOT use class-level `@Shared` properties or `$shared.withLock` patterns in test setup.",
+      "rule": "In tests, declare `@Shared` locally inside each test method with an initial value: `@Shared(.key) var key = initialValue`. Do NOT use class-level `@Shared` properties or `$shared.withLock` patterns anywhere in tests.",
       "scope": ["PlayolaRadio/**/*Tests.swift"],
       "severity": "high"
     },
@@ -75,7 +75,7 @@
     {
       "id": "tests-colocated",
       "rule": "Test files must be colocated with the code they test. `SomePageModel.swift` should have `SomePageTests.swift` in the same folder. New Models should have corresponding test files.",
-      "scope": ["PlayolaRadio/Views/**/*.swift"],
+      "scope": ["PlayolaRadio/**/*.swift"],
       "severity": "medium"
     },
     {

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,53 @@
+{
+  "files": [
+    {
+      "path": "CLAUDE.md",
+      "description": "Project-level conventions, architecture overview, and task-type quick reference"
+    },
+    {
+      "path": ".claude/API_CLIENT.md",
+      "description": "API client patterns, endpoint definitions, and state management guidelines"
+    },
+    {
+      "path": ".claude/NAVIGATION.md",
+      "description": "Navigation patterns — sheets, stack navigation, and tab switching"
+    },
+    {
+      "path": ".claude/TESTING.md",
+      "description": "Testing conventions, @Shared state in tests, analytics mocking patterns"
+    },
+    {
+      "path": ".claude/VIEWS.md",
+      "description": "View styling guide — colors, fonts, list setup, navigation bar styling"
+    },
+    {
+      "path": ".claude/PAGE_CREATION.md",
+      "description": "Step-by-step guide for creating new pages (Model + View + Tests)"
+    },
+    {
+      "path": "PlayolaRadio/Views/Reusable Components/ViewModel.swift",
+      "description": "Base ViewModel class that all page models must inherit from",
+      "scope": ["PlayolaRadio/Views/**/*Model.swift"]
+    },
+    {
+      "path": "PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift",
+      "description": "PlayolaAlert enum — all alert definitions and the .playolaAlert modifier",
+      "scope": ["PlayolaRadio/Views/**/*.swift"]
+    },
+    {
+      "path": "PlayolaRadio/Views/Reusable Components/PlayolaSheet.swift",
+      "description": "PlayolaSheet enum — all sheet presentation cases",
+      "scope": ["PlayolaRadio/Views/**/*.swift"]
+    },
+    {
+      "path": "PlayolaRadio/Core/API/APIClient.swift",
+      "description": "API endpoint signatures and the APIClient dependency",
+      "scope": ["PlayolaRadio/Core/API/**"]
+    },
+    {
+      "path": "PlayolaRadio/State/SharedUserDefaults.swift",
+      "description": "All @Shared key definitions (auth, nowPlaying, stationLists, etc.)",
+      "scope": ["PlayolaRadio/State/**", "PlayolaRadio/Views/**/*Model.swift"]
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,105 @@
+# Playola Radio iOS — Review Rules
+
+## Architecture: MV Pattern (Not MVVM)
+
+This project uses an MV pattern with `@Observable` models. The **Model is the complete, portable representation of the page** — if ported to another platform, only the View should need rebuilding.
+
+### Model Provides Everything (except visuals)
+
+- All display text: navigation titles, labels, button text, empty states, error messages
+- All computed display values: formatted dates, durations, progress percentages
+- All business logic, state management, and action handlers
+- Validation logic and error states
+
+```swift
+// Model — provides all content
+var navigationTitle: String { "My Library" }
+var emptyStateMessage: String { "No songs yet." }
+var isDeleteButtonEnabled: Bool { selectedSongs.count > 0 }
+```
+
+### Views Are Visuals Only
+
+- Layout, spacing, colors, fonts
+- Binds to model properties for ALL content
+- Calls model methods for ALL user actions
+- Contains zero logic
+
+```swift
+// Good
+Text(model.emptyStateMessage)
+
+// Bad — hardcoded string in View
+Text("No songs yet")
+```
+
+## Model Structure
+
+Models must follow this MARK section order:
+
+1. `// MARK: - Dependencies` — `@ObservationIgnored @Dependency` injections
+2. `// MARK: - Shared State` — `@ObservationIgnored @Shared` declarations
+3. `// MARK: - Initialization`
+4. `// MARK: - Properties` — observable state (`isLoading`, `items`, `presentedAlert`, etc.)
+5. `// MARK: - User Actions` — methods named after user actions
+6. `// MARK: - View Helpers` — computed display properties
+7. `// MARK: - Private Helpers`
+
+## User Action Naming
+
+Method names describe what the **user** did, not the implementation:
+
+```swift
+// Good — describes user action
+func recordButtonTapped() async { }
+func stopButtonTapped() async { }
+func itemRowTapped(_ item: Item) async { }
+
+// Bad — describes implementation
+func startRecording() async { }
+func toggleExpanded() { }
+```
+
+## Dependencies & Shared State
+
+- All `@Dependency` and `@Shared` properties **must** be `@ObservationIgnored`
+- Update shared state via `$sharedVar.withLock { $0 = newValue }`
+- Dependencies are `Sendable` structs from `swift-dependencies`
+
+## Alerts & Navigation
+
+- **Alerts**: Use `.playolaAlert($model.presentedAlert)` with `PlayolaAlert` enum cases. Never use SwiftUI's `.alert()` directly.
+- **Sheets**: Present via `mainContainerNavigationCoordinator.presentedSheet = .someSheet(model)` using `PlayolaSheet` enum.
+- **Navigation**: Push/pop via `MainContainerNavigationCoordinator`. Don't use `NavigationLink` directly.
+
+## Testing Rules
+
+- **Test location**: Colocated — `SomePageModel.swift` → `SomePageTests.swift` in same folder
+- **Test class**: `@MainActor final class SomeTests: XCTestCase`
+- **Naming**: camelCase, no underscores — `testOnRecordTappedRequestsPermission`
+- **NEVER use `Task.sleep` in tests** — it makes tests slow and flaky
+- **@Shared in tests**: Declare locally per test method with initial value:
+
+```swift
+func testSomething() async {
+  @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+  let model = withDependencies { ... } operation: { SomeModel() }
+  // ...
+}
+```
+
+Do NOT use class-level `@Shared` properties in tests.
+
+## Error Handling
+
+- All API calls must be in `do/catch` blocks
+- Errors set `presentedAlert` to a `PlayolaAlert` case
+- Use `isLoading = true` / `defer { isLoading = false }` pattern
+- Never silently swallow errors
+
+## Code Style
+
+- Use async/await, never completion handlers
+- Use `IdentifiedArrayOf<T>` for identifiable collections
+- Run `make format` and `make lint` before committing
+- Comments only when code isn't self-explanatory


### PR DESCRIPTION
## Summary

Adds a `.greptile/` folder with version-controlled review rules that enforce project conventions during automated PR reviews:

- **`config.json`** — 17 structured rules covering model/view separation, dependency patterns, testing anti-patterns, alert/navigation conventions, and error handling
- **`rules.md`** — Prose guidelines with code examples for the MV architecture, naming conventions, and testing rules
- **`files.json`** — Points the reviewer to 11 key reference files (ViewModel base class, PlayolaAlert, APIClient, shared state definitions, etc.)

## Test plan

- [ ] Verify Greptile picks up the rules on next PR review
- [ ] Confirm rule scoping targets the correct file paths