### PR TITLE
ci: make release_production lane runnable on CircleCI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -65,7 +65,7 @@ platform :ios do
   desc "Release PRODUCTION build to TestFlight"
   lane :release_production do
     ensure_git_status_clean
-    ensure_git_branch(branch: 'main')
+    ensure_git_branch(branch: 'main') unless ENV['CI']
 
     scan(
       include_simulator_logs: false,
@@ -81,7 +81,15 @@ platform :ios do
       export_method: "app-store"
     )
 
+    key_content = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] || File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])
+    api_key = app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
+      key_content: key_content
+    )
+
     upload_to_testflight(
+      api_key: api_key,
       app_identifier: "fm.playola.playolaradio",
       skip_waiting_for_build_processing: true
     )

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,7 +81,9 @@ platform :ios do
       export_method: "app-store"
     )
 
-    key_content = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] || File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])
+    key_content = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] ||
+                  (ENV["APP_STORE_CONNECT_API_KEY_PATH"] && File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])) ||
+                  UI.user_error!("Set APP_STORE_CONNECT_API_KEY_CONTENT (CI) or APP_STORE_CONNECT_API_KEY_PATH (local)")
     api_key = app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],


### PR DESCRIPTION
## Summary
- Add explicit `app_store_connect_api_key` call to `release_production`, reading key content from `APP_STORE_CONNECT_API_KEY_CONTENT` (CI) or falling back to `File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])` (local). Passed into `upload_to_testflight`.
- Skip `ensure_git_branch('main')` when `ENV['CI']` is truthy — CircleCI checks tags out in detached HEAD, so the branch check would fail. `ensure_git_status_clean` still runs everywhere.
- No CircleCI config changes; staging lane and other steps untouched.

Part of the TestFlight release automation plan (PR 2 of 5). See `/Users/brian/.claude/playola-release-automation-plan.md`.

## Test plan
- [x] `bundle exec fastlane lanes` still lists both `release_staging` and `release_production`.
- [ ] Brian can optionally run `bundle exec fastlane release_production` locally (with existing `APP_STORE_CONNECT_API_KEY_PATH`) to confirm nothing regressed.
- [ ] Follow-up PRs will wire up the CircleCI job that actually invokes this lane.