### PR TITLE
xcode 26 updates

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -119,15 +119,10 @@
 		D30F00A22E8592F0007BCC73 /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = D30F003F2E8592F0007BCC73 /* GoogleSignIn */; };
 		D30F00A42E8592F0007BCC73 /* Inter-Italic.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D37257BF2DF8E407001BC6F9 /* Inter-Italic.ttf */; };
 		D30F00A52E8592F0007BCC73 /* Inter.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D37257BE2DF8E407001BC6F9 /* Inter.ttf */; };
-		D30F00A62E8592F0007BCC73 /* Secrets-Local.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D3B662C22D4272ED00975D2F /* Secrets-Local.xcconfig */; };
 		D30F00A72E8592F0007BCC73 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3536A0B2BFA4F4A006942D6 /* Preview Assets.xcassets */; };
 		D30F00A82E8592F0007BCC73 /* SpaceGrotesk.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D37257BA2DF891D5001BC6F9 /* SpaceGrotesk.ttf */; };
-		D30F00A92E8592F0007BCC73 /* Secrets-Example.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D35673BF2D3DCA3600E4E926 /* Secrets-Example.xcconfig */; };
 		D30F00AA2E8592F0007BCC73 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3536A082BFA4F4A006942D6 /* Assets.xcassets */; };
-		D30F00AB2E8592F0007BCC73 /* Secrets-Staging.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D3EAC9222E81731A001194CF /* Secrets-Staging.xcconfig */; };
 		D30F00AC2E8592F0007BCC73 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D37257AA2DF87C72001BC6F9 /* LaunchScreen.storyboard */; };
-		D30F00AD2E8592F0007BCC73 /* Secrets-Development.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D35673CA2D3EE5E100E4E926 /* Secrets-Development.xcconfig */; };
-		D30F00AE2E8592F0007BCC73 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D35673BD2D3DCA1E00E4E926 /* Secrets.xcconfig */; };
 		D30F00B72E871945007BCC73 /* StationListStationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30F00B62E871940007BCC73 /* StationListStationRowView.swift */; };
 		D30F00B82E871945007BCC73 /* StationListStationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30F00B62E871940007BCC73 /* StationListStationRowView.swift */; };
 		D30F00BA2E87194D007BCC73 /* StationListStationRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30F00B92E871948007BCC73 /* StationListStationRowModel.swift */; };
@@ -183,12 +178,9 @@
 		D35673B22D3DC59300E4E926 /* RadioStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673B12D3DC59100E4E926 /* RadioStation.swift */; };
 		D35673B72D3DC6EC00E4E926 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = D35673B62D3DC6EC00E4E926 /* Mixpanel */; };
 		D35673BA2D3DC9EE00E4E926 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673B92D3DC9ED00E4E926 /* Config.swift */; };
-		D35673BE2D3DCA2600E4E926 /* Secrets.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D35673BD2D3DCA1E00E4E926 /* Secrets.xcconfig */; };
-		D35673C02D3DCA3F00E4E926 /* Secrets-Example.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D35673BF2D3DCA3600E4E926 /* Secrets-Example.xcconfig */; };
 		D35673C32D3E872600E4E926 /* CPListItem+InitWithRemoteUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C22D3E871800E4E926 /* CPListItem+InitWithRemoteUrl.swift */; };
 		D35673C62D3E91BD00E4E926 /* MainSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C52D3E91B900E4E926 /* MainSceneDelegate.swift */; };
 		D35673C82D3EBFBA00E4E926 /* NowPlayingUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C72D3EBFB000E4E926 /* NowPlayingUpdater.swift */; };
-		D35673CB2D3EE5E900E4E926 /* Secrets-Development.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D35673CA2D3EE5E100E4E926 /* Secrets-Development.xcconfig */; };
 		D35905EC2DFCDA140064A9C1 /* StationListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35905EB2DFCDA110064A9C1 /* StationListModel.swift */; };
 		D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */; };
 		D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */; };
