### PR TITLE
ci: add secrets encode/decode helpers

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -106,11 +106,14 @@ release workflow. Names only; values live in CircleCI.
 
 ## Rotating or adding a secret
 
-PR 3 will add `scripts/encode-secrets.sh` and `scripts/ci-write-secrets.sh`
-to automate the encode/decode of the xcconfig secrets. Until those land,
-rotate by running `base64 -i <file>` locally, pasting the output into the
-matching CircleCI context variable, and updating the source of truth under
-`~/playola/playola-radio-ios/PlayolaRadio/Config/` on the release machine.
+To rotate the xcconfig secrets, update the source of truth under
+`~/playola/playola-radio-ios/PlayolaRadio/Config/` on the release machine,
+then run `./scripts/encode-secrets.sh` to print `VAR=<base64>` lines for
+each xcconfig. Paste each line's value into the matching CircleCI context
+variable. CircleCI decodes them at the start of the release job by running
+`./scripts/ci-write-secrets.sh`, which reads the four `SECRETS_*_B64` env
+vars and writes the xcconfig files back into `PlayolaRadio/Config/`.
+
 For the ASC API key and Match passphrase, update the CircleCI context
 variable directly; there is no file to regenerate. After any rotation,
 re-run the release workflow on a test tag to confirm CI can still sign and

--- a/scripts/ci-write-secrets.sh
+++ b/scripts/ci-write-secrets.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+set -euo pipefail
+
+# Decode the four SECRETS_*_B64 env vars and write them into
+# PlayolaRadio/Config/ so that xcodebuild can find the xcconfig files.
+# Intended to run on CircleCI before `fastlane build_app`.
+#
+# Usage: ./scripts/ci-write-secrets.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="$SCRIPT_DIR/../PlayolaRadio/Config"
+
+# Env var -> destination filename pairs.
+VARS=(
+  "SECRETS_XCCONFIG_B64:Secrets.xcconfig"
+  "SECRETS_LOCAL_XCCONFIG_B64:Secrets-Local.xcconfig"
+  "SECRETS_DEVELOPMENT_XCCONFIG_B64:Secrets-Development.xcconfig"
+  "SECRETS_STAGING_XCCONFIG_B64:Secrets-Staging.xcconfig"
+)
+
+missing=()
+for pair in "${VARS[@]}"; do
+  var="${pair%%:*}"
+  if [ -z "${!var:-}" ]; then
+    missing+=("$var")
+  fi
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "Error: required env var(s) not set:" >&2
+  for var in "${missing[@]}"; do
+    echo "  $var" >&2
+  done
+  echo "Set them in the CircleCI context that runs this job." >&2
+  exit 1
+fi
+
+if [ ! -d "$CONFIG_DIR" ]; then
+  echo "Error: config directory not found at $CONFIG_DIR" >&2
+  exit 1
+fi
+
+for pair in "${VARS[@]}"; do
+  var="${pair%%:*}"
+  file="${pair##*:}"
+  printf '%s' "${!var}" | base64 --decode > "$CONFIG_DIR/$file"
+  echo "  WROTE $file"
+done

--- a/scripts/encode-secrets.sh
+++ b/scripts/encode-secrets.sh
@@ -38,6 +38,6 @@ fi
 for pair in "${FILES[@]}"; do
   file="${pair%%:*}"
   var="${pair##*:}"
-  encoded="$(base64 -i "$CONFIG_DIR/$file")"
+  encoded="$(base64 -i "$CONFIG_DIR/$file" | tr -d '\n')"
   echo "${var}=${encoded}"
 done

--- a/scripts/encode-secrets.sh
+++ b/scripts/encode-secrets.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+set -euo pipefail
+
+# Encode the four Secrets-*.xcconfig files as base64 for CircleCI env vars.
+# Prints `VAR=<base64>` lines to stdout, one per file, suitable for pasting
+# into the CircleCI `ios-release` context.
+#
+# Usage: ./scripts/encode-secrets.sh
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CONFIG_DIR="$SCRIPT_DIR/../PlayolaRadio/Config"
+
+# File -> env var name pairs.
+FILES=(
+  "Secrets.xcconfig:SECRETS_XCCONFIG_B64"
+  "Secrets-Local.xcconfig:SECRETS_LOCAL_XCCONFIG_B64"
+  "Secrets-Development.xcconfig:SECRETS_DEVELOPMENT_XCCONFIG_B64"
+  "Secrets-Staging.xcconfig:SECRETS_STAGING_XCCONFIG_B64"
+)
+
+missing=()
+for pair in "${FILES[@]}"; do
+  file="${pair%%:*}"
+  if [ ! -f "$CONFIG_DIR/$file" ]; then
+    missing+=("$CONFIG_DIR/$file")
+  fi
+done
+
+if [ "${#missing[@]}" -gt 0 ]; then
+  echo "Error: required secrets file(s) not found:" >&2
+  for path in "${missing[@]}"; do
+    echo "  $path" >&2
+  done
+  echo "Run ./scripts/setup-secrets.sh first to copy them from the release machine." >&2
+  exit 1
+fi
+
+for pair in "${FILES[@]}"; do
+  file="${pair%%:*}"
+  var="${pair##*:}"
+  encoded="$(base64 -i "$CONFIG_DIR/$file")"
+  echo "${var}=${encoded}"
+done


### PR DESCRIPTION
## Summary

Adds two small, standalone helper scripts for the CircleCI release automation (PR 3 of the rollout described in RELEASE.md):

- `scripts/encode-secrets.sh` — reads the four `Secrets-*.xcconfig` files under `PlayolaRadio/Config/` and prints `VAR=<base64>` lines for pasting into the CircleCI `ios-release` context.
- `scripts/ci-write-secrets.sh` — reads the four `SECRETS_*_B64` env vars, decodes them, and writes the xcconfig files back into `PlayolaRadio/Config/`. Idempotent.

Both fail fast with a clear stderr message if any input is missing (no partial writes). Neither is wired into CI yet — PR 4 adds the release job that calls `ci-write-secrets.sh`.

Also updates the "Rotating or adding a secret" section of `RELEASE.md` to point at the new scripts instead of the placeholder `base64 -i <file>` instructions.

## Test plan

- [x] `bash scripts/encode-secrets.sh` prints four `VAR=<base64>` lines when the xcconfigs are present locally.
- [x] `bash scripts/ci-write-secrets.sh` with no env vars set exits non-zero and names each missing var.
- [x] `bash scripts/ci-write-secrets.sh` with dummy base64 values decodes and writes all four files.
- [x] Both scripts are executable (`chmod +x`) and start with `#!/bin/bash`.
- [x] `.circleci/config.yml` and `fastlane/Fastfile` untouched.