### PR TITLE
Improve Sentry hang reporting and dSYM coverage

### DIFF
--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -46,7 +46,6 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
             $0.lifecycle = .trace
           }
           options.enableLogs = true
-          options.enableAppHangTrackingV2 = true
         }
       }
     #endif

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -41,6 +41,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
             "https://c024cbc3afc46a4539e4cd73ea4f32c0@o4511043985801216.ingest.us.sentry.io/4511043987898368"
           options.sendDefaultPii = false
           options.tracesSampleRate = 0.1
+          options.enableAppHangTrackingV2 = true
           options.configureProfiling = {
             $0.sessionSampleRate = 0.1
             $0.lifecycle = .trace

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -41,7 +41,6 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
             "https://c024cbc3afc46a4539e4cd73ea4f32c0@o4511043985801216.ingest.us.sentry.io/4511043987898368"
           options.sendDefaultPii = false
           options.tracesSampleRate = 0.1
-          options.enableAppHangTrackingV2 = true
           options.configureProfiling = {
             $0.sessionSampleRate = 0.1
             $0.lifecycle = .trace

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -34,16 +34,20 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil
   ) -> Bool {
     #if canImport(Sentry)
-      SentrySDK.start { options in
-        options.dsn =
-          "https://c024cbc3afc46a4539e4cd73ea4f32c0@o4511043985801216.ingest.us.sentry.io/4511043987898368"
-        options.sendDefaultPii = false
-        options.tracesSampleRate = 0.1
-        options.configureProfiling = {
-          $0.sessionSampleRate = 0.1
-          $0.lifecycle = .trace
+      let isRunningTests = ProcessInfo.processInfo.environment["XCTestConfigurationFilePath"] != nil
+      if !isRunningTests {
+        SentrySDK.start { options in
+          options.dsn =
+            "https://c024cbc3afc46a4539e4cd73ea4f32c0@o4511043985801216.ingest.us.sentry.io/4511043987898368"
+          options.sendDefaultPii = false
+          options.tracesSampleRate = 0.1
+          options.configureProfiling = {
+            $0.sessionSampleRate = 0.1
+            $0.lifecycle = .trace
+          }
+          options.enableLogs = true
+          options.enableAppHangTrackingV2 = true
         }
-        options.enableLogs = true
       }
     #endif
 

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -62,6 +62,12 @@ platform :ios do
       }
     )
 
+    sentry_debug_files_upload(
+      org_slug: 'playola-radio',
+      project_slug: 'apple-ios',
+      include_sources: true
+    )
+
     api_key = app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],


### PR DESCRIPTION
## Summary
- Skip `SentrySDK.start` under XCTest so CircleCI's `build-and-test` job stops generating simulator "App Hang Fully Blocked" events (these were unsymbolicatable CI noise, not real user issues).
- Enable `enableAppHangTrackingV2` so future hang events include main-thread stack traces instead of only a breadcrumb.
- Add `sentry_debug_files_upload` to the `release_staging` Fastlane lane so staging TestFlight builds upload dSYMs (production already did).

## Test plan
- [ ] Run the test suite locally; confirm no Sentry events are sent from `Sentry.sdk` during XCTest.
- [ ] Next `release_staging` CI run: confirm fastlane logs "Successfully uploaded N debug files".
- [ ] After next production release, trigger a real app hang and confirm the Sentry issue now has a symbolicated main-thread stack trace.