### PR TITLE
Lazy-create support conversations to fix empty-conversation accumulation

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"6917dff7-53c4-41fd-9d4d-c524ced387c7","pid":53691,"procStart":"Thu Apr 30 18:30:30 2026","acquiredAt":1777574532010}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"6917dff7-53c4-41fd-9d4d-c524ced387c7","pid":53691,"procStart":"Thu Apr 30 18:30:30 2026","acquiredAt":1777574532010}

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ output/
 
 # Claude generated files
 claude-files/
+.claude/scheduled_tasks.lock
 
 DerivedData/
 

--- a/PlayolaRadio/Core/API/APIClient.swift
+++ b/PlayolaRadio/Core/API/APIClient.swift
@@ -506,16 +506,6 @@ struct APIClient: Sendable {
       )
     }
 
-  /// Gets the existing support conversation or creates one if none exists
-  /// - Parameter jwtToken: The JWT token for authentication
-  /// - Returns: The support Conversation
-  /// - Throws: APIError if the request fails
-  func getOrCreateSupportConversation(_ jwtToken: String) async throws -> Conversation {
-    let response = try await getSupportConversation(jwtToken)
-    if let existing = response.conversation { return existing }
-    return try await createSupportConversation(jwtToken).conversation
-  }
-
   /// Fetches messages for a conversation
   /// - Parameters:
   ///   - jwtToken: The JWT token for authentication

--- a/PlayolaRadio/Core/Analytics/AnalyticsEvent.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsEvent.swift
@@ -70,7 +70,6 @@ enum AnalyticsEvent: Equatable {
   case ratingPromptNotEnjoying
   case ratingPromptDismissed
   case feedbackSheetPresented
-  case feedbackSheetFailed(error: String)
 }
 
 // MARK: - Event Properties
@@ -115,7 +114,6 @@ extension AnalyticsEvent {
     case .ratingPromptNotEnjoying: return "Rating Prompt Not Enjoying"
     case .ratingPromptDismissed: return "Rating Prompt Dismissed"
     case .feedbackSheetPresented: return "Feedback Sheet Presented"
-    case .feedbackSheetFailed: return "Feedback Sheet Failed"
     }
   }
 