@@ -338,7 +330,6 @@
 		D3B662702D40352500975D2F /* Alamofire in Frameworks */ = {isa = PBXBuildFile; productRef = D3B6626F2D40352500975D2F /* Alamofire */; };
 		D3B662742D419C3300975D2F /* LoggedInUser.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B662732D419C3100975D2F /* LoggedInUser.swift */; };
 		D3B662762D41B0D200975D2F /* SignInPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B662752D41B0C700975D2F /* SignInPageTests.swift */; };
-		D3B662C32D4272F900975D2F /* Secrets-Local.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D3B662C22D4272ED00975D2F /* Secrets-Local.xcconfig */; };
 		D3B744A12E2ED6AC0042A427 /* Dependencies in Frameworks */ = {isa = PBXBuildFile; productRef = D3B744A02E2ED6AC0042A427 /* Dependencies */; };
 		D3B744A32E2ED6AC0042A427 /* DependenciesMacros in Frameworks */ = {isa = PBXBuildFile; productRef = D3B744A22E2ED6AC0042A427 /* DependenciesMacros */; };
 		D3B744A82E2F185F0042A427 /* SmallPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744A62E2F18530042A427 /* SmallPlayerTests.swift */; };
@@ -381,7 +372,6 @@
 		D3CE19032D3C825C0091B888 /* PlayolaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D3CE19022D3C825C0091B888 /* PlayolaPlayer */; };
 		D3CE19052D3CA6180091B888 /* SharedUserDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3CE19042D3CA6150091B888 /* SharedUserDefaults.swift */; };
 		D3D6CE5F2D5ECED50059BDCA /* UrlStreamListeningSessionReporter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3D6CE5E2D5ECECB0059BDCA /* UrlStreamListeningSessionReporter.swift */; };
-		D3EAC9232E817326001194CF /* Secrets-Staging.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = D3EAC9222E81731A001194CF /* Secrets-Staging.xcconfig */; };
 		D3F493B82EEDD2AC008ED463 /* RecordPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F493B72EEDD2A7008ED463 /* RecordPageModel.swift */; };
 		D3F493B92EEDD2AC008ED463 /* RecordPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F493B72EEDD2A7008ED463 /* RecordPageModel.swift */; };
 		D3F493BB2EEDD2B3008ED463 /* RecordPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F493BA2EEDD2B1008ED463 /* RecordPageView.swift */; };
@@ -1568,7 +1558,7 @@
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
 				LastSwiftUpdateCheck = 1530;
