### PR TITLE
Swift 6 Cluster E: Sendable sweep for Toast, singletons, call-sites, APIClient

### DIFF
--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -623,7 +623,7 @@ extension APIClient: DependencyKey {
         let url =
           "\(Config.shared.productionBaseUrl.absoluteString)/v1/ios/stations/\(stationId)/source-tapes"
         let headers: HTTPHeaders = ["Authorization": "Bearer \(jwtToken)"]
-        var parameters: [String: Any] = [
+        var parameters: [String: any Sendable] = [
           "s3Key": s3Key,
           "name": name,
           "durationMS": durationMS,

--- a/PlayolaRadio/Core/Likes/LikesManager.swift
+++ b/PlayolaRadio/Core/Likes/LikesManager.swift
@@ -239,7 +239,7 @@ final class LikesManager: ObservableObject {
 
 // MARK: - Dependency
 
-extension LikesManager: DependencyKey {
+extension LikesManager: @preconcurrency DependencyKey {
   static let liveValue = LikesManager()
 }
 

--- a/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinator.swift
+++ b/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinator.swift
@@ -17,8 +17,9 @@ enum AppMode: Equatable {
 /// This class coordinates any ViewControllers that need to be pushed onto the
 /// top stack, meaning they will be presented over the MainContainer, covering the
 /// tabs.
+@MainActor
 @Observable
-final class MainContainerNavigationCoordinator: Sendable {
+final class MainContainerNavigationCoordinator {
   // Per-tab navigation paths
   var homePath: [Path] = []
   var stationsPath: [Path] = []
@@ -34,6 +35,8 @@ final class MainContainerNavigationCoordinator: Sendable {
 
   @ObservationIgnored @Shared(.activeTab) var activeTab
   @ObservationIgnored @Dependency(\.continuousClock) var clock
+
+  nonisolated init() {}
 
   /// Returns a binding-compatible path for the current active tab
   var path: [Path] {

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -23,8 +23,12 @@ enum NotificationPayload {
 }
 
 extension [AnyHashable: Any] {
-  /// Extracts the string fields we care about from an APNs userInfo dict
-  /// into a Sendable payload that can cross actor boundaries.
+  /// Extracts an APNs userInfo dict into a Sendable payload that can cross actor boundaries.
+  ///
+  /// Intentionally narrowed to primitive leaf values (String/Int/Double/Bool) keyed by String.
+  /// Non-string keys, nested dictionaries, arrays, and any other types are silently dropped.
+  /// If a future APNs payload adds nested structure we need to read, extend this helper to
+  /// handle the new shape explicitly rather than loosening the type guards.
   func sendablePayload() -> [String: any Sendable] {
     var result: [String: any Sendable] = [:]
     for (key, value) in self {
@@ -166,21 +170,17 @@ extension PushNotificationsClient: DependencyKey {
       let navCoordinatorShared = $navCoordinator
 
       if NotificationPayload.notificationType(from: userInfo) == "support_message" {
-        let isSupportPageVisible = await MainActor.run {
-          navCoordinatorShared.wrappedValue.path.contains { pathItem in
+        await MainActor.run {
+          let coordinator = navCoordinatorShared.wrappedValue
+          let isSupportPageVisible = coordinator.path.contains { pathItem in
             if case .supportPage = pathItem { return true }
             return false
           }
-        }
 
-        if isSupportPageVisible {
-          await MainActor.run {
+          if isSupportPageVisible {
             NotificationCenter.default.post(name: .refreshSupportMessages, object: nil)
-          }
-        } else {
-          await MainActor.run {
+          } else {
             let supportModel = SupportPageModel()
-            let coordinator = navCoordinatorShared.wrappedValue
             Task { await coordinator.navigateToSupport(supportModel) }
           }
         }

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -142,9 +142,11 @@ extension PushNotificationsClient: DependencyKey {
       @Shared(.mainContainerNavigationCoordinator) var navCoordinator
 
       if NotificationPayload.notificationType(from: userInfo) == "support_message" {
-        let isSupportPageVisible = navCoordinator.path.contains { pathItem in
-          if case .supportPage = pathItem { return true }
-          return false
+        let isSupportPageVisible = await MainActor.run {
+          navCoordinator.path.contains { pathItem in
+            if case .supportPage = pathItem { return true }
+            return false
+          }
         }
 
         if isSupportPageVisible {

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -13,12 +13,33 @@ import UIKit
 import UserNotifications
 
 enum NotificationPayload {
-  static func stationId(from userInfo: [AnyHashable: Any]) -> String? {
+  static func stationId(from userInfo: [String: any Sendable]) -> String? {
     userInfo["stationId"] as? String
   }
 
-  static func notificationType(from userInfo: [AnyHashable: Any]) -> String? {
+  static func notificationType(from userInfo: [String: any Sendable]) -> String? {
     userInfo["type"] as? String
+  }
+}
+
+extension [AnyHashable: Any] {
+  /// Extracts the string fields we care about from an APNs userInfo dict
+  /// into a Sendable payload that can cross actor boundaries.
+  func sendablePayload() -> [String: any Sendable] {
+    var result: [String: any Sendable] = [:]
+    for (key, value) in self {
+      guard let keyString = key as? String else { continue }
+      if let value = value as? String {
+        result[keyString] = value
+      } else if let value = value as? Int {
+        result[keyString] = value
+      } else if let value = value as? Double {
+        result[keyString] = value
+      } else if let value = value as? Bool {
+        result[keyString] = value
+      }
+    }
+    return result
   }
 }
 
@@ -56,7 +77,7 @@ struct PushNotificationsClient: Sendable {
 
   /// Handle notification tap - extracts station ID and plays it
   /// - Parameter userInfo: The notification payload
-  var handleNotificationTap: @Sendable (_ userInfo: [AnyHashable: Any]) async -> Void
+  var handleNotificationTap: @Sendable (_ userInfo: [String: any Sendable]) async -> Void
 
   /// Set the app icon badge count
   /// - Parameter count: The badge count to display
@@ -130,8 +151,10 @@ extension PushNotificationsClient: DependencyKey {
       do {
         let device = try await api.registerDevice(jwt, hexToken, "ios", appVersion)
         print("📱 Device registered successfully: \(device.id)")
+        let deviceId = device.id
+        let registeredDeviceIdShared = $registeredDeviceId
         await MainActor.run {
-          $registeredDeviceId.withLock { $0 = device.id }
+          registeredDeviceIdShared.withLock { $0 = deviceId }
         }
       } catch {
         print("📱 Failed to register device: \(error)")
@@ -140,10 +163,11 @@ extension PushNotificationsClient: DependencyKey {
     handleNotificationTap: { userInfo in
       @Shared(.stationLists) var stationLists
       @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      let navCoordinatorShared = $navCoordinator
 
       if NotificationPayload.notificationType(from: userInfo) == "support_message" {
         let isSupportPageVisible = await MainActor.run {
-          navCoordinator.path.contains { pathItem in
+          navCoordinatorShared.wrappedValue.path.contains { pathItem in
             if case .supportPage = pathItem { return true }
             return false
           }
@@ -156,7 +180,8 @@ extension PushNotificationsClient: DependencyKey {
         } else {
           await MainActor.run {
             let supportModel = SupportPageModel()
-            Task { await navCoordinator.navigateToSupport(supportModel) }
+            let coordinator = navCoordinatorShared.wrappedValue
+            Task { await coordinator.navigateToSupport(supportModel) }
           }
         }
         return

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -85,15 +85,8 @@ final class PushNotificationsTests: XCTestCase {
   // MARK: - Notification Payload Parsing
 
   func testParseNotificationPayloadExtractsStationId() {
-    let userInfo: [AnyHashable: Any] = [
-      "aps": [
-        "alert": [
-          "title": "Brian's Station",
-          "body": "I'm going live!",
-        ],
-        "sound": "default",
-      ],
-      "stationId": "test-station-123",
+    let userInfo: [String: any Sendable] = [
+      "stationId": "test-station-123"
     ]
 
     let stationId = NotificationPayload.stationId(from: userInfo)
@@ -102,14 +95,7 @@ final class PushNotificationsTests: XCTestCase {
   }
 
   func testParseNotificationPayloadReturnsNilWhenNoStationId() {
-    let userInfo: [AnyHashable: Any] = [
-      "aps": [
-        "alert": [
-          "title": "Test",
-          "body": "Test message",
-        ]
-      ]
-    ]
+    let userInfo: [String: any Sendable] = [:]
 
     let stationId = NotificationPayload.stationId(from: userInfo)
 
@@ -129,7 +115,7 @@ final class PushNotificationsTests: XCTestCase {
       }
     } operation: {
       @Dependency(\.pushNotifications) var pushNotifications
-      let userInfo: [AnyHashable: Any] = ["stationId": "station-abc"]
+      let userInfo: [String: any Sendable] = ["stationId": "station-abc"]
       await pushNotifications.handleNotificationTap(userInfo)
     }
 
@@ -215,7 +201,7 @@ final class PushNotificationsTests: XCTestCase {
 
     defer { NotificationCenter.default.removeObserver(observer) }
 
-    let userInfo: [AnyHashable: Any] = [
+    let userInfo: [String: any Sendable] = [
       "type": "support_message",
       "conversationId": "conv-123",
     ]

--- a/PlayolaRadio/Core/Toast/ToastClient.swift
+++ b/PlayolaRadio/Core/Toast/ToastClient.swift
@@ -10,7 +10,7 @@ import DependenciesMacros
 import Foundation
 
 @DependencyClient
-public struct ToastClient {
+public struct ToastClient: Sendable {
   public var show: @Sendable (PlayolaToast) async -> Void
   public var currentToast: @Sendable () async -> PlayolaToast?
   public var dismiss: @Sendable () async -> Void

--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -171,7 +171,7 @@ struct LoggedInUser: Codable {
   }
 }
 
-class AuthService {
+final class AuthService: @unchecked Sendable {
   static let shared = AuthService()
   @Shared(.auth) var auth: Auth
 

--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -171,7 +171,7 @@ struct LoggedInUser: Codable {
   }
 }
 
-final class AuthService: @unchecked Sendable {
+class AuthService: @unchecked Sendable {
   static let shared = AuthService()
   @Shared(.auth) var auth: Auth
 

--- a/PlayolaRadio/Models/Toast.swift
+++ b/PlayolaRadio/Models/Toast.swift
@@ -7,18 +7,18 @@
 
 import Foundation
 
-public struct PlayolaToast: Identifiable {
+public struct PlayolaToast: Identifiable, Sendable {
   public let id = UUID()
   public let message: String
   public let buttonTitle: String
   public let duration: TimeInterval
-  public let action: (() -> Void)?
+  public let action: (@Sendable () -> Void)?
 
   public init(
     message: String,
     buttonTitle: String,
     duration: TimeInterval = 3.0,
-    action: (() -> Void)? = nil
+    action: (@Sendable () -> Void)? = nil
   ) {
     self.message = message
     self.buttonTitle = buttonTitle

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -133,7 +133,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
     didReceive response: UNNotificationResponse,
     withCompletionHandler completionHandler: @escaping () -> Void
   ) {
-    let userInfo = response.notification.request.content.userInfo
+    let userInfo = response.notification.request.content.userInfo.sendablePayload()
     Task {
       await pushNotifications.handleNotificationTap(userInfo)
     }

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -24,7 +24,9 @@ extension Notification.Name {
   static let scheduleUpdated = Notification.Name("scheduleUpdated")
 }
 
-class AppDelegate: NSObject, UIApplicationDelegate, UNUserNotificationCenterDelegate {
+@MainActor
+class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotificationCenterDelegate
+{
   @Dependency(\.pushNotifications) var pushNotifications
 
   func application(

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -88,13 +88,14 @@ class SignInPageModel: ViewModel {
           print("Error signing into Google -- no serverAuthCode on signInResult.")
           return
         }
-        Task {
+        let userId = signInResult.user.userID ?? "unknown"
+        Task { @MainActor in
           do {
             let token = try await self.api.signInViaGoogle(serverAuthCode)
             self.$auth.withLock { $0 = Auth(jwtToken: token) }
             self.appRating.recordInstallDateIfNeeded()
             await self.analytics.track(
-              .signInCompleted(method: .google, userId: signInResult.user.userID ?? "unknown"))
+              .signInCompleted(method: .google, userId: userId))
           } catch {
             print("Google sign in failed: \(error)")
             await self.analytics.track(


### PR DESCRIPTION
## Summary

Bundles the remaining small Swift 6 warnings across several files into four logical sub-commits (plus a test-target fixup). URLStreamPlayer is intentionally out of scope — it needs an architectural refactor and will be a separate PR.

**Warning count: 33 → 13** (all 13 remaining in URLStreamPlayer).

## Sub-clusters cleared

1. **PlayolaToast + ToastClient Sendable** — Toast struct gains `Sendable` conformance with `@Sendable` action closure; ToastClient struct declared `Sendable` (its endpoint closures were already `@Sendable` from PR 5). Clears 9 warnings across ToastClient, MainContainerModel, and LikesManager.
2. **Singleton/static Sendable** — `AuthService: @unchecked Sendable`, `AppDelegate: @MainActor` with `@preconcurrency UNUserNotificationCenterDelegate` conformance, `MainContainerNavigationCoordinator: @MainActor` (implicitly Sendable, with `nonisolated init()` for the InMemoryKey default).
3. **Actor-boundary call-site fixes** — SignInPageModel Google callback hops back to `@MainActor` via `Task { @MainActor in }` with `userId` extracted locally; PushNotifications' `handleDeviceToken` and `handleNotificationTap` capture `@Shared` projections locally before `MainActor.run`; `handleNotificationTap`'s userInfo param narrowed from `[AnyHashable: Any]` to `[String: any Sendable]` with a new `sendablePayload()` helper on the AppDelegate side; `LikesManager: @preconcurrency DependencyKey`.
4. **APIClient+Live** — `createSpin` parameters dict typed `[String: any Sendable]`.
5. **Test fixup** — drop `final` on AuthService (AuthServiceMock subclasses it); update PushNotificationsTests userInfo fixtures to `[String: any Sendable]`.

## Out of scope

- `URLStreamPlayer.swift` (13 warnings) — architectural, separate PR.
- `SWIFT_VERSION = 6.0` flip — final PR after URLStreamPlayer.

## Test plan

- [x] App target clean build: 33 → 13 unique Swift 6 warnings (all in URLStreamPlayer)
- [x] Test target builds clean (`build-for-testing`)
- [x] `make format` + `make lint`: 0 violations
- [ ] Full XCTest suite passes in Xcode (user will run — Toast and PushNotifications changes can ripple into UI + delivery flows)