### PR TITLE
Show user-facing alert on sign-in errors

### DIFF
--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -20,6 +20,8 @@ class SignInPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.errorReporting) var errorReporting
   @ObservationIgnored @Shared(.auth) var auth: Auth
 
+  var presentedAlert: PlayolaAlert?
+
   @MainActor
   override init() {
     super.init()
@@ -43,6 +45,7 @@ class SignInPageModel: ViewModel {
         let authCode = String(data: authCodeData, encoding: .utf8)
       else {
         print("Error decoding signin info from apple")
+        presentedAlert = .signInError
         Task {
           await errorReporting.reportMessage(
             "Error decoding sign-in info from Apple",
@@ -68,6 +71,7 @@ class SignInPageModel: ViewModel {
           await analytics.track(.signInCompleted(method: .apple, userId: appleIDCredential.user))
         } catch {
           print("Sign in failed: \(error)")
+          presentedAlert = .signInError
           await analytics.track(.signInFailed(method: .apple, error: error.localizedDescription))
           await errorReporting.reportError(
             error,
@@ -75,15 +79,20 @@ class SignInPageModel: ViewModel {
         }
       }
     case .failure(let error):
-      print(error)
-      if let authError = error as? ASAuthorizationError, authError.code == .canceled {
-        return
-      }
-      Task {
-        await errorReporting.reportError(
-          error,
-          ["auth_method": "apple", "sign_in_step": "authorization_failure"])
-      }
+      handleAppleAuthorizationFailure(error)
+    }
+  }
+
+  private func handleAppleAuthorizationFailure(_ error: any Error) {
+    print(error)
+    if let authError = error as? ASAuthorizationError, authError.code == .canceled {
+      return
+    }
+    presentedAlert = .signInError
+    Task {
+      await errorReporting.reportError(
+        error,
+        ["auth_method": "apple", "sign_in_step": "authorization_failure"])
     }
   }
 
@@ -91,6 +100,7 @@ class SignInPageModel: ViewModel {
     await analytics.track(.signInStarted(method: .google))
     guard let presentingVC = UIApplication.shared.keyWindowPresentedController else {
       print("Error presenting VC -- no key window")
+      presentedAlert = .signInError
       await errorReporting.reportMessage(
         "Unable to present Google sign-in: no key window",
         ["auth_method": "google", "sign_in_step": "present_view_controller"])
@@ -106,6 +116,7 @@ class SignInPageModel: ViewModel {
         _ = try await signInResult.user.refreshTokensIfNeeded()
         guard let serverAuthCode = signInResult.serverAuthCode else {
           print("Error signing into Google -- no serverAuthCode on signInResult.")
+          presentedAlert = .signInError
           await errorReporting.reportMessage(
             "Google sign-in missing serverAuthCode",
             ["auth_method": "google", "sign_in_step": "server_auth_code"])
@@ -124,6 +135,7 @@ class SignInPageModel: ViewModel {
         if nsError.domain != kGIDSignInErrorDomain
           || nsError.code != GIDSignInError.canceled.rawValue
         {
+          presentedAlert = .signInError
           await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
           await errorReporting.reportError(
             error,

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -14,20 +14,31 @@ import SwiftUI
 @MainActor
 @Observable
 class SignInPageModel: ViewModel {
+
+  // MARK: - Dependencies
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.appRating) var appRating
   @ObservationIgnored @Dependency(\.errorReporting) var errorReporting
+
+  // MARK: - Shared State
   @ObservationIgnored @Shared(.auth) var auth: Auth
 
-  var presentedAlert: PlayolaAlert?
-
+  // MARK: - Initialization
   @MainActor
   override init() {
     super.init()
   }
 
-  // MARK: Actions
+  // MARK: - Properties
+  var presentedAlert: PlayolaAlert?
+
+  @ObservationIgnored
+  var keyWindowProvider: @MainActor () -> UIViewController? = {
+    UIApplication.shared.keyWindowPresentedController
+  }
+
+  // MARK: - User Actions
 
   func signInWithAppleButtonTapped(request: ASAuthorizationAppleIDRequest) {
     request.requestedScopes = [.email, .fullName]
@@ -83,22 +94,9 @@ class SignInPageModel: ViewModel {
     }
   }
 
-  private func handleAppleAuthorizationFailure(_ error: any Error) {
-    print(error)
-    if let authError = error as? ASAuthorizationError, authError.code == .canceled {
-      return
-    }
-    presentedAlert = .signInError
-    Task {
-      await errorReporting.reportError(
-        error,
-        ["auth_method": "apple", "sign_in_step": "authorization_failure"])
-    }
-  }
-
   func signInWithGoogleButtonTapped() async {
     await analytics.track(.signInStarted(method: .google))
-    guard let presentingVC = UIApplication.shared.keyWindowPresentedController else {
+    guard let presentingVC = keyWindowProvider() else {
       print("Error presenting VC -- no key window")
       presentedAlert = .signInError
       await errorReporting.reportMessage(
@@ -142,6 +140,21 @@ class SignInPageModel: ViewModel {
             ["auth_method": "google", "sign_in_step": "google_sign_in_flow"])
         }
       }
+    }
+  }
+
+  // MARK: - Private Helpers
+
+  private func handleAppleAuthorizationFailure(_ error: any Error) {
+    print(error)
+    if let authError = error as? ASAuthorizationError, authError.code == .canceled {
+      return
+    }
+    presentedAlert = .signInError
+    Task {
+      await errorReporting.reportError(
+        error,
+        ["auth_method": "apple", "sign_in_step": "authorization_failure"])
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -122,4 +122,32 @@ final class SignInPageTests: XCTestCase {
       reportedErrors.value.isEmpty,
       "Should not report ASAuthorizationError.canceled (user cancellations are not bugs)")
   }
+
+  // MARK: - presentedAlert Tests
+
+  func testSignInWithAppleCompletedPresentsAlertOnAuthorizationFailure() async {
+    let model = SignInPageModel()
+    let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
+
+    model.signInWithAppleCompleted(result: .failure(genericError))
+
+    XCTAssertEqual(model.presentedAlert, .signInError)
+  }
+
+  func testSignInWithAppleCompletedDoesNotPresentAlertOnUserCancel() async {
+    let model = SignInPageModel()
+    let cancelError = ASAuthorizationError(.canceled)
+
+    model.signInWithAppleCompleted(result: .failure(cancelError))
+
+    XCTAssertNil(model.presentedAlert)
+  }
+
+  func testSignInWithGooglePresentsAlertWhenNoKeyWindow() async {
+    let model = SignInPageModel()
+
+    await model.signInWithGoogleButtonTapped()
+
+    XCTAssertEqual(model.presentedAlert, .signInError)
+  }
 }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -126,25 +126,39 @@ final class SignInPageTests: XCTestCase {
   // MARK: - presentedAlert Tests
 
   func testSignInWithAppleCompletedPresentsAlertOnAuthorizationFailure() async {
-    let model = SignInPageModel()
-    let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
+    let model = withDependencies {
+      $0.errorReporting.reportError = { _, _ in }
+    } operation: {
+      SignInPageModel()
+    }
 
+    let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
     model.signInWithAppleCompleted(result: .failure(genericError))
 
     XCTAssertEqual(model.presentedAlert, .signInError)
   }
 
   func testSignInWithAppleCompletedDoesNotPresentAlertOnUserCancel() async {
-    let model = SignInPageModel()
-    let cancelError = ASAuthorizationError(.canceled)
+    let model = withDependencies {
+      $0.errorReporting.reportError = { _, _ in }
+    } operation: {
+      SignInPageModel()
+    }
 
+    let cancelError = ASAuthorizationError(.canceled)
     model.signInWithAppleCompleted(result: .failure(cancelError))
 
     XCTAssertNil(model.presentedAlert)
   }
 
   func testSignInWithGooglePresentsAlertWhenNoKeyWindow() async {
-    let model = SignInPageModel()
+    let model = withDependencies {
+      $0.errorReporting.reportMessage = { _, _ in }
+      $0.analytics.track = { _ in }
+    } operation: {
+      SignInPageModel()
+    }
+    model.keyWindowProvider = { nil }
 
     await model.signInWithGoogleButtonTapped()
 

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -13,7 +13,7 @@ import SwiftUI
 
 @MainActor
 struct SignInPage: View {
-  var model: SignInPageModel
+  @Bindable var model: SignInPageModel
 
   var body: some View {
     NavigationView {
@@ -107,6 +107,7 @@ struct SignInPage: View {
       .navigationBarHidden(true)
     }
     .navigationViewStyle(StackNavigationViewStyle())
+    .playolaAlert($model.presentedAlert)
   }
 }
 

--- a/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
@@ -6,6 +6,7 @@
 //
 
 import SwiftUI
+import UIKit
 
 @MainActor
 struct PlayolaAlert: Equatable, Identifiable, Hashable {
@@ -259,5 +260,24 @@ extension PlayolaAlert {
       title: "Prize Redeemed!",
       message: "We'll follow up via email to coordinate your reward.",
       dismissButton: .cancel(Text("OK")))
+  }
+
+  static var signInError: PlayolaAlert {
+    let message =
+      "We have a rare bug on sign-in that only affects 1 out of every 1000 people. "
+      + "So sorry about this -- if you're up for it, please contact me at "
+      + "brian@playola.fm and we'll get you signed in and we'll send you a koozie "
+      + "or something. Sorry again!"
+    return PlayolaAlert(
+      title: "You win the lottery!",
+      message: message,
+      primaryButtonText: "Email Brian",
+      primaryAction: {
+        guard let url = URL(string: "mailto:brian@playola.fm?subject=Sign-in%20issue") else {
+          return
+        }
+        _ = await UIApplication.shared.open(url)
+      },
+      secondaryButtonText: "OK")
   }
 }


### PR DESCRIPTION
## Summary

A user gave a 1-star review reporting they could not sign in with Google or Apple — and the app silently dumped them back to the sign-in screen with no message. Sentry sign-in error reporting (PR #255) landed three days *after* v6.0.0-b82 was tagged, so the user on v6.0 had neither a UI alert nor any Sentry breadcrumb.

This PR adds the missing user-facing alert. The Sentry wiring already on `develop` will start working with the next release.

## Changes

- New `PlayolaAlert.signInError` with title "You win the lottery!", the lottery message, and two buttons:
  - "Email Brian" → opens `mailto:brian@playola.fm?subject=Sign-in%20issue`
  - "OK" → dismiss
- `SignInPageModel` now exposes `presentedAlert` and sets `.signInError` on every silent error path (Apple credential decode, Apple auth failure, Apple API call, Google no-key-window, Google missing serverAuthCode, Google API/SDK failure)
- User-cancel paths still stay silent (Apple `.canceled`, Google `kGIDSignInError.canceled`)
- Existing Sentry calls untouched on every path
- `SignInPage` view now `@Bindable` with `.playolaAlert($model.presentedAlert)`

## Test plan

- [ ] Tap Apple → cancel from system sheet → no alert (correct silent cancel)
- [ ] Tap Google → cancel from system sheet → no alert
- [ ] Trigger a real Apple/Google failure (e.g. airplane mode after auth) → alert appears with Email Brian button
- [ ] Tap "Email Brian" → mail app opens with prefilled recipient + subject
- [ ] After next release, verify Sentry events arrive with `auth_method` + `sign_in_step` tags