@@ -292,9 +290,6 @@ extension AnalyticsEvent {
     case .ratingPromptEnjoying, .ratingPromptNotEnjoying, .ratingPromptDismissed,
       .feedbackSheetPresented:
       return [:]
-
-    case .feedbackSheetFailed(let error):
-      return ["error": error]
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -186,7 +186,17 @@ class ContactPageModel: ViewModel {
 
   private func handleRegularUserFlow(jwt: String) async {
     do {
-      let conversation = try await api.getOrCreateSupportConversation(jwt)
+      let response = try await api.getSupportConversation(jwt)
+
+      guard let conversation = response.conversation else {
+        isCheckingSupport = false
+        let feedbackModel = FeedbackSheetModel { [weak self] in
+          self?.presentedAlert = .messageSentSuccess
+        }
+        mainContainerNavigationCoordinator.presentedSheet = .feedbackSheet(feedbackModel)
+        return
+      }
+
       let messages = try await api.getConversationMessages(jwt, conversation.id)
 
       isCheckingSupport = false

--- a/PlayolaRadio/Views/Pages/FeedbackSheet/FeedbackSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/FeedbackSheet/FeedbackSheetModel.swift
@@ -24,7 +24,7 @@ class FeedbackSheetModel: ViewModel {
   // MARK: - Initialization
 
   init(
-    conversation: Conversation,
+    conversation: Conversation? = nil,
     title: String = defaultTitle,
     message: String = "",
     placeholderText: String = defaultPlaceholderText,
@@ -39,7 +39,7 @@ class FeedbackSheetModel: ViewModel {
 
   // MARK: - Properties
 
-  let conversation: Conversation
+  var conversation: Conversation?
   let title: String
   let placeholderText: String
   var message: String
@@ -73,7 +73,14 @@ class FeedbackSheetModel: ViewModel {
     isSending = true
 
     do {
-      _ = try await api.sendConversationMessage(jwt, conversation.id, messageText)
+      if conversation == nil {
+        let response = try await api.createSupportConversation(jwt)
+        conversation = response.conversation
+      }
+      guard let conversationId = conversation?.id else {
+        throw APIError.dataNotValid
+      }
+      _ = try await api.sendConversationMessage(jwt, conversationId, messageText)
       isSending = false
       message = ""
       mainContainerNavigationCoordinator.presentedSheet = nil

--- a/PlayolaRadio/Views/Pages/FeedbackSheet/FeedbackSheetTests.swift
+++ b/PlayolaRadio/Views/Pages/FeedbackSheet/FeedbackSheetTests.swift
@@ -208,6 +208,97 @@ struct FeedbackSheetTests {
   }
 
   @Test
+  func testSendButtonTappedCreatesConversationLazilyWhenNil() async {
+    @Shared(.auth) var auth = Auth(
+      currentUser: LoggedInUser(
+        id: "user-1",
+        firstName: "Test",
+        lastName: "User",
+        email: "test@example.com",
+        profileImageUrl: nil,
+        role: "user"
+      ),
+      jwt: "test-jwt"
+    )
+
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
+      MainContainerNavigationCoordinator()
+
+    let createdConversation = Conversation(
+      id: "lazy-conv",
+      type: "support",
+      contextType: nil,
+      contextId: nil,
+      status: "open",
+      createdAt: Date(),
+      updatedAt: Date(),
+      participants: nil
+    )
+
+    let sentMessage = Message(
+      id: "msg-1",
+      conversationId: "lazy-conv",
+      senderId: "user-1",
+      message: "Hi",
+      createdAt: Date(),
+      updatedAt: Date(),
+      sender: nil
+    )
+
+    let model = withDependencies {
+      $0.api.createSupportConversation = { _ in
+        CreateSupportConversationResponse(conversation: createdConversation, unreadCount: 0)
+      }
+      $0.api.sendConversationMessage = { _, conversationId, _ in
+        #expect(conversationId == "lazy-conv")
+        return sentMessage
+      }
+    } operation: {
+      FeedbackSheetModel()
+    }
+
+    navCoordinator.presentedSheet = .feedbackSheet(model)
+    model.message = "Hi"
+
+    await model.sendButtonTapped()
+
+    #expect(model.conversation?.id == "lazy-conv")
+    #expect(model.message.isEmpty)
+    #expect(navCoordinator.presentedSheet == nil)
+  }
+
+  @Test
+  func testSendButtonTappedShowsErrorWhenLazyCreateFails() async {
+    @Shared(.auth) var auth = Auth(
+      currentUser: LoggedInUser(
+        id: "user-1",
+        firstName: "Test",
+        lastName: "User",
+        email: "test@example.com",
+        profileImageUrl: nil,
+        role: "user"
+      ),
+      jwt: "test-jwt"
+    )
+
+    let model = withDependencies {
+      $0.api.createSupportConversation = { _ in
+        throw APIError.validationError("create failed")
+      }
+    } operation: {
+      FeedbackSheetModel()
+    }
+
+    model.message = "Hi"
+
+    await model.sendButtonTapped()
+
+    #expect(model.conversation == nil)
+    #expect(model.presentedAlert == .errorSendingMessage)
+    #expect(model.isSending == false)
+  }
+
+  @Test
   func testCancelButtonTappedDismissesSheet() {
     @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
       MainContainerNavigationCoordinator()

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -283,8 +283,8 @@ class HomePageModel: ViewModel {
       if let conversation = response.conversation {
         model.conversation = conversation
         model.messages = try await api.getConversationMessages(jwt, conversation.id)
+        model.isLoading = false
       }
-      model.isLoading = false
       await mainContainerNavigationCoordinator.navigateToSupport(model)
     } catch {
       presentedAlert = .errorLoadingConversation

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -278,11 +278,12 @@ class HomePageModel: ViewModel {
   private func navigateToSupportPage() async {
     guard let jwt = auth.jwt else { return }
     do {
-      let conversation = try await api.getOrCreateSupportConversation(jwt)
-      let messages = try await api.getConversationMessages(jwt, conversation.id)
+      let response = try await api.getSupportConversation(jwt)
       let model = SupportPageModel()
-      model.conversation = conversation
-      model.messages = messages
+      if let conversation = response.conversation {
+        model.conversation = conversation
+        model.messages = try await api.getConversationMessages(jwt, conversation.id)
+      }
       model.isLoading = false
       await mainContainerNavigationCoordinator.navigateToSupport(model)
     } catch {

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -252,23 +252,16 @@ class MainContainerModel: ViewModel {
   }
 
   private func showFeedbackSheet() {
-    guard let jwt = auth.jwt else { return }
     Task {
-      do {
-        let conversation = try await api.getOrCreateSupportConversation(jwt)
-        let feedbackModel = FeedbackSheetModel(
-          conversation: conversation,
-          title: "Would you be up for letting us know what we can do better?",
-          placeholderText: "",
-          onSuccess: { [weak self] in
-            self?.presentedAlert = .thankYouForFeedback
-          }
-        )
-        await analytics.track(.feedbackSheetPresented)
-        mainContainerNavigationCoordinator.presentedSheet = .feedbackSheet(feedbackModel)
-      } catch {
-        await analytics.track(.feedbackSheetFailed(error: error.localizedDescription))
-      }
+      let feedbackModel = FeedbackSheetModel(
+        title: "Would you be up for letting us know what we can do better?",
+        placeholderText: "",
+        onSuccess: { [weak self] in
+          self?.presentedAlert = .thankYouForFeedback
+        }
+      )
+      await analytics.track(.feedbackSheetPresented)
+      mainContainerNavigationCoordinator.presentedSheet = .feedbackSheet(feedbackModel)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -782,7 +782,6 @@ final class MainContainerTests: XCTestCase {
 
       let mainContainerModel = withDependencies {
         $0.api.getStations = { [] }
-        $0.api.getSupportConversation = { _ in .mockWith() }
         $0.pushNotifications.registerForRemoteNotifications = {}
         $0.appRating.shouldShowRatingPrompt = { _ in true }
         $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
@@ -812,59 +811,6 @@ final class MainContainerTests: XCTestCase {
         XCTFail("Expected feedback sheet to be presented")
         return
       }
-    }
-  }
-
-  func testFeedbackSheetFailedTracksErrorEvent() async {
-    await withMainSerialExecutor {
-      let testJWT = MainContainerTests.createTestJWT()
-      @Shared(.auth) var auth
-      $auth.withLock { $0 = Auth(jwtToken: testJWT) }
-      @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
-        byAdding: .day, value: -10, to: Date()
-      )
-      @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String?
-      @Shared(.listeningTracker) var listeningTracker = ListeningTracker(
-        rewardsProfile: RewardsProfile(
-          totalTimeListenedMS: 2 * 60 * 60 * 1000,
-          totalMSAvailableForRewards: 0,
-          accurateAsOfTime: Date()
-        )
-      )
-
-      let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-
-      let mainContainerModel = withDependencies {
-        $0.api.getStations = { [] }
-        $0.api.getSupportConversation = { _ in throw NSError(domain: "test", code: 500) }
-        $0.pushNotifications.registerForRemoteNotifications = {}
-        $0.appRating.shouldShowRatingPrompt = { _ in true }
-        $0.appRating.markRatingPromptShown = {}
-        $0.appRating.markRatingPromptDismissed = {}
-        $0.analytics.track = { @Sendable event in
-          capturedEvents.withValue { $0.append(event) }
-        }
-      } operation: {
-        MainContainerModel()
-      }
-
-      mainContainerModel.checkAndShowRatingPromptIfNeeded()
-
-      // Simulate tapping "Not really" — triggers showFeedbackSheet() which spawns a Task
-      // that calls api.getSupportConversation (throws) then analytics.track in the catch.
-      // Multiple yields needed for the spawned Task's suspension points.
-      await mainContainerModel.presentedAlert?.secondaryAction?()
-      await Task.yield()
-      await Task.yield()
-      await Task.yield()
-
-      XCTAssertTrue(
-        capturedEvents.value.contains {
-          if case .feedbackSheetFailed = $0 { return true }
-          return false
-        },
-        "Should track feedbackSheetFailed event when API fails"
-      )
     }
   }
 

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
@@ -47,9 +47,10 @@ class SupportPageModel: ViewModel {
     isLoading = true
 
     do {
-      conversation = try await api.getOrCreateSupportConversation(jwt)
-      if let conversationId = conversation?.id {
-        messages = try await api.getConversationMessages(jwt, conversationId)
+      let response = try await api.getSupportConversation(jwt)
+      if let existing = response.conversation {
+        conversation = existing
+        messages = try await api.getConversationMessages(jwt, existing.id)
         await markAsRead()
       }
     } catch {
@@ -71,16 +72,20 @@ class SupportPageModel: ViewModel {
   }
 
   func sendMessage() async {
-    guard let jwt = auth.jwt,
-      let conversationId = conversation?.id,
-      canSend
-    else { return }
+    guard let jwt = auth.jwt, canSend else { return }
 
     let messageText = newMessage.trimmingCharacters(in: .whitespacesAndNewlines)
     isSending = true
     newMessage = ""
 
     do {
+      if conversation == nil {
+        let response = try await api.createSupportConversation(jwt)
+        conversation = response.conversation
+      }
+      guard let conversationId = conversation?.id else {
+        throw APIError.dataNotValid
+      }
       let message = try await api.sendConversationMessage(jwt, conversationId, messageText)
       messages.append(message)
     } catch {

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
@@ -333,7 +333,7 @@ final class SupportPageTests: XCTestCase {
     XCTAssertEqual(model.messages.first?.message, "New reply")
   }
 
-  func testOnViewAppearedCreatesConversationWhenGetReturnsNil() async {
+  func testOnViewAppearedDoesNotCreateConversationWhenGetReturnsNil() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
         id: "user-1",
@@ -346,8 +346,54 @@ final class SupportPageTests: XCTestCase {
       jwt: "test-jwt"
     )
 
-    let createdConversation = makeConversation(id: "created-conv")
     let createCalled = LockIsolated(false)
+    let getMessagesCalled = LockIsolated(false)
+
+    let model = withDependencies {
+      $0.api.getSupportConversation = { _ in
+        SupportConversationResponse(conversation: nil, unreadCount: 0)
+      }
+      $0.api.createSupportConversation = { _ in
+        createCalled.setValue(true)
+        return .mockWith()
+      }
+      $0.api.getConversationMessages = { _, _ in
+        getMessagesCalled.setValue(true)
+        return []
+      }
+    } operation: {
+      SupportPageModel()
+    }
+
+    await model.onViewAppeared()
+
+    XCTAssertFalse(
+      createCalled.value, "Should not create a conversation just from viewing the page")
+    XCTAssertFalse(getMessagesCalled.value, "No conversation = no messages to fetch")
+    XCTAssertNil(model.conversation)
+    XCTAssertTrue(model.messages.isEmpty)
+    XCTAssertFalse(model.isLoading)
+    XCTAssertNil(model.presentedAlert)
+  }
+
+  func testSendMessageCreatesConversationWhenNoneExists() async {
+    @Shared(.auth) var auth = Auth(
+      currentUser: LoggedInUser(
+        id: "user-1",
+        firstName: "Test",
+        lastName: "User",
+        email: "test@example.com",
+        profileImageUrl: nil,
+        role: "user"
+      ),
+      jwt: "test-jwt"
+    )
+
+    let createdConversation = makeConversation(id: "lazy-conv")
+    let createCalled = LockIsolated(false)
+    let sentMessage = makeMessage(
+      id: "msg-1", conversationId: "lazy-conv", senderId: "user-1", text: "Hi there"
+    )
 
     let model = withDependencies {
       $0.api.getSupportConversation = { _ in
@@ -358,6 +404,58 @@ final class SupportPageTests: XCTestCase {
         return CreateSupportConversationResponse(
           conversation: createdConversation, unreadCount: 0)
       }
+      $0.api.sendConversationMessage = { _, conversationId, text in
+        XCTAssertEqual(conversationId, "lazy-conv")
+        XCTAssertEqual(text, "Hi there")
+        return sentMessage
+      }
+      $0.api.getConversationMessages = { _, _ in [] }
+    } operation: {
+      SupportPageModel()
+    }
+
+    await model.onViewAppeared()
+    XCTAssertNil(model.conversation)
+
+    model.newMessage = "Hi there"
+    await model.sendMessage()
+
+    XCTAssertTrue(createCalled.value)
+    XCTAssertEqual(model.conversation?.id, "lazy-conv")
+    XCTAssertEqual(model.messages.count, 1)
+    XCTAssertEqual(model.messages.first?.message, "Hi there")
+    XCTAssertTrue(model.newMessage.isEmpty)
+  }
+
+  func testSendMessageRestoresMessageAndShowsAlertWhenCreateFails() async {
+    @Shared(.auth) var auth = Auth(
+      currentUser: LoggedInUser(
+        id: "user-1",
+        firstName: "Test",
+        lastName: "User",
+        email: "test@example.com",
+        profileImageUrl: nil,
+        role: "user"
+      ),
+      jwt: "test-jwt"
+    )
+
+    let sendCalled = LockIsolated(false)
+
+    let model = withDependencies {
+      $0.api.getSupportConversation = { _ in
+        SupportConversationResponse(conversation: nil, unreadCount: 0)
+      }
+      $0.api.createSupportConversation = { _ in
+        throw APIError.validationError("create failed")
+      }
+      $0.api.sendConversationMessage = { _, _, _ in
+        sendCalled.setValue(true)
+        return Message(
+          id: "x", conversationId: "x", senderId: "x",
+          message: "x", createdAt: Date(), updatedAt: Date(), sender: nil
+        )
+      }
       $0.api.getConversationMessages = { _, _ in [] }
     } operation: {
       SupportPageModel()
@@ -365,9 +463,14 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertTrue(createCalled.value)
-    XCTAssertEqual(model.conversation?.id, "created-conv")
-    XCTAssertFalse(model.isLoading)
+    model.newMessage = "Hello"
+    await model.sendMessage()
+
+    XCTAssertFalse(sendCalled.value, "Should not call send when create fails")
+    XCTAssertNil(model.conversation)
+    XCTAssertEqual(model.newMessage, "Hello", "newMessage should be restored")
+    XCTAssertEqual(model.presentedAlert, .errorSendingMessage)
+    XCTAssertFalse(model.isSending)
   }
 
   func testOnViewAppearedUsesExistingConversationFromGet() async {


### PR DESCRIPTION
## The bug

Users were accumulating empty support conversations over time. The cycle:

1. iOS auto-created a conversation whenever the user opened the support page (and several other entry points), via `getOrCreateSupportConversation`.
2. The server's `GET /v1/conversations/support` is itself a find-or-create that filters by `status='open'`.
3. An hourly server cron closes empty conversations.

So: open support → empty conv created → leave → cron closes it → open support again → server can't see closed one (status filter) → creates a new one. Loop forever.

The Apr 2 commit c2fde6f set up the right architecture (added a separate POST `createSupportConversation`, made the GET response's `conversation` field optional) but the call sites were never flipped.

## The fix: lazy creation

A conversation is now only created when the user actually sends their first message.

### Specific changes

- **`SupportPageModel`** — `onViewAppeared` switches to read-only `getSupportConversation`; if `conversation` is nil it leaves the page in an empty-but-valid state. `sendMessage` lazy-creates if `conversation == nil` and restores the unsent text on failure.
- **`HomePageModel.navigateToSupportPage`** — read-only fetch; opens a `SupportPageModel` with no preset conversation if none exists.
- **`ContactPageModel.handleRegularUserFlow`** — read-only fetch; if no conversation exists it routes to the FeedbackSheet (preserving the existing UX where users with no message history see the feedback form instead of the chat view).
- **`MainContainerModel.showFeedbackSheet`** — drops the eager getOrCreate entirely. The sheet always shows; the create happens on send.
- **`FeedbackSheetModel`** — `conversation` is now optional; `sendButtonTapped` calls `createSupportConversation` on demand if needed.
- **`APIClient`** — removed unused `getOrCreateSupportConversation` helper.
- Removed unused `feedbackSheetFailed` analytics event (the failure path it tracked no longer exists).

## Server coordination

This depends on a matching server fix going out separately that makes `GET /v1/conversations/support` a true read — returning `{ conversation: null, unreadCount: 0 }` when no open or closed conversation exists. The iOS response type already supports null since c2fde6f.

## Test plan

- [ ] Run the full XCTest suite in Xcode
- [ ] Manual: open support page with no prior conversation → should load empty, no API conversation created
- [ ] Manual: send first message → conversation is created, message appears
- [ ] Manual: open support again with a previously-created (now closed-by-cron) conversation → should not loop-create a new one (requires the server PR to land)
- [ ] Manual: ContactPage → "Contact Us" with no existing conversation → FeedbackSheet appears, sending creates the conversation
- [ ] Manual: rating prompt "Not really" → feedback sheet appears, sending succeeds