### PR TITLE
ci: base64-decode match SSH private key

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
           command: |
             mkdir -p ~/.ssh
             chmod 700 ~/.ssh
-            printf '%s\n' "$MATCH_GIT_PRIVATE_KEY" > ~/.ssh/id_rsa
+            printf '%s' "$MATCH_GIT_PRIVATE_KEY_B64" | base64 --decode > ~/.ssh/id_rsa
             chmod 600 ~/.ssh/id_rsa
             ssh-keyscan github.com >> ~/.ssh/known_hosts
       - run:


### PR DESCRIPTION
## Summary

- Follow-up to #236. The first tag push (`v0.0.0-ci-test`, pipeline 807) failed in `match` with:
  ```
  Load key "/Users/distiller/.ssh/id_rsa": invalid format
  git@github.com: Permission denied (publickey).
  ```
- Root cause: CircleCI context env vars collapse embedded newlines, so the PEM private key pasted into `MATCH_GIT_PRIVATE_KEY` came out as one line and ssh rejected it.
- Fix: store the key as base64 (`MATCH_GIT_PRIVATE_KEY_B64`) and decode at runtime — same pattern already used for `SECRETS_*_XCCONFIG_B64`.

## Context var swap needed

In CircleCI → Org Settings → Contexts → `ios-release`:
1. `base64 -i ~/.ssh/match_ci | tr -d '\n' | pbcopy`
2. Add `MATCH_GIT_PRIVATE_KEY_B64` with the pasted value.
3. Delete the old `MATCH_GIT_PRIVATE_KEY`.

## Test plan

- [ ] Merge, swap context vars, re-tag (`v0.0.0-ci-test-2`).
- [ ] Confirm `release_build` gets past the `match` step.
- [ ] Confirm `.ipa` lands in artifacts.
- [ ] Delete the test tag.