### PR TITLE
fix: show Coming Soon label for inactive stations

### DIFF
--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowModel.swift
@@ -60,15 +60,11 @@ struct StationListStationRowModel {
   }
 
   var subtitleText: String {
-    if item.visibility == .comingSoon {
-      if !showSecretStations {
-        return comingSoonText
-      }
-      if let isActiveStation = item.station?.active,
-        !isActiveStation
-      {
-        return comingSoonText
-      }
+    let isInactive = !item.anyStation.active
+    let isComingSoonAndHidden = item.visibility == .comingSoon && !showSecretStations
+
+    if isInactive || isComingSoonAndHidden {
+      return comingSoonText
     }
     return item.anyStation.stationName
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
@@ -237,8 +237,8 @@ final class StationListStationRowTests: XCTestCase {
     XCTAssertEqual(model.subtitleColor, Color.playolaRed)
   }
 
-  func testInactiveUrlStationShowsComingSoon() {
-    @Shared(.showSecretStations) var showSecretStations: Bool = false
+  func testInactiveUrlStationShowsComingSoonWhenSecretsShowing() {
+    @Shared(.showSecretStations) var showSecretStations: Bool = true
     let inactiveUrlStation = UrlStation(
       id: "inactive-url",
       name: "Inactive FM",

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
@@ -183,6 +183,88 @@ final class StationListStationRowTests: XCTestCase {
     XCTAssertEqual(model.subtitleText, "Coming Dec 25th")
   }
 
+  func testInactiveVisibleStationShowsComingSoonWhenSecretsHidden() {
+    @Shared(.showSecretStations) var showSecretStations: Bool = false
+    let now = Date(timeIntervalSince1970: 1_758_915_200)
+    let inactiveStation = PlayolaPlayer.Station(
+      id: "inactive-visible",
+      name: "Moondog Radio",
+      curatorName: "Jacob Stelly",
+      imageUrl: URL(string: "https://example.com/moondog.png"),
+      description: "An inactive station",
+      active: false,
+      createdAt: now,
+      updatedAt: now
+    )
+
+    let item = APIStationItem(
+      sortOrder: 0,
+      visibility: .visible,
+      station: inactiveStation,
+      urlStation: nil
+    )
+
+    let model = StationListStationRowModel(item: item)
+
+    XCTAssertEqual(model.subtitleText, "Coming Soon")
+    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
+  }
+
+  func testInactiveVisibleStationShowsComingSoonWhenSecretsShowing() {
+    @Shared(.showSecretStations) var showSecretStations: Bool = true
+    let now = Date(timeIntervalSince1970: 1_758_915_200)
+    let inactiveStation = PlayolaPlayer.Station(
+      id: "inactive-visible",
+      name: "Moondog Radio",
+      curatorName: "Jacob Stelly",
+      imageUrl: URL(string: "https://example.com/moondog.png"),
+      description: "An inactive station",
+      active: false,
+      createdAt: now,
+      updatedAt: now
+    )
+
+    let item = APIStationItem(
+      sortOrder: 0,
+      visibility: .visible,
+      station: inactiveStation,
+      urlStation: nil
+    )
+
+    let model = StationListStationRowModel(item: item)
+
+    XCTAssertEqual(model.subtitleText, "Coming Soon")
+    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
+  }
+
+  func testInactiveUrlStationShowsComingSoon() {
+    @Shared(.showSecretStations) var showSecretStations: Bool = false
+    let inactiveUrlStation = UrlStation(
+      id: "inactive-url",
+      name: "Inactive FM",
+      streamUrl: "https://mock.stream.url",
+      imageUrl: "https://mock.image.url",
+      description: "An inactive URL station",
+      website: nil,
+      location: "Austin, TX",
+      active: false,
+      createdAt: Date(),
+      updatedAt: Date()
+    )
+
+    let item = APIStationItem(
+      sortOrder: 0,
+      visibility: .comingSoon,
+      station: nil,
+      urlStation: inactiveUrlStation
+    )
+
+    let model = StationListStationRowModel(item: item)
+
+    XCTAssertEqual(model.subtitleText, "Coming Soon")
+    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
+  }
+
   // MARK: - Live Sort Priority Tests
 
   func testLiveSortPriorityReturnsZeroForVoicetracking() {


### PR DESCRIPTION
## Summary
- Fixed inactive stations not showing "Coming Soon" / "Coming {date}" label in the station list
- The `subtitleText` logic only checked `item.visibility == .comingSoon`, so inactive stations with `.visible` visibility were displayed as normal stations
- Also fixed `item.station?.active` which silently failed for URL stations (nil optional chain) — now uses `item.anyStation.active` which works for both station types
- Added 3 regression tests covering inactive visible stations and inactive URL stations

## Test plan
- [ ] Verify inactive stations with `.visible` visibility show "Coming Soon" in red
- [ ] Verify inactive stations still show "Coming Soon" even when `showSecretStations` is true
- [ ] Verify active stations with `.comingSoon` visibility show normally when secrets are enabled
- [ ] Run all `StationListStationRowTests` in Xcode

🤖 Generated with [Claude Code](https://claude.com/claude-code)