### PR TITLE
refactor: convert PlayolaAlert to struct (Swift 6 Cluster B)

### DIFF
--- a/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
@@ -8,13 +8,15 @@
 import SwiftUI
 
 @MainActor
-class PlayolaAlert: Equatable, Identifiable, Hashable {
-  static func == (lhs: PlayolaAlert, rhs: PlayolaAlert) -> Bool {
+struct PlayolaAlert: Equatable, Identifiable, Hashable {
+  nonisolated let id = UUID()
+
+  nonisolated static func == (lhs: PlayolaAlert, rhs: PlayolaAlert) -> Bool {
     lhs.title == rhs.title && lhs.message == rhs.message
   }
 
-  let title: String
-  let message: String?
+  nonisolated let title: String
+  nonisolated let message: String?
   let dismissButton: Alert.Button?
   let secondaryButton: Alert.Button?
   let primaryButtonText: String?
@@ -148,7 +150,7 @@ class PlayolaAlert: Equatable, Identifiable, Hashable {
     }
   }
 
-  func hash(into hasher: inout Hasher) {
+  nonisolated func hash(into hasher: inout Hasher) {
     hasher.combine(title)
     hasher.combine(message)
   }


### PR DESCRIPTION
## Summary

PR 2 of the [Swift 6 migration plan](../.context/attachments/swift-6-conversion-plan.md) — fixes Cluster B (`PlayolaAlert` conformance errors) without flipping `SWIFT_VERSION = 6.0`.

Under Swift 6 strict concurrency, the `@MainActor class PlayolaAlert` raised two conformance errors: `Equatable` and `Hashable` are nonisolated protocols, and synthesizing their witnesses on a MainActor-isolated type crosses actor boundaries.

**Fix:** convert to `@MainActor struct` and mark the three protocol witnesses + their two input fields as `nonisolated`:
- `id`, `title`, `message` → `nonisolated let`
- `static func ==` and `hash(into:)` → `nonisolated`

Keeping `@MainActor` on the type preserves all existing SwiftUI capture patterns (`Alert.Button` action closures, `Task {}` inheriting MainActor, `UIApplication.shared` access in the Settings factory) and requires **zero caller changes**.

### Answered open question

> For Cluster B, confirm `Alert.Button` (which holds an `@escaping` action) is `Sendable` enough to live inside a `Sendable struct`. If not, the actions may need to become `@Sendable () async -> Void`.

Answer: **no changes to `Alert.Button` needed**. I initially tried a plain `Sendable struct` with `@Sendable () async -> Void` actions — it compiled the file itself but rippled 3+ errors into `MainContainerModel` (MainActor state access from `@Sendable` closures) and required widening `@Sendable` across every factory that takes a closure (`ratingPrompt`, `notificationPermissionPrompt`, etc.). Keeping the struct `@MainActor` and only making the protocol-bridging members `nonisolated` is a dramatically smaller, safer change.

### 11 static factories — all migrate cleanly

`cannotOpenMailAlert`, `secretStationsTurnedOnAlert`, `secretStationsHiddenAlert`, `errorLoadingStation`, `notificationsDisabled`, `notificationScheduled`, `errorSchedulingNotification`, `ratingPrompt(...)`, `errorRedeemingPrize`, `prizeRedeemed` — plus the `extension PlayolaAlert` factories scattered across 16 other files. All continue to compile unchanged.

## Test plan

- [x] App `PlayolaRadio` Debug build: clean, 0 errors
- [x] App `PlayolaRadio-Staging` Debug build: clean, 0 errors
- [x] `PlayolaRadio` test scheme: 889 passed / 0 failures (~67s)
- [x] Warning diff vs pre-change: 2 warnings removed (the targeted Swift-6-mode conformance warnings on line 11), 0 new warnings
- [x] `make format` + `make lint`: clean

No second-wave errors surfaced in the app target from this change. Test-target dry-run under `SWIFT_VERSION = 6.0` is still part of a future PR (PR 3 in the plan).