### PR TITLE
refactor: image loading async/await (Swift 6 prep, Cluster A)

### DIFF
--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -281,12 +281,11 @@ class NowPlayingUpdater {
     }
 
     // For CarPlay/Lock Screen: always use station image, ignore album artwork
-    station.getImage { image in
-      Task {
-        self.updateNowPlayingImage(image)
-        await MainActor.run {
-          self.currentArtworkURL = station.imageUrl?.absoluteString
-        }
+    Task {
+      let image = await station.getImage()
+      self.updateNowPlayingImage(image)
+      await MainActor.run {
+        self.currentArtworkURL = station.imageUrl?.absoluteString
       }
     }
   }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -284,9 +284,7 @@ class NowPlayingUpdater {
     Task {
       let image = await station.getImage()
       self.updateNowPlayingImage(image)
-      await MainActor.run {
-        self.currentArtworkURL = station.imageUrl?.absoluteString
-      }
+      self.currentArtworkURL = station.imageUrl?.absoluteString
     }
   }
 

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -88,7 +88,7 @@ extension URLStreamPlayer {
 
     Task { [weak self] in
       let image = await station.getImage()
-      self?.updateLockScreen(with: image)
+      await MainActor.run { self?.updateLockScreen(with: image) }
     }
   }
 
@@ -140,11 +140,13 @@ extension URLStreamPlayer: FRadioPlayerObserver {
 
     Task { [weak self] in
       let image = await UIImage.image(from: artworkURL)
-      guard let image else {
-        self?.resetArtwork(with: self?.currentStation)
-        return
+      await MainActor.run {
+        guard let image else {
+          self?.resetArtwork(with: self?.currentStation)
+          return
+        }
+        self?.updateLockScreen(with: image)
       }
-      self?.updateLockScreen(with: image)
     }
   }
 

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -86,7 +86,8 @@ extension URLStreamPlayer {
       return
     }
 
-    station.getImage { [weak self] image in
+    Task { [weak self] in
+      let image = await station.getImage()
       self?.updateLockScreen(with: image)
     }
   }
@@ -137,12 +138,12 @@ extension URLStreamPlayer: FRadioPlayerObserver {
       return
     }
 
-    UIImage.image(from: artworkURL) { [weak self] image in
+    Task { [weak self] in
+      let image = await UIImage.image(from: artworkURL)
       guard let image else {
         self?.resetArtwork(with: self?.currentStation)
         return
       }
-
       self?.updateLockScreen(with: image)
     }
   }

--- a/PlayolaRadio/Extensions/UIImage+Cache.swift
+++ b/PlayolaRadio/Extensions/UIImage+Cache.swift
@@ -8,34 +8,30 @@
 import UIKit
 
 extension UIImage {
-  static func image(from url: URL?, completion: @Sendable @escaping (_ image: UIImage?) -> Void) {
-    guard let url else {
-      completion(nil)
-      return
-    }
+  static func image(from url: URL?) async -> UIImage? {
+    guard let url else { return nil }
 
     let cache = URLCache.shared
     let request = URLRequest(url: url)
 
     if let data = cache.cachedResponse(for: request)?.data, let image = UIImage(data: data) {
-      DispatchQueue.main.async {
-        completion(image)
-      }
-    } else {
-      URLSession.shared.dataTask(with: request) { data, response, _ in
-        guard let data,
-          let httpResponse = response as? HTTPURLResponse,
-          200...299 ~= httpResponse.statusCode,
-          let image = UIImage(data: data)
-        else {
-          DispatchQueue.main.async { completion(nil) }
-          return
-        }
+      return image
+    }
 
-        let cachedData = CachedURLResponse(response: httpResponse, data: data)
-        cache.storeCachedResponse(cachedData, for: request)
-        DispatchQueue.main.async { completion(image) }
-      }.resume()
+    do {
+      let (data, response) = try await URLSession.shared.data(for: request)
+      guard let httpResponse = response as? HTTPURLResponse,
+        200...299 ~= httpResponse.statusCode,
+        let image = UIImage(data: data)
+      else {
+        return nil
+      }
+
+      let cachedData = CachedURLResponse(response: httpResponse, data: data)
+      cache.storeCachedResponse(cachedData, for: request)
+      return image
+    } catch {
+      return nil
     }
   }
 }

--- a/PlayolaRadio/Models/RadioStation.swift
+++ b/PlayolaRadio/Models/RadioStation.swift
@@ -42,19 +42,14 @@ struct RadioStation: Codable, Identifiable, Equatable, Sendable {
 }
 
 extension RadioStation {
-  func getImage(completion: @escaping (_ image: UIImage) -> Void) {
+  func getImage() async -> UIImage {
     if imageURL.range(of: "http") != nil, let url = URL(string: imageURL) {
-      // load current station image from network
-      UIImage.image(from: url) { image in
-        // swiftlint:disable:next force_unwrapping
-        completion(image ?? UIImage(named: "stationImage")!)
-      }
-    } else {
-      // load local station image
+      let image = await UIImage.image(from: url)
       // swiftlint:disable:next force_unwrapping
-      let image = UIImage(named: imageURL) ?? UIImage(named: "stationImage")!
-      completion(image)
+      return image ?? UIImage(named: "stationImage")!
     }
+    // swiftlint:disable:next force_unwrapping
+    return UIImage(named: imageURL) ?? UIImage(named: "stationImage")!
   }
 }
 

--- a/PlayolaRadio/Models/StationList.swift
+++ b/PlayolaRadio/Models/StationList.swift
@@ -91,21 +91,18 @@ enum AnyStation: Identifiable, Codable, Equatable {
   }
 
   // Image loading method for UI components
-  func getImage(completion: @escaping (_ image: UIImage) -> Void) {
+  func getImage() async -> UIImage {
     switch self {
     case .playola(let station):
       if let imageUrl = station.imageUrl {
-        UIImage.image(from: imageUrl) { image in
-          // swiftlint:disable:next force_unwrapping
-          completion(image ?? UIImage(named: "stationImage")!)
-        }
-      } else {
+        let image = await UIImage.image(from: imageUrl)
         // swiftlint:disable:next force_unwrapping
-        let image = UIImage(named: "stationImage")!
-        completion(image)
+        return image ?? UIImage(named: "stationImage")!
       }
+      // swiftlint:disable:next force_unwrapping
+      return UIImage(named: "stationImage")!
     case .url(let station):
-      station.getImage(completion: completion)
+      return await station.getImage()
     }
   }
 }

--- a/PlayolaRadio/Models/UrlStation.swift
+++ b/PlayolaRadio/Models/UrlStation.swift
@@ -107,19 +107,14 @@ struct UrlStation: Codable, Identifiable, Equatable, Sendable {
 }
 
 extension UrlStation {
-  func getImage(completion: @escaping (_ image: UIImage) -> Void) {
+  func getImage() async -> UIImage {
     if let imageUrl = imageUrl {
-      // load current station image from network
-      UIImage.image(from: imageUrl) { image in
-        // swiftlint:disable:next force_unwrapping
-        completion(image ?? UIImage(named: "stationImage")!)
-      }
-    } else {
-      // load default station image
+      let image = await UIImage.image(from: imageUrl)
       // swiftlint:disable:next force_unwrapping
-      let image = UIImage(named: "stationImage")!
-      completion(image)
+      return image ?? UIImage(named: "stationImage")!
     }
+    // swiftlint:disable:next force_unwrapping
+    return UIImage(named: "stationImage")!
   }
 
   var trackName: String {


### PR DESCRIPTION
## Summary

PR 1 of the Swift 6 migration plan (`.context/attachments/swift-6-conversion-plan.md`) — **Cluster A**.

Replaces the `@Sendable @escaping` completion handler on `UIImage.image(from:)` and the three station `getImage` wrappers (`UrlStation`, `AnyStation`, `RadioStation`) with `async/await`, and updates the three callers in `URLStreamPlayer` and `NowPlayingUpdater` to wrap (or fold into) a `Task`. Drops the `DispatchQueue.main.async` plumbing in `UIImage+Cache.swift` in favor of `URLSession.shared.data(for:)`.

## Why

These were the 3 errors the plan's dry-run surfaced when flipping `SWIFT_VERSION = 6.0`. The fix is valid Swift 5 code, so it ships incremental concurrency safety without requiring the language-mode flip.

## Verification

- ✅ Debug build of `PlayolaRadio` scheme: succeeds
- ✅ All 889 tests pass
- 📉 Unique warnings: 199 → **170**; "this is an error in the Swift 6 language mode" occurrences: 1326 → **291**
- ⚠️ 2 new "passing closure as a 'sending' parameter" warnings at `URLStreamPlayer.swift:89,141` — same root cause as a pre-existing line-142 warning we removed (`URLStreamPlayer` not `Sendable`); deferred to plan item #6 (singleton-isolation audit).

## Test plan

- [ ] Pull, build, and verify lock-screen / CarPlay artwork still updates when changing stations
- [ ] Confirm the now-playing image refreshes on track changes for both Playola and URL stations