### PR TITLE
style: design-review pass on StationListPage + palette cleanup

### DIFF
--- a/PlayolaRadio/Extensions/Color+Palette.swift
+++ b/PlayolaRadio/Extensions/Color+Palette.swift
@@ -8,12 +8,6 @@
 import SwiftUI
 
 extension Color {
-  // MARK: - Primary Colors
-
-  static var primary: Color { Color(hex: "#EF6962") }
-  static var primaryHover: Color { Color(hex: "#FF7E78") }
-  static var primaryDeep: Color { Color(hex: "#C4514A") }
-
   // MARK: - Surfaces
 
   static var background: Color { Color(hex: "#130000") }

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageView.swift
@@ -56,7 +56,7 @@ struct BroadcastersListenerQuestionPageView: View {
               .padding(.vertical, 8)
               .background(
                 model.selectedFilter == filter
-                  ? Color.primary
+                  ? Color.playolaRed
                   : Color.elevatedSurface
               )
               .cornerRadius(20)
@@ -231,11 +231,11 @@ struct ListenerQuestionRow: View {
               HStack(spacing: 4) {
                 Text(isExpanded ? "Show less" : "Show more")
                   .font(.custom(FontNames.Inter_500_Medium, size: 13))
-                  .foregroundColor(.primary)
+                  .foregroundColor(.playolaRed)
 
                 Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
                   .font(.system(size: 11, weight: .semibold))
-                  .foregroundColor(.primary)
+                  .foregroundColor(.playolaRed)
               }
             }
           }
@@ -274,7 +274,7 @@ struct ListenerQuestionRow: View {
       .foregroundColor(.textPrimary)
       .padding(.horizontal, 12)
       .padding(.vertical, 8)
-      .background(Color.primary)
+      .background(Color.playolaRed)
       .cornerRadius(20)
     }
   }

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
@@ -14,7 +14,7 @@ struct ContactPageView: View {
 
   var body: some View {
     VStack(spacing: 0) {
-      // Sticky Title
+      // Title
       HStack {
         Text("Your Profile")
           .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 32))

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
@@ -172,7 +172,7 @@ struct ContactPageView: View {
               .frame(maxWidth: .infinity)
               .frame(height: 50)
               .padding(.horizontal, 16)
-              .background(Color.primary)
+              .background(Color.playolaRed)
               .cornerRadius(6)
             }
           )
@@ -200,7 +200,7 @@ struct ContactPageView: View {
               .frame(maxWidth: .infinity)
               .frame(height: 50)
               .padding(.horizontal, 16)
-              .background(Color.primary)
+              .background(Color.playolaRed)
               .cornerRadius(6)
             }
           )
@@ -228,7 +228,7 @@ struct ContactPageView: View {
                     if unreadSupportCount > 0 {
                       Text("\(unreadSupportCount)")
                         .font(.system(size: 10, weight: .bold))
-                        .foregroundColor(Color.primary)
+                        .foregroundColor(Color.playolaRed)
                         .frame(minWidth: 16, minHeight: 16)
                         .background(Circle().fill(Color.white))
                         .offset(x: 8, y: -8)
@@ -247,7 +247,7 @@ struct ContactPageView: View {
               .frame(maxWidth: .infinity)
               .frame(height: 50)
               .padding(.horizontal, 16)
-              .background(Color.primary)
+              .background(Color.playolaRed)
               .cornerRadius(6)
             }
           )
@@ -276,7 +276,7 @@ struct ContactPageView: View {
               .frame(maxWidth: .infinity)
               .frame(height: 50)
               .padding(.horizontal, 16)
-              .background(Color.primary)
+              .background(Color.playolaRed)
               .cornerRadius(6)
             }
           )

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
@@ -114,13 +114,13 @@ struct ListenerQuestionDetailPageView: View {
         .foregroundColor(.textPrimary)
         .padding(.horizontal, 16)
         .padding(.vertical, 10)
-        .background(Color.primary)
+        .background(Color.playolaRed)
         .cornerRadius(20)
       }
 
       if model.questionPlaybackState.isPlaying {
         ProgressView(value: model.questionPlaybackState.progress)
-          .progressViewStyle(LinearProgressViewStyle(tint: .primary))
+          .progressViewStyle(LinearProgressViewStyle(tint: .playolaRed))
           .background(Color.elevatedSurface)
       }
     }
