### PR TITLE
fix: address Greptile review comments on PR #230

### DIFF
--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
@@ -12,6 +12,7 @@ import XCTest
 
 @testable import PlayolaRadio
 
+@MainActor
 final class StationListStationRowTests: XCTestCase {
   func testModelInitializationFromStation() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
@@ -37,9 +37,9 @@ class SupportPageModel: ViewModel {
     guard let jwt = auth.jwt else { return }
     startListeningForRefresh()
 
-    // If conversation is already set (e.g., from ConversationListPage), don't fetch
+    // If conversation is already set (e.g., from ConversationListPage), refresh messages
     if conversation != nil {
-      await markAsRead()
+      await refreshMessages()
       return
     }
 

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
@@ -40,6 +40,7 @@ class SupportPageModel: ViewModel {
     // If conversation is already set (e.g., from ConversationListPage), refresh messages
     if conversation != nil {
       await refreshMessages()
+      isLoading = false
       return
     }
 

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
@@ -234,6 +234,7 @@ final class SupportPageTests: XCTestCase {
       }
       $0.api.getConversationMessages = { _, _ in [] }
       $0.api.markConversationRead = { _, _ in }
+      $0.pushNotifications.clearSupportBadge = {}
     } operation: {
       SupportPageModel()
     }
@@ -279,6 +280,7 @@ final class SupportPageTests: XCTestCase {
         return newMessages
       }
       $0.api.markConversationRead = { _, _ in }
+      $0.pushNotifications.clearSupportBadge = {}
     } operation: {
       SupportPageModel()
     }
@@ -316,6 +318,7 @@ final class SupportPageTests: XCTestCase {
         return updatedMessages
       }
       $0.api.markConversationRead = { _, _ in }
+      $0.pushNotifications.clearSupportBadge = {}
     } operation: {
       SupportPageModel()
     }

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
@@ -241,12 +241,12 @@ final class SupportPageTests: XCTestCase {
 
     model.conversation = presetConversation
     model.messages = presetMessages
-    model.isLoading = false
 
     await model.onViewAppeared()
 
     XCTAssertEqual(model.conversation?.id, "preset-conv-id")
     XCTAssertFalse(getSupportConversationCalled.value)
+    XCTAssertFalse(model.isLoading)
   }
 
   func testOnViewAppearedRefreshesMessagesWhenConversationAlreadySet() async {
@@ -287,13 +287,13 @@ final class SupportPageTests: XCTestCase {
 
     model.conversation = presetConversation
     model.messages = oldMessages
-    model.isLoading = false
 
     await model.onViewAppeared()
 
     XCTAssertTrue(getConversationMessagesCalled.value)
     XCTAssertEqual(model.messages.count, 2)
     XCTAssertEqual(model.messages.last?.message, "New message")
+    XCTAssertFalse(model.isLoading)
   }
 
   func testHandleScenePhaseChangeRefreshesMessagesWhenActive() async {

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
@@ -5,16 +5,17 @@
 //  Created by Claude on 1/15/26.
 //
 
+import ConcurrencyExtras
 import Dependencies
 import Foundation
 import Sharing
 import SwiftUI
-import Testing
+import XCTest
 
 @testable import PlayolaRadio
 
 @MainActor
-struct SupportPageTests {
+final class SupportPageTests: XCTestCase {
   private func makeConversation(id: String) -> Conversation {
     Conversation(
       id: id,
@@ -42,7 +43,6 @@ struct SupportPageTests {
     )
   }
 
-  @Test
   func testOnViewAppearedLoadsConversationAndMessages() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -88,18 +88,17 @@ struct SupportPageTests {
       SupportPageModel()
     }
 
-    #expect(model.isLoading == true)
-    #expect(model.messages.isEmpty)
+    XCTAssertTrue(model.isLoading)
+    XCTAssertTrue(model.messages.isEmpty)
 
     await model.onViewAppeared()
 
-    #expect(model.isLoading == false)
-    #expect(model.conversation?.id == "conv-1")
-    #expect(model.messages.count == 1)
-    #expect(model.hasExistingMessages == true)
+    XCTAssertFalse(model.isLoading)
+    XCTAssertEqual(model.conversation?.id, "conv-1")
+    XCTAssertEqual(model.messages.count, 1)
+    XCTAssertTrue(model.hasExistingMessages)
   }
 
-  @Test
   func testHasExistingMessagesReturnsFalseWhenEmpty() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -135,10 +134,9 @@ struct SupportPageTests {
 
     await model.onViewAppeared()
 
-    #expect(model.hasExistingMessages == false)
+    XCTAssertFalse(model.hasExistingMessages)
   }
 
-  @Test
   func testSendMessageAppendsToMessages() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -186,30 +184,28 @@ struct SupportPageTests {
     await model.onViewAppeared()
     model.newMessage = "Test message"
 
-    #expect(model.canSend == true)
+    XCTAssertTrue(model.canSend)
 
     await model.sendMessage()
 
-    #expect(model.messages.count == 1)
-    #expect(model.messages.first?.message == "Test message")
-    #expect(model.newMessage.isEmpty)
+    XCTAssertEqual(model.messages.count, 1)
+    XCTAssertEqual(model.messages.first?.message, "Test message")
+    XCTAssertTrue(model.newMessage.isEmpty)
   }
 
-  @Test
   func testCanSendReturnsFalseWhenMessageEmpty() {
     let model = SupportPageModel()
 
     model.newMessage = ""
-    #expect(model.canSend == false)
+    XCTAssertFalse(model.canSend)
 
     model.newMessage = "   "
-    #expect(model.canSend == false)
+    XCTAssertFalse(model.canSend)
 
     model.newMessage = "Hello"
-    #expect(model.canSend == true)
+    XCTAssertTrue(model.canSend)
   }
 
-  @Test
   func testOnViewAppearedDoesNotOverwritePresetConversation() async {
     // Regression test: When navigating from ConversationListPage, the model
     // already has a conversation set. onViewAppeared should NOT overwrite it.
@@ -229,11 +225,11 @@ struct SupportPageTests {
       )
     ]
 
-    var getSupportConversationCalled = false
+    let getSupportConversationCalled = LockIsolated(false)
 
     let model = withDependencies {
       $0.api.getSupportConversation = { _ in
-        getSupportConversationCalled = true
+        getSupportConversationCalled.setValue(true)
         return SupportConversationResponse(conversation: wrongConversation, unreadCount: 0)
       }
       $0.api.getConversationMessages = { _, _ in [] }
@@ -248,11 +244,10 @@ struct SupportPageTests {
 
     await model.onViewAppeared()
 
-    #expect(model.conversation?.id == "preset-conv-id")
-    #expect(getSupportConversationCalled == false)
+    XCTAssertEqual(model.conversation?.id, "preset-conv-id")
+    XCTAssertFalse(getSupportConversationCalled.value)
   }
 
-  @Test
   func testOnViewAppearedRefreshesMessagesWhenConversationAlreadySet() async {
     // Regression test: When navigating to support page with conversation already set,
     // onViewAppeared should still refresh the messages to get any new ones.
@@ -276,11 +271,11 @@ struct SupportPageTests {
         id: "new-msg", conversationId: "conv-1", senderId: "support-1", text: "New message"),
     ]
 
-    var getConversationMessagesCalled = false
+    let getConversationMessagesCalled = LockIsolated(false)
 
     let model = withDependencies {
       $0.api.getConversationMessages = { _, _ in
-        getConversationMessagesCalled = true
+        getConversationMessagesCalled.setValue(true)
         return newMessages
       }
       $0.api.markConversationRead = { _, _ in }
@@ -294,12 +289,11 @@ struct SupportPageTests {
 
     await model.onViewAppeared()
 
-    #expect(getConversationMessagesCalled == true)
-    #expect(model.messages.count == 2)
-    #expect(model.messages.last?.message == "New message")
+    XCTAssertTrue(getConversationMessagesCalled.value)
+    XCTAssertEqual(model.messages.count, 2)
+    XCTAssertEqual(model.messages.last?.message, "New message")
   }
 
-  @Test
   func testHandleScenePhaseChangeRefreshesMessagesWhenActive() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -314,11 +308,11 @@ struct SupportPageTests {
       makeMessage(id: "msg-1", conversationId: "conv-1", senderId: "support", text: "New reply")
     ]
 
-    var getConversationMessagesCalled = false
+    let getConversationMessagesCalled = LockIsolated(false)
 
     let model = withDependencies {
       $0.api.getConversationMessages = { _, _ in
-        getConversationMessagesCalled = true
+        getConversationMessagesCalled.setValue(true)
         return updatedMessages
       }
       $0.api.markConversationRead = { _, _ in }
@@ -331,12 +325,11 @@ struct SupportPageTests {
 
     await model.handleScenePhaseChange(.active)
 
-    #expect(getConversationMessagesCalled == true)
-    #expect(model.messages.count == 1)
-    #expect(model.messages.first?.message == "New reply")
+    XCTAssertTrue(getConversationMessagesCalled.value)
+    XCTAssertEqual(model.messages.count, 1)
+    XCTAssertEqual(model.messages.first?.message, "New reply")
   }
 
-  @Test
   func testOnViewAppearedCreatesConversationWhenGetReturnsNil() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -351,14 +344,14 @@ struct SupportPageTests {
     )
 
     let createdConversation = makeConversation(id: "created-conv")
-    var createCalled = false
+    let createCalled = LockIsolated(false)
 
     let model = withDependencies {
       $0.api.getSupportConversation = { _ in
         SupportConversationResponse(conversation: nil, unreadCount: 0)
       }
       $0.api.createSupportConversation = { _ in
-        createCalled = true
+        createCalled.setValue(true)
         return CreateSupportConversationResponse(
           conversation: createdConversation, unreadCount: 0)
       }
@@ -369,12 +362,11 @@ struct SupportPageTests {
 
     await model.onViewAppeared()
 
-    #expect(createCalled == true)
-    #expect(model.conversation?.id == "created-conv")
-    #expect(model.isLoading == false)
+    XCTAssertTrue(createCalled.value)
+    XCTAssertEqual(model.conversation?.id, "created-conv")
+    XCTAssertFalse(model.isLoading)
   }
 
-  @Test
   func testOnViewAppearedUsesExistingConversationFromGet() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -389,14 +381,14 @@ struct SupportPageTests {
     )
 
     let existingConversation = makeConversation(id: "existing-conv")
-    var createCalled = false
+    let createCalled = LockIsolated(false)
 
     let model = withDependencies {
       $0.api.getSupportConversation = { _ in
         SupportConversationResponse(conversation: existingConversation, unreadCount: 0)
       }
       $0.api.createSupportConversation = { _ in
-        createCalled = true
+        createCalled.setValue(true)
         return .mockWith()
       }
       $0.api.getConversationMessages = { _, _ in [] }
@@ -406,11 +398,10 @@ struct SupportPageTests {
 
     await model.onViewAppeared()
 
-    #expect(createCalled == false)
-    #expect(model.conversation?.id == "existing-conv")
+    XCTAssertFalse(createCalled.value)
+    XCTAssertEqual(model.conversation?.id, "existing-conv")
   }
 
-  @Test
   func testHandleScenePhaseChangeDoesNothingWhenNotActive() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -422,11 +413,11 @@ struct SupportPageTests {
 
     let conversation = makeConversation(id: "conv-1")
 
-    var getConversationMessagesCalled = false
+    let getConversationMessagesCalled = LockIsolated(false)
 
     let model = withDependencies {
       $0.api.getConversationMessages = { _, _ in
-        getConversationMessagesCalled = true
+        getConversationMessagesCalled.setValue(true)
         return []
       }
     } operation: {
@@ -436,9 +427,9 @@ struct SupportPageTests {
     model.conversation = conversation
 
     await model.handleScenePhaseChange(.background)
-    #expect(getConversationMessagesCalled == false)
+    XCTAssertFalse(getConversationMessagesCalled.value)
 
     await model.handleScenePhaseChange(.inactive)
-    #expect(getConversationMessagesCalled == false)
+    XCTAssertFalse(getConversationMessagesCalled.value)
   }
 }


### PR DESCRIPTION
## Summary
Addresses all 3 Greptile findings from the release PR (#230):

- **P1** — `SupportPageModel.onViewAppeared`: call `refreshMessages()` on the preset-conversation path so admin-navigated support pages fetch fresh messages (previously only marked as read, which also broke the existing regression test).
- **P2** — `SupportPageTests`: convert from Swift Testing (`struct` + `@Test`/`#expect`) to XCTest (`@MainActor final class … XCTestCase`, `XCTAssert…`) per project convention.
- **P2** — `StationListStationRowTests`: add `@MainActor` annotation per project convention.

## Test plan
- [ ] Run SupportPageTests in Xcode — all tests pass, including `testOnViewAppearedRefreshesMessagesWhenConversationAlreadySet`
- [ ] Run StationListStationRowTests in Xcode — all tests pass
- [ ] Verify `make lint` and `make format` pass