### PR TITLE
Clean up user state on sign-out

### DIFF
--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -159,7 +159,7 @@ extension APIClient: DependencyKey {
         .serializingData()
         .value
 
-        AuthService.shared.signOut()
+        await AuthService.shared.signOut()
       },
       signInViaGoogle: { code in
         let parameters: [String: Sendable] = [

--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -189,6 +189,7 @@ class AuthService: @unchecked Sendable {
   func signOut() async {
     @Dependency(\.api) var api
     @Dependency(\.analytics) var analytics
+    @Shared(.auth) var auth
     @Shared(.registeredDeviceId) var registeredDeviceId
     @Shared(.userLikes) var userLikes
     @Shared(.pendingLikeOperations) var pendingLikeOperations

--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -183,6 +183,7 @@ class AuthService: @unchecked Sendable {
       object: nil,
       queue: nil
     ) { _ in
+      Task { await AuthService.shared.signOut() }
     }
   }
 

--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 1/22/25.
 //
 import AuthenticationServices
+import Dependencies
 import Foundation
 import Sharing
 
@@ -185,8 +186,34 @@ class AuthService: @unchecked Sendable {
     }
   }
 
-  func signOut() {
+  func signOut() async {
+    @Dependency(\.api) var api
+    @Dependency(\.analytics) var analytics
+    @Shared(.registeredDeviceId) var registeredDeviceId
+    @Shared(.userLikes) var userLikes
+    @Shared(.pendingLikeOperations) var pendingLikeOperations
+    @Shared(.airings) var airings
+    @Shared(.lastNotificationSentAt) var lastNotificationSentAt
+    @Shared(.isBroadcaster) var isBroadcaster
+
+    let jwt = auth.jwt
+    let deviceId = registeredDeviceId
+
+    if let jwt, let deviceId {
+      try? await api.unregisterDevice(jwt, deviceId)
+    }
+
+    await analytics.reset()
+
     $auth.withLock { $0 = Auth() }
+    $registeredDeviceId.withLock { $0 = nil }
+    $userLikes.withLock { $0 = [:] }
+    $pendingLikeOperations.withLock { $0 = [] }
+    $airings.withLock { $0 = [] }
+    $lastNotificationSentAt.withLock { $0 = [:] }
+    $isBroadcaster.withLock { $0 = false }
+
+    UserDefaults.standard.removeObject(forKey: "analytics_session_paused_at")
   }
 
 }

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -125,10 +125,10 @@ class ContactPageModel: ViewModel {
     }
   }
 
-  func onLogOutTapped() {
+  func onLogOutTapped() async {
     stationPlayer.stop()
     mainContainerNavigationCoordinator.switchToListeningMode()
-    $auth.withLock { $0 = Auth() }
+    await AuthService.shared.signOut()
   }
 
   func callIntoStationButtonTapped() {

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -6,6 +6,7 @@
 //
 import ConcurrencyExtras
 import Dependencies
+import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
 import XCTest
@@ -19,8 +20,7 @@ final class ContactPageTests: XCTestCase {
     @Shared(.auth) var auth
   }
 
-  func testOnLogOutTapped_StopsPlayerAndClearsAuth() {
-    // Set up initial logged-in state using the new LoggedInUser initializer
+  func testOnLogOutTappedStopsPlayerAndClearsAllUserState() async {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -28,28 +28,60 @@ final class ContactPageTests: XCTestCase {
       email: "john@example.com",
       role: "user"
     )
+    let audioBlock = AudioBlock.mock
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
+    @Shared(.registeredDeviceId) var registeredDeviceId = "device-xyz"
+    @Shared(.userLikes) var userLikes = [
+      audioBlock.id: UserSongLike(
+        userId: "user-1",
+        audioBlockId: audioBlock.id,
+        audioBlock: audioBlock
+      )
+    ]
+    @Shared(.pendingLikeOperations) var pendingLikeOperations = [
+      LikeOperation(audioBlock: audioBlock, type: .like)
+    ]
+    @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = [Airing.mockWith(id: "airing-1")]
+    @Shared(.lastNotificationSentAt) var lastNotificationSentAt = ["station-1": Date()]
+    @Shared(.isBroadcaster) var isBroadcaster = true
+    UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "analytics_session_paused_at")
 
+    let unregisterCalls = LockIsolated<[(jwt: String, deviceId: String)]>([])
+    let resetCallCount = LockIsolated(0)
     let stationPlayerMock = StationPlayerMock()
-    let model = ContactPageModel(stationPlayer: stationPlayerMock)
 
-    // Verify initial state
-    XCTAssertTrue(auth.isLoggedIn)
-    XCTAssertEqual(auth.currentUser?.firstName, "John")
-    XCTAssertEqual(auth.currentUser?.lastName, "Doe")
-    XCTAssertEqual(auth.currentUser?.email, "john@example.com")
-    XCTAssertEqual(stationPlayerMock.stopCalledCount, 0)
+    await withDependencies {
+      $0.api.unregisterDevice = { jwt, deviceId in
+        unregisterCalls.withValue { $0.append((jwt: jwt, deviceId: deviceId)) }
+      }
+      $0.analytics = .noop
+      $0.analytics.reset = {
+        resetCallCount.withValue { $0 += 1 }
+      }
+    } operation: {
+      let model = ContactPageModel(stationPlayer: stationPlayerMock)
+      await model.onLogOutTapped()
+    }
 
-    // Call sign out
-    model.onLogOutTapped()
-
-    // Verify station player was stopped
     XCTAssertEqual(stationPlayerMock.stopCalledCount, 1)
 
-    // Verify auth was cleared
+    let calls = unregisterCalls.value
+    XCTAssertEqual(calls.count, 1)
+    XCTAssertEqual(calls.first?.jwt, loggedInUser.jwt)
+    XCTAssertEqual(calls.first?.deviceId, "device-xyz")
+
+    XCTAssertEqual(resetCallCount.value, 1)
+
     XCTAssertFalse(auth.isLoggedIn)
     XCTAssertNil(auth.currentUser)
     XCTAssertNil(auth.jwt)
+    XCTAssertNil(registeredDeviceId)
+    XCTAssertTrue(userLikes.isEmpty)
+    XCTAssertTrue(pendingLikeOperations.isEmpty)
+    XCTAssertTrue(airings.isEmpty)
+    XCTAssertTrue(lastNotificationSentAt.isEmpty)
+    XCTAssertFalse(isBroadcaster)
+    XCTAssertNil(UserDefaults.standard.object(forKey: "analytics_session_paused_at"))
   }
 
   func testNameDisplay_ReturnsFullNameWhenLoggedIn() {
@@ -436,7 +468,7 @@ final class ContactPageTests: XCTestCase {
     XCTAssertEqual(coordinator.appMode, .listening)
   }
 
-  func testLogoutResetsAppModeToListening() {
+  func testLogoutResetsAppModeToListening() async {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
     coordinator.appMode = .broadcasting(stationId: "station-123")
@@ -453,9 +485,54 @@ final class ContactPageTests: XCTestCase {
     let stationPlayerMock = StationPlayerMock()
     let model = ContactPageModel(stationPlayer: stationPlayerMock)
 
-    model.onLogOutTapped()
+    await withDependencies {
+      $0.api.unregisterDevice = { _, _ in }
+      $0.analytics = .noop
+    } operation: {
+      await model.onLogOutTapped()
+    }
 
     XCTAssertEqual(coordinator.appMode, .listening)
+  }
+
+  // MARK: - Sign Out Edge Cases
+
+  func testOnLogOutTappedSkipsServerCallWhenDeviceNotRegistered() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt-abc")
+    @Shared(.registeredDeviceId) var registeredDeviceId = String?.none
+
+    let unregisterCallCount = LockIsolated(0)
+
+    await withDependencies {
+      $0.api.unregisterDevice = { _, _ in
+        unregisterCallCount.withValue { $0 += 1 }
+      }
+      $0.analytics = .noop
+    } operation: {
+      let model = ContactPageModel(stationPlayer: StationPlayerMock())
+      await model.onLogOutTapped()
+    }
+
+    XCTAssertEqual(unregisterCallCount.value, 0)
+    XCTAssertFalse(auth.isLoggedIn)
+  }
+
+  func testOnLogOutTappedStillClearsLocalStateWhenServerCallFails() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt-abc")
+    @Shared(.registeredDeviceId) var registeredDeviceId = "device-xyz"
+
+    struct UnregisterError: Error {}
+
+    await withDependencies {
+      $0.api.unregisterDevice = { _, _ in throw UnregisterError() }
+      $0.analytics = .noop
+    } operation: {
+      let model = ContactPageModel(stationPlayer: StationPlayerMock())
+      await model.onLogOutTapped()
+    }
+
+    XCTAssertFalse(auth.isLoggedIn)
+    XCTAssertNil(registeredDeviceId)
   }
 
   func testMyStationButtonHiddenWhenInBroadcastMode() async {

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -21,22 +21,11 @@ final class ContactPageTests: XCTestCase {
   }
 
   func testOnLogOutTappedStopsPlayerAndClearsAllUserState() async {
-    let loggedInUser = LoggedInUser(
-      id: "123",
-      firstName: "John",
-      lastName: "Doe",
-      email: "john@example.com",
-      role: "user"
-    )
     let audioBlock = AudioBlock.mock
-    @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.registeredDeviceId) var registeredDeviceId = "device-xyz"
     @Shared(.userLikes) var userLikes = [
-      audioBlock.id: UserSongLike(
-        userId: "user-1",
-        audioBlockId: audioBlock.id,
-        audioBlock: audioBlock
-      )
+      audioBlock.id: UserSongLike(userId: "u1", audioBlockId: audioBlock.id, audioBlock: audioBlock)
     ]
     @Shared(.pendingLikeOperations) var pendingLikeOperations = [
       LikeOperation(audioBlock: audioBlock, type: .like)
@@ -46,35 +35,26 @@ final class ContactPageTests: XCTestCase {
     @Shared(.isBroadcaster) var isBroadcaster = true
     UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "analytics_session_paused_at")
 
-    let unregisterCalls = LockIsolated<[(jwt: String, deviceId: String)]>([])
+    let unregisterCalls = LockIsolated<[(String, String)]>([])
     let resetCallCount = LockIsolated(0)
     let stationPlayerMock = StationPlayerMock()
 
     await withDependencies {
       $0.api.unregisterDevice = { jwt, deviceId in
-        unregisterCalls.withValue { $0.append((jwt: jwt, deviceId: deviceId)) }
+        unregisterCalls.withValue { $0.append((jwt, deviceId)) }
       }
       $0.analytics = .noop
-      $0.analytics.reset = {
-        resetCallCount.withValue { $0 += 1 }
-      }
+      $0.analytics.reset = { resetCallCount.withValue { $0 += 1 } }
     } operation: {
-      let model = ContactPageModel(stationPlayer: stationPlayerMock)
-      await model.onLogOutTapped()
+      await ContactPageModel(stationPlayer: stationPlayerMock).onLogOutTapped()
     }
 
     XCTAssertEqual(stationPlayerMock.stopCalledCount, 1)
-
-    let calls = unregisterCalls.value
-    XCTAssertEqual(calls.count, 1)
-    XCTAssertEqual(calls.first?.jwt, loggedInUser.jwt)
-    XCTAssertEqual(calls.first?.deviceId, "device-xyz")
-
+    XCTAssertEqual(unregisterCalls.value.count, 1)
+    XCTAssertEqual(unregisterCalls.value.first?.0, "test-jwt")
+    XCTAssertEqual(unregisterCalls.value.first?.1, "device-xyz")
     XCTAssertEqual(resetCallCount.value, 1)
-
     XCTAssertFalse(auth.isLoggedIn)
-    XCTAssertNil(auth.currentUser)
-    XCTAssertNil(auth.jwt)
     XCTAssertNil(registeredDeviceId)
     XCTAssertTrue(userLikes.isEmpty)
     XCTAssertTrue(pendingLikeOperations.isEmpty)

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -463,12 +463,12 @@ final class ContactPageTests: XCTestCase {
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
     let stationPlayerMock = StationPlayerMock()
-    let model = ContactPageModel(stationPlayer: stationPlayerMock)
 
     await withDependencies {
       $0.api.unregisterDevice = { _, _ in }
       $0.analytics = .noop
     } operation: {
+      let model = ContactPageModel(stationPlayer: stationPlayerMock)
       await model.onLogOutTapped()
     }
 

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
@@ -285,7 +285,7 @@ struct ContactPageView: View {
           // Log Out Button
           Button(
             action: {
-              model.onLogOutTapped()
+              Task { await model.onLogOutTapped() }
             },
             label: {
               HStack(spacing: 8) {

--- a/PlayolaRadioTests/Mocks/AuthServiceMock.swift
+++ b/PlayolaRadioTests/Mocks/AuthServiceMock.swift
@@ -12,7 +12,7 @@ class AuthServiceMock: AuthService, @unchecked Sendable {
   private let signOutCallCountStorage = LockIsolated(0)
   var signOutCallCount: Int { signOutCallCountStorage.value }
 
-  override func signOut() {
+  override func signOut() async {
     signOutCallCountStorage.withValue { $0 += 1 }
   }
 }


### PR DESCRIPTION
## Summary
Centralizes sign-out in `AuthService.signOut()` so both the contact-page logout button and the Apple-credential-revocation path run the same cleanup. In addition to clearing auth, sign-out now unregisters the device from the push server, resets Mixpanel, clears user-scoped shared state (`userLikes`, `pendingLikeOperations`, `airings`, `lastNotificationSentAt`, `isBroadcaster`, `registeredDeviceId`), and clears the `analytics_session_paused_at` UserDefaults key. Server-side JWT invalidation is intentionally not added (we want stateless JWTs).

## Test plan
- [ ] Sign in, then sign out → verify push notifications stop arriving for the signed-out user
- [ ] Sign in as user A with likes, sign out, sign in as user B → verify user A's likes are gone
- [ ] Sign out while offline → verify local state still clears even though `unregisterDevice` fails
- [ ] Run `ContactPageTests` in Xcode