### PR TITLE
ci: skip package-plugin validation in build_app

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -78,7 +78,8 @@ platform :ios do
     build_app(
       project: "PlayolaRadio.xcodeproj",
       scheme: "PlayolaRadio",
-      export_method: "app-store"
+      export_method: "app-store",
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )
 
     key_content = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] ||
@@ -129,7 +130,8 @@ platform :ios do
       project: "PlayolaRadio.xcodeproj",
       scheme: "PlayolaRadio",
       export_method: "app-store",
-      output_directory: "./build"
+      output_directory: "./build",
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )
 
     puts "✅ Build complete. Upload skipped (PR 4 dry run)."


### PR DESCRIPTION
## Summary

- Follow-up to #237. The `v0.0.0-ci-test-2` run got past `match` (1s) and `scan` (125s), then `build_app` failed at archive time:
  ```
  ** ARCHIVE FAILED **
  Validate plug-in "SwiftLintBuildToolPlugin" in package "swiftlintplugins"
  ```
- Xcode 15+ requires explicit user approval for SwiftPM build tool plugins. On CI that approval can't be granted interactively.
- `scan` already opts out via `xcargs: "-skipMacroValidation -skipPackagePluginValidation"`. `build_app` didn't. Added the same xcargs to both `release_production` (latent bug) and `release_build_only` (the dry-run lane).

## Test plan

- [ ] Merge and re-tag (`v0.0.0-ci-test-3`).
- [ ] Confirm `build_app` succeeds and `.ipa` lands in artifacts.
- [ ] Delete the test tags.