### PR TITLE
ci: upload to TestFlight + Sentry dSYMs on v* tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,8 +81,8 @@ jobs:
           name: Resolve Swift Package Dependencies
           command: xcodebuild -resolvePackageDependencies -project PlayolaRadio.xcodeproj
       - run:
-          name: Fastlane release_build_only (dry run, no upload)
-          command: bundle exec fastlane release_build_only
+          name: Fastlane release_production (build + upload to TestFlight + Sentry dSYMs)
+          command: bundle exec fastlane release_production
       - store_artifacts:
           path: build
       - store_test_results:

--- a/.claude/skills/fix-review/SKILL.md
+++ b/.claude/skills/fix-review/SKILL.md
@@ -40,23 +40,41 @@ gh api graphql -f query='
 ```
 
 **Polling behavior:**
-- If the query returns unresolved threads, proceed to Step 3.
-- If it returns nothing, wait 20 seconds and retry. Repeat up to 9 times (~3 minutes total).
-- If still no unresolved threads after that, say "No unresolved review comments after polling for 3 minutes" and exit. The user can re-invoke the skill later if a review lands.
+- If the query returns unresolved threads OR the summary body has findings (see below), proceed to Step 3.
+- If both are empty, wait 20 seconds and retry. Repeat up to 9 times (~3 minutes total).
+- If still nothing after that, say "No unresolved review comments after polling for 3 minutes" and exit. The user can re-invoke the skill later if a review lands.
+
+**Also check the PR summary body.** Some reviewers (e.g. Greptile) post findings as an issue comment on the PR rather than as inline review threads. These appear under a "Comments Outside Diff" / "greptile_failed_comments" section and are NOT returned by the `reviewThreads` query. Always fetch them too:
+
+```bash
+gh api repos/{owner}/{repo}/issues/{number}/comments \
+  --jq '.[] | select(.user.login | test("greptile|claude"; "i")) | {id, body}'
+```
+
+If any of those comment bodies contain a "Comments Outside Diff" block or P0/P1/P2 badges, treat each bulleted finding as a review comment and feed it into Step 4 alongside any inline threads.
 
 ## Step 3: Fetch review comments
 
-Fetch the inline review comments from the PR:
+Fetch both the inline review comments AND the summary-body findings from the PR:
 
 ```bash
-# Get all reviews
+# Inline reviews (threads on specific lines)
 gh api repos/{owner}/{repo}/pulls/{number}/reviews --jq '.[] | {id, state, user: .user.login}'
-
-# For each review by claude[bot], get the comments
 gh api repos/{owner}/{repo}/pulls/{number}/reviews/{review_id}/comments --jq '.[] | {id, path, line, body}'
+
+# Summary-body findings (Greptile "Comments Outside Diff", etc.)
+gh api repos/{owner}/{repo}/issues/{number}/comments \
+  --jq '.[] | select(.user.login | test("greptile|claude"; "i")) | .body' > /tmp/pr_summary_{number}.html
 ```
 
-Extract all FAIL and WARN items — each will reference:
+For the summary body, extract each bulleted finding — it'll reference:
+- The file and line range (e.g., `fastlane/Fastfile`, line 84-91)
+- A P0/P1/P2 badge
+- A title and description
+
+Summary-body findings don't have a thread to resolve or reply to individually. Track them separately — for these, add a thumbs-up reaction to the parent issue comment and mention the fix in the commit message (no per-thread reply).
+
+Extract all FAIL and WARN items from inline reviews — each will reference:
 - The comment ID (needed for acknowledging fixes)
 - The check that failed
 - Specific files and line numbers
@@ -72,14 +90,16 @@ Work through each issue, starting with FAILs:
 4. The user will run tests in Xcode. If a test file changed, ask the user to run the relevant tests and report the result before proceeding.
 5. After fixing, acknowledge the review comment (but do NOT resolve the thread yet — resolution happens in Step 6 once all checks pass):
    ```bash
-   # Add a 👍 reaction
+   # For INLINE review comments:
    gh api repos/{owner}/{repo}/pulls/comments/{comment_id}/reactions -f content="+1"
-
-   # Reply to the comment thread — see reply guidelines below
    gh api repos/{owner}/{repo}/pulls/{number}/comments/{comment_id}/replies -f body="Fixed"
