### PR TITLE
fix: eliminate remaining Swift 6 and build warnings

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2915,6 +2915,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		A749B0FA144D4CBFB5A75066 /* Upload Debug Symbols to Sentry */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -12,7 +12,7 @@ import IdentifiedCollections
 import Sharing
 
 @MainActor
-class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
+class CarPlaySceneDelegate: UIResponder, @preconcurrency CPTemplateApplicationSceneDelegate {
   private func tabImage(_ identifier: String) -> UIImage? {
     switch identifier {
     case StationList.KnownIDs.artistList.rawValue:

--- a/PlayolaRadio/Core/Mail/Mail.swift
+++ b/PlayolaRadio/Core/Mail/Mail.swift
@@ -10,7 +10,8 @@ import MessageUI
 import SwiftUI
 import UIKit
 
-class EmailService: NSObject, MFMailComposeViewControllerDelegate {
+@MainActor
+class EmailService: NSObject, @preconcurrency MFMailComposeViewControllerDelegate {
   public static func createEmailUrl(
     to: String, subject: String, body: String? = nil
   ) -> URL? {
@@ -91,7 +92,8 @@ struct MailComposeView: UIViewControllerRepresentable {
     return mail
   }
 
-  final class Coordinator: NSObject, MFMailComposeViewControllerDelegate {
+  @MainActor
+  final class Coordinator: NSObject, @preconcurrency MFMailComposeViewControllerDelegate {
     var parent: MailComposeView
 
     init(_ mailController: MailComposeView) {

--- a/PlayolaRadio/Core/Mail/MailService.swift
+++ b/PlayolaRadio/Core/Mail/MailService.swift
@@ -8,9 +8,10 @@
 import Foundation
 import MessageUI
 
+@MainActor
 public class MailService {
-  func canSendEmail() async -> Bool {
-    await MFMailComposeViewController.canSendMail()
+  func canSendEmail() -> Bool {
+    MFMailComposeViewController.canSendMail()
   }
 
   func mailSendURL(recipientEmail: String, subject: String) -> URL? {

--- a/PlayolaRadio/Extensions/FRadioPlayerMetadata+Equatable.swift
+++ b/PlayolaRadio/Extensions/FRadioPlayerMetadata+Equatable.swift
@@ -8,12 +8,16 @@
 import FRadioPlayer
 import Foundation
 
-extension FRadioPlayer.Metadata: Equatable {
+// swift-format-ignore: AvoidRetroactiveConformances
+extension FRadioPlayer.Metadata: @retroactive Equatable {
   public static func == (lhs: FRadioPlayer.Metadata, rhs: FRadioPlayer.Metadata) -> Bool {
     lhs.artistName == rhs.artistName && lhs.trackName == rhs.trackName
   }
 }
 
-extension FRadioPlayer.PlaybackState: @unchecked Sendable {}
-extension FRadioPlayer.State: @unchecked Sendable {}
-extension FRadioPlayer.Metadata: @unchecked Sendable {}
+// swift-format-ignore: AvoidRetroactiveConformances
+extension FRadioPlayer.PlaybackState: @retroactive @unchecked Sendable {}
+// swift-format-ignore: AvoidRetroactiveConformances
+extension FRadioPlayer.State: @retroactive @unchecked Sendable {}
+// swift-format-ignore: AvoidRetroactiveConformances
+extension FRadioPlayer.Metadata: @retroactive @unchecked Sendable {}

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -76,28 +76,33 @@ class SignInPageModel: ViewModel {
       print("Error presenting VC -- no key window")
       return
     }
-    do {
-      let signInResult = try await GIDSignIn.sharedInstance.signIn(withPresenting: presentingVC)
-      print(signInResult)
+    // Run the sign-in flow in a detached Task so the caller returns immediately
+    // after firing .signInStarted, matching the prior callback-style contract.
+    Task {
+      do {
+        let signInResult = try await GIDSignIn.sharedInstance.signIn(withPresenting: presentingVC)
+        print(signInResult)
 
-      _ = try await signInResult.user.refreshTokensIfNeeded()
-      guard let serverAuthCode = signInResult.serverAuthCode else {
-        print("Error signing into Google -- no serverAuthCode on signInResult.")
-        return
-      }
-      let userId = signInResult.user.userID ?? "unknown"
-      let token = try await api.signInViaGoogle(serverAuthCode)
-      $auth.withLock { $0 = Auth(jwtToken: token) }
-      appRating.recordInstallDateIfNeeded()
-      await analytics.track(.signInCompleted(method: .google, userId: userId))
-    } catch {
-      print("Google sign in failed: \(error)")
-      let nsError = error as NSError
-      // Match the prior callback behavior: silently drop user-cancelled sign-ins
-      // (GIDSignInError.canceled = -5) instead of tracking them as failures.
-      if nsError.domain != kGIDSignInErrorDomain || nsError.code != GIDSignInError.canceled.rawValue
-      {
-        await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
+        _ = try await signInResult.user.refreshTokensIfNeeded()
+        guard let serverAuthCode = signInResult.serverAuthCode else {
+          print("Error signing into Google -- no serverAuthCode on signInResult.")
+          return
+        }
+        let userId = signInResult.user.userID ?? "unknown"
+        let token = try await api.signInViaGoogle(serverAuthCode)
+        $auth.withLock { $0 = Auth(jwtToken: token) }
+        appRating.recordInstallDateIfNeeded()
+        await analytics.track(.signInCompleted(method: .google, userId: userId))
+      } catch {
+        print("Google sign in failed: \(error)")
+        let nsError = error as NSError
+        // Match the prior callback behavior: silently drop user-cancelled sign-ins
+        // (GIDSignInError.canceled = -5) instead of tracking them as failures.
+        if nsError.domain != kGIDSignInErrorDomain
+          || nsError.code != GIDSignInError.canceled.rawValue
+        {
+          await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
+        }
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -1,6 +1,6 @@
 import AuthenticationServices
 import Dependencies
-import GoogleSignIn
+@preconcurrency import GoogleSignIn
 import GoogleSignInSwift
 import Sharing
 //
@@ -76,33 +76,23 @@ class SignInPageModel: ViewModel {
       print("Error presenting VC -- no key window")
       return
     }
-    GIDSignIn.sharedInstance.signIn(withPresenting: presentingVC) { signInResult, error in
-      guard let signInResult else {
-        return
-      }
+    do {
+      let signInResult = try await GIDSignIn.sharedInstance.signIn(withPresenting: presentingVC)
       print(signInResult)
 
-      signInResult.user.refreshTokensIfNeeded { _, error in
-        guard error == nil else { return }
-        guard let serverAuthCode = signInResult.serverAuthCode else {
-          print("Error signing into Google -- no serverAuthCode on signInResult.")
-          return
-        }
-        let userId = signInResult.user.userID ?? "unknown"
-        Task { @MainActor in
-          do {
-            let token = try await self.api.signInViaGoogle(serverAuthCode)
-            self.$auth.withLock { $0 = Auth(jwtToken: token) }
-            self.appRating.recordInstallDateIfNeeded()
-            await self.analytics.track(
-              .signInCompleted(method: .google, userId: userId))
-          } catch {
-            print("Google sign in failed: \(error)")
-            await self.analytics.track(
-              .signInFailed(method: .google, error: error.localizedDescription))
-          }
-        }
+      _ = try await signInResult.user.refreshTokensIfNeeded()
+      guard let serverAuthCode = signInResult.serverAuthCode else {
+        print("Error signing into Google -- no serverAuthCode on signInResult.")
+        return
       }
+      let userId = signInResult.user.userID ?? "unknown"
+      let token = try await api.signInViaGoogle(serverAuthCode)
+      $auth.withLock { $0 = Auth(jwtToken: token) }
+      appRating.recordInstallDateIfNeeded()
+      await analytics.track(.signInCompleted(method: .google, userId: userId))
+    } catch {
+      print("Google sign in failed: \(error)")
+      await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -92,7 +92,13 @@ class SignInPageModel: ViewModel {
       await analytics.track(.signInCompleted(method: .google, userId: userId))
     } catch {
       print("Google sign in failed: \(error)")
-      await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
+      let nsError = error as NSError
+      // Match the prior callback behavior: silently drop user-cancelled sign-ins
+      // (GIDSignInError.canceled = -5) instead of tracking them as failures.
+      if nsError.domain != kGIDSignInErrorDomain || nsError.code != GIDSignInError.canceled.rawValue
+      {
+        await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
+      }
     }
   }
 }

--- a/PlayolaRadioTests/Mocks/MailServiceMock.swift
+++ b/PlayolaRadioTests/Mocks/MailServiceMock.swift
@@ -8,6 +8,7 @@ import Foundation
 
 @testable import PlayolaRadio
 
+@MainActor
 class MailServiceMock: MailService {
   var shouldBeAbleToSendEmail: Bool = true
   var canCreateUrl: Bool = true
@@ -22,7 +23,7 @@ class MailServiceMock: MailService {
     self.canCreateUrl = canCreateUrl
   }
 
-  override func canSendEmail() async -> Bool {
+  override func canSendEmail() -> Bool {
     shouldBeAbleToSendEmail
   }
 


### PR DESCRIPTION
## Summary
- Silences the Sentry upload script "will run every build" warning by marking the phase `alwaysOutOfDate`.
- Resolves Swift 6 main-actor conformance warnings: `@preconcurrency` on `CPTemplateApplicationSceneDelegate` and `MFMailComposeViewControllerDelegate`; `@MainActor` on `EmailService`, `MailService`, and `MailComposeView.Coordinator` (drops an unused `async` on `canSendEmail`).
- Marks `FRadioPlayer` `Equatable`/`Sendable` extensions `@retroactive` (with `swift-format-ignore` pragmas) and adds `@preconcurrency` to the `GoogleSignIn` import, converting the sign-in and token-refresh callbacks to their `async throws` alternatives.

## Test plan
- [ ] Build in Xcode and confirm all six warnings are gone
- [ ] Sign in via Google on device/simulator still works end-to-end
- [ ] CarPlay scene still launches and responds to station taps