@@ -190,12 +190,12 @@ struct ListenerQuestionDetailPageView: View {
   private var recordingIndicator: some View {
     HStack(spacing: 8) {
       Circle()
-        .fill(Color.primary)
+        .fill(Color.playolaRed)
         .frame(width: 10, height: 10)
 
       Text("Recording")
         .font(.custom(FontNames.Inter_600_SemiBold, size: 14))
-        .foregroundColor(.primary)
+        .foregroundColor(.playolaRed)
 
       Spacer()
 
@@ -213,7 +213,7 @@ struct ListenerQuestionDetailPageView: View {
       } label: {
         ZStack {
           Circle()
-            .fill(Color.primary)
+            .fill(Color.playolaRed)
             .frame(width: 80, height: 80)
 
           if model.recordingPhase == .recording {
@@ -237,7 +237,7 @@ struct ListenerQuestionDetailPageView: View {
   private var uploadStatusView: some View {
     VStack(spacing: 8) {
       ProgressView(value: model.uploadProgress)
-        .progressViewStyle(LinearProgressViewStyle(tint: .primary))
+        .progressViewStyle(LinearProgressViewStyle(tint: .playolaRed))
 
       Text(model.uploadStatusText)
         .font(.custom(FontNames.Inter_500_Medium, size: 14))
@@ -266,12 +266,12 @@ struct ListenerQuestionDetailPageView: View {
           Text(model.discardButtonTitle)
         }
         .font(.custom(FontNames.Inter_600_SemiBold, size: 15))
-        .foregroundColor(.primary)
+        .foregroundColor(.playolaRed)
         .frame(maxWidth: .infinity)
         .frame(height: 48)
         .overlay(
           RoundedRectangle(cornerRadius: 24)
-            .stroke(Color.primary, lineWidth: 2)
+            .stroke(Color.playolaRed, lineWidth: 2)
         )
       }
 
@@ -286,7 +286,7 @@ struct ListenerQuestionDetailPageView: View {
         .foregroundColor(.textPrimary)
         .frame(maxWidth: .infinity)
         .frame(height: 48)
-        .background(Color.primary)
+        .background(Color.playolaRed)
         .cornerRadius(24)
       }
     }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -50,7 +50,9 @@ class StationListModel: ViewModel {
   let navigationTitle = "Radio Stations"
   let suggestArtistButtonText = "Suggest Station"
   let searchBarPlaceholder = "Search stations"
+  let noResultsIconName = "music.note.list"
   let noResultsMessage = "No stations found"
+  let noResultsHint = "Try a different search, or tap Suggest Station to request one."
 
   // MARK: - User Actions
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -140,7 +140,7 @@ struct StationListPage: View {
     if !items.isEmpty {
       VStack(alignment: .leading, spacing: 1) {
         Text(list.title)
-          .font(.custom("Inter-Regular", size: 16))
+          .font(.custom(FontNames.Inter_600_SemiBold, size: 14))
           .foregroundColor(.white)
           .padding(.horizontal)
           .padding(.bottom, 8)

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -69,6 +69,15 @@ struct StationListPage: View {
           .padding(.top, 24)
         }
         .padding(.vertical, 8)
+        .overlay(alignment: .trailing) {
+          LinearGradient(
+            colors: [Color.black.opacity(0), Color.black],
+            startPoint: .leading,
+            endPoint: .trailing
+          )
+          .frame(width: 24)
+          .allowsHitTesting(false)
+        }
       }
       .background(Color.black)
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -99,7 +99,7 @@ struct StationListPage: View {
     .navigationBarTitleDisplayMode(.inline)
     .background(Color.black)
     .onAppear { Task { await model.viewAppeared() } }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 
   private var searchBar: some View {

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -155,16 +155,8 @@ struct StationListPage: View {
                 Task { await model.stationSelected(item) }
               })
           }
-
         }
       }
-      .animation(
-        .easeInOut(duration: 0.5),
-        value: items.map { item in
-          let liveStatus = model.liveStatusForStation(item.anyStation.id)
-          return "\(item.anyStation.id)-\(liveStatus?.rawValue ?? "none")"
-        }
-      )
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -37,7 +37,7 @@ struct StationListPage: View {
             .foregroundColor(.white)
             .padding(.horizontal, 12)
             .padding(.vertical, 6)
-            .background(Color.primary)
+            .background(Color.playolaRed)
             .cornerRadius(16)
           }
         }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -77,11 +77,21 @@ struct StationListPage: View {
       // ---------------------------------------------------------
       ScrollView {
         if model.isShowingNoResults {
-          Text(model.noResultsMessage)
-            .font(.custom(FontNames.Inter_500_Medium, size: 16))
-            .foregroundColor(.playolaGray)
-            .frame(maxWidth: .infinity)
-            .padding(.top, 40)
+          VStack(spacing: 12) {
+            Image(systemName: model.noResultsIconName)
+              .font(.system(size: 40, weight: .light))
+              .foregroundColor(.playolaGray)
+            Text(model.noResultsMessage)
+              .font(.custom(FontNames.Inter_600_SemiBold, size: 18))
+              .foregroundColor(.white)
+            Text(model.noResultsHint)
+              .font(.custom(FontNames.Inter_400_Regular, size: 14))
+              .foregroundColor(.playolaGray)
+              .multilineTextAlignment(.center)
+              .padding(.horizontal, 32)
+          }
+          .frame(maxWidth: .infinity)
+          .padding(.top, 64)
         } else {
           VStack(alignment: .leading, spacing: 20) {
             ForEach(model.stationListsForDisplay) { list in

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -59,7 +59,7 @@ struct StationListPage: View {
                   .background(
                     model.selectedSegment == segment
                       ? Color.playolaRed
-                      : Color(white: 0.2)
+                      : Color(hex: "#333333")
                   )
                   .cornerRadius(20)
               }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -15,9 +15,7 @@ struct StationListPage: View {
   // MARK: - View
   var body: some View {
     VStack(spacing: 0) {
-      // ---------------------------------------------------------
-      // Sticky Header
-      // ---------------------------------------------------------
+      // Header
       VStack(spacing: 0) {
         // Page Title
         HStack {
@@ -81,9 +79,7 @@ struct StationListPage: View {
       }
       .background(Color.black)
 
-      // ---------------------------------------------------------
       // Station Lists
-      // ---------------------------------------------------------
       ScrollView {
         if model.isShowingNoResults {
           VStack(spacing: 12) {
@@ -179,9 +175,9 @@ struct StationListPage: View {
     }
   }
 }
-// ------------------------------------------------------------------
+
 // MARK: - Preview
-// ------------------------------------------------------------------
+
 #Preview {
   NavigationStack {
     StationListPage(model: StationListModel())

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -36,7 +36,7 @@ struct StationListPage: View {
             }
             .foregroundColor(.white)
             .padding(.horizontal, 12)
-            .padding(.vertical, 6)
+            .padding(.vertical, 10)
             .background(Color.playolaRed)
             .cornerRadius(16)
           }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -41,7 +41,7 @@ struct StationListPage: View {
             .cornerRadius(16)
           }
         }
-        .padding(.horizontal, 20)
+        .padding(.horizontal, 16)
         .padding(.top, 20)
 
         // Segment Control

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowModel.swift
@@ -78,9 +78,3 @@ struct StationListStationRowModel {
     self.liveStatus = liveStatus
   }
 }
-
-extension StationListStationRowModel: Equatable {
-  static func == (lhs: StationListStationRowModel, rhs: StationListStationRowModel) -> Bool {
-    return lhs.item.anyStation.id == rhs.item.anyStation.id
-  }
-}

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
@@ -47,6 +47,7 @@ struct StationListStationRowView: View {
       }
       .padding(.horizontal)
       .padding(.vertical, 12)
+      .animation(.easeInOut(duration: 0.5), value: model.liveStatus)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
@@ -19,7 +19,7 @@ struct StationListStationRowView: View {
             .resizable()
             .aspectRatio(contentMode: .fill)
         } placeholder: {
-          Color(white: 0.2)
+          Color(hex: "#333333")
         }
         .frame(width: 64, height: 64)
         .clipped()

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -94,7 +94,7 @@ struct StationSuggestionPageView: View {
             .foregroundColor(.white)
             .padding(.horizontal, 16)
             .padding(.vertical, 10)
-            .background(Color.primary)
+            .background(Color.playolaRed)
             .cornerRadius(10)
         }
       }
@@ -161,13 +161,13 @@ struct StationSuggestionPageView: View {
           Text(model.voteButtonText(suggestion))
             .font(.custom(FontNames.Inter_500_Medium, size: 13))
         }
-        .foregroundColor(suggestion.hasVoted ? .white : .primary)
+        .foregroundColor(suggestion.hasVoted ? .white : .playolaRed)
         .padding(.horizontal, 14)
         .padding(.vertical, 8)
-        .background(suggestion.hasVoted ? Color.primary : Color.clear)
+        .background(suggestion.hasVoted ? Color.playolaRed : Color.clear)
         .overlay(
           RoundedRectangle(cornerRadius: 18)
-            .strokeBorder(Color.primary, lineWidth: suggestion.hasVoted ? 0 : 1)
+            .strokeBorder(Color.playolaRed, lineWidth: suggestion.hasVoted ? 0 : 1)
         )
         .cornerRadius(18)
       }


### PR DESCRIPTION
## Summary

Design-review pass on `StationListPage.swift` plus a repo-wide palette cleanup removing `Color.primary` as a shadow of SwiftUI's system color. 14 atomic commits, no new dependencies, no test changes required.

## Changes

**Palette:** removed `Color.primary` / `primaryHover` / `primaryDeep` from `Color+Palette.swift`. `Color.primary` shadowed SwiftUI's system label color — a footgun. All brand-red call sites across `BroadcastersListenerQuestionPageView`, `ContactPageView`, `ListenerQuestionDetailPageView`, `StationSuggestionPageView` migrated to `.playolaRed` to preserve rendering. `primaryHover` / `primaryDeep` were unused.

**StationListPage:**
- Suggest pill: `.primary` → `.playolaRed`, vertical padding 6 → 10 (44pt touch target).
- Section titles: hardcoded `"Inter-Regular" 16pt` → `FontNames.Inter_600_SemiBold 14pt`.
- Unselected segment chip: `Color(white: 0.2)` → `Color(hex: "#333333")`; row image placeholder same swap.
- Page title horizontal padding 20 → 16 for consistency with rows/sections/search.
- `.alert(item:)` → `.playolaAlert(...)` (matches `.claude/VIEWS.md`).
- Moved liveStatus `.animation` from the section VStack into `StationListStationRowView` so ripples scope to one row.
- No-results empty state: icon + stronger headline + softer hint (driven from `StationListModel`).
- 24pt trailing fade on the horizontal segment scroll as an overflow affordance.
- Dropped decorative `// ---` dividers and misleading "Sticky" comments on this page and `ContactPageView`.
- Dropped unused, partial `Equatable` on `StationListStationRowModel` (`==` ignored `liveStatus`, a latent footgun).

## Test plan

- [ ] Run full XCTest suite in Xcode — green.
- [ ] Eyeball `StationListPage` in sim: header alignment, empty-state layout, trailing fade on segment scroll, liveStatus animations on individual rows.
- [ ] Eyeball `ContactPage`, `StationSuggestionPage`, `ListenerQuestionDetailPage`, `BroadcastersListenerQuestionPage` to confirm palette refactor is visually identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)