### PR TITLE
build: enable InferSendableFromCaptures upcoming feature (Swift 6 Cluster C fix)

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2085,6 +2085,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
@@ -2128,6 +2129,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
@@ -2171,6 +2173,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
@@ -2333,6 +2336,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
@@ -2378,6 +2382,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore fm.playola.playolaradio";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;
@@ -2524,6 +2529,7 @@
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
+				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_STRICT_CONCURRENCY = complete;
 				SWIFT_VERSION = 5.0;


### PR DESCRIPTION
## Summary

Adds `-enable-upcoming-feature InferSendableFromCaptures` to all six PlayolaRadio / PlayolaRadio Staging build configurations. Eliminates **81 of 175** Swift-6-mode warnings (46% of the remaining wave) with a single project-setting change — no source-file churn.

## Why this, not `@preconcurrency import Dependencies`

Cluster C in [.context/swift6-second-wave.md](https://github.com/playola-radio/playola-radio-ios/blob/develop/.context/swift6-second-wave.md) is the 81 warnings of the form `type 'KeyPath<DependencyValues, T>' does not conform to 'Sendable'` emitted at every `@Dependency(\.x)` declaration site. The audit initially proposed `@preconcurrency import Dependencies` across 41 files; empirically that fix does **zero** — `@preconcurrency import` only suppresses warnings about symbols coming *from* that module, but `KeyPath` is from the Swift stdlib.

Per swift-dependencies maintainer [`stephencelis`](https://github.com/pointfreeco/swift-dependencies/discussions/267), the correct remedy is either to move to Swift 6 language mode, or to enable the [`InferSendableFromCaptures` upcoming feature](https://github.com/swiftlang/swift-evolution/blob/main/proposals/0418-inferring-sendable-for-methods.md) (SE-0418). We're not ready for the full Swift 6 flip, so the upcoming-feature route keeps the migration incremental.

Related:
- Swift compiler issue [#68943](https://github.com/apple/swift/issues/68943) — keypath sendability warning should be suppressed
- swift-dependencies discussion [#267](https://github.com/pointfreeco/swift-dependencies/discussions/267)
- Audit doc: `.context/swift6-second-wave.md` (updated in this branch's sibling context; gitignored)

## Verification

| Metric | Before | After |
|--------|-------:|------:|
| Unique "Swift 6 language mode" warnings (app target, clean build) | 175 | **94** |
| Unique `KeyPath<DependencyValues, _>` warnings | 81 | **0** |
| Build status | succeeds | succeeds |
| build-for-testing | succeeds | succeeds |

Exact xcodebuild command used for verification:

```sh
xcodebuild -project PlayolaRadio.xcodeproj \
  -scheme PlayolaRadio \
  -destination 'platform=iOS Simulator,id=0ED95016-7E41-4C57-B113-540BF2FF9624' \
  -configuration Debug clean build
grep "this is an error in the Swift 6 language mode" <log> | sort -u | wc -l
```

## Test plan

- [ ] Xcode opens the project without re-sorting / touching additional lines
- [ ] Clean build (Debug, any device) succeeds
- [ ] Unit test target builds
- [ ] Full test suite passes locally
- [ ] Launch staging build on a real device to confirm no runtime behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)