### PR TITLE
fix: stop auto-creating empty support conversations on launch

### DIFF
--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -676,6 +676,9 @@ extension APIClient: DependencyKey {
       getSupportConversation: { jwtToken in
         try await authenticatedGet(path: "/v1/conversations/support", token: jwtToken)
       },
+      createSupportConversation: { jwtToken in
+        try await authenticatedPost(path: "/v1/conversations/support", token: jwtToken)
+      },
       getConversationMessages: { jwtToken, conversationId in
         try await authenticatedGet(
           path: "/v1/conversations/\(conversationId)/messages", token: jwtToken)

--- a/PlayolaRadio/Core/API/APIClient.swift
+++ b/PlayolaRadio/Core/API/APIClient.swift
@@ -457,26 +457,39 @@ struct APIClient: Sendable {
   /// - Throws: APIError if the request fails
   var fetchLiveStations: (_ jwtToken: String) async throws -> [LiveStationInfo] = { _ in [] }
 
-  /// Gets or creates the user's support conversation
+  /// Gets the user's support conversation (may be nil if none exists)
   /// - Parameter jwtToken: The JWT token for authentication
-  /// - Returns: SupportConversationResponse containing the conversation and unread count
+  /// - Returns: SupportConversationResponse containing the conversation (nullable) and unread count
   /// - Throws: APIError if the request fails
   var getSupportConversation: (_ jwtToken: String) async throws -> SupportConversationResponse = {
     _ in
     SupportConversationResponse(
-      conversation: Conversation(
-        id: "",
-        type: "support",
-        contextType: nil,
-        contextId: nil,
-        status: "open",
-        createdAt: Date(),
-        updatedAt: Date(),
-        participants: nil
-      ),
+      conversation: nil,
       unreadCount: 0
     )
   }
+
+  /// Creates a support conversation for the user
+  /// - Parameter jwtToken: The JWT token for authentication
+  /// - Returns: CreateSupportConversationResponse containing the conversation and unread count
+  /// - Throws: APIError if the request fails
+  var createSupportConversation:
+    (_ jwtToken: String) async throws -> CreateSupportConversationResponse = {
+      _ in
+      CreateSupportConversationResponse(
+        conversation: Conversation(
+          id: "",
+          type: "support",
+          contextType: nil,
+          contextId: nil,
+          status: "open",
+          createdAt: Date(),
+          updatedAt: Date(),
+          participants: nil
+        ),
+        unreadCount: 0
+      )
+    }
 
   /// Fetches messages for a conversation
   /// - Parameters:

--- a/PlayolaRadio/Core/API/APIClient.swift
+++ b/PlayolaRadio/Core/API/APIClient.swift
@@ -491,6 +491,16 @@ struct APIClient: Sendable {
       )
     }
 
+  /// Gets the existing support conversation or creates one if none exists
+  /// - Parameter jwtToken: The JWT token for authentication
+  /// - Returns: The support Conversation
+  /// - Throws: APIError if the request fails
+  func getOrCreateSupportConversation(_ jwtToken: String) async throws -> Conversation {
+    let response = try await getSupportConversation(jwtToken)
+    if let existing = response.conversation { return existing }
+    return try await createSupportConversation(jwtToken).conversation
+  }
+
   /// Fetches messages for a conversation
   /// - Parameters:
   ///   - jwtToken: The JWT token for authentication

--- a/PlayolaRadio/Models/Conversation.swift
+++ b/PlayolaRadio/Models/Conversation.swift
@@ -70,6 +70,11 @@ struct ParticipantUser: Codable, Equatable {
 }
 
 struct SupportConversationResponse: Codable, Equatable {
+  let conversation: Conversation?
+  let unreadCount: Int
+}
+
+struct CreateSupportConversationResponse: Codable, Equatable {
   let conversation: Conversation
   let unreadCount: Int
 }
@@ -109,10 +114,22 @@ extension Conversation {
 
 extension SupportConversationResponse {
   static func mockWith(
-    conversation: Conversation = .mockWith(),
+    conversation: Conversation? = .mockWith(),
     unreadCount: Int = 0
   ) -> SupportConversationResponse {
     SupportConversationResponse(
+      conversation: conversation,
+      unreadCount: unreadCount
+    )
+  }
+}
+
+extension CreateSupportConversationResponse {
+  static func mockWith(
+    conversation: Conversation = .mockWith(),
+    unreadCount: Int = 0
+  ) -> CreateSupportConversationResponse {
+    CreateSupportConversationResponse(
       conversation: conversation,
       unreadCount: unreadCount
     )

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -187,20 +187,25 @@ class ContactPageModel: ViewModel {
   private func handleRegularUserFlow(jwt: String) async {
     do {
       let response = try await api.getSupportConversation(jwt)
-      let messages = try await api.getConversationMessages(jwt, response.conversation.id)
+      let conversation: Conversation
+      if let existing = response.conversation {
+        conversation = existing
+      } else {
+        let createResponse = try await api.createSupportConversation(jwt)
+        conversation = createResponse.conversation
+      }
+      let messages = try await api.getConversationMessages(jwt, conversation.id)
 
       isCheckingSupport = false
 
       if messages.isEmpty {
-        // No messages yet - show feedback sheet
-        let feedbackModel = FeedbackSheetModel(conversation: response.conversation) { [weak self] in
+        let feedbackModel = FeedbackSheetModel(conversation: conversation) { [weak self] in
           self?.presentedAlert = .messageSentSuccess
         }
         mainContainerNavigationCoordinator.presentedSheet = .feedbackSheet(feedbackModel)
       } else {
-        // Has messages - navigate to chat page
         let model = SupportPageModel()
-        model.conversation = response.conversation
+        model.conversation = conversation
         model.messages = messages
         model.isLoading = false
         supportPageModel = model

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -186,14 +186,7 @@ class ContactPageModel: ViewModel {
 
   private func handleRegularUserFlow(jwt: String) async {
     do {
-      let response = try await api.getSupportConversation(jwt)
-      let conversation: Conversation
-      if let existing = response.conversation {
-        conversation = existing
-      } else {
-        let createResponse = try await api.createSupportConversation(jwt)
-        conversation = createResponse.conversation
-      }
+      let conversation = try await api.getOrCreateSupportConversation(jwt)
       let messages = try await api.getConversationMessages(jwt, conversation.id)
 
       isCheckingSupport = false

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -301,14 +301,7 @@ class HomePageModel: ViewModel {
   private func navigateToSupportPage() async {
     guard let jwt = auth.jwt else { return }
     do {
-      let response = try await api.getSupportConversation(jwt)
-      let conversation: Conversation
-      if let existing = response.conversation {
-        conversation = existing
-      } else {
-        let createResponse = try await api.createSupportConversation(jwt)
-        conversation = createResponse.conversation
-      }
+      let conversation = try await api.getOrCreateSupportConversation(jwt)
       let messages = try await api.getConversationMessages(jwt, conversation.id)
       let model = SupportPageModel()
       model.conversation = conversation

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -302,9 +302,16 @@ class HomePageModel: ViewModel {
     guard let jwt = auth.jwt else { return }
     do {
       let response = try await api.getSupportConversation(jwt)
-      let messages = try await api.getConversationMessages(jwt, response.conversation.id)
+      let conversation: Conversation
+      if let existing = response.conversation {
+        conversation = existing
+      } else {
+        let createResponse = try await api.createSupportConversation(jwt)
+        conversation = createResponse.conversation
+      }
+      let messages = try await api.getConversationMessages(jwt, conversation.id)
       let model = SupportPageModel()
-      model.conversation = response.conversation
+      model.conversation = conversation
       model.messages = messages
       model.isLoading = false
       await mainContainerNavigationCoordinator.navigateToSupport(model)

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -260,8 +260,15 @@ class MainContainerModel: ViewModel {
     Task {
       do {
         let response = try await api.getSupportConversation(jwt)
+        let conversation: Conversation
+        if let existing = response.conversation {
+          conversation = existing
+        } else {
+          let createResponse = try await api.createSupportConversation(jwt)
+          conversation = createResponse.conversation
+        }
         let feedbackModel = FeedbackSheetModel(
-          conversation: response.conversation,
+          conversation: conversation,
           title: "Would you be up for letting us know what we can do better?",
           placeholderText: "",
           onSuccess: { [weak self] in

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -259,14 +259,7 @@ class MainContainerModel: ViewModel {
     guard let jwt = auth.jwt else { return }
     Task {
       do {
-        let response = try await api.getSupportConversation(jwt)
-        let conversation: Conversation
-        if let existing = response.conversation {
-          conversation = existing
-        } else {
-          let createResponse = try await api.createSupportConversation(jwt)
-          conversation = createResponse.conversation
-        }
+        let conversation = try await api.getOrCreateSupportConversation(jwt)
         let feedbackModel = FeedbackSheetModel(
           conversation: conversation,
           title: "Would you be up for letting us know what we can do better?",

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
@@ -47,7 +47,12 @@ class SupportPageModel: ViewModel {
 
     do {
       let response = try await api.getSupportConversation(jwt)
-      conversation = response.conversation
+      if let conv = response.conversation {
+        conversation = conv
+      } else {
+        let createResponse = try await api.createSupportConversation(jwt)
+        conversation = createResponse.conversation
+      }
       if let conversationId = conversation?.id {
         messages = try await api.getConversationMessages(jwt, conversationId)
         await markAsRead()

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
@@ -46,13 +46,7 @@ class SupportPageModel: ViewModel {
     isLoading = true
 
     do {
-      let response = try await api.getSupportConversation(jwt)
-      if let conv = response.conversation {
-        conversation = conv
-      } else {
-        let createResponse = try await api.createSupportConversation(jwt)
-        conversation = createResponse.conversation
-      }
+      conversation = try await api.getOrCreateSupportConversation(jwt)
       if let conversationId = conversation?.id {
         messages = try await api.getConversationMessages(jwt, conversationId)
         await markAsRead()

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
@@ -337,6 +337,80 @@ struct SupportPageTests {
   }
 
   @Test
+  func testOnViewAppearedCreatesConversationWhenGetReturnsNil() async {
+    @Shared(.auth) var auth = Auth(
+      currentUser: LoggedInUser(
+        id: "user-1",
+        firstName: "Test",
+        lastName: "User",
+        email: "test@example.com",
+        profileImageUrl: nil,
+        role: "user"
+      ),
+      jwt: "test-jwt"
+    )
+
+    let createdConversation = makeConversation(id: "created-conv")
+    var createCalled = false
+
+    let model = withDependencies {
+      $0.api.getSupportConversation = { _ in
+        SupportConversationResponse(conversation: nil, unreadCount: 0)
+      }
+      $0.api.createSupportConversation = { _ in
+        createCalled = true
+        return CreateSupportConversationResponse(
+          conversation: createdConversation, unreadCount: 0)
+      }
+      $0.api.getConversationMessages = { _, _ in [] }
+    } operation: {
+      SupportPageModel()
+    }
+
+    await model.onViewAppeared()
+
+    #expect(createCalled == true)
+    #expect(model.conversation?.id == "created-conv")
+    #expect(model.isLoading == false)
+  }
+
+  @Test
+  func testOnViewAppearedUsesExistingConversationFromGet() async {
+    @Shared(.auth) var auth = Auth(
+      currentUser: LoggedInUser(
+        id: "user-1",
+        firstName: "Test",
+        lastName: "User",
+        email: "test@example.com",
+        profileImageUrl: nil,
+        role: "user"
+      ),
+      jwt: "test-jwt"
+    )
+
+    let existingConversation = makeConversation(id: "existing-conv")
+    var createCalled = false
+
+    let model = withDependencies {
+      $0.api.getSupportConversation = { _ in
+        SupportConversationResponse(conversation: existingConversation, unreadCount: 0)
+      }
+      $0.api.createSupportConversation = { _ in
+        createCalled = true
+        return .mockWith()
+      }
+      $0.api.getConversationMessages = { _, _ in [] }
+    } operation: {
+      SupportPageModel()
+    }
+
+    await model.onViewAppeared()
+
+    #expect(createCalled == false)
+    #expect(model.conversation?.id == "existing-conv")
+  }
+
+  @Test
   func testHandleScenePhaseChangeDoesNothingWhenNotActive() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(


### PR DESCRIPTION
## Summary
- Makes `SupportConversationResponse.conversation` optional to handle null from `GET /v1/conversations/support`
- Adds `createSupportConversation()` calling `POST /v1/conversations/support` for lazy conversation creation
- Updates all UI entry points (SupportPage, ContactPage, HomePage, MainContainer) to only create a conversation when the user actually opens support/feedback
- Adds tests for both the nil-conversation (create) and existing-conversation (reuse) paths

## Test plan
- [x] All 910 tests pass
- [ ] Verify unread count polling still works on launch without creating a conversation
- [ ] Verify opening support/feedback creates a conversation if none exists
- [ ] Verify existing conversations are reused without calling POST