### PR TITLE
ci: hotfix build-bump flow with vX.Y.Z-bN tags

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -17,22 +17,28 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Extract version from project
+      - name: Extract version and build from project
         id: version
         run: |
           VERSION=$(grep -m1 'MARKETING_VERSION' PlayolaRadio.xcodeproj/project.pbxproj | sed 's/.*= //' | sed 's/;.*//' | tr -d ' ')
+          BUILD=$(grep 'CURRENT_PROJECT_VERSION' PlayolaRadio.xcodeproj/project.pbxproj | sed 's/.*= //' | sed 's/;.*//' | tr -d ' ' | sort -n | tail -1)
+          TAG="v${VERSION}-b${BUILD}"
           echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "build=$BUILD" >> $GITHUB_OUTPUT
+          echo "tag=$TAG" >> $GITHUB_OUTPUT
           echo "Detected version: $VERSION"
+          echo "Detected build: $BUILD"
+          echo "Tag: $TAG"
 
       - name: Check if tag exists
         id: check
         run: |
-          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+          if git rev-parse "${{ steps.version.outputs.tag }}" >/dev/null 2>&1; then
             echo "exists=true" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.version.outputs.version }} already exists"
+            echo "Tag ${{ steps.version.outputs.tag }} already exists"
           else
             echo "exists=false" >> $GITHUB_OUTPUT
-            echo "Tag v${{ steps.version.outputs.version }} does not exist"
+            echo "Tag ${{ steps.version.outputs.tag }} does not exist"
           fi
 
       - name: Create tag
@@ -40,15 +46,15 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag -a "v${{ steps.version.outputs.version }}" -m "Release ${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
+          git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.version }} build ${{ steps.version.outputs.build }}"
+          git push origin "${{ steps.version.outputs.tag }}"
 
       - name: Summary
         run: |
           echo "## Release Tag" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           if [ "${{ steps.check.outputs.exists }}" == "true" ]; then
-            echo "Tag \`v${{ steps.version.outputs.version }}\` already exists - no action taken" >> $GITHUB_STEP_SUMMARY
+            echo "Tag \`${{ steps.version.outputs.tag }}\` already exists - no action taken" >> $GITHUB_STEP_SUMMARY
           else
-            echo "Created tag \`v${{ steps.version.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+            echo "Created tag \`${{ steps.version.outputs.tag }}\`" >> $GITHUB_STEP_SUMMARY
           fi

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 ORIGINAL_REPO := $(HOME)/playola/playola-radio-ios
 
-.PHONY: lint format format-check release bump-build release-production release-staging setup-conductor
+.PHONY: lint format format-check create-release create-new-build release-production release-staging setup-conductor
 
 # Run SwiftLint (strict mode to match CI)
 lint:
@@ -14,12 +14,12 @@ format:
 format-check:
 	xcrun swift-format lint --strict --recursive .
 
-# Create a release PR (develop -> main)
-release:
+# Create a release PR (develop -> main) with a version bump
+create-release:
 	./scripts/release.sh
 
-# Increment build number only (for hotfixes)
-bump-build:
+# Create a hotfix PR that bumps only the build number (version unchanged)
+create-new-build:
 	./scripts/bump-build.sh
 
 # Build and upload production to TestFlight

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -30,8 +30,10 @@ in both flows.
    accurate.
 
 3. **Auto-tag fires.** `.github/workflows/auto-tag-release.yml` runs on push
-   to `main`, reads `MARKETING_VERSION` from the pbxproj, and pushes tag
-   `vX.Y.Z` if it does not already exist.
+   to `main`, reads `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` from
+   the pbxproj, and pushes tag `vX.Y.Z-bN` if it does not already exist.
+   Each TestFlight build gets a unique `v<version>-b<build>` tag so hotfix
+   build bumps trigger a fresh CircleCI upload under the same version.
 
 4. **Sync-back PR opens.** `.github/workflows/sync-main-to-develop.yml` fires
    on the same push and opens a PR merging `main` back into `develop`. Merge
@@ -73,17 +75,29 @@ The incremental rollout is:
 
 ## Hotfix path
 
-For a build-number-only bump on an existing version (for example, to
-re-upload after a TestFlight processing failure), run:
+For a build-number-only bump on an existing version (for example, to fix a
+bug found by TestFlight testers on a shipped version, or to re-upload after
+a TestFlight processing failure), on a clean `develop` run:
 
 ```sh
