### PR TITLE
Add xcresultparser failure summary to fastlane scan lanes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,7 +32,7 @@ jobs:
       FASTLANE_LANE: test
     steps:
       - checkout
-      - run: brew install xcbeautify
+      - run: brew install xcbeautify xcresultparser
       - run: cp ./PlayolaRadio/Config/Secrets-Example.xcconfig ./PlayolaRadio/Config/Secrets.xcconfig
       - run: cp ./PlayolaRadio/Config/Secrets-Example.xcconfig ./PlayolaRadio/Config/Secrets-Development.xcconfig
       - run: cp ./PlayolaRadio/Config/Secrets-Example.xcconfig ./PlayolaRadio/Config/Secrets-Local.xcconfig
@@ -72,8 +72,8 @@ jobs:
           name: Install Fastlane
           command: bundle install
       - run:
-          name: Install xcbeautify
-          command: brew install xcbeautify
+          name: Install xcbeautify and xcresultparser
+          command: brew install xcbeautify xcresultparser
       - run:
           name: Decode xcconfig secrets
           command: bash scripts/ci-write-secrets.sh

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -26,7 +26,11 @@ def print_failed_tests_summary(output_dir)
   end
 
   UI.header("Failed tests")
-  sh("xcresultparser -o cli --failed-tests-only #{xcresult.shellescape}")
+  begin
+    sh("xcresultparser -o cli --failed-tests-only #{xcresult.shellescape}")
+  rescue => e
+    UI.important("xcresultparser failed to produce a summary: #{e.message}")
+  end
 end
 
 platform :ios do
@@ -101,7 +105,7 @@ platform :ios do
     rescue => e
       test_error = e
     end
-    print_failed_tests_summary('./fastlane/test_output/xctest')
+    print_failed_tests_summary('./fastlane/test_output/xctest') if test_error
     raise test_error if test_error
 
     build_app(
@@ -175,7 +179,7 @@ platform :ios do
     rescue => e
       test_error = e
     end
-    print_failed_tests_summary('./fastlane/test_output/xctest')
+    print_failed_tests_summary('./fastlane/test_output/xctest') if test_error
     raise test_error if test_error
   end
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -15,6 +15,20 @@
 
 default_platform(:ios)
 
+def print_failed_tests_summary(output_dir)
+  abs_dir = File.expand_path(output_dir)
+  xcresult = Dir[File.join(abs_dir, '*.xcresult')].max_by { |f| File.mtime(f) }
+  return unless xcresult
+
+  unless system("command -v xcresultparser > /dev/null 2>&1")
+    UI.important("xcresultparser not installed — skipping failure summary. Run: brew install xcresultparser")
+    return
+  end
+
+  UI.header("Failed tests")
+  sh("xcresultparser -o cli --failed-tests-only #{xcresult.shellescape}")
+end
+
 platform :ios do
   before_all do
     setup_circle_ci if ENV['CI']
@@ -73,13 +87,22 @@ platform :ios do
       readonly: true
     )
 
-    scan(
-      include_simulator_logs: false,
-      parallel_testing: false,
-      scheme: "PlayolaRadio",
-      xcargs: "-skipMacroValidation -skipPackagePluginValidation",
-      xcodebuild_formatter: "xcbeautify"
-    )
+    test_error = nil
+    begin
+      scan(
+        include_simulator_logs: false,
+        parallel_testing: false,
+        scheme: "PlayolaRadio",
+        xcargs: "-skipMacroValidation -skipPackagePluginValidation",
+        xcodebuild_formatter: "xcbeautify",
+        output_directory: './fastlane/test_output/xctest',
+        result_bundle: true
+      )
+    rescue => e
+      test_error = e
+    end
+    print_failed_tests_summary('./fastlane/test_output/xctest')
+    raise test_error if test_error
 
     build_app(
       project: "PlayolaRadio.xcodeproj",
@@ -138,13 +161,22 @@ platform :ios do
 
   desc "Runs all the tests"
   lane :test do
-    scan(
-      include_simulator_logs: false,
-      parallel_testing: false,
-      scheme: "PlayolaRadio",
-      xcargs: "-skipMacroValidation -skipPackagePluginValidation",
-      xcodebuild_formatter: "xcbeautify",
-      output_directory: './fastlane/test_output/xctest')
+    test_error = nil
+    begin
+      scan(
+        include_simulator_logs: false,
+        parallel_testing: false,
+        scheme: "PlayolaRadio",
+        xcargs: "-skipMacroValidation -skipPackagePluginValidation",
+        xcodebuild_formatter: "xcbeautify",
+        output_directory: './fastlane/test_output/xctest',
+        result_bundle: true
+      )
+    rescue => e
+      test_error = e
+    end
+    print_failed_tests_summary('./fastlane/test_output/xctest')
+    raise test_error if test_error
   end
 
   lane :lint_code do


### PR DESCRIPTION
## Summary
- After `scan` finishes in the `test` and `release_production` lanes, the xcresult bundle is parsed and a colored, failure-only summary is printed so failing tests surface at the bottom of the log instead of being buried in xcbeautify output.
- Both lanes now pass `result_bundle: true`, rescue scan failures so the summary always prints, then re-raise to preserve exit status.
- Installs `xcresultparser` via Homebrew in the CircleCI `build-and-test` and `release_build` jobs; if missing locally, the helper prints an install hint and skips gracefully.

## Test plan
- [ ] Run `bundle exec fastlane test` locally with all tests passing — confirm clean "No test failures" summary at the end
- [ ] Break one assertion intentionally, run `bundle exec fastlane test` — confirm failing test name, file:line, and assertion message appear in red at the end
- [ ] Verify CI run on this PR installs xcresultparser and prints the same summary