-				LastUpgradeCheck = 1530;
+				LastUpgradeCheck = 2640;
 				TargetAttributes = {
 					D3536A002BFA4F49006942D6 = {
 						CreatedOnToolsVersion = 15.3;
@@ -1621,15 +1611,10 @@
 			files = (
 				D30F00A42E8592F0007BCC73 /* Inter-Italic.ttf in Resources */,
 				D30F00A52E8592F0007BCC73 /* Inter.ttf in Resources */,
-				D30F00A62E8592F0007BCC73 /* Secrets-Local.xcconfig in Resources */,
 				D30F00A72E8592F0007BCC73 /* Preview Assets.xcassets in Resources */,
 				D30F00A82E8592F0007BCC73 /* SpaceGrotesk.ttf in Resources */,
-				D30F00A92E8592F0007BCC73 /* Secrets-Example.xcconfig in Resources */,
 				D30F00AA2E8592F0007BCC73 /* Assets.xcassets in Resources */,
-				D30F00AB2E8592F0007BCC73 /* Secrets-Staging.xcconfig in Resources */,
 				D30F00AC2E8592F0007BCC73 /* LaunchScreen.storyboard in Resources */,
-				D30F00AD2E8592F0007BCC73 /* Secrets-Development.xcconfig in Resources */,
-				D30F00AE2E8592F0007BCC73 /* Secrets.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1639,15 +1624,10 @@
 			files = (
 				D37257C02DF8E407001BC6F9 /* Inter-Italic.ttf in Resources */,
 				D37257C12DF8E407001BC6F9 /* Inter.ttf in Resources */,
-				D3B662C32D4272F900975D2F /* Secrets-Local.xcconfig in Resources */,
 				D3536A0C2BFA4F4A006942D6 /* Preview Assets.xcassets in Resources */,
 				D37257BB2DF891D5001BC6F9 /* SpaceGrotesk.ttf in Resources */,
-				D35673C02D3DCA3F00E4E926 /* Secrets-Example.xcconfig in Resources */,
 				D3536A092BFA4F4A006942D6 /* Assets.xcassets in Resources */,
-				D3EAC9232E817326001194CF /* Secrets-Staging.xcconfig in Resources */,
 				D37257AB2DF87C72001BC6F9 /* LaunchScreen.storyboard in Resources */,
-				D35673CB2D3EE5E900E4E926 /* Secrets-Development.xcconfig in Resources */,
-				D35673BE2D3DCA2600E4E926 /* Secrets.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2242,6 +2222,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
@@ -2298,6 +2279,7 @@
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_COMPILATION_MODE = wholemodule;
 				VALIDATE_PRODUCT = YES;
 			};
@@ -2489,6 +2471,7 @@
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -1557,7 +1557,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastSwiftUpdateCheck = 1530;
+				LastSwiftUpdateCheck = 2640;
 				LastUpgradeCheck = 2640;
 				TargetAttributes = {
 					D3536A002BFA4F49006942D6 = {

--- a/PlayolaRadio.xcodeproj/xcshareddata/xcschemes/PlayolaRadio-Local.xcscheme
+++ b/PlayolaRadio.xcodeproj/xcshareddata/xcschemes/PlayolaRadio-Local.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1620"
+   LastUpgradeVersion = "2640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PlayolaRadio.xcodeproj/xcshareddata/xcschemes/PlayolaRadio-Staging.xcscheme
+++ b/PlayolaRadio.xcodeproj/xcshareddata/xcschemes/PlayolaRadio-Staging.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1620"
+   LastUpgradeVersion = "2640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/PlayolaRadio.xcodeproj/xcshareddata/xcschemes/PlayolaRadio.xcscheme
+++ b/PlayolaRadio.xcodeproj/xcshareddata/xcschemes/PlayolaRadio.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "1620"
+   LastUpgradeVersion = "2640"
    version = "1.7">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
This pull request updates the Xcode project configuration by removing all `Secrets*.xcconfig` files from the project resources and updating the project and scheme settings to match a newer Xcode version. It also introduces a new build setting for string catalog symbol generation.

Key changes:

**Removal of secrets configuration files:**
- Removed all references to `Secrets.xcconfig` and related files (`Secrets-Local.xcconfig`, `Secrets-Example.xcconfig`, `Secrets-Staging.xcconfig`, `Secrets-Development.xcconfig`) from the project resources in `project.pbxproj`. These files are no longer included in the build phases or resource lists. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L122-L130) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L186-L191) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L341) [[4]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L384) [[5]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1624-L1632) [[6]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1642-L1650)

**Project and scheme upgrades:**
- Updated the `LastUpgradeCheck` and `LastUpgradeVersion` fields in the main project and all shared schemes to version `2640`, reflecting an upgrade to a newer Xcode toolchain. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8L1571-R1561) [[2]](diffhunk://#diff-80b04470559230c1f7abc6c691d2e641d57bcba17dd430ccafe38369fed1fb45L3-R3) [[3]](diffhunk://#diff-c228273f892fdf9d9ae5ca3eee4d99015e2be782fa8fe24fa92f7807d402d205L3-R3) [[4]](diffhunk://#diff-d985e90b607f3c51b4e51187a77d638e6e0786f88bdeed5d8a3cc4da6f8b1609L3-R3)

**Build settings:**
- Added the `STRING_CATALOG_GENERATE_SYMBOLS = YES;` build setting to relevant build configurations in the Xcode project, enabling symbol generation for string catalogs. [[1]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R2225) [[2]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R2282) [[3]](diffhunk://#diff-6628173c56363a64e1697b078913096e29b0cd05ca5866964641a44af49ff4a8R2474)