### PR TITLE
Address PR #264 review comments: structured async + @MainActor closures

### DIFF
--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -104,41 +104,37 @@ class SignInPageModel: ViewModel {
         ["auth_method": "google", "sign_in_step": "present_view_controller"])
       return
     }
-    // Run the sign-in flow in a detached Task so the caller returns immediately
-    // after firing .signInStarted, matching the prior callback-style contract.
-    Task {
-      do {
-        let signInResult = try await GIDSignIn.sharedInstance.signIn(withPresenting: presentingVC)
-        print(signInResult)
+    do {
+      let signInResult = try await GIDSignIn.sharedInstance.signIn(withPresenting: presentingVC)
+      print(signInResult)
 
-        _ = try await signInResult.user.refreshTokensIfNeeded()
-        guard let serverAuthCode = signInResult.serverAuthCode else {
-          print("Error signing into Google -- no serverAuthCode on signInResult.")
-          presentedAlert = .signInError
-          await errorReporting.reportMessage(
-            "Google sign-in missing serverAuthCode",
-            ["auth_method": "google", "sign_in_step": "server_auth_code"])
-          return
-        }
-        let userId = signInResult.user.userID ?? "unknown"
-        let token = try await api.signInViaGoogle(serverAuthCode)
-        $auth.withLock { $0 = Auth(jwtToken: token) }
-        appRating.recordInstallDateIfNeeded()
-        await analytics.track(.signInCompleted(method: .google, userId: userId))
-      } catch {
-        print("Google sign in failed: \(error)")
-        let nsError = error as NSError
-        // Match the prior callback behavior: silently drop user-cancelled sign-ins
-        // (GIDSignInError.canceled = -5) instead of tracking them as failures.
-        if nsError.domain != kGIDSignInErrorDomain
-          || nsError.code != GIDSignInError.canceled.rawValue
-        {
-          presentedAlert = .signInError
-          await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
-          await errorReporting.reportError(
-            error,
-            ["auth_method": "google", "sign_in_step": "google_sign_in_flow"])
-        }
+      _ = try await signInResult.user.refreshTokensIfNeeded()
+      guard let serverAuthCode = signInResult.serverAuthCode else {
+        print("Error signing into Google -- no serverAuthCode on signInResult.")
+        presentedAlert = .signInError
+        await errorReporting.reportMessage(
+          "Google sign-in missing serverAuthCode",
+          ["auth_method": "google", "sign_in_step": "server_auth_code"])
+        return
+      }
+      let userId = signInResult.user.userID ?? "unknown"
+      let token = try await api.signInViaGoogle(serverAuthCode)
+      $auth.withLock { $0 = Auth(jwtToken: token) }
+      appRating.recordInstallDateIfNeeded()
+      await analytics.track(.signInCompleted(method: .google, userId: userId))
+    } catch {
+      print("Google sign in failed: \(error)")
+      let nsError = error as NSError
+      // Match the prior callback behavior: silently drop user-cancelled sign-ins
+      // (GIDSignInError.canceled = -5) instead of tracking them as failures.
+      if nsError.domain != kGIDSignInErrorDomain
+        || nsError.code != GIDSignInError.canceled.rawValue
+      {
+        presentedAlert = .signInError
+        await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
+        await errorReporting.reportError(
+          error,
+          ["auth_method": "google", "sign_in_step": "google_sign_in_flow"])
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -58,9 +58,12 @@ final class SignInPageTests: XCTestCase {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.errorReporting.reportMessage = { _, _ in }
     } operation: {
       SignInPageModel()
     }
+    // Avoid invoking the real Google SDK in tests by short-circuiting on no key window.
+    model.keyWindowProvider = { nil }
 
     await model.signInWithGoogleButtonTapped()
 

--- a/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
@@ -23,9 +23,9 @@ struct PlayolaAlert: Equatable, Identifiable, Hashable {
   let primaryButtonText: String?
   let secondaryButtonText: String?
   let tertiaryButtonText: String?
-  let primaryAction: (() async -> Void)?
-  let secondaryAction: (() async -> Void)?
-  let tertiaryAction: (() async -> Void)?
+  let primaryAction: (@MainActor () async -> Void)?
+  let secondaryAction: (@MainActor () async -> Void)?
+  let tertiaryAction: (@MainActor () async -> Void)?
 
   init(
     title: String,
@@ -49,9 +49,9 @@ struct PlayolaAlert: Equatable, Identifiable, Hashable {
     title: String,
     message: String?,
     primaryButtonText: String,
-    primaryAction: @escaping () async -> Void,
+    primaryAction: @escaping @MainActor () async -> Void,
     secondaryButtonText: String,
-    secondaryAction: (() async -> Void)? = nil
+    secondaryAction: (@MainActor () async -> Void)? = nil
   ) {
     self.title = title
     self.message = message
@@ -69,11 +69,11 @@ struct PlayolaAlert: Equatable, Identifiable, Hashable {
     title: String,
     message: String?,
     primaryButtonText: String,
-    primaryAction: @escaping () async -> Void,
+    primaryAction: @escaping @MainActor () async -> Void,
     secondaryButtonText: String,
-    secondaryAction: @escaping () async -> Void,
+    secondaryAction: @escaping @MainActor () async -> Void,
     tertiaryButtonText: String,
-    tertiaryAction: @escaping () async -> Void
+    tertiaryAction: @escaping @MainActor () async -> Void
   ) {
     self.title = title
     self.message = message
@@ -232,9 +232,9 @@ extension PlayolaAlert {
   }
 
   static func ratingPrompt(
-    onEnjoying: @escaping () async -> Void,
-    onNotEnjoying: @escaping () async -> Void,
-    onNotNow: @escaping () async -> Void
+    onEnjoying: @escaping @MainActor () async -> Void,
+    onNotEnjoying: @escaping @MainActor () async -> Void,
+    onNotNow: @escaping @MainActor () async -> Void
   ) -> PlayolaAlert {
     PlayolaAlert(
       title: "Are you enjoying Playola Radio?",


### PR DESCRIPTION
## Summary
Addresses both unresolved Greptile review comments on #264.

- **`signInWithGoogleButtonTapped`**: Removed the unstructured `Task {}` so the `async` function actually awaits the full Google sign-in flow. The detached Task was a holdover from the callback-style API; now that `GIDSignIn.signIn(withPresenting:)` is properly `async`, callers (and tests) can rely on the function completing the work it advertises.
- **`PlayolaAlert` action closures**: Annotated `primaryAction` / `secondaryAction` / `tertiaryAction` (and matching init params + `ratingPrompt` factory) as `@MainActor () async -> Void`. The `signInError` alert calls `UIApplication.shared.open` (a `@MainActor` API) inside one of these closures — under Swift 6 strict concurrency the closure type now matches its actual usage.

## Test plan
- [ ] Run `SignInPageTests` in Xcode — existing tests still pass with the structured async flow.
- [ ] Run `MainContainerTests` — `ratingPrompt` callers compile cleanly with the new `@MainActor` closure types.
- [ ] Build succeeds on iPhone 17 simulator (verified locally).