### PR TITLE
Add sign-in Sentry context

### DIFF
--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -27,6 +27,34 @@ private struct CreateVoicetrackParameters: Encodable, Sendable {
 
 private let sharedIsoDecoder = JSONDecoderWithIsoFull()
 
+private func signInPost(
+  authMethod: AuthMethod,
+  endpointPath: String,
+  parameters: Parameters
+) async throws -> String {
+  let dataResponse = await AF.request(
+    "\(Config.shared.baseUrl.absoluteString)\(endpointPath)",
+    method: .post,
+    parameters: parameters,
+    encoding: JSONEncoding.default
+  )
+  .validate(statusCode: 200..<300)
+  .serializingDecodable(LoginResponse.self)
+  .response
+
+  switch dataResponse.result {
+  case .success(let response):
+    return response.playolaToken
+  case .failure(let error):
+    throw SignInAPIError(
+      authMethod: authMethod,
+      endpointPath: endpointPath,
+      statusCode: dataResponse.response?.statusCode,
+      responseBody: dataResponse.data.flatMap { String(data: $0, encoding: .utf8) },
+      underlyingError: error)
+  }
+}
+
 private func authenticatedGet<T: Decodable & Sendable>(
   path: String,
   token: String,
@@ -127,7 +155,7 @@ extension APIClient: DependencyKey {
         return IdentifiedArray(uniqueElements: response)
       },
       signInViaApple: { identityToken, email, authCode, firstName, lastName in
-        var parameters: [String: String] = [
+        var parameters: Parameters = [
           "identityToken": identityToken,
           "authCode": authCode,
           "firstName": firstName,
@@ -138,14 +166,10 @@ extension APIClient: DependencyKey {
         if let lastName {
           parameters["lastName"] = lastName
         }
-        let response = try await AF.request(
-          "\(Config.shared.baseUrl.absoluteString)/v1/auth/apple/mobile/signup",
-          method: .post,
-          parameters: parameters,
-          encoding: JSONEncoding.default
-        ).serializingDecodable(LoginResponse.self).value
-
-        return response.playolaToken
+        return try await signInPost(
+          authMethod: .apple,
+          endpointPath: "/v1/auth/apple/mobile/signup",
+          parameters: parameters)
       },
       revokeAppleCredentials: { appleUserId in
         let parameters: [String: String] = ["appleUserId": appleUserId]
@@ -162,21 +186,15 @@ extension APIClient: DependencyKey {
         AuthService.shared.signOut()
       },
       signInViaGoogle: { code in
-        let parameters: [String: Sendable] = [
+        let parameters: Parameters = [
           "code": code,
           "originatesFromIOS": true,
         ]
 
-        let response = try await AF.request(
-          "\(Config.shared.baseUrl.absoluteString)/v1/auth/google/signin",
-          method: .post,
-          parameters: parameters,
-          encoding: JSONEncoding.default
-        )
-        .validate(statusCode: 200..<300)
-        .serializingDecodable(LoginResponse.self).value
-
-        return response.playolaToken
+        return try await signInPost(
+          authMethod: .google,
+          endpointPath: "/v1/auth/google/signin",
+          parameters: parameters)
       },
       getRewardsProfile: { jwtToken in
         try await authenticatedGet(path: "/v1/rewards/users/me/profile", token: jwtToken)

--- a/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
+++ b/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
@@ -21,6 +21,10 @@ struct ErrorReportingClient: Sendable {
   /// Tags are attached to the event for filtering in the Sentry UI.
   var reportError: @Sendable (_ error: Error, _ tags: [String: String]) async -> Void
 
+  /// Report an Error with tags and contextual data to the crash/error reporting backend (Sentry).
+  var reportErrorWithContext:
+    @Sendable (_ error: Error, _ tags: [String: String], _ context: [String: String]) async -> Void
+
   /// Report a message (non-Error situation) to the crash/error reporting backend.
   /// Tags are attached to the event for filtering in the Sentry UI.
   var reportMessage: @Sendable (_ message: String, _ tags: [String: String]) async -> Void
@@ -52,6 +56,18 @@ extension ErrorReportingClient: DependencyKey {
         }
       #endif
     },
+    reportErrorWithContext: { error, tags, context in
+      #if canImport(Sentry)
+        SentrySDK.capture(error: error) { scope in
+          for (key, value) in tags {
+            scope.setTag(value: value, key: key)
+          }
+          if !context.isEmpty {
+            scope.setContext(value: context, key: "sign_in")
+          }
+        }
+      #endif
+    },
     reportMessage: { message, tags in
       #if canImport(Sentry)
         SentrySDK.capture(message: message) { scope in
@@ -69,6 +85,114 @@ extension ErrorReportingClient: DependencyKey {
 extension ErrorReportingClient {
   static let noop = Self(
     reportError: { _, _ in },
+    reportErrorWithContext: { _, _, _ in },
     reportMessage: { _, _ in }
   )
+}
+
+struct SignInAPIError: Error, LocalizedError {
+  let authMethod: AuthMethod
+  let endpointPath: String
+  let statusCode: Int?
+  let responseBody: String?
+  let underlyingError: Error
+
+  var errorDescription: String? {
+    var description = "Sign-in API exchange failed for \(authMethod.rawValue)"
+    if let statusCode {
+      description += " with HTTP \(statusCode)"
+    }
+    description += ": \(underlyingError.localizedDescription)"
+    return description
+  }
+}
+
+struct SignInErrorReport {
+  let tags: [String: String]
+  let context: [String: String]
+
+  init(error: Error, authMethod: AuthMethod, step: String) {
+    var tags = [
+      "auth_method": authMethod.rawValue,
+      "sign_in_step": step,
+    ]
+    var context: [String: String] = [:]
+
+    let errorForDomain = (error as? SignInAPIError)?.underlyingError ?? error
+    let nsError = errorForDomain as NSError
+    tags["error_domain"] = nsError.domain
+    tags["error_code"] = "\(nsError.code)"
+
+    if let apiError = error as? SignInAPIError {
+      tags["endpoint_path"] = apiError.endpointPath
+      if let statusCode = apiError.statusCode {
+        tags["http_status_code"] = "\(statusCode)"
+      }
+      context["endpoint_path"] = apiError.endpointPath
+      if let responseBody = apiError.responseBody {
+        context["response_body"] = Self.redactedResponseBody(responseBody)
+        context["response_body_bytes"] = "\(responseBody.lengthOfBytes(using: .utf8))"
+        if let keys = Self.topLevelJSONKeys(responseBody), !keys.isEmpty {
+          context["response_body_top_level_keys"] = keys.joined(separator: ",")
+        }
+      }
+    }
+
+    self.tags = tags
+    self.context = context
+  }
+
+  private static func redactedResponseBody(_ responseBody: String) -> String {
+    guard let data = responseBody.data(using: .utf8),
+      let json = try? JSONSerialization.jsonObject(with: data)
+    else {
+      return responseBody
+    }
+
+    let redacted = redactSensitiveValues(in: json)
+    guard JSONSerialization.isValidJSONObject(redacted),
+      let redactedData = try? JSONSerialization.data(
+        withJSONObject: redacted, options: [.sortedKeys]),
+      let redactedString = String(data: redactedData, encoding: .utf8)
+    else {
+      return responseBody
+    }
+    return redactedString
+  }
+
+  private static func redactSensitiveValues(in value: Any) -> Any {
+    if let dictionary = value as? [String: Any] {
+      return dictionary.reduce(into: [String: Any]()) { result, item in
+        if shouldRedact(key: item.key) {
+          result[item.key] = "[REDACTED]"
+        } else {
+          result[item.key] = redactSensitiveValues(in: item.value)
+        }
+      }
+    }
+
+    if let array = value as? [Any] {
+      return array.map { redactSensitiveValues(in: $0) }
+    }
+
+    return value
+  }
+
+  private static func shouldRedact(key: String) -> Bool {
+    let normalizedKey = key.lowercased()
+    return normalizedKey.contains("token")
+      || normalizedKey == "authcode"
+      || normalizedKey == "authorizationcode"
+      || normalizedKey == "identitytoken"
+      || normalizedKey == "idtoken"
+  }
+
+  private static func topLevelJSONKeys(_ responseBody: String) -> [String]? {
+    guard let data = responseBody.data(using: .utf8),
+      let dictionary = try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    else {
+      return nil
+    }
+    return dictionary.keys.sorted()
+  }
 }

--- a/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
+++ b/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
@@ -23,7 +23,9 @@ struct ErrorReportingClient: Sendable {
 
   /// Report an Error with tags and contextual data to the crash/error reporting backend (Sentry).
   var reportErrorWithContext:
-    @Sendable (_ error: Error, _ tags: [String: String], _ context: [String: String]) async -> Void
+    @Sendable (
+      _ error: Error, _ tags: [String: String], _ contextKey: String, _ context: [String: String]
+    ) async -> Void
 
   /// Report a message (non-Error situation) to the crash/error reporting backend.
   /// Tags are attached to the event for filtering in the Sentry UI.
@@ -56,14 +58,14 @@ extension ErrorReportingClient: DependencyKey {
         }
       #endif
     },
-    reportErrorWithContext: { error, tags, context in
+    reportErrorWithContext: { error, tags, contextKey, context in
       #if canImport(Sentry)
         SentrySDK.capture(error: error) { scope in
           for (key, value) in tags {
             scope.setTag(value: value, key: key)
           }
           if !context.isEmpty {
-            scope.setContext(value: context, key: "sign_in")
+            scope.setContext(value: context, key: contextKey)
           }
         }
       #endif
@@ -85,7 +87,7 @@ extension ErrorReportingClient: DependencyKey {
 extension ErrorReportingClient {
   static let noop = Self(
     reportError: { _, _ in },
-    reportErrorWithContext: { _, _, _ in },
+    reportErrorWithContext: { _, _, _, _ in },
     reportMessage: { _, _ in }
   )
 }
@@ -108,6 +110,7 @@ struct SignInAPIError: Error, LocalizedError {
 }
 
 struct SignInErrorReport {
+  let contextKey = "sign_in"
   let tags: [String: String]
   let context: [String: String]
 
@@ -183,8 +186,6 @@ struct SignInErrorReport {
     return normalizedKey.contains("token")
       || normalizedKey == "authcode"
       || normalizedKey == "authorizationcode"
-      || normalizedKey == "identitytoken"
-      || normalizedKey == "idtoken"
   }
 
   private static func topLevelJSONKeys(_ responseBody: String) -> [String]? {

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -84,9 +84,7 @@ class SignInPageModel: ViewModel {
           print("Sign in failed: \(error)")
           presentedAlert = .signInError
           await analytics.track(.signInFailed(method: .apple, error: error.localizedDescription))
-          await errorReporting.reportError(
-            error,
-            ["auth_method": "apple", "sign_in_step": "api_call"])
+          await reportSignInError(error, authMethod: .apple, step: "api_call")
         }
       }
     case .failure(let error):
@@ -132,9 +130,7 @@ class SignInPageModel: ViewModel {
       {
         presentedAlert = .signInError
         await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
-        await errorReporting.reportError(
-          error,
-          ["auth_method": "google", "sign_in_step": "google_sign_in_flow"])
+        await reportSignInError(error, authMethod: .google, step: "google_sign_in_flow")
       }
     }
   }
@@ -148,9 +144,12 @@ class SignInPageModel: ViewModel {
     }
     presentedAlert = .signInError
     Task {
-      await errorReporting.reportError(
-        error,
-        ["auth_method": "apple", "sign_in_step": "authorization_failure"])
+      await reportSignInError(error, authMethod: .apple, step: "authorization_failure")
     }
+  }
+
+  private func reportSignInError(_ error: Error, authMethod: AuthMethod, step: String) async {
+    let report = SignInErrorReport(error: error, authMethod: authMethod, step: step)
+    await errorReporting.reportErrorWithContext(error, report.tags, report.context)
   }
 }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -150,6 +150,7 @@ class SignInPageModel: ViewModel {
 
   private func reportSignInError(_ error: Error, authMethod: AuthMethod, step: String) async {
     let report = SignInErrorReport(error: error, authMethod: authMethod, step: step)
-    await errorReporting.reportErrorWithContext(error, report.tags, report.context)
+    await errorReporting.reportErrorWithContext(
+      error, report.tags, report.contextKey, report.context)
   }
 }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -84,7 +84,7 @@ final class SignInPageTests: XCTestCase {
     let expectation = XCTestExpectation(description: "reportError called")
 
     let model = withDependencies {
-      $0.errorReporting.reportErrorWithContext = { error, tags, _ in
+      $0.errorReporting.reportErrorWithContext = { error, tags, _, _ in
         reportedErrors.withValue { $0.append((error, tags)) }
         expectation.fulfill()
       }
@@ -108,7 +108,7 @@ final class SignInPageTests: XCTestCase {
     invertedExpectation.isInverted = true
 
     let model = withDependencies {
-      $0.errorReporting.reportErrorWithContext = { error, tags, _ in
+      $0.errorReporting.reportErrorWithContext = { error, tags, _, _ in
         reportedErrors.withValue { $0.append((error, tags)) }
         invertedExpectation.fulfill()
       }
@@ -130,7 +130,7 @@ final class SignInPageTests: XCTestCase {
 
   func testSignInWithAppleCompletedPresentsAlertOnAuthorizationFailure() async {
     let model = withDependencies {
-      $0.errorReporting.reportErrorWithContext = { _, _, _ in }
+      $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
     } operation: {
       SignInPageModel()
     }
@@ -143,7 +143,7 @@ final class SignInPageTests: XCTestCase {
 
   func testSignInWithAppleCompletedDoesNotPresentAlertOnUserCancel() async {
     let model = withDependencies {
-      $0.errorReporting.reportErrorWithContext = { _, _, _ in }
+      $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
     } operation: {
       SignInPageModel()
     }
@@ -182,6 +182,7 @@ final class SignInPageTests: XCTestCase {
     XCTAssertEqual(report.tags["sign_in_step"], "google_sign_in_flow")
     XCTAssertEqual(report.tags["error_domain"], "com.google.GIDSignIn")
     XCTAssertEqual(report.tags["error_code"], "-4")
+    XCTAssertEqual(report.contextKey, "sign_in")
   }
 
   func testSignInErrorReportIncludesHTTPContextAndRedactsTokens() {

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -84,7 +84,7 @@ final class SignInPageTests: XCTestCase {
     let expectation = XCTestExpectation(description: "reportError called")
 
     let model = withDependencies {
-      $0.errorReporting.reportError = { error, tags in
+      $0.errorReporting.reportErrorWithContext = { error, tags, _ in
         reportedErrors.withValue { $0.append((error, tags)) }
         expectation.fulfill()
       }
@@ -108,7 +108,7 @@ final class SignInPageTests: XCTestCase {
     invertedExpectation.isInverted = true
 
     let model = withDependencies {
-      $0.errorReporting.reportError = { error, tags in
+      $0.errorReporting.reportErrorWithContext = { error, tags, _ in
         reportedErrors.withValue { $0.append((error, tags)) }
         invertedExpectation.fulfill()
       }
@@ -130,7 +130,7 @@ final class SignInPageTests: XCTestCase {
 
   func testSignInWithAppleCompletedPresentsAlertOnAuthorizationFailure() async {
     let model = withDependencies {
-      $0.errorReporting.reportError = { _, _ in }
+      $0.errorReporting.reportErrorWithContext = { _, _, _ in }
     } operation: {
       SignInPageModel()
     }
@@ -143,7 +143,7 @@ final class SignInPageTests: XCTestCase {
 
   func testSignInWithAppleCompletedDoesNotPresentAlertOnUserCancel() async {
     let model = withDependencies {
-      $0.errorReporting.reportError = { _, _ in }
+      $0.errorReporting.reportErrorWithContext = { _, _, _ in }
     } operation: {
       SignInPageModel()
     }
@@ -166,5 +166,46 @@ final class SignInPageTests: XCTestCase {
     await model.signInWithGoogleButtonTapped()
 
     XCTAssertEqual(model.presentedAlert, .signInError)
+  }
+
+  // MARK: - Sign-in Error Reporting Context Tests
+
+  func testSignInErrorReportIncludesNSErrorDomainAndCode() {
+    let error = NSError(domain: "com.google.GIDSignIn", code: -4)
+
+    let report = SignInErrorReport(
+      error: error,
+      authMethod: .google,
+      step: "google_sign_in_flow")
+
+    XCTAssertEqual(report.tags["auth_method"], "google")
+    XCTAssertEqual(report.tags["sign_in_step"], "google_sign_in_flow")
+    XCTAssertEqual(report.tags["error_domain"], "com.google.GIDSignIn")
+    XCTAssertEqual(report.tags["error_code"], "-4")
+  }
+
+  func testSignInErrorReportIncludesHTTPContextAndRedactsTokens() {
+    let responseBody = #"{"playolaToken":"secret-jwt","message":"unexpected shape"}"#
+    let error = SignInAPIError(
+      authMethod: .apple,
+      endpointPath: "/v1/auth/apple/mobile/signup",
+      statusCode: 200,
+      responseBody: responseBody,
+      underlyingError: NSError(domain: "decode", code: 7))
+
+    let report = SignInErrorReport(error: error, authMethod: .apple, step: "api_call")
+
+    XCTAssertEqual(report.tags["auth_method"], "apple")
+    XCTAssertEqual(report.tags["sign_in_step"], "api_call")
+    XCTAssertEqual(report.tags["http_status_code"], "200")
+    XCTAssertEqual(report.context["endpoint_path"], "/v1/auth/apple/mobile/signup")
+    XCTAssertEqual(
+      report.context["response_body_bytes"], "\(responseBody.lengthOfBytes(using: .utf8))")
+    XCTAssertEqual(report.context["response_body_top_level_keys"], "message,playolaToken")
+    XCTAssertTrue(
+      report.context["response_body"]?.contains(#""playolaToken":"[REDACTED]""#) ?? false)
+    XCTAssertTrue(
+      report.context["response_body"]?.contains(#""message":"unexpected shape""#) ?? false)
+    XCTAssertFalse(report.context["response_body"]?.contains("secret-jwt") ?? true)
   }
 }

--- a/PlayolaRadioTests/Mocks/ErrorReportingClientMock.swift
+++ b/PlayolaRadioTests/Mocks/ErrorReportingClientMock.swift
@@ -14,11 +14,18 @@ extension ErrorReportingClient {
   /// Test mock that forwards reported errors/messages to caller-supplied handlers.
   static func mock(
     errorHandler: @escaping @Sendable (Error, [String: String]) -> Void = { _, _ in },
+    errorWithContextHandler:
+      @escaping @Sendable (
+        Error, [String: String], [String: String]
+      ) -> Void = { _, _, _ in },
     messageHandler: @escaping @Sendable (String, [String: String]) -> Void = { _, _ in }
   ) -> Self {
     Self(
       reportError: { error, tags in
         errorHandler(error, tags)
+      },
+      reportErrorWithContext: { error, tags, context in
+        errorWithContextHandler(error, tags, context)
       },
       reportMessage: { message, tags in
         messageHandler(message, tags)

--- a/PlayolaRadioTests/Mocks/ErrorReportingClientMock.swift
+++ b/PlayolaRadioTests/Mocks/ErrorReportingClientMock.swift
@@ -16,16 +16,16 @@ extension ErrorReportingClient {
     errorHandler: @escaping @Sendable (Error, [String: String]) -> Void = { _, _ in },
     errorWithContextHandler:
       @escaping @Sendable (
-        Error, [String: String], [String: String]
-      ) -> Void = { _, _, _ in },
+        Error, [String: String], String, [String: String]
+      ) -> Void = { _, _, _, _ in },
     messageHandler: @escaping @Sendable (String, [String: String]) -> Void = { _, _ in }
   ) -> Self {
     Self(
       reportError: { error, tags in
         errorHandler(error, tags)
       },
-      reportErrorWithContext: { error, tags, context in
-        errorWithContextHandler(error, tags, context)
+      reportErrorWithContext: { error, tags, contextKey, context in
+        errorWithContextHandler(error, tags, contextKey, context)
       },
       reportMessage: { message, tags in
         messageHandler(message, tags)


### PR DESCRIPTION
Adds richer Sentry context for Apple and Google sign-in failures, including auth step, error domain/code, endpoint path, HTTP status, and response body metadata. Captures redacted response bodies for auth exchange failures so token-like fields are replaced with [REDACTED]. Updates sign-in tests and the error-reporting mock to cover the new reporting shape.

Test plan:
- xcodebuild test -project PlayolaRadio.xcodeproj -scheme PlayolaRadio -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:PlayolaRadioTests/SignInPageTests -quiet
- xcodebuild build -project PlayolaRadio.xcodeproj -scheme PlayolaRadio -destination 'platform=iOS Simulator,name=iPhone 17' -quiet