-./scripts/bump-build.sh          # local commit only
-./scripts/bump-build.sh --push   # commit and push
+./scripts/bump-build.sh
 ```
 
-This bumps the build number via `agvtool`, commits the change, and
-optionally pushes. Use this on a branch that will still go through the
-normal release-PR flow. It does not create a PR or tag by itself.
+The script:
+
+1. Verifies you are on `develop` with a clean working tree.
+2. Fetches `origin/main` and `origin/develop`.
+3. Bumps the build number via `agvtool` (version stays the same).
+4. Creates `hotfix/<version>-b<new_build>`, commits, and pushes.
+5. Opens a PR targeting `main` with the PRs merged to `develop` since the
+   last release tag.
+
+Merge the hotfix PR using **"Create a merge commit"** (same rule as the
+release PR — do not squash). Auto-tag then fires with `vX.Y.Z-bN` and
+CircleCI uploads a new TestFlight build under the unchanged version.
+
+If the fix warrants a version bump (not just a build rebuild), use
+`./scripts/release.sh` with the `patch` option instead.
 
 ## Secrets
 

--- a/scripts/bump-build.sh
+++ b/scripts/bump-build.sh
@@ -2,26 +2,106 @@
 
 set -e
 
+echo "Create Hotfix Build Bump PR"
+echo "==========================="
+echo ""
+
+current_branch=$(git rev-parse --abbrev-ref HEAD)
+if [ "$current_branch" != "develop" ]; then
+  echo "Error: Must be on 'develop' branch (currently on '$current_branch')"
+  exit 1
+fi
+
 if ! git diff --quiet || ! git diff --cached --quiet; then
   echo "Error: Working tree is not clean. Commit or stash changes first."
   exit 1
 fi
 
+git fetch origin main develop --quiet
+git fetch origin --tags --quiet
+
+current_version=$(agvtool what-marketing-version -terse1 | head -1)
 current_build=$(agvtool what-version -terse | sort -n | tail -1)
 new_build=$((current_build + 1))
 
-echo "Bumping build number: $current_build -> $new_build"
+last_tag=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")
+
+echo "Hotfix Summary"
+echo "--------------"
+echo "  Version:       $current_version (unchanged)"
+echo "  Build number:  $current_build -> $new_build"
+echo "  Last tag:      ${last_tag:-<none>}"
+echo ""
+
+if [ -n "$last_tag" ]; then
+  echo "PRs since $last_tag:"
+  echo "----------------------"
+  git log "$last_tag..origin/develop" --first-parent --pretty=format:"%s" 2>/dev/null | grep -oE '#[0-9]+' | sort -t'#' -k1 -rn | uniq | while read pr; do
+    num=${pr#\#}
+    title=$(gh pr view "$num" --json title --jq '.title' 2>/dev/null)
+    echo "  $pr: $title"
+  done
+  echo ""
+fi
+
+read -p "Proceed? [y/N] " confirm
+if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
+  echo "Aborted."
+  exit 1
+fi
+
+hotfix_branch="hotfix/${current_version}-b${new_build}"
+
+echo ""
+echo "Creating hotfix branch..."
+git checkout -b "$hotfix_branch"
+
+echo ""
+echo "Bumping build number..."
 agvtool new-version -all "$new_build"
 
+echo ""
+echo "Committing..."
 git add -A
 git commit -m "Bump build number to $new_build"
 
-current_version=$(agvtool what-marketing-version -terse1 | head -1)
 echo ""
-echo "Done: $current_version ($new_build)"
+echo "Pushing hotfix branch..."
+git push -u origin "$hotfix_branch"
 
-if [ "$1" = "--push" ]; then
-  echo "Pushing..."
-  git push
-  echo "Pushed."
+echo ""
+echo "Creating PR..."
+
+changes_section=""
+if [ -n "$last_tag" ]; then
+  changes_section=$(git log "$last_tag..origin/develop" --first-parent --pretty=format:"%s" 2>/dev/null | grep -oE '#[0-9]+' | sort -t'#' -k1 -rn | uniq | while read pr; do
+    num=${pr#\#}
+    title=$(gh pr view "$num" --json title --jq '.title' 2>/dev/null)
+    echo "- $pr: $title"
+  done)
 fi
+
+pr_body="Build-only bump — no version change. Rebuilds \`$current_version\` as build \`$new_build\` so CircleCI uploads a fresh TestFlight build under the same version.
+
+> ⚠️ **Merge this PR using \"Create a merge commit\". Do NOT squash.**
+>
+> Squashing collapses merge history on \`main\` and the next release's PR list will re-include PRs that already shipped. Use a merge commit to preserve the first-parent chain.
+
+### Changes since last build
+${changes_section:-_No PRs merged to develop since ${last_tag:-initial}._}
+
+### Version
+\`$current_version\` (build \`$new_build\`)"
+
+gh pr create \
+  --base main \
+  --head "$hotfix_branch" \
+  --title "Hotfix: $current_version build $new_build" \
+  --body "$pr_body"
+
+echo ""
+echo "Switching back to develop..."
+git checkout develop
+
+echo ""
+echo "Done! Merge the PR on GitHub using 'Create a merge commit'."

--- a/scripts/bump-build.sh
+++ b/scripts/bump-build.sh
@@ -17,6 +17,11 @@ if ! git diff --quiet || ! git diff --cached --quiet; then
   exit 1
 fi
 
+if ! gh auth status --hostname github.com >/dev/null 2>&1; then
+  echo "Error: 'gh' is not authenticated. Run 'gh auth login' first."
+  exit 1
+fi
+
 git fetch origin main develop --quiet
 git fetch origin --tags --quiet
 
@@ -36,7 +41,7 @@ echo ""
 if [ -n "$last_tag" ]; then
   echo "PRs since $last_tag:"
   echo "----------------------"
-  git log "$last_tag..origin/develop" --first-parent --pretty=format:"%s" 2>/dev/null | grep -oE '#[0-9]+' | sort -t'#' -k1 -rn | uniq | while read pr; do
+  git log "$last_tag..origin/develop" --first-parent --pretty=format:"%s" 2>/dev/null | grep -oE '#[0-9]+' | sort -t'#' -k2 -rn | uniq | while read pr; do
     num=${pr#\#}
     title=$(gh pr view "$num" --json title --jq '.title' 2>/dev/null)
     echo "  $pr: $title"
@@ -51,6 +56,11 @@ if [ "$confirm" != "y" ] && [ "$confirm" != "Y" ]; then
 fi
 
 hotfix_branch="hotfix/${current_version}-b${new_build}"
+
+if git show-ref --quiet "refs/heads/$hotfix_branch"; then
+  echo "Error: branch '$hotfix_branch' already exists locally. Delete it first or push manually."
+  exit 1
+fi
 
 echo ""
 echo "Creating hotfix branch..."
@@ -74,7 +84,7 @@ echo "Creating PR..."
 
 changes_section=""
 if [ -n "$last_tag" ]; then
-  changes_section=$(git log "$last_tag..origin/develop" --first-parent --pretty=format:"%s" 2>/dev/null | grep -oE '#[0-9]+' | sort -t'#' -k1 -rn | uniq | while read pr; do
+  changes_section=$(git log "$last_tag..origin/develop" --first-parent --pretty=format:"%s" 2>/dev/null | grep -oE '#[0-9]+' | sort -t'#' -k2 -rn | uniq | while read pr; do
     num=${pr#\#}
     title=$(gh pr view "$num" --json title --jq '.title' 2>/dev/null)
     echo "- $pr: $title"


### PR DESCRIPTION
## Summary

- Tag each TestFlight build with `v<version>-b<build>` so hotfix build bumps
  re-trigger CircleCI under an unchanged version (closes the gap where
  bumping the build alone never created a new tag).
- Rewrite `scripts/bump-build.sh` to follow the release.sh-style flow:
  require clean `develop`, create `hotfix/<version>-b<new_build>`, commit
  the `agvtool` bump, push, and open a PR to `main` with the PRs merged to
  `develop` since the last release tag.
- Update `RELEASE.md` Hotfix path to describe the new flow and the tag
  format.

## How it closes the gap

Previously, `.github/workflows/auto-tag-release.yml` tagged `v5.6.1` and
skipped if the tag already existed. A subsequent build-number bump never
fired a new tag, so CircleCI never uploaded a replacement TestFlight build.
The new tag format `v5.6.1-b82` is unique per build, so every build-number
bump merged to `main` produces a new tag and a new CircleCI upload.

The CircleCI `v*` tag filter already matches `vX.Y.Z-bN`; no CI-config
change is needed.

## Test plan

- [ ] `bash -n scripts/bump-build.sh` (done locally — passes)
- [ ] YAML parses (done locally — passes)
- [ ] Walk through `bump-build.sh` checkpoints: dirty tree, not on develop,
      missing `gh` auth all error out correctly
- [ ] After merge: merge a trivial fix to develop, run
      `scripts/bump-build.sh`, merge the hotfix PR with a **merge commit**,
      watch for tag `v5.6.1-b<N+1>` and a fresh TestFlight build