+
+   # For SUMMARY-BODY findings (no inline thread exists):
+   gh api repos/{owner}/{repo}/issues/comments/{issue_comment_id}/reactions -f content="+1"
+   # No per-finding reply — mention what was fixed in the commit message instead.
    ```
 
-   Track each `{comment_id}` you replied to with "Fixed" — you'll need the matching thread IDs in Step 6.
+   Track each inline `{comment_id}` you replied to with "Fixed" — you'll need the matching thread IDs in Step 6. Summary-body findings don't have threads to resolve, so they're done after the thumbs-up + commit.
 
    **Reply guidelines:**
    - If the fix was straightforward, reply "Fixed".

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -67,6 +67,12 @@ platform :ios do
     ensure_git_status_clean
     ensure_git_branch(branch: 'main') unless ENV['CI']
 
+    match(
+      type: "appstore",
+      app_identifier: "fm.playola.playolaradio",
+      readonly: true
+    )
+
     scan(
       include_simulator_logs: false,
       parallel_testing: false,
@@ -79,6 +85,7 @@ platform :ios do
       project: "PlayolaRadio.xcodeproj",
       scheme: "PlayolaRadio",
       export_method: "app-store",
+      output_directory: "./build",
       xcargs: "-skipPackagePluginValidation -skipMacroValidation"
     )
 
@@ -105,36 +112,6 @@ platform :ios do
       project_slug: 'apple-ios',
       include_sources: true
     )
-  end
-
-  desc "Build PRODUCTION (no upload) — CI signing dry run"
-  lane :release_build_only do
-    ensure_git_status_clean
-    ensure_git_branch(branch: 'main') unless ENV['CI']
-
-    match(
-      type: "appstore",
-      app_identifier: "fm.playola.playolaradio",
-      readonly: true
-    )
-
-    scan(
-      include_simulator_logs: false,
-      parallel_testing: false,
-      scheme: "PlayolaRadio",
-      xcargs: "-skipMacroValidation -skipPackagePluginValidation",
-      xcodebuild_formatter: "xcbeautify"
-    )
-
-    build_app(
-      project: "PlayolaRadio.xcodeproj",
-      scheme: "PlayolaRadio",
-      export_method: "app-store",
-      output_directory: "./build",
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
-    )
-
-    puts "✅ Build complete. Upload skipped (PR 4 dry run)."
   end
 
   desc "Upload debug symbols to Sentry"

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -86,7 +86,19 @@ platform :ios do
       scheme: "PlayolaRadio",
       export_method: "app-store",
       output_directory: "./build",
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation"
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation",
+      export_options: {
+        method: "app-store",
+        provisioningProfiles: {
+          "fm.playola.playolaradio" => "match AppStore fm.playola.playolaradio"
+        }
+      }
+    )
+
+    sentry_debug_files_upload(
+      org_slug: 'playola-radio',
+      project_slug: 'apple-ios',
+      include_sources: true
     )
 
     key_content = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] ||
@@ -106,12 +118,6 @@ platform :ios do
 
     puts "✅ Production build uploaded to TestFlight!"
     puts "📱 App: fm.playola.playolaradio"
-
-    sentry_debug_files_upload(
-      org_slug: 'playola-radio',
-      project_slug: 'apple-ios',
-      include_sources: true
-    )
   end
 
   desc "Upload debug symbols to Sentry"


### PR DESCRIPTION
## Summary

Final piece of the TestFlight automation ([plan](https://github.com/playola-radio/playola-radio-ios/blob/develop/.claude/playola-release-automation-plan.md) PR 5). PR 4 proved signing works on CI without uploading; this flips the switch.

- `release_production` now pulls the cert/profile via `match` (readonly) — required on CI, harmless locally.
- `build_app` gets `output_directory: "./build"` so CI artifacts pick up the `.ipa` + `.dSYM.zip`.
- Dropped `release_build_only` — dry-run lane from PR 4, redundant now.
- CircleCI `release_build` job invokes `release_production` instead of `release_build_only`.

## Prerequisite

`SENTRY_AUTH_TOKEN` (org:ci scope) must be present in the `ios-release` CircleCI context. All other context vars (ASC API key, MATCH, SECRETS_*) are already in place from PR 4.

## What happens on the next real release

1. Merge a release PR to `main`.
2. `auto-tag-release.yml` creates `vX.Y.Z`.
3. The `release` workflow fires, runs `release_production`:
   - match → scan → build_app → upload_to_testflight → sentry_debug_files_upload
4. Build appears in TestFlight under `fm.playola.playolaradio`.
5. App Store promotion stays manual on purpose.

## Test plan

- [ ] Merge PR.
- [ ] Watch the first real release tag (not a fake `v0.0.0-*`) — TestFlight rejects duplicate version/build combos, so we can't meaningfully dry-run the upload with a fake tag.
- [ ] Confirm the build shows up in TestFlight.
- [ ] Confirm Sentry has new dSYMs for that build.