### PR TITLE
Clean up Swift 6 test build warnings

### DIFF
--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -4,7 +4,7 @@
 //
 //  Created by Brian D Keane on 1/19/25.
 //
-import CarPlay
+@preconcurrency import CarPlay
 import Combine
 import Dependencies
 import FRadioPlayer

--- a/PlayolaRadio/Core/AudioRecording/IntroUploadServiceTests.swift
+++ b/PlayolaRadio/Core/AudioRecording/IntroUploadServiceTests.swift
@@ -3,6 +3,7 @@
 //  PlayolaRadio
 //
 
+import ConcurrencyExtras
 import Dependencies
 import XCTest
 
@@ -15,7 +16,7 @@ final class IntroUploadServiceTests: XCTestCase {
   private let testSongTitle = "Bohemian Rhapsody"
 
   func testUploadIntroTransitionsThroughAllStatuses() async throws {
-    var statusChanges: [IntroUploadStatus] = []
+    let statusChanges = LockIsolated<[IntroUploadStatus]>([])
     let testURL = FileManager.default.temporaryDirectory.appendingPathComponent("test.wav")
 
     let service = withDependencies {
@@ -39,29 +40,30 @@ final class IntroUploadServiceTests: XCTestCase {
       testSongTitle,
       "test-audio-block-id"
     ) { status in
-      statusChanges.append(status)
+      statusChanges.withValue { $0.append(status) }
     }
 
-    XCTAssertTrue(statusChanges.contains(.converting))
+    let recordedStatuses = statusChanges.value
+    XCTAssertTrue(recordedStatuses.contains(.converting))
     XCTAssertTrue(
-      statusChanges.contains(where: {
+      recordedStatuses.contains(where: {
         if case .uploading = $0 { return true }
         return false
       }))
-    XCTAssertTrue(statusChanges.contains(.registering))
-    XCTAssertTrue(statusChanges.contains(.completed))
+    XCTAssertTrue(recordedStatuses.contains(.registering))
+    XCTAssertTrue(recordedStatuses.contains(.completed))
   }
 
   func testUploadIntroPassesCorrectStationIdAndFilename() async throws {
-    var capturedStationId: String?
-    var capturedFilename: String?
+    let capturedStationId = LockIsolated<String?>(nil)
+    let capturedFilename = LockIsolated<String?>(nil)
     let testURL = FileManager.default.temporaryDirectory.appendingPathComponent("test.wav")
 
     let service = withDependencies {
       $0.audioConverter = .testValue
       $0.api.getIntroPresignedURL = { _, stationId, filename in
-        capturedStationId = stationId
-        capturedFilename = filename
+        capturedStationId.setValue(stationId)
+        capturedFilename.setValue(filename)
         return IntroPresignedURLResponse(
           presignedUrl: URL(string: "https://intake.s3.amazonaws.com/test.m4a")!,
           s3Key: "station/uuid-intro.m4a"
@@ -81,15 +83,15 @@ final class IntroUploadServiceTests: XCTestCase {
       "test-audio-block-id"
     ) { _ in }
 
-    XCTAssertEqual(capturedStationId, testStationId)
-    XCTAssertEqual(capturedFilename, "Bohemian Rhapsody.m4a")
+    XCTAssertEqual(capturedStationId.value, testStationId)
+    XCTAssertEqual(capturedFilename.value, "Bohemian Rhapsody.m4a")
   }
 
   func testUploadIntroPassesCorrectDataToCreateSourceTape() async throws {
-    var capturedS3Key: String?
-    var capturedName: String?
-    var capturedDurationMS: Int?
-    var capturedAudioBlockId: String?
+    let capturedS3Key = LockIsolated<String?>(nil)
+    let capturedName = LockIsolated<String?>(nil)
+    let capturedDurationMS = LockIsolated<Int?>(nil)
+    let capturedAudioBlockId = LockIsolated<String?>(nil)
     let testURL = FileManager.default.temporaryDirectory.appendingPathComponent("test.wav")
 
     let service = withDependencies {
@@ -102,10 +104,10 @@ final class IntroUploadServiceTests: XCTestCase {
       }
       $0.api.uploadToS3 = { _, _, _, _ in }
       $0.api.createIntroSourceTape = { _, _, s3Key, name, durationMS, audioBlockId in
-        capturedS3Key = s3Key
-        capturedName = name
-        capturedDurationMS = durationMS
-        capturedAudioBlockId = audioBlockId
+        capturedS3Key.setValue(s3Key)
+        capturedName.setValue(name)
+        capturedDurationMS.setValue(durationMS)
+        capturedAudioBlockId.setValue(audioBlockId)
       }
     } operation: {
       IntroUploadService.liveValue
@@ -119,9 +121,9 @@ final class IntroUploadServiceTests: XCTestCase {
       "test-audio-block-id"
     ) { _ in }
 
-    XCTAssertEqual(capturedS3Key, "station/uuid-intro.m4a")
-    XCTAssertEqual(capturedName, "Bohemian Rhapsody")
-    XCTAssertEqual(capturedDurationMS, 15000)
-    XCTAssertEqual(capturedAudioBlockId, "test-audio-block-id")
+    XCTAssertEqual(capturedS3Key.value, "station/uuid-intro.m4a")
+    XCTAssertEqual(capturedName.value, "Bohemian Rhapsody")
+    XCTAssertEqual(capturedDurationMS.value, 15000)
+    XCTAssertEqual(capturedAudioBlockId.value, "test-audio-block-id")
   }
 }

--- a/PlayolaRadio/Core/AudioRecording/VoicetrackUploadServiceTests.swift
+++ b/PlayolaRadio/Core/AudioRecording/VoicetrackUploadServiceTests.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 12/16/25.
 //
 
+import ConcurrencyExtras
 import Dependencies
 import PlayolaPlayer
 import XCTest
@@ -30,7 +31,7 @@ final class VoicetrackUploadServiceTests: XCTestCase {
   // MARK: - Normalization Polling Tests
 
   func testProcessVoicetrack_handlesS3KeyWithSlash() async throws {
-    var capturedS3Key: String?
+    let capturedS3Key = LockIsolated<String?>(nil)
     let voicetrack = createTestVoicetrack()
     let s3KeyWithSlash = "station123/mock-uuid.m4a"
 
@@ -45,7 +46,7 @@ final class VoicetrackUploadServiceTests: XCTestCase {
       }
       $0.api.uploadToS3 = { _, _, _, _ in }
       $0.api.getVoicetrackStatus = { _, _, s3Key in
-        capturedS3Key = s3Key
+        capturedS3Key.setValue(s3Key)
         return VoicetrackStatusResponse(ready: true, s3Key: s3Key)
       }
       $0.api.createVoicetrack = { _, _, _, _ in AudioBlock.mockWith() }
@@ -60,11 +61,11 @@ final class VoicetrackUploadServiceTests: XCTestCase {
     ) { _ in }
 
     XCTAssertEqual(
-      capturedS3Key, s3KeyWithSlash, "s3Key with slash should be passed through correctly")
+      capturedS3Key.value, s3KeyWithSlash, "s3Key with slash should be passed through correctly")
   }
 
   func testProcessVoicetrack_transitionsThroughNormalizingStatus() async throws {
-    var statusChanges: [LocalVoicetrackStatus] = []
+    let statusChanges = LockIsolated<[LocalVoicetrackStatus]>([])
     let voicetrack = createTestVoicetrack()
 
     let service = withDependencies {
@@ -90,28 +91,29 @@ final class VoicetrackUploadServiceTests: XCTestCase {
       testStationId,
       testJwtToken
     ) { status in
-      statusChanges.append(status)
+      statusChanges.withValue { $0.append(status) }
     }
 
+    let recordedStatuses = statusChanges.value
     // Verify that .normalizing status was reached
     XCTAssertTrue(
-      statusChanges.contains(.normalizing),
-      "Expected .normalizing status, got: \(statusChanges)"
+      recordedStatuses.contains(.normalizing),
+      "Expected .normalizing status, got: \(recordedStatuses)"
     )
 
     // Verify correct order: uploading comes before normalizing
-    if let uploadingIndex = statusChanges.firstIndex(where: {
+    if let uploadingIndex = recordedStatuses.firstIndex(where: {
       if case .uploading = $0 { return true }
       return false
     }),
-      let normalizingIndex = statusChanges.firstIndex(of: .normalizing)
+      let normalizingIndex = recordedStatuses.firstIndex(of: .normalizing)
     {
       XCTAssertLessThan(uploadingIndex, normalizingIndex)
     }
 
     // Verify normalizing comes before finalizing
-    if let normalizingIndex = statusChanges.firstIndex(of: .normalizing),
-      let finalizingIndex = statusChanges.firstIndex(of: .finalizing)
+    if let normalizingIndex = recordedStatuses.firstIndex(of: .normalizing),
+      let finalizingIndex = recordedStatuses.firstIndex(of: .finalizing)
     {
       XCTAssertLessThan(normalizingIndex, finalizingIndex)
     }
@@ -120,7 +122,7 @@ final class VoicetrackUploadServiceTests: XCTestCase {
   func testProcessVoicetrackPassesS3KeyWithSlashesToStatusCheck() async throws {
     let voicetrack = createTestVoicetrack()
     let s3KeyWithSlashes = "voicetracks/station123/abc-def-123.m4a"
-    var capturedS3Key: String?
+    let capturedS3Key = LockIsolated<String?>(nil)
 
     let service = withDependencies {
       $0.audioConverter = .testValue
@@ -133,7 +135,7 @@ final class VoicetrackUploadServiceTests: XCTestCase {
       }
       $0.api.uploadToS3 = { _, _, _, _ in }
       $0.api.getVoicetrackStatus = { _, _, s3Key in
-        capturedS3Key = s3Key
+        capturedS3Key.setValue(s3Key)
         return VoicetrackStatusResponse(ready: true, s3Key: s3Key)
       }
       $0.api.createVoicetrack = { _, _, _, _ in AudioBlock.mockWith() }
@@ -147,6 +149,6 @@ final class VoicetrackUploadServiceTests: XCTestCase {
       testJwtToken
     ) { _ in }
 
-    XCTAssertEqual(capturedS3Key, s3KeyWithSlashes)
+    XCTAssertEqual(capturedS3Key.value, s3KeyWithSlashes)
   }
 }

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 12/17/25.
 //
 
+import ConcurrencyExtras
 import Dependencies
 import Sharing
 import XCTest
@@ -17,11 +18,11 @@ final class PushNotificationsTests: XCTestCase {
   // MARK: - registerForRemoteNotifications
 
   func testRegisterForRemoteNotificationsRequestsAuthorization() async throws {
-    var authorizationRequested = false
+    let authorizationRequested = LockIsolated(false)
 
     try await withDependencies {
       $0.pushNotifications.requestAuthorization = {
-        authorizationRequested = true
+        authorizationRequested.setValue(true)
         return true
       }
       $0.pushNotifications.registerForRemoteNotifications = {}
@@ -30,22 +31,22 @@ final class PushNotificationsTests: XCTestCase {
       _ = try await pushNotifications.requestAuthorization()
     }
 
-    XCTAssertTrue(authorizationRequested)
+    XCTAssertTrue(authorizationRequested.value)
   }
 
   func testRegisterForRemoteNotificationsCallsUIApplicationRegister() async throws {
-    var registerCalled = false
+    let registerCalled = LockIsolated(false)
 
     await withDependencies {
       $0.pushNotifications.registerForRemoteNotifications = {
-        registerCalled = true
+        registerCalled.setValue(true)
       }
     } operation: {
       @Dependency(\.pushNotifications) var pushNotifications
       await pushNotifications.registerForRemoteNotifications()
     }
 
-    XCTAssertTrue(registerCalled)
+    XCTAssertTrue(registerCalled.value)
   }
 
   // MARK: - Device Token Handling
@@ -60,15 +61,15 @@ final class PushNotificationsTests: XCTestCase {
   }
 
   func testHandleDeviceTokenCallsAPIWhenLoggedIn() async throws {
-    var capturedToken: String?
-    var capturedPlatform: String?
-    var capturedAppVersion: String?
+    let capturedToken = LockIsolated<String?>(nil)
+    let capturedPlatform = LockIsolated<String?>(nil)
+    let capturedAppVersion = LockIsolated<String?>(nil)
 
     await withDependencies {
       $0.pushNotifications.handleDeviceToken = { deviceToken in
-        capturedToken = deviceToken.map { String(format: "%02x", $0) }.joined()
-        capturedPlatform = "ios"
-        capturedAppVersion = "1.0.0"
+        capturedToken.setValue(deviceToken.map { String(format: "%02x", $0) }.joined())
+        capturedPlatform.setValue("ios")
+        capturedAppVersion.setValue("1.0.0")
       }
     } operation: {
       @Dependency(\.pushNotifications) var pushNotifications
@@ -77,9 +78,9 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleDeviceToken(tokenData)
     }
 
-    XCTAssertEqual(capturedToken, "abcdef12")
-    XCTAssertEqual(capturedPlatform, "ios")
-    XCTAssertEqual(capturedAppVersion, "1.0.0")
+    XCTAssertEqual(capturedToken.value, "abcdef12")
+    XCTAssertEqual(capturedPlatform.value, "ios")
+    XCTAssertEqual(capturedAppVersion.value, "1.0.0")
   }
 
   // MARK: - Notification Payload Parsing
@@ -105,12 +106,12 @@ final class PushNotificationsTests: XCTestCase {
   // MARK: - Notification Response Handling
 
   func testHandleNotificationResponsePlaysStation() async {
-    var playedStationId: String?
+    let playedStationId = LockIsolated<String?>(nil)
 
     await withDependencies {
       $0.pushNotifications.handleNotificationTap = { userInfo in
         if let stationId = userInfo["stationId"] as? String {
-          playedStationId = stationId
+          playedStationId.setValue(stationId)
         }
       }
     } operation: {
@@ -119,65 +120,69 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleNotificationTap(userInfo)
     }
 
-    XCTAssertEqual(playedStationId, "station-abc")
+    XCTAssertEqual(playedStationId.value, "station-abc")
   }
 
   // MARK: - Support Notification Badge Handling
 
   func testHandleSupportNotificationBadgeSetsCountFromPayload() async {
     @Shared(.unreadSupportCount) var unreadSupportCount = 0
-    var capturedBadgeCount: Int?
+    let capturedBadgeCount = LockIsolated<Int?>(nil)
 
     await withDependencies {
       $0.pushNotifications.setBadgeCount = { count in
-        capturedBadgeCount = count
+        capturedBadgeCount.setValue(count)
       }
-      $0.pushNotifications.handleSupportNotificationBadge =
-        PushNotificationsClient.liveValue.handleSupportNotificationBadge
+      $0.pushNotifications.handleSupportNotificationBadge = { badgeFromPayload in
+        await PushNotificationsClient.liveValue.handleSupportNotificationBadge(badgeFromPayload)
+      }
     } operation: {
       @Dependency(\.pushNotifications) var pushNotifications
       await pushNotifications.handleSupportNotificationBadge(badgeFromPayload: 5)
     }
 
     XCTAssertEqual(unreadSupportCount, 5)
-    XCTAssertEqual(capturedBadgeCount, 5)
+    XCTAssertEqual(capturedBadgeCount.value, 5)
   }
 
   func testHandleSupportNotificationBadgeIncrementsWhenNoPayload() async {
     @Shared(.unreadSupportCount) var unreadSupportCount = 2
-    var capturedBadgeCount: Int?
+    let capturedBadgeCount = LockIsolated<Int?>(nil)
 
     await withDependencies {
       $0.pushNotifications.setBadgeCount = { count in
-        capturedBadgeCount = count
+        capturedBadgeCount.setValue(count)
       }
-      $0.pushNotifications.handleSupportNotificationBadge =
-        PushNotificationsClient.liveValue.handleSupportNotificationBadge
+      $0.pushNotifications.handleSupportNotificationBadge = { badgeFromPayload in
+        await PushNotificationsClient.liveValue.handleSupportNotificationBadge(badgeFromPayload)
+      }
     } operation: {
       @Dependency(\.pushNotifications) var pushNotifications
       await pushNotifications.handleSupportNotificationBadge(badgeFromPayload: nil)
     }
 
     XCTAssertEqual(unreadSupportCount, 3)
-    XCTAssertEqual(capturedBadgeCount, 3)
+    XCTAssertEqual(capturedBadgeCount.value, 3)
   }
 
   func testClearSupportBadgeSetsCountToZero() async {
     @Shared(.unreadSupportCount) var unreadSupportCount = 5
-    var capturedBadgeCount: Int?
+    let capturedBadgeCount = LockIsolated<Int?>(nil)
 
     await withDependencies {
       $0.pushNotifications.setBadgeCount = { count in
-        capturedBadgeCount = count
+        capturedBadgeCount.setValue(count)
       }
-      $0.pushNotifications.clearSupportBadge = PushNotificationsClient.liveValue.clearSupportBadge
+      $0.pushNotifications.clearSupportBadge = {
+        await PushNotificationsClient.liveValue.clearSupportBadge()
+      }
     } operation: {
       @Dependency(\.pushNotifications) var pushNotifications
       await pushNotifications.clearSupportBadge()
     }
 
     XCTAssertEqual(unreadSupportCount, 0)
-    XCTAssertEqual(capturedBadgeCount, 0)
+    XCTAssertEqual(capturedBadgeCount.value, 0)
   }
 
   // MARK: - Support Message Notification Tap
@@ -190,13 +195,13 @@ final class PushNotificationsTests: XCTestCase {
     let supportModel = SupportPageModel()
     navCoordinator.path.append(.supportPage(supportModel))
 
-    var refreshNotificationPosted = false
+    let refreshNotificationPosted = LockIsolated(false)
     let observer = NotificationCenter.default.addObserver(
       forName: .refreshSupportMessages,
       object: nil,
       queue: .main
     ) { _ in
-      refreshNotificationPosted = true
+      refreshNotificationPosted.setValue(true)
     }
 
     defer { NotificationCenter.default.removeObserver(observer) }
@@ -207,6 +212,6 @@ final class PushNotificationsTests: XCTestCase {
     ]
     await PushNotificationsClient.liveValue.handleNotificationTap(userInfo)
 
-    XCTAssertTrue(refreshNotificationPosted)
+    XCTAssertTrue(refreshNotificationPosted.value)
   }
 }

--- a/PlayolaRadio/Core/Toast/ToastClientTests.swift
+++ b/PlayolaRadio/Core/Toast/ToastClientTests.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 8/30/25.
 //
 
+import ConcurrencyExtras
 import Dependencies
 import XCTest
 
@@ -254,9 +255,9 @@ final class ToastClientTests: XCTestCase {
 
       let client = ToastClient.liveValue
 
-      async let show1 = client.show(toast1)
-      async let show2 = client.show(toast2)
-      async let show3 = client.show(toast3)
+      async let show1: Void = client.show(toast1)
+      async let show2: Void = client.show(toast2)
+      async let show3: Void = client.show(toast3)
 
       await show1
       await show2
@@ -284,23 +285,23 @@ final class ToastClientTests: XCTestCase {
 
   // MARK: - Toast Actions
 
-  func testToastAction_ExecutesWhenInvoked() async {
-    await withDependencies {
+  func testToastAction_ExecutesWhenInvoked() {
+    withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
-      var actionExecuted = false
+      let actionExecuted = LockIsolated(false)
 
       let toast = PlayolaToast(
         message: "Test",
         buttonTitle: "OK",
         action: {
-          actionExecuted = true
+          actionExecuted.setValue(true)
         }
       )
 
       toast.action?()
 
-      XCTAssertTrue(actionExecuted)
+      XCTAssertTrue(actionExecuted.value)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
@@ -3,6 +3,7 @@
 //  PlayolaRadio
 //
 
+import ConcurrencyExtras
 import Dependencies
 import PlayolaPlayer
 import Sharing
@@ -40,18 +41,18 @@ final class AskQuestionPageTests: XCTestCase {
   // MARK: - Recording
 
   func testRecordTappedRequestsPermissionBeforeRecording() async {
-    var requestPermissionCalled = false
-    var startRecordingCalled = false
+    let requestPermissionCalled = LockIsolated(false)
+    let startRecordingCalled = LockIsolated(false)
 
     await withDependencies {
       $0.audioRecorder.requestPermission = {
-        requestPermissionCalled = true
+        requestPermissionCalled.setValue(true)
         return true
       }
       $0.audioRecorder.startRecording = {
         XCTAssertTrue(
-          requestPermissionCalled, "Permission should be requested before recording starts")
-        startRecordingCalled = true
+          requestPermissionCalled.value, "Permission should be requested before recording starts")
+        startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = AskQuestionPageModel(station: .mock)
@@ -59,26 +60,26 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.recordTapped()
 
-      XCTAssertTrue(requestPermissionCalled)
-      XCTAssertTrue(startRecordingCalled)
+      XCTAssertTrue(requestPermissionCalled.value)
+      XCTAssertTrue(startRecordingCalled.value)
       XCTAssertEqual(model.recordingPhase, .recording)
     }
   }
 
   func testRecordTappedShowsAlertWhenPermissionDenied() async {
-    var startRecordingCalled = false
+    let startRecordingCalled = LockIsolated(false)
 
     await withDependencies {
       $0.audioRecorder.requestPermission = { false }
       $0.audioRecorder.startRecording = {
-        startRecordingCalled = true
+        startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = AskQuestionPageModel(station: .mock)
 
       await model.recordTapped()
 
-      XCTAssertFalse(startRecordingCalled)
+      XCTAssertFalse(startRecordingCalled.value)
       XCTAssertEqual(model.recordingPhase, .idle)
       XCTAssertNotNil(model.presentedAlert)
       XCTAssertEqual(model.presentedAlert?.title, "Microphone Access Required")
@@ -162,10 +163,10 @@ final class AskQuestionPageTests: XCTestCase {
   // MARK: - Playback
 
   func testPlayPauseTappedPlaysWhenNotPlaying() async {
-    var playCalled = false
+    let playCalled = LockIsolated(false)
 
     await withDependencies {
-      $0.audioPlayer.play = { playCalled = true }
+      $0.audioPlayer.play = { playCalled.setValue(true) }
       $0.audioPlayer.currentTime = { 0 }
       $0.audioPlayer.isPlaying = { true }
     } operation: {
@@ -175,16 +176,16 @@ final class AskQuestionPageTests: XCTestCase {
       model.playPauseTapped()
       try? await Task.sleep(for: .milliseconds(10))
 
-      XCTAssertTrue(playCalled)
+      XCTAssertTrue(playCalled.value)
       XCTAssertTrue(model.isPlaying)
     }
   }
 
   func testPlayPauseTappedPausesWhenPlaying() async {
-    var pauseCalled = false
+    let pauseCalled = LockIsolated(false)
 
     await withDependencies {
-      $0.audioPlayer.pause = { pauseCalled = true }
+      $0.audioPlayer.pause = { pauseCalled.setValue(true) }
     } operation: {
       let model = AskQuestionPageModel(station: .mock)
       model.isPlaying = true
@@ -192,16 +193,16 @@ final class AskQuestionPageTests: XCTestCase {
       model.playPauseTapped()
       try? await Task.sleep(for: .milliseconds(10))
 
-      XCTAssertTrue(pauseCalled)
+      XCTAssertTrue(pauseCalled.value)
       XCTAssertFalse(model.isPlaying)
     }
   }
 
   func testRewindTappedSeeksToZero() async {
-    var seekTime: TimeInterval?
+    let seekTime = LockIsolated<TimeInterval?>(nil)
 
     await withDependencies {
-      $0.audioPlayer.seek = { time in seekTime = time }
+      $0.audioPlayer.seek = { time in seekTime.setValue(time) }
     } operation: {
       let model = AskQuestionPageModel(station: .mock)
       model.playbackPosition = 30.0
@@ -209,7 +210,7 @@ final class AskQuestionPageTests: XCTestCase {
       model.rewindTapped()
       try? await Task.sleep(for: .milliseconds(10))
 
-      XCTAssertEqual(seekTime, 0)
+      XCTAssertEqual(seekTime.value, 0)
       XCTAssertEqual(model.playbackPosition, 0)
     }
   }

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -688,29 +688,43 @@ extension BroadcastPageTests {
   func testMoveSpinMarksAllSpinsAsReschedulingDuringCall() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-
-    nonisolated(unsafe) var model: BroadcastPageModel!
-    nonisolated(unsafe) var capturedReschedulingIds: Set<String> = []
+    let moveStarted = LockIsolated(false)
+    let moveContinuation = LockIsolated<CheckedContinuation<Void, Never>?>(nil)
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in initialSpins }
       $0.api.moveSpin = { _, _, _ in
-        await MainActor.run {
-          capturedReschedulingIds = model.spinIdsBeingRescheduled
+        moveStarted.setValue(true)
+        await withCheckedContinuation { continuation in
+          moveContinuation.setValue(continuation)
         }
         return initialSpins
       }
     } operation: {
-      model = BroadcastPageModel(stationId: testStationId)
+      let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
       XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
 
-      await model.moveSpins(from: IndexSet(integer: 0), to: 2)
+      let moveTask = Task {
+        await model.moveSpins(from: IndexSet(integer: 0), to: 2)
+      }
+
+      while !moveStarted.value {
+        await Task.yield()
+      }
 
       // During the call, all spins should be marked as rescheduling
-      XCTAssertEqual(capturedReschedulingIds, ["spin-1", "spin-2", "spin-3"])
+      XCTAssertEqual(model.spinIdsBeingRescheduled, ["spin-1", "spin-2", "spin-3"])
+
+      moveContinuation.withValue { continuation in
+        continuation?.resume()
+        continuation = nil
+      }
+
+      await moveTask.value
+
       // After the call completes, the set should be cleared
       XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
     }
@@ -798,29 +812,43 @@ extension BroadcastPageTests {
   func testDeleteSpinMarksSpinsAfterDeletedAsReschedulingDuringCall() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-
-    nonisolated(unsafe) var model: BroadcastPageModel!
-    nonisolated(unsafe) var capturedReschedulingIds: Set<String> = []
+    let deleteStarted = LockIsolated(false)
+    let deleteContinuation = LockIsolated<CheckedContinuation<Void, Never>?>(nil)
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in initialSpins }
       $0.api.deleteSpin = { _, _ in
-        await MainActor.run {
-          capturedReschedulingIds = model.spinIdsBeingRescheduled
+        deleteStarted.setValue(true)
+        await withCheckedContinuation { continuation in
+          deleteContinuation.setValue(continuation)
         }
         return [initialSpins[0], initialSpins[2]]
       }
     } operation: {
-      model = BroadcastPageModel(stationId: testStationId)
+      let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
       XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
 
-      await model.deleteSpin(initialSpins[1])
+      let deleteTask = Task {
+        await model.deleteSpin(initialSpins[1])
+      }
+
+      while !deleteStarted.value {
+        await Task.yield()
+      }
 
       // During the call, spin-3 should have been marked as rescheduling (it comes after spin-2)
-      XCTAssertEqual(capturedReschedulingIds, ["spin-3"])
+      XCTAssertEqual(model.spinIdsBeingRescheduled, ["spin-3"])
+
+      deleteContinuation.withValue { continuation in
+        continuation?.resume()
+        continuation = nil
+      }
+
+      await deleteTask.value
+
       // After the call completes, the set should be cleared
       XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
     }
@@ -883,15 +911,15 @@ extension BroadcastPageTests {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
-    var capturedAudioBlockId: String?
-    var capturedPlaceAfterSpinId: String?
+    let capturedAudioBlockId = LockIsolated<String?>(nil)
+    let capturedPlaceAfterSpinId = LockIsolated<String?>(nil)
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in initialSpins }
       $0.api.insertSpin = { _, audioBlockId, placeAfterSpinId in
-        capturedAudioBlockId = audioBlockId
-        capturedPlaceAfterSpinId = placeAfterSpinId
+        capturedAudioBlockId.setValue(audioBlockId)
+        capturedPlaceAfterSpinId.setValue(placeAfterSpinId)
         return initialSpins
       }
     } operation: {
@@ -906,8 +934,8 @@ extension BroadcastPageTests {
       // Drop voicetrack before spin-2 (should insert after spin-1)
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-2")
 
-      XCTAssertEqual(capturedAudioBlockId, voicetrackAudioBlockId)
-      XCTAssertEqual(capturedPlaceAfterSpinId, "spin-1")
+      XCTAssertEqual(capturedAudioBlockId.value, voicetrackAudioBlockId)
+      XCTAssertEqual(capturedPlaceAfterSpinId.value, "spin-1")
     }
   }
 
@@ -968,13 +996,13 @@ extension BroadcastPageTests {
     let allSpins = [nowPlayingSpin] + upcomingSpins
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
-    var capturedPlaceAfterSpinId: String?
+    let capturedPlaceAfterSpinId = LockIsolated<String?>(nil)
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in allSpins }
       $0.api.insertSpin = { _, _, placeAfterSpinId in
-        capturedPlaceAfterSpinId = placeAfterSpinId
+        capturedPlaceAfterSpinId.setValue(placeAfterSpinId)
         return allSpins
       }
     } operation: {
@@ -989,7 +1017,7 @@ extension BroadcastPageTests {
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-1")
 
-      XCTAssertEqual(capturedPlaceAfterSpinId, "now-playing")
+      XCTAssertEqual(capturedPlaceAfterSpinId.value, "now-playing")
       XCTAssertNil(model.presentedAlert)
     }
   }
@@ -998,13 +1026,13 @@ extension BroadcastPageTests {
     let upcomingSpins = makeSpins(ids: ["spin-1", "spin-2"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
-    var apiWasCalled = false
+    let apiWasCalled = LockIsolated(false)
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in upcomingSpins }
       $0.api.insertSpin = { _, _, _ in
-        apiWasCalled = true
+        apiWasCalled.setValue(true)
         return upcomingSpins
       }
     } operation: {
@@ -1018,7 +1046,7 @@ extension BroadcastPageTests {
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-1")
 
-      XCTAssertFalse(apiWasCalled)
+      XCTAssertFalse(apiWasCalled.value)
       XCTAssertNotNil(model.presentedAlert)
       XCTAssertEqual(model.presentedAlert?.title, "Cannot Place Here")
     }
@@ -1051,14 +1079,14 @@ extension BroadcastPageTests {
 
   func testSendNotificationCallsAPIWithMessage() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var capturedStationId: String?
-    var capturedMessage: String?
+    let capturedStationId = LockIsolated<String?>(nil)
+    let capturedMessage = LockIsolated<String?>(nil)
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.sendStationNotification = { _, stationId, message in
-        capturedStationId = stationId
-        capturedMessage = message
+        capturedStationId.setValue(stationId)
+        capturedMessage.setValue(message)
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
@@ -1066,8 +1094,8 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertEqual(capturedStationId, testStationId)
-      XCTAssertEqual(capturedMessage, "I'm going live from the van!")
+      XCTAssertEqual(capturedStationId.value, testStationId)
+      XCTAssertEqual(capturedMessage.value, "I'm going live from the van!")
     }
   }
 
@@ -1215,12 +1243,12 @@ extension BroadcastPageTests {
 
   func testSendNotificationDoesNothingWhenMessageIsEmpty() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var apiWasCalled = false
+    let apiWasCalled = LockIsolated(false)
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.sendStationNotification = { _, _, _ in
-        apiWasCalled = true
+        apiWasCalled.setValue(true)
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
@@ -1229,19 +1257,19 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertFalse(apiWasCalled)
+      XCTAssertFalse(apiWasCalled.value)
       XCTAssertTrue(model.showNotifyListenersSheet)
     }
   }
 
   func testSendNotificationDoesNothingWhenMessageIsWhitespaceOnly() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var apiWasCalled = false
+    let apiWasCalled = LockIsolated(false)
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.sendStationNotification = { _, _, _ in
-        apiWasCalled = true
+        apiWasCalled.setValue(true)
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
@@ -1250,7 +1278,7 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertFalse(apiWasCalled)
+      XCTAssertFalse(apiWasCalled.value)
       XCTAssertTrue(model.showNotifyListenersSheet)
     }
   }
@@ -1297,25 +1325,40 @@ extension BroadcastPageTests {
 
   func testIsSendingNotificationTracksLoadingState() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    nonisolated(unsafe) var model: BroadcastPageModel!
-    nonisolated(unsafe) var capturedIsSending = false
+    let requestStarted = LockIsolated(false)
+    let requestContinuation = LockIsolated<CheckedContinuation<Void, Never>?>(nil)
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.sendStationNotification = { _, _, _ in
-        await MainActor.run {
-          capturedIsSending = model.isSendingNotification
+        requestStarted.setValue(true)
+        await withCheckedContinuation { continuation in
+          requestContinuation.setValue(continuation)
         }
       }
     } operation: {
-      model = BroadcastPageModel(stationId: testStationId)
+      let model = BroadcastPageModel(stationId: testStationId)
       model.notifyMessage = "Test"
 
       XCTAssertFalse(model.isSendingNotification)
 
-      await model.sendNotification()
+      let sendTask = Task {
+        await model.sendNotification()
+      }
 
-      XCTAssertTrue(capturedIsSending)
+      while !requestStarted.value {
+        await Task.yield()
+      }
+
+      XCTAssertTrue(model.isSendingNotification)
+
+      requestContinuation.withValue { continuation in
+        continuation?.resume()
+        continuation = nil
+      }
+
+      await sendTask.value
+
       XCTAssertFalse(model.isSendingNotification)
     }
   }
@@ -1329,7 +1372,7 @@ extension BroadcastPageTests {
     let fixedDate = Date(timeIntervalSince1970: 1_702_486_800)
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
-    var capturedStatuses: [LocalVoicetrackStatus] = []
+    let capturedStatuses = LockIsolated<[LocalVoicetrackStatus]>([])
 
     await withDependencies {
       $0.date.now = fixedDate
@@ -1344,7 +1387,7 @@ extension BroadcastPageTests {
         ]
         for status in statuses {
           await onStatusChange(status)
-          capturedStatuses.append(status)
+          capturedStatuses.withValue { $0.append(status) }
         }
         return AudioBlock.mockWith()
       }
@@ -1355,13 +1398,14 @@ extension BroadcastPageTests {
       let recordingURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
       await model.recordPageModel?.onRecordingAccepted?(recordingURL)
 
-      XCTAssertEqual(capturedStatuses.count, 6)
-      XCTAssertEqual(capturedStatuses[0], .converting)
-      XCTAssertEqual(capturedStatuses[1], .uploading(progress: 0.0))
-      XCTAssertEqual(capturedStatuses[2], .uploading(progress: 0.5))
-      XCTAssertEqual(capturedStatuses[3], .uploading(progress: 1.0))
-      XCTAssertEqual(capturedStatuses[4], .finalizing)
-      XCTAssertEqual(capturedStatuses[5], .completed)
+      let statuses = capturedStatuses.value
+      XCTAssertEqual(statuses.count, 6)
+      XCTAssertEqual(statuses[0], .converting)
+      XCTAssertEqual(statuses[1], .uploading(progress: 0.0))
+      XCTAssertEqual(statuses[2], .uploading(progress: 0.5))
+      XCTAssertEqual(statuses[3], .uploading(progress: 1.0))
+      XCTAssertEqual(statuses[4], .finalizing)
+      XCTAssertEqual(statuses[5], .completed)
       let voicetrack = model.stagingItems.first as? LocalVoicetrack
       XCTAssertEqual(voicetrack?.status, .completed)
     }

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageTests.swift
@@ -51,13 +51,13 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
   // MARK: - Fetch Tests
 
   func testViewAppearedCallsAPIWithStationId() async {
-    var calledStationId: String?
+    let calledStationId = LockIsolated<String?>(nil)
 
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
     let model = withDependencies {
       $0.api.getListenerQuestions = { _, stationId in
-        calledStationId = stationId
+        calledStationId.setValue(stationId)
         return []
       }
     } operation: {
@@ -66,7 +66,7 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertEqual(calledStationId, testStationId)
+    XCTAssertEqual(calledStationId.value, testStationId)
   }
 
   func testViewAppearedPopulatesQuestionsArray() async {
@@ -126,13 +126,13 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
   }
 
   func testViewAppearedDoesNothingWithoutJwt() async {
-    var apiCalled = false
+    let apiCalled = LockIsolated(false)
 
     @Shared(.auth) var auth = Auth()
 
     let model = withDependencies {
       $0.api.getListenerQuestions = { _, _ in
-        apiCalled = true
+        apiCalled.setValue(true)
         return []
       }
     } operation: {
@@ -141,17 +141,17 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertFalse(apiCalled)
+    XCTAssertFalse(apiCalled.value)
   }
 
   func testViewAppearedCallsFetchQuestions() async {
-    var fetchCalled = false
+    let fetchCalled = LockIsolated(false)
 
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
     let model = withDependencies {
       $0.api.getListenerQuestions = { _, _ in
-        fetchCalled = true
+        fetchCalled.setValue(true)
         return []
       }
     } operation: {
@@ -160,17 +160,17 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertTrue(fetchCalled)
+    XCTAssertTrue(fetchCalled.value)
   }
 
   func testRefreshPulledDownCallsFetchQuestions() async {
-    var fetchCalled = false
+    let fetchCalled = LockIsolated(false)
 
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
     let model = withDependencies {
       $0.api.getListenerQuestions = { _, _ in
-        fetchCalled = true
+        fetchCalled.setValue(true)
         return []
       }
     } operation: {
@@ -179,7 +179,7 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.refreshPulledDown()
 
-    XCTAssertTrue(fetchCalled)
+    XCTAssertTrue(fetchCalled.value)
   }
 
   // MARK: - Expand/Collapse Tests
@@ -458,18 +458,18 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
   // MARK: - Decline Question Tests
 
   func testDeclineQuestionCallsAPI() async {
-    var declineCalled = false
-    var capturedStationId: String?
-    var capturedQuestionId: String?
+    let declineCalled = LockIsolated(false)
+    let capturedStationId = LockIsolated<String?>(nil)
+    let capturedQuestionId = LockIsolated<String?>(nil)
 
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
     let model = withDependencies {
       $0.api.getListenerQuestions = { _, _ in [] }
       $0.api.declineListenerQuestion = { _, stationId, questionId in
-        declineCalled = true
-        capturedStationId = stationId
-        capturedQuestionId = questionId
+        declineCalled.setValue(true)
+        capturedStationId.setValue(stationId)
+        capturedQuestionId.setValue(questionId)
         return .mockWith(id: questionId, stationId: stationId, status: .declined)
       }
     } operation: {
@@ -482,9 +482,9 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.declineQuestionSwiped(model.questions[0])
 
-    XCTAssertTrue(declineCalled)
-    XCTAssertEqual(capturedStationId, testStationId)
-    XCTAssertEqual(capturedQuestionId, "q1")
+    XCTAssertTrue(declineCalled.value)
+    XCTAssertEqual(capturedStationId.value, testStationId)
+    XCTAssertEqual(capturedQuestionId.value, "q1")
   }
 
   func testDeclineQuestionUpdatesLocalState() async {

--- a/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageTests.swift
@@ -3,6 +3,7 @@
 //  PlayolaRadio
 //
 
+import ConcurrencyExtras
 import Dependencies
 import Foundation
 import Sharing
@@ -188,8 +189,8 @@ struct ConversationListPageTests {
     @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
       MainContainerNavigationCoordinator()
 
-    var markAsReadCalled = false
-    var markedConversationId: String?
+    let markAsReadCalled = LockIsolated(false)
+    let markedConversationId = LockIsolated<String?>(nil)
 
     let testConversation = AdminConversationResponse(
       conversation: makeConversation(id: "conv-1", ownerFirstName: "John"),
@@ -200,8 +201,8 @@ struct ConversationListPageTests {
       $0.api.getConversations = { _, _ in [testConversation] }
       $0.api.getConversationMessages = { _, _ in [] }
       $0.api.markConversationRead = { _, conversationId in
-        markAsReadCalled = true
-        markedConversationId = conversationId
+        markAsReadCalled.setValue(true)
+        markedConversationId.setValue(conversationId)
       }
     } operation: {
       ConversationListPageModel()
@@ -213,8 +214,8 @@ struct ConversationListPageTests {
 
     await model.onConversationTapped(testConversation)
 
-    #expect(markAsReadCalled == true)
-    #expect(markedConversationId == "conv-1")
+    #expect(markAsReadCalled.value == true)
+    #expect(markedConversationId.value == "conv-1")
     #expect(model.conversations.first?.unreadCountFromOwner == 0)
   }
 }

--- a/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageTests.swift
+++ b/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageTests.swift
@@ -175,6 +175,7 @@ final class EditProfilePageTests: XCTestCase {
       email: "john@example.com"
     )
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
+    let expectedJwt = auth.jwt
 
     let updatedUser = LoggedInUser(
       id: "123",
@@ -186,7 +187,7 @@ final class EditProfilePageTests: XCTestCase {
 
     let model = withDependencies {
       $0.api.updateUser = { jwtToken, firstName, lastName, _ in
-        XCTAssertEqual(jwtToken, auth.jwt)
+        XCTAssertEqual(jwtToken, expectedJwt)
         XCTAssertEqual(firstName, "Joe")
         XCTAssertEqual(lastName, "Jones")
         return expectedAuth

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -7,6 +7,7 @@
 
 // swiftlint:disable force_try
 
+import ConcurrencyExtras
 import Dependencies
 import IdentifiedCollections
 import PlayolaPlayer
@@ -525,11 +526,11 @@ final class HomePageTests: XCTestCase {
 
   func testViewAppearedDoesNotCheckAiringsWhenNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
-    var apiCalled = false
+    let apiCalled = LockIsolated(false)
 
     await withDependencies {
       $0.api.getMyListenerQuestionAirings = { _ in
-        apiCalled = true
+        apiCalled.setValue(true)
         return []
       }
     } operation: {
@@ -537,7 +538,7 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(apiCalled)
+      XCTAssertFalse(apiCalled.value)
       XCTAssertNil(model.upcomingQuestionAiring)
     }
   }

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
@@ -16,8 +16,8 @@ final class LikedSongsPageTests: XCTestCase {
     $pendingOperations.withLock { $0 = [] }
   }
 
-  func testGroupedLikedSongs_EmptyWhenNoLikes() async {
-    await withDependencies {
+  func testGroupedLikedSongs_EmptyWhenNoLikes() {
+    withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
       let model = LikedSongsPageModel()
@@ -30,7 +30,7 @@ final class LikedSongsPageTests: XCTestCase {
     let audioBlock1 = AudioBlock.mock
     let audioBlock2 = AudioBlock.mockWith(id: "different-id")
 
-    await withDependencies {
+    withDependencies {
       let likesManager = LikesManager()
       likesManager.like(audioBlock1)
       likesManager.like(audioBlock2)
@@ -43,8 +43,8 @@ final class LikedSongsPageTests: XCTestCase {
     }
   }
 
-  func testFormatTimestamp() async {
-    await withDependencies {
+  func testFormatTimestamp() {
+    withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
       let model = LikedSongsPageModel()
@@ -60,7 +60,7 @@ final class LikedSongsPageTests: XCTestCase {
   func testRemoveSong() async {
     let audioBlock = AudioBlock.mock
 
-    await withDependencies {
+    withDependencies {
       let likesManager = LikesManager()
       likesManager.like(audioBlock)
       $0.likesManager = likesManager

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageTests.swift
@@ -432,10 +432,10 @@ final class ListenerQuestionDetailPageTests: XCTestCase {
   // MARK: - Upload Answer API Integration Tests
 
   func testUploadButtonTappedCallsRegisterListenerQuestionAnswerAPI() async {
-    var registerAnswerCalled = false
-    var capturedStationId: String?
-    var capturedQuestionId: String?
-    var capturedAudioBlockId: String?
+    let registerAnswerCalled = LockIsolated(false)
+    let capturedStationId = LockIsolated<String?>(nil)
+    let capturedQuestionId = LockIsolated<String?>(nil)
+    let capturedAudioBlockId = LockIsolated<String?>(nil)
 
     let testQuestion = ListenerQuestion.mockWith(
       id: "test-question-123",
@@ -455,10 +455,10 @@ final class ListenerQuestionDetailPageTests: XCTestCase {
         }
       )
       $0.api.registerListenerQuestionAnswer = { _, stationId, questionId, audioBlockId in
-        registerAnswerCalled = true
-        capturedStationId = stationId
-        capturedQuestionId = questionId
-        capturedAudioBlockId = audioBlockId
+        registerAnswerCalled.setValue(true)
+        capturedStationId.setValue(stationId)
+        capturedQuestionId.setValue(questionId)
+        capturedAudioBlockId.setValue(audioBlockId)
         return testQuestion
       }
     } operation: {
@@ -470,10 +470,10 @@ final class ListenerQuestionDetailPageTests: XCTestCase {
 
     await model.uploadButtonTapped()
 
-    XCTAssertTrue(registerAnswerCalled)
-    XCTAssertEqual(capturedStationId, "test-station-789")
-    XCTAssertEqual(capturedQuestionId, "test-question-123")
-    XCTAssertEqual(capturedAudioBlockId, "uploaded-audio-block-456")
+    XCTAssertTrue(registerAnswerCalled.value)
+    XCTAssertEqual(capturedStationId.value, "test-station-789")
+    XCTAssertEqual(capturedQuestionId.value, "test-question-123")
+    XCTAssertEqual(capturedAudioBlockId.value, "uploaded-audio-block-456")
   }
 
   func testUploadButtonTappedSetsLinkingAnswerPhase() async {

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -61,29 +61,29 @@ final class MainContainerTests: XCTestCase {
 
   func testViewAppearedRegistersForRemoteNotifications() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
-    var registerForRemoteNotificationsCalled = false
+    let registerForRemoteNotificationsCalled = LockIsolated(false)
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {
-        registerForRemoteNotificationsCalled = true
+        registerForRemoteNotificationsCalled.setValue(true)
       }
     } operation: {
       MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertTrue(registerForRemoteNotificationsCalled)
+    XCTAssertTrue(registerForRemoteNotificationsCalled.value)
   }
 
   func testViewAppeared_CorrectlyRetrievesStationListsWhenApiIsSuccessful() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
-    var getStationsCallCount = 0
+    let getStationsCallCount = LockIsolated(0)
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = {
-        getStationsCallCount += 1
+        getStationsCallCount.withValue { $0 += 1 }
         return StationList.mocks
       }
       $0.pushNotifications.registerForRemoteNotifications = {}
@@ -92,7 +92,7 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertEqual(getStationsCallCount, 1)
+    XCTAssertEqual(getStationsCallCount.value, 1)
     XCTAssertEqual(stationLists, StationList.mocks)
     XCTAssertTrue(stationListsLoaded)
   }
@@ -136,11 +136,11 @@ final class MainContainerTests: XCTestCase {
 
   func testViewAppeared_ExitsEarlyWhenStationListsAlreadyLoaded() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = true
-    var getStationsCallCount = 0
+    let getStationsCallCount = LockIsolated(0)
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = {
-        getStationsCallCount += 1
+        getStationsCallCount.withValue { $0 += 1 }
         return StationList.mocks
       }
       $0.pushNotifications.registerForRemoteNotifications = {}
@@ -149,7 +149,7 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertEqual(getStationsCallCount, 0)
+    XCTAssertEqual(getStationsCallCount.value, 0)
   }
 
   func testViewAppearedLoadsAiringsWhenLoggedIn() async {
@@ -158,7 +158,7 @@ final class MainContainerTests: XCTestCase {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
 
-    var getAiringsCallCount = 0
+    let getAiringsCallCount = LockIsolated(0)
     let mockAirings = [
       Airing.mockWith(id: "airing1"),
       Airing.mockWith(id: "airing2"),
@@ -167,7 +167,7 @@ final class MainContainerTests: XCTestCase {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { StationList.mocks }
       $0.api.getAirings = { _, _ in
-        getAiringsCallCount += 1
+        getAiringsCallCount.withValue { $0 += 1 }
         return mockAirings
       }
       $0.pushNotifications.registerForRemoteNotifications = {}
@@ -177,7 +177,7 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.viewAppeared()
 
-    XCTAssertEqual(getAiringsCallCount, 1)
+    XCTAssertEqual(getAiringsCallCount.value, 1)
     XCTAssertEqual(airings.count, 2)
   }
 
@@ -410,8 +410,8 @@ final class MainContainerTests: XCTestCase {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
 
-    var getStationsCallCount = 0
-    var getAiringsCallCount = 0
+    let getStationsCallCount = LockIsolated(0)
+    let getAiringsCallCount = LockIsolated(0)
     let mockAirings = [
       Airing.mockWith(id: "airing1"),
       Airing.mockWith(id: "airing2"),
@@ -419,11 +419,11 @@ final class MainContainerTests: XCTestCase {
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = {
-        getStationsCallCount += 1
+        getStationsCallCount.withValue { $0 += 1 }
         return StationList.mocks
       }
       $0.api.getAirings = { _, _ in
-        getAiringsCallCount += 1
+        getAiringsCallCount.withValue { $0 += 1 }
         return mockAirings
       }
     } operation: {
@@ -432,8 +432,8 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.refreshOnForeground()
 
-    XCTAssertEqual(getStationsCallCount, 1)
-    XCTAssertEqual(getAiringsCallCount, 1)
+    XCTAssertEqual(getStationsCallCount.value, 1)
+    XCTAssertEqual(getAiringsCallCount.value, 1)
     XCTAssertEqual(stationLists, StationList.mocks)
     XCTAssertEqual(airings.count, 2)
     XCTAssertEqual(airings[id: "airing1"]?.id, "airing1")
@@ -445,16 +445,16 @@ final class MainContainerTests: XCTestCase {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
 
-    var getStationsCallCount = 0
-    var getAiringsCallCount = 0
+    let getStationsCallCount = LockIsolated(0)
+    let getAiringsCallCount = LockIsolated(0)
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = {
-        getStationsCallCount += 1
+        getStationsCallCount.withValue { $0 += 1 }
         return StationList.mocks
       }
       $0.api.getAirings = { _, _ in
-        getAiringsCallCount += 1
+        getAiringsCallCount.withValue { $0 += 1 }
         return []
       }
     } operation: {
@@ -463,8 +463,8 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.refreshOnForeground()
 
-    XCTAssertEqual(getStationsCallCount, 1)
-    XCTAssertEqual(getAiringsCallCount, 0)
+    XCTAssertEqual(getStationsCallCount.value, 1)
+    XCTAssertEqual(getAiringsCallCount.value, 0)
     XCTAssertEqual(stationLists, StationList.mocks)
     XCTAssertTrue(airings.isEmpty)
   }
@@ -508,13 +508,13 @@ final class MainContainerTests: XCTestCase {
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
     @Shared(.unreadSupportCount) var unreadSupportCount = 0
 
-    var getSupportConversationCallCount = 0
+    let getSupportConversationCallCount = LockIsolated(0)
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.api.getAirings = { _, _ in [] }
       $0.api.getSupportConversation = { _ in
-        getSupportConversationCallCount += 1
+        getSupportConversationCallCount.withValue { $0 += 1 }
         return SupportConversationResponse(
           conversation: Conversation(
             id: "conv-1",
@@ -535,7 +535,7 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.refreshOnForeground()
 
-    XCTAssertEqual(getSupportConversationCallCount, 1)
+    XCTAssertEqual(getSupportConversationCallCount.value, 1)
     XCTAssertEqual(unreadSupportCount, 3)
   }
 
@@ -639,13 +639,13 @@ final class MainContainerTests: XCTestCase {
       )
     )
 
-    var shouldShowCallCount = 0
+    let shouldShowCallCount = LockIsolated(0)
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
       $0.appRating.shouldShowRatingPrompt = { _ in
-        shouldShowCallCount += 1
+        shouldShowCallCount.withValue { $0 += 1 }
         return true
       }
     } operation: {
@@ -656,7 +656,7 @@ final class MainContainerTests: XCTestCase {
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertEqual(shouldShowCallCount, 1)
+    XCTAssertEqual(shouldShowCallCount.value, 1)
   }
 
   func testCheckRatingPromptDoesNotShowWhenNoListeningTracker() {
@@ -665,13 +665,13 @@ final class MainContainerTests: XCTestCase {
     )
     @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
 
-    var shouldShowCalled = false
+    let shouldShowCalled = LockIsolated(false)
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
       $0.appRating.shouldShowRatingPrompt = { _ in
-        shouldShowCalled = true
+        shouldShowCalled.setValue(true)
         return true
       }
     } operation: {
@@ -680,7 +680,7 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertFalse(shouldShowCalled)
+    XCTAssertFalse(shouldShowCalled.value)
     XCTAssertNil(mainContainerModel.presentedAlert)
   }
 
@@ -697,14 +697,14 @@ final class MainContainerTests: XCTestCase {
       )
     )
 
-    var shouldShowCalled = false
+    let shouldShowCalled = LockIsolated(false)
 
     let stationPlayerMock = StationPlayerMock()
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
       $0.appRating.shouldShowRatingPrompt = { _ in
-        shouldShowCalled = true
+        shouldShowCalled.setValue(true)
         return false
       }
     } operation: {
@@ -715,7 +715,7 @@ final class MainContainerTests: XCTestCase {
     $activeTab.withLock { $0 = .stationsList }
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertTrue(shouldShowCalled)
+    XCTAssertTrue(shouldShowCalled.value)
   }
 
   func testRatingPromptEnjoyingTracksAnalyticsAndRequestsReview() async {
@@ -732,15 +732,15 @@ final class MainContainerTests: XCTestCase {
     )
 
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-    var markShownCalled = false
-    var requestReviewCalled = false
+    let markShownCalled = LockIsolated(false)
+    let requestReviewCalled = LockIsolated(false)
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
       $0.appRating.shouldShowRatingPrompt = { _ in true }
-      $0.appRating.markRatingPromptShown = { markShownCalled = true }
-      $0.appRating.requestAppStoreReview = { requestReviewCalled = true }
+      $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
+      $0.appRating.requestAppStoreReview = { requestReviewCalled.setValue(true) }
       $0.analytics.track = { @Sendable event in
         capturedEvents.withValue { $0.append(event) }
       }
@@ -753,8 +753,8 @@ final class MainContainerTests: XCTestCase {
     // Simulate tapping "Yes!"
     await mainContainerModel.presentedAlert?.primaryAction?()
 
-    XCTAssertTrue(markShownCalled)
-    XCTAssertTrue(requestReviewCalled)
+    XCTAssertTrue(markShownCalled.value)
+    XCTAssertTrue(requestReviewCalled.value)
     XCTAssertTrue(capturedEvents.value.contains { $0 == .ratingPromptEnjoying })
   }
 
@@ -775,8 +775,8 @@ final class MainContainerTests: XCTestCase {
       )
 
       let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-      var markShownCalled = false
-      var markDismissedCalled = false
+      let markShownCalled = LockIsolated(false)
+      let markDismissedCalled = LockIsolated(false)
       let feedbackSheetExpectation = XCTestExpectation(
         description: "feedbackSheetPresented tracked")
 
@@ -785,8 +785,8 @@ final class MainContainerTests: XCTestCase {
         $0.api.getSupportConversation = { _ in .mockWith() }
         $0.pushNotifications.registerForRemoteNotifications = {}
         $0.appRating.shouldShowRatingPrompt = { _ in true }
-        $0.appRating.markRatingPromptShown = { markShownCalled = true }
-        $0.appRating.markRatingPromptDismissed = { markDismissedCalled = true }
+        $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
+        $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
         $0.analytics.track = { @Sendable event in
           capturedEvents.withValue { $0.append(event) }
           if event == .feedbackSheetPresented { feedbackSheetExpectation.fulfill() }
@@ -799,9 +799,9 @@ final class MainContainerTests: XCTestCase {
       await mainContainerModel.presentedAlert?.secondaryAction?()
       await fulfillment(of: [feedbackSheetExpectation], timeout: 1.0)
 
-      XCTAssertTrue(markShownCalled)
+      XCTAssertTrue(markShownCalled.value)
       XCTAssertTrue(
-        markDismissedCalled, "Not really should also set dismiss date for 7-day cooldown")
+        markDismissedCalled.value, "Not really should also set dismiss date for 7-day cooldown")
       XCTAssertTrue(capturedEvents.value.contains { $0 == .ratingPromptNotEnjoying })
       XCTAssertNil(
         mainContainerModel.presentedAlert, "Alert should be dismissed before showing feedback sheet"
@@ -882,13 +882,13 @@ final class MainContainerTests: XCTestCase {
     )
 
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-    var markDismissedCalled = false
+    let markDismissedCalled = LockIsolated(false)
 
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
       $0.appRating.shouldShowRatingPrompt = { _ in true }
-      $0.appRating.markRatingPromptDismissed = { markDismissedCalled = true }
+      $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
       $0.analytics.track = { @Sendable event in
         capturedEvents.withValue { $0.append(event) }
       }
@@ -901,7 +901,7 @@ final class MainContainerTests: XCTestCase {
     // Simulate tapping "Not now"
     await mainContainerModel.presentedAlert?.tertiaryAction?()
 
-    XCTAssertTrue(markDismissedCalled)
+    XCTAssertTrue(markDismissedCalled.value)
     XCTAssertTrue(capturedEvents.value.contains { $0 == .ratingPromptDismissed })
   }
 

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageTests.swift
@@ -5,6 +5,7 @@
 //  Created by Claude on 1/2/26.
 //
 
+import ConcurrencyExtras
 import Dependencies
 import IdentifiedCollections
 import PlayolaPlayer
@@ -136,14 +137,14 @@ final class NotificationsSettingsPageTests: XCTestCase {
     let mockSubs = [
       mockSubscriptionWithStation(stationId: "station-1", isSubscribed: true)
     ]
-    var unsubscribeCalled = false
-    var unsubscribedStationId: String?
+    let unsubscribeCalled = LockIsolated(false)
+    let unsubscribedStationId = LockIsolated<String?>(nil)
 
     await withDependencies {
       $0.api.getPushNotificationSubscriptions = { _ in mockSubs }
       $0.api.unsubscribeFromStationNotifications = { _, stationId in
-        unsubscribeCalled = true
-        unsubscribedStationId = stationId
+        unsubscribeCalled.setValue(true)
+        unsubscribedStationId.setValue(stationId)
         return self.mockSubscription(stationId: stationId, isSubscribed: false)
       }
     } operation: {
@@ -152,22 +153,22 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.toggleSubscription(for: "station-1")
 
-      XCTAssertTrue(unsubscribeCalled)
-      XCTAssertEqual(unsubscribedStationId, "station-1")
+      XCTAssertTrue(unsubscribeCalled.value)
+      XCTAssertEqual(unsubscribedStationId.value, "station-1")
     }
   }
 
   func testToggleSubscriptionCallsSubscribeWhenNotSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
-    var subscribeCalled = false
-    var subscribedStationId: String?
+    let subscribeCalled = LockIsolated(false)
+    let subscribedStationId = LockIsolated<String?>(nil)
 
     await withDependencies {
       $0.api.getPushNotificationSubscriptions = { _ in [] }
       $0.api.subscribeToStationNotifications = { _, stationId in
-        subscribeCalled = true
-        subscribedStationId = stationId
+        subscribeCalled.setValue(true)
+        subscribedStationId.setValue(stationId)
         return self.mockSubscription(stationId: stationId, isSubscribed: true)
       }
     } operation: {
@@ -176,8 +177,8 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.toggleSubscription(for: "station-1")
 
-      XCTAssertTrue(subscribeCalled)
-      XCTAssertEqual(subscribedStationId, "station-1")
+      XCTAssertTrue(subscribeCalled.value)
+      XCTAssertEqual(subscribedStationId.value, "station-1")
     }
   }
 

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
@@ -47,18 +47,18 @@ final class RecordIntroPageTests: XCTestCase {
   // MARK: - Lifecycle
 
   func testViewAppearedPreparesForRecording() async {
-    var prepareCalled = false
+    let prepareCalled = LockIsolated(false)
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {
-        prepareCalled = true
+        prepareCalled.setValue(true)
       }
     } operation: {
       let model = makeModel()
 
       await model.viewAppeared()
 
-      XCTAssertTrue(prepareCalled)
+      XCTAssertTrue(prepareCalled.value)
     }
   }
 
@@ -100,18 +100,18 @@ final class RecordIntroPageTests: XCTestCase {
   // MARK: - Recording
 
   func testOnRecordTappedRequestsPermissionBeforeRecording() async {
-    var requestPermissionCalled = false
-    var startRecordingCalled = false
+    let requestPermissionCalled = LockIsolated(false)
+    let startRecordingCalled = LockIsolated(false)
 
     await withDependencies {
       $0.audioRecorder.requestPermission = {
-        requestPermissionCalled = true
+        requestPermissionCalled.setValue(true)
         return true
       }
       $0.audioRecorder.startRecording = {
         XCTAssertTrue(
-          requestPermissionCalled, "Permission should be requested before recording starts")
-        startRecordingCalled = true
+          requestPermissionCalled.value, "Permission should be requested before recording starts")
+        startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = makeModel()
@@ -119,26 +119,27 @@ final class RecordIntroPageTests: XCTestCase {
 
       await model.onRecordTapped()
 
-      XCTAssertTrue(requestPermissionCalled)
-      XCTAssertTrue(startRecordingCalled)
+      XCTAssertTrue(requestPermissionCalled.value)
+      XCTAssertTrue(startRecordingCalled.value)
       XCTAssertEqual(model.recordingPhase, .recording)
     }
   }
 
   func testOnRecordTappedDoesNotRecordWhenPermissionDenied() async {
-    var startRecordingCalled = false
+    let startRecordingCalled = LockIsolated(false)
 
     await withDependencies {
       $0.audioRecorder.requestPermission = { false }
       $0.audioRecorder.startRecording = {
-        startRecordingCalled = true
+        startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = makeModel()
 
       await model.onRecordTapped()
 
-      XCTAssertFalse(startRecordingCalled, "Recording should not start when permission is denied")
+      XCTAssertFalse(
+        startRecordingCalled.value, "Recording should not start when permission is denied")
       XCTAssertEqual(model.recordingPhase, .idle)
       XCTAssertNotNil(model.presentedAlert)
       XCTAssertEqual(model.presentedAlert?.title, "Microphone Access Required")
@@ -215,13 +216,13 @@ final class RecordIntroPageTests: XCTestCase {
 
   func testOnAcceptRecordingTappedStartsUpload() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var uploadCalled = false
+    let uploadCalled = LockIsolated(false)
 
     await withMainSerialExecutor {
       await withDependencies {
         $0.audioPlayer.stop = {}
         $0.introUploadService.uploadIntro = { _, _, _, _, _, onStatus in
-          uploadCalled = true
+          uploadCalled.setValue(true)
           await onStatus(.completed)
         }
       } operation: {
@@ -233,7 +234,7 @@ final class RecordIntroPageTests: XCTestCase {
         await Task.yield()
 
         XCTAssertNotNil(model.uploadStatus)
-        XCTAssertTrue(uploadCalled)
+        XCTAssertTrue(uploadCalled.value)
       }
     }
   }
@@ -284,13 +285,13 @@ final class RecordIntroPageTests: XCTestCase {
 
   func testOnRetryTappedRestartsUpload() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var uploadCallCount = 0
+    let uploadCallCount = LockIsolated(0)
 
     await withMainSerialExecutor {
       await withDependencies {
         $0.audioPlayer.stop = {}
         $0.introUploadService.uploadIntro = { _, _, _, _, _, onStatus in
-          uploadCallCount += 1
+          uploadCallCount.withValue { $0 += 1 }
           await onStatus(.completed)
         }
       } operation: {
@@ -301,14 +302,14 @@ final class RecordIntroPageTests: XCTestCase {
         model.onRetryTapped()
         await Task.yield()
 
-        XCTAssertEqual(uploadCallCount, 1)
+        XCTAssertEqual(uploadCallCount.value, 1)
       }
     }
   }
 
   func testUploadSuccessCallsOnUploadCompleted() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var completedCalled = false
+    let completedCalled = LockIsolated(false)
 
     await withMainSerialExecutor {
       await withDependencies {
@@ -320,13 +321,13 @@ final class RecordIntroPageTests: XCTestCase {
         let model = makeModel()
         model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
         model.onUploadCompleted = {
-          completedCalled = true
+          completedCalled.setValue(true)
         }
 
         model.onAcceptRecordingTapped()
         await Task.yield()
 
-        XCTAssertTrue(completedCalled)
+        XCTAssertTrue(completedCalled.value)
         XCTAssertEqual(model.uploadStatus, .completed)
       }
     }

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 12/13/25.
 //
 
+import ConcurrencyExtras
 import Dependencies
 import Sharing
 import XCTest
@@ -22,18 +23,18 @@ final class RecordPageTests: XCTestCase {
   // MARK: - Lifecycle
 
   func testViewAppeared_PreparesForRecording() async {
-    var prepareCalled = false
+    let prepareCalled = LockIsolated(false)
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {
-        prepareCalled = true
+        prepareCalled.setValue(true)
       }
     } operation: {
       let model = RecordPageModel()
 
       await model.viewAppeared()
 
-      XCTAssertTrue(prepareCalled)
+      XCTAssertTrue(prepareCalled.value)
     }
   }
 
@@ -68,18 +69,18 @@ final class RecordPageTests: XCTestCase {
   // MARK: - Recording
 
   func testOnRecordTappedRequestsPermissionBeforeRecording() async {
-    var requestPermissionCalled = false
-    var startRecordingCalled = false
+    let requestPermissionCalled = LockIsolated(false)
+    let startRecordingCalled = LockIsolated(false)
 
     await withDependencies {
       $0.audioRecorder.requestPermission = {
-        requestPermissionCalled = true
+        requestPermissionCalled.setValue(true)
         return true
       }
       $0.audioRecorder.startRecording = {
         XCTAssertTrue(
-          requestPermissionCalled, "Permission should be requested before recording starts")
-        startRecordingCalled = true
+          requestPermissionCalled.value, "Permission should be requested before recording starts")
+        startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = RecordPageModel()
@@ -87,26 +88,27 @@ final class RecordPageTests: XCTestCase {
 
       await model.onRecordTapped()
 
-      XCTAssertTrue(requestPermissionCalled)
-      XCTAssertTrue(startRecordingCalled)
+      XCTAssertTrue(requestPermissionCalled.value)
+      XCTAssertTrue(startRecordingCalled.value)
       XCTAssertEqual(model.recordingPhase, .recording)
     }
   }
 
   func testOnRecordTappedDoesNotRecordWhenPermissionDenied() async {
-    var startRecordingCalled = false
+    let startRecordingCalled = LockIsolated(false)
 
     await withDependencies {
       $0.audioRecorder.requestPermission = { false }
       $0.audioRecorder.startRecording = {
-        startRecordingCalled = true
+        startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = RecordPageModel()
 
       await model.onRecordTapped()
 
-      XCTAssertFalse(startRecordingCalled, "Recording should not start when permission is denied")
+      XCTAssertFalse(
+        startRecordingCalled.value, "Recording should not start when permission is denied")
       XCTAssertEqual(model.recordingPhase, .idle)
       XCTAssertNotNil(model.presentedAlert)
       XCTAssertEqual(model.presentedAlert?.title, "Microphone Access Required")
@@ -218,12 +220,12 @@ final class RecordPageTests: XCTestCase {
 
     let expectedURL = URL(fileURLWithPath: "/tmp/test.wav")
     let callbackExpectation = XCTestExpectation(description: "onRecordingAccepted called")
-    var receivedURL: URL?
+    let receivedURL = LockIsolated<URL?>(nil)
 
     let model = RecordPageModel()
     model.recordingURL = expectedURL
     model.onRecordingAccepted = { url in
-      receivedURL = url
+      receivedURL.setValue(url)
       callbackExpectation.fulfill()
     }
     coordinator.presentedSheet = .recordPage(model)
@@ -234,18 +236,18 @@ final class RecordPageTests: XCTestCase {
     XCTAssertNil(coordinator.presentedSheet)
 
     await fulfillment(of: [callbackExpectation], timeout: 1.0)
-    XCTAssertEqual(receivedURL, expectedURL)
+    XCTAssertEqual(receivedURL.value, expectedURL)
   }
 
   func testOnAcceptRecordingTapped_DoesNothingWithoutURL() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
-    var callbackCalled = false
+    let callbackCalled = LockIsolated(false)
 
     let model = RecordPageModel()
     model.recordingURL = nil
     model.onRecordingAccepted = { _ in
-      callbackCalled = true
+      callbackCalled.setValue(true)
     }
     coordinator.presentedSheet = .recordPage(model)
 
@@ -254,17 +256,17 @@ final class RecordPageTests: XCTestCase {
     // Allow any spawned Task to complete
     await Task.yield()
 
-    XCTAssertFalse(callbackCalled)
+    XCTAssertFalse(callbackCalled.value)
     XCTAssertNotNil(coordinator.presentedSheet)
   }
 
   // MARK: - Playback
 
   func testOnPlayPauseTapped_PlaysWhenNotPlaying() async {
-    var playCalled = false
+    let playCalled = LockIsolated(false)
 
     await withDependencies {
-      $0.audioPlayer.play = { playCalled = true }
+      $0.audioPlayer.play = { playCalled.setValue(true) }
       $0.audioPlayer.currentTime = { 0 }
       $0.audioPlayer.isPlaying = { true }
     } operation: {
@@ -275,16 +277,16 @@ final class RecordPageTests: XCTestCase {
       // Allow Task to execute
       try? await Task.sleep(for: .milliseconds(10))
 
-      XCTAssertTrue(playCalled)
+      XCTAssertTrue(playCalled.value)
       XCTAssertTrue(model.isPlaying)
     }
   }
 
   func testOnPlayPauseTapped_PausesWhenPlaying() async {
-    var pauseCalled = false
+    let pauseCalled = LockIsolated(false)
 
     await withDependencies {
-      $0.audioPlayer.pause = { pauseCalled = true }
+      $0.audioPlayer.pause = { pauseCalled.setValue(true) }
     } operation: {
       let model = RecordPageModel()
       model.isPlaying = true
@@ -293,16 +295,16 @@ final class RecordPageTests: XCTestCase {
       // Allow Task to execute
       try? await Task.sleep(for: .milliseconds(10))
 
-      XCTAssertTrue(pauseCalled)
+      XCTAssertTrue(pauseCalled.value)
       XCTAssertFalse(model.isPlaying)
     }
   }
 
   func testOnRewindTapped_SeeksToZero() async {
-    var seekTime: TimeInterval?
+    let seekTime = LockIsolated<TimeInterval?>(nil)
 
     await withDependencies {
-      $0.audioPlayer.seek = { time in seekTime = time }
+      $0.audioPlayer.seek = { time in seekTime.setValue(time) }
     } operation: {
       let model = RecordPageModel()
       model.playbackPosition = 30.0
@@ -311,16 +313,16 @@ final class RecordPageTests: XCTestCase {
       // Allow Task to execute
       try? await Task.sleep(for: .milliseconds(10))
 
-      XCTAssertEqual(seekTime, 0)
+      XCTAssertEqual(seekTime.value, 0)
       XCTAssertEqual(model.playbackPosition, 0)
     }
   }
 
   func testSeekTo_UpdatesPlaybackPosition() async {
-    var seekTime: TimeInterval?
+    let seekTime = LockIsolated<TimeInterval?>(nil)
 
     await withDependencies {
-      $0.audioPlayer.seek = { time in seekTime = time }
+      $0.audioPlayer.seek = { time in seekTime.setValue(time) }
     } operation: {
       let model = RecordPageModel()
       model.recordingDuration = 60.0
@@ -329,7 +331,7 @@ final class RecordPageTests: XCTestCase {
       // Allow Task to execute
       try? await Task.sleep(for: .milliseconds(10))
 
-      XCTAssertEqual(seekTime, 30.0)
+      XCTAssertEqual(seekTime.value, 30.0)
       XCTAssertEqual(model.playbackPosition, 30.0)
     }
   }

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
@@ -3,6 +3,7 @@
 //  PlayolaRadio
 //
 
+import ConcurrencyExtras
 import Dependencies
 import PlayolaPlayer
 import Sharing
@@ -14,13 +15,13 @@ import XCTest
 final class SeriesCardModelTests: XCTestCase {
   func testRemindMeTappedCallsSubscribeAPI() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var subscribeCalled = false
-    var subscribedStationId: String?
+    let subscribeCalled = LockIsolated(false)
+    let subscribedStationId = LockIsolated<String?>(nil)
 
     await withDependencies {
       $0.api.subscribeToStationNotifications = { _, stationId in
-        subscribeCalled = true
-        subscribedStationId = stationId
+        subscribeCalled.setValue(true)
+        subscribedStationId.setValue(stationId)
         return self.mockSubscription(stationId: stationId)
       }
     } operation: {
@@ -31,8 +32,8 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertTrue(subscribeCalled)
-      XCTAssertEqual(subscribedStationId, "station-123")
+      XCTAssertTrue(subscribeCalled.value)
+      XCTAssertEqual(subscribedStationId.value, "station-123")
     }
   }
 
@@ -76,11 +77,11 @@ final class SeriesCardModelTests: XCTestCase {
 
   func testRemindMeTappedDoesNotCallAPIWithoutJWT() async {
     @Shared(.auth) var auth = Auth(jwt: nil)
-    var subscribeCalled = false
+    let subscribeCalled = LockIsolated(false)
 
     await withDependencies {
       $0.api.subscribeToStationNotifications = { _, _ in
-        subscribeCalled = true
+        subscribeCalled.setValue(true)
         throw APIError.dataNotValid
       }
     } operation: {
@@ -91,17 +92,17 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertFalse(subscribeCalled)
+      XCTAssertFalse(subscribeCalled.value)
     }
   }
 
   func testRemindMeTappedDoesNotCallAPIWithoutStation() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var subscribeCalled = false
+    let subscribeCalled = LockIsolated(false)
 
     await withDependencies {
       $0.api.subscribeToStationNotifications = { _, _ in
-        subscribeCalled = true
+        subscribeCalled.setValue(true)
         throw APIError.dataNotValid
       }
     } operation: {
@@ -112,19 +113,17 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertFalse(subscribeCalled)
+      XCTAssertFalse(subscribeCalled.value)
     }
   }
 
   func testRemindMeTappedSetsIsSubscribingDuringRequest() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var wasSubscribingDuringCall = false
+    let wasSubscribingDuringCall = LockIsolated(false)
 
     await withDependencies {
       $0.api.subscribeToStationNotifications = { _, stationId in
-        await MainActor.run {
-          wasSubscribingDuringCall = true
-        }
+        wasSubscribingDuringCall.setValue(true)
         return self.mockSubscription(stationId: stationId)
       }
     } operation: {
@@ -135,7 +134,7 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertTrue(wasSubscribingDuringCall)
+      XCTAssertTrue(wasSubscribingDuringCall.value)
       XCTAssertFalse(model.isSubscribing)
     }
   }

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
@@ -3,6 +3,7 @@
 //  PlayolaRadio
 //
 
+import ConcurrencyExtras
 import Dependencies
 import PlayolaPlayer
 import Sharing
@@ -14,13 +15,13 @@ import XCTest
 final class SeriesListPageModelTests: XCTestCase {
   func testViewAppearedCallsGetAiringsAPI() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var apiCalled = false
-    var passedJwt: String?
+    let apiCalled = LockIsolated(false)
+    let passedJwt = LockIsolated<String?>(nil)
 
     await withDependencies {
       $0.api.getAirings = { jwt, _ in
-        apiCalled = true
-        passedJwt = jwt
+        apiCalled.setValue(true)
+        passedJwt.setValue(jwt)
         return []
       }
     } operation: {
@@ -28,8 +29,8 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertTrue(apiCalled)
-      XCTAssertEqual(passedJwt, "test-jwt")
+      XCTAssertTrue(apiCalled.value)
+      XCTAssertEqual(passedJwt.value, "test-jwt")
     }
   }
 
@@ -91,11 +92,11 @@ final class SeriesListPageModelTests: XCTestCase {
 
   func testViewAppearedDoesNotCallAPIWithoutJWT() async {
     @Shared(.auth) var auth = Auth(jwt: nil)
-    var apiCalled = false
+    let apiCalled = LockIsolated(false)
 
     await withDependencies {
       $0.api.getAirings = { _, _ in
-        apiCalled = true
+        apiCalled.setValue(true)
         return []
       }
     } operation: {
@@ -103,7 +104,7 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(apiCalled)
+      XCTAssertFalse(apiCalled.value)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -17,7 +17,7 @@ final class SignInPageTests: XCTestCase {
   func testSignInWithApple_CorrectlyAddsScopeToTheAppleSignInRequest() async {
     let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
     let model = SignInPageModel()
-    await model.signInWithAppleButtonTapped(request: request)
+    model.signInWithAppleButtonTapped(request: request)
     XCTAssertEqual(request.requestedScopes, [.email, .fullName])
   }
 

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
@@ -176,13 +176,13 @@ final class SongSearchPageTests: XCTestCase {
     await withMainSerialExecutor {
       let clock = TestClock()
       @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-      var capturedKeywords: String?
+      let capturedKeywords = LockIsolated<String?>(nil)
 
       await withDependencies {
         $0.continuousClock = clock
         $0.date = .constant(Date())
         $0.api.searchSongs = { _, keywords in
-          capturedKeywords = keywords
+          capturedKeywords.setValue(keywords)
           return []
         }
       } operation: {
@@ -191,7 +191,7 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(capturedKeywords, "Bob Dylan")
+        XCTAssertEqual(capturedKeywords.value, "Bob Dylan")
       }
     }
   }
@@ -200,13 +200,13 @@ final class SongSearchPageTests: XCTestCase {
     await withMainSerialExecutor {
       let clock = TestClock()
       @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-      var capturedKeywords: String?
+      let capturedKeywords = LockIsolated<String?>(nil)
 
       await withDependencies {
         $0.continuousClock = clock
         $0.date = .constant(Date())
         $0.api.searchSongs = { _, keywords in
-          capturedKeywords = keywords
+          capturedKeywords.setValue(keywords)
           return []
         }
       } operation: {
@@ -215,7 +215,7 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(capturedKeywords, "Bob Dylan")
+        XCTAssertEqual(capturedKeywords.value, "Bob Dylan")
       }
     }
   }
@@ -224,13 +224,13 @@ final class SongSearchPageTests: XCTestCase {
     await withMainSerialExecutor {
       let clock = TestClock()
       @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-      var searchCount = 0
+      let searchCount = LockIsolated(0)
 
       await withDependencies {
         $0.continuousClock = clock
         $0.date = .constant(Date())
         $0.api.searchSongs = { _, _ in
-          searchCount += 1
+          searchCount.withValue { $0 += 1 }
           return []
         }
       } operation: {
@@ -243,7 +243,7 @@ final class SongSearchPageTests: XCTestCase {
         model.searchText = "Bob"
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(searchCount, 1)
+        XCTAssertEqual(searchCount.value, 1)
       }
     }
   }
@@ -252,13 +252,13 @@ final class SongSearchPageTests: XCTestCase {
     await withMainSerialExecutor {
       let clock = TestClock()
       @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-      var searchCount = 0
+      let searchCount = LockIsolated(0)
 
       await withDependencies {
         $0.continuousClock = clock
         $0.date = .constant(Date())
         $0.api.searchSongs = { _, _ in
-          searchCount += 1
+          searchCount.withValue { $0 += 1 }
           return []
         }
       } operation: {
@@ -267,11 +267,11 @@ final class SongSearchPageTests: XCTestCase {
         model.searchText = "test"
         await clock.advance(by: .milliseconds(200))
 
-        XCTAssertEqual(searchCount, 0)
+        XCTAssertEqual(searchCount.value, 0)
 
         await clock.advance(by: .milliseconds(100))
 
-        XCTAssertEqual(searchCount, 1)
+        XCTAssertEqual(searchCount.value, 1)
       }
     }
   }
@@ -319,18 +319,18 @@ final class SongSearchPageTests: XCTestCase {
     await withMainSerialExecutor {
       let clock = TestClock()
       @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-      var songsSearchCalled = false
-      var songRequestsSearchCalled = false
+      let songsSearchCalled = LockIsolated(false)
+      let songRequestsSearchCalled = LockIsolated(false)
 
       await withDependencies {
         $0.continuousClock = clock
         $0.date = .constant(Date())
         $0.api.searchSongs = { _, _ in
-          songsSearchCalled = true
+          songsSearchCalled.setValue(true)
           return []
         }
         $0.api.searchSongRequests = { _, _ in
-          songRequestsSearchCalled = true
+          songRequestsSearchCalled.setValue(true)
           return []
         }
       } operation: {
@@ -339,8 +339,8 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertTrue(songsSearchCalled)
-        XCTAssertTrue(songRequestsSearchCalled)
+        XCTAssertTrue(songsSearchCalled.value)
+        XCTAssertTrue(songRequestsSearchCalled.value)
       }
     }
   }
@@ -445,12 +445,12 @@ final class SongSearchPageTests: XCTestCase {
 
   func testOnRequestSongCallsAPIWithAppleId() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    var capturedSongRequest: SongRequest?
+    let capturedSongRequest = LockIsolated<SongRequest?>(nil)
 
     await withDependencies {
       $0.date = .constant(Date())
       $0.api.requestSong = { _, songRequest in
-        capturedSongRequest = songRequest
+        capturedSongRequest.setValue(songRequest)
       }
     } operation: {
       let model = SongSearchPageModel()
@@ -458,7 +458,7 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onRequestSong(testSongRequest)
 
-      XCTAssertEqual(capturedSongRequest?.appleId, "test-apple-123")
+      XCTAssertEqual(capturedSongRequest.value?.appleId, "test-apple-123")
     }
   }
 
@@ -547,18 +547,18 @@ final class SongSearchPageTests: XCTestCase {
     await withMainSerialExecutor {
       let clock = TestClock()
       @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-      var songsSearchCalled = false
-      var songRequestsSearchCalled = false
+      let songsSearchCalled = LockIsolated(false)
+      let songRequestsSearchCalled = LockIsolated(false)
 
       await withDependencies {
         $0.continuousClock = clock
         $0.date = .constant(Date())
         $0.api.searchSongs = { _, _ in
-          songsSearchCalled = true
+          songsSearchCalled.setValue(true)
           return []
         }
         $0.api.searchSongRequests = { _, _ in
-          songRequestsSearchCalled = true
+          songRequestsSearchCalled.setValue(true)
           return []
         }
       } operation: {
@@ -567,8 +567,8 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertTrue(songsSearchCalled)
-        XCTAssertFalse(songRequestsSearchCalled)
+        XCTAssertTrue(songsSearchCalled.value)
+        XCTAssertFalse(songRequestsSearchCalled.value)
       }
     }
   }
@@ -577,18 +577,18 @@ final class SongSearchPageTests: XCTestCase {
     await withMainSerialExecutor {
       let clock = TestClock()
       @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-      var songsSearchCalled = false
-      var songRequestsSearchCalled = false
+      let songsSearchCalled = LockIsolated(false)
+      let songRequestsSearchCalled = LockIsolated(false)
 
       await withDependencies {
         $0.continuousClock = clock
         $0.date = .constant(Date())
         $0.api.searchSongs = { _, _ in
-          songsSearchCalled = true
+          songsSearchCalled.setValue(true)
           return []
         }
         $0.api.searchSongRequests = { _, _ in
-          songRequestsSearchCalled = true
+          songRequestsSearchCalled.setValue(true)
           return []
         }
       } operation: {
@@ -597,8 +597,8 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertFalse(songsSearchCalled)
-        XCTAssertTrue(songRequestsSearchCalled)
+        XCTAssertFalse(songsSearchCalled.value)
+        XCTAssertTrue(songRequestsSearchCalled.value)
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -538,7 +538,6 @@ final class StationListPageTests: XCTestCase {
   func testSearchByCuratorNameFiltersStations() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
-    let now = Date()
 
     let station1 = Station.mockWith(id: "s1", name: "Show One", curatorName: "Alice")
     let station2 = Station.mockWith(id: "s2", name: "Show Two", curatorName: "Bob")
@@ -894,16 +893,16 @@ final class StationListNotificationPromptTests: XCTestCase {
 
   func testNotificationAlertYesTappedRequestsPermission() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
-    var authorizationRequested = false
-    var registrationCalled = false
+    let authorizationRequested = LockIsolated(false)
+    let registrationCalled = LockIsolated(false)
 
     let model = withDependencies {
       $0.pushNotifications.requestAuthorization = {
-        authorizationRequested = true
+        authorizationRequested.setValue(true)
         return true
       }
       $0.pushNotifications.registerForRemoteNotifications = {
-        registrationCalled = true
+        registrationCalled.setValue(true)
       }
     } operation: {
       StationListModel()
@@ -911,19 +910,19 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.notificationAlertYesTapped()
 
-    XCTAssertTrue(authorizationRequested)
-    XCTAssertTrue(registrationCalled)
+    XCTAssertTrue(authorizationRequested.value)
+    XCTAssertTrue(registrationCalled.value)
     XCTAssertTrue(hasAsked)
     XCTAssertNil(model.presentedAlert)
   }
 
   func testNotificationAlertNoTappedSetsHasAskedWithoutRequesting() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
-    var authorizationRequested = false
+    let authorizationRequested = LockIsolated(false)
 
     let model = withDependencies {
       $0.pushNotifications.requestAuthorization = {
-        authorizationRequested = true
+        authorizationRequested.setValue(true)
         return true
       }
       $0.pushNotifications.registerForRemoteNotifications = {}
@@ -933,21 +932,21 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.notificationAlertNoTapped()
 
-    XCTAssertFalse(authorizationRequested)
+    XCTAssertFalse(authorizationRequested.value)
     XCTAssertTrue(hasAsked)
     XCTAssertNil(model.presentedAlert)
   }
 
   func testNotificationAlertDoesNotRegisterIfPermissionDenied() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
-    var registrationCalled = false
+    let registrationCalled = LockIsolated(false)
 
     let model = withDependencies {
       $0.pushNotifications.requestAuthorization = {
         return false
       }
       $0.pushNotifications.registerForRemoteNotifications = {
-        registrationCalled = true
+        registrationCalled.setValue(true)
       }
     } operation: {
       StationListModel()
@@ -955,7 +954,7 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.notificationAlertYesTapped()
 
-    XCTAssertFalse(registrationCalled)
+    XCTAssertFalse(registrationCalled.value)
     XCTAssertTrue(hasAsked)
   }
 }

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
@@ -34,20 +34,24 @@ final class StationSuggestionPageTests: XCTestCase {
 
   private func makeModel(
     suggestions: [ArtistSuggestion]? = nil,
-    onGetSuggestions: ((_ jwt: String, _ search: String?) throws -> [ArtistSuggestion])? = nil,
-    onCreate: ((_ jwt: String, _ name: String) throws -> ArtistSuggestion)? = nil,
-    onVote: ((_ jwt: String, _ id: String) throws -> Void)? = nil,
-    onRemoveVote: ((_ jwt: String, _ id: String) throws -> Void)? = nil
+    onGetSuggestions: (
+      @Sendable (_ jwt: String, _ search: String?) async throws -> [ArtistSuggestion]
+    )? = nil,
+    onCreate: (@Sendable (_ jwt: String, _ name: String) async throws -> ArtistSuggestion)? = nil,
+    onVote: (@Sendable (_ jwt: String, _ id: String) async throws -> Void)? = nil,
+    onRemoveVote: (@Sendable (_ jwt: String, _ id: String) async throws -> Void)? = nil
   ) -> StationSuggestionPageModel {
     let defaultSuggestions = suggestions ?? mockSuggestions()
-    let defaultGet: (String, String?) throws -> [ArtistSuggestion] = { _, _ in defaultSuggestions }
-    let defaultCreate: (String, String) throws -> ArtistSuggestion = { _, name in
+    let defaultGet: @Sendable (String, String?) async throws -> [ArtistSuggestion] = { _, _ in
+      defaultSuggestions
+    }
+    let defaultCreate: @Sendable (String, String) async throws -> ArtistSuggestion = { _, name in
       ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
         voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
     }
-    let defaultVote: (String, String) throws -> Void = { _, _ in }
-    let defaultRemoveVote: (String, String) throws -> Void = { _, _ in }
+    let defaultVote: @Sendable (String, String) async throws -> Void = { _, _ in }
+    let defaultRemoveVote: @Sendable (String, String) async throws -> Void = { _, _ in }
     return withDependencies {
       $0.api.getArtistSuggestions = onGetSuggestions ?? defaultGet
       $0.api.createArtistSuggestion = onCreate ?? defaultCreate

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
@@ -149,7 +149,7 @@ final class SongDrawerTests: XCTestCase {
     let audioBlock = AudioBlock.mock
     var dismissCalled = false
 
-    await withDependencies {
+    withDependencies {
       let likesManager = LikesManager()
       // Pre-like the song
       likesManager.like(audioBlock)
@@ -178,7 +178,7 @@ final class SongDrawerTests: XCTestCase {
     var onRemoveCalled = false
     var removedAudioBlock: AudioBlock?
 
-    await withDependencies {
+    withDependencies {
       let likesManager = LikesManager()
       likesManager.like(audioBlock)
       $0.likesManager = likesManager

--- a/PlayolaRadioTests/Mocks/AuthServiceMock.swift
+++ b/PlayolaRadioTests/Mocks/AuthServiceMock.swift
@@ -6,7 +6,7 @@
 //
 @testable import PlayolaRadio
 
-class AuthServiceMock: AuthService {
+class AuthServiceMock: AuthService, @unchecked Sendable {
   var signOutCallCount = 0
 
   override func signOut() {

--- a/PlayolaRadioTests/Mocks/AuthServiceMock.swift
+++ b/PlayolaRadioTests/Mocks/AuthServiceMock.swift
@@ -4,12 +4,15 @@
 //
 //  Created by Brian D Keane on 2/27/25.
 //
+import ConcurrencyExtras
+
 @testable import PlayolaRadio
 
 class AuthServiceMock: AuthService, @unchecked Sendable {
-  var signOutCallCount = 0
+  private let signOutCallCountStorage = LockIsolated(0)
+  var signOutCallCount: Int { signOutCallCountStorage.value }
 
   override func signOut() {
-    signOutCallCount += 1
+    signOutCallCountStorage.withValue { $0 += 1 }
   }
 }


### PR DESCRIPTION
## Summary
This PR removes the Swift 6 build warnings in the scoped PlayolaRadio test and mock files for the PlayolaRadio scheme test build.
It moves mutable state captured by async dependency closures into `LockIsolated` across MainContainer, SongSearch, PushNotifications, Record, Broadcast, BroadcastersListenerQuestion, RecordIntro, AskQuestion, StationList, and IntroUpload tests.
It also wraps live function assignments at the smallest `@Sendable` boundary, restates `@unchecked Sendable` on `AuthServiceMock`, and removes the unused local in `StationListPageTests`.

## Verification
`xcodebuild -project PlayolaRadio.xcodeproj -scheme PlayolaRadio -destination 'platform=iOS Simulator,name=iPhone 16,OS=26.0' -skipMacroValidation -skipPackagePluginValidation build-for-testing` succeeds; the only remaining warning lines are Xcode App Intents metadata extraction tool messages.