### PR TITLE
refactor: make URLStreamPlayer Swift 6 Sendable-safe

### DIFF
--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -11,6 +11,7 @@ import Foundation
 import MediaPlayer
 import UIKit
 
+@MainActor
 public class URLStreamPlayer: ObservableObject {
   var urlStreamReporter: UrlStreamListeningSessionReporter?
   struct State: Sendable, Equatable {
@@ -47,10 +48,7 @@ public class URLStreamPlayer: ObservableObject {
 
   init() {
     addObserverToPlayer()
-    Task {
-      self.urlStreamReporter = await UrlStreamListeningSessionReporter(
-        urlStreamPlayer: self)
-    }
+    self.urlStreamReporter = UrlStreamListeningSessionReporter(urlStreamPlayer: self)
   }
 
   func addObserverToPlayer() {
@@ -88,7 +86,7 @@ extension URLStreamPlayer {
 
     Task { [weak self] in
       let image = await station.getImage()
-      await MainActor.run { self?.updateLockScreen(with: image) }
+      self?.updateLockScreen(with: image)
     }
   }
 
@@ -119,7 +117,7 @@ extension URLStreamPlayer {
 
 // MARK: - FRadioPlayerObserver
 
-extension URLStreamPlayer: FRadioPlayerObserver {
+extension URLStreamPlayer: @preconcurrency FRadioPlayerObserver {
   public func radioPlayer(
     _: FRadioPlayer, metadataDidChange _: FRadioPlayer.Metadata?
   ) {
@@ -140,13 +138,11 @@ extension URLStreamPlayer: FRadioPlayerObserver {
 
     Task { [weak self] in
       let image = await UIImage.image(from: artworkURL)
-      await MainActor.run {
-        guard let image else {
-          self?.resetArtwork(with: self?.currentStation)
-          return
-        }
-        self?.updateLockScreen(with: image)
+      guard let image else {
+        self?.resetArtwork(with: self?.currentStation)
+        return
       }
+      self?.updateLockScreen(with: image)
     }
   }
 

--- a/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
+++ b/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
@@ -108,12 +108,14 @@ public class UrlStreamListeningSessionReporter {
     self.timer = Timer.scheduledTimer(
       withTimeInterval: 10.0, repeats: true,
       block: { [weak self] _ in
-        guard let self else { return }
-        guard let stationUrl = self.urlStreamPlayer?.currentStation?.streamUrl else {
-          print("Error -- stationId should exist")
-          return
+        Task { @MainActor in
+          guard let self else { return }
+          guard let stationUrl = self.urlStreamPlayer?.currentStation?.streamUrl else {
+            print("Error -- stationId should exist")
+            return
+          }
+          self.reportOrExtendListeningSession(stationUrl)
         }
-        self.reportOrExtendListeningSession(stationUrl)
       })
   }
 


### PR DESCRIPTION
## Summary
- Mark `URLStreamPlayer` as `@MainActor` and conform to `FRadioPlayerObserver` via `@preconcurrency`. All consumers (`StationPlayer`, `NowPlayingUpdater`, `UrlStreamListeningSessionReporter`) are already main-actor, so no call-site changes are needed.
- Simplify init and artwork-loading paths now that `Task { }` inherits main-actor isolation — drops redundant `await MainActor.run { ... }` hops and the unnecessary `Task` wrapper around the synchronous reporter init.
- Wrap the periodic `Timer` block in `UrlStreamListeningSessionReporter` in `Task { @MainActor in }` to satisfy `@Sendable`-closure isolation, fixing 2 pre-existing warnings plus 1 surfaced by making `URLStreamPlayer` main-actor.

Drives the `PlayolaRadio` target's Swift 6 concurrency warning count from 13 → 0 (final cluster of the Swift 6 migration).

## Test plan
- [x] App target builds clean (0 Swift 6 warnings)
- [x] Test target builds clean (0 URLStreamPlayer-related warnings)
- [x] `make format` / `make lint` pass
- [ ] Full XCTest suite runs green in Xcode