### PR TITLE
Add TLS 1.2 fallback for sign-in and route network errors to a calmer alert

### DIFF
--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -27,12 +27,19 @@ private struct CreateVoicetrackParameters: Encodable, Sendable {
 
 private let sharedIsoDecoder = JSONDecoderWithIsoFull()
 
+private let tls12SignInSession: Alamofire.Session = {
+  let configuration = URLSessionConfiguration.af.default
+  configuration.tlsMaximumSupportedProtocolVersion = .TLSv12
+  return Alamofire.Session(configuration: configuration)
+}()
+
 private func signInPost(
   authMethod: AuthMethod,
   endpointPath: String,
-  parameters: Parameters
+  parameters: Parameters,
+  session: Alamofire.Session = AF
 ) async throws -> String {
-  let dataResponse = await AF.request(
+  let dataResponse = await session.request(
     "\(Config.shared.baseUrl.absoluteString)\(endpointPath)",
     method: .post,
     parameters: parameters,
@@ -52,6 +59,44 @@ private func signInPost(
       statusCode: dataResponse.response?.statusCode,
       responseBody: dataResponse.data.flatMap { String(data: $0, encoding: .utf8) },
       underlyingError: error)
+  }
+}
+
+// Some users sit behind middleboxes (antivirus SSL inspection, parental-control routers, etc.)
+// that drop iOS 26's larger TLS 1.3 ClientHello with post-quantum hybrid key shares. Capping
+// to TLS 1.2 produces a smaller ClientHello that those middleboxes pass through. We retry
+// only the auth endpoints; everything else stays on modern TLS 1.3.
+private func signInPostWithTLS12Fallback(
+  authMethod: AuthMethod,
+  endpointPath: String,
+  parameters: Parameters
+) async throws -> String {
+  do {
+    return try await signInPost(
+      authMethod: authMethod,
+      endpointPath: endpointPath,
+      parameters: parameters)
+  } catch let originalError {
+    guard SignInNetworkErrorClassifier.isSecureConnectionFailed(originalError) else {
+      throw originalError
+    }
+    @Dependency(\.errorReporting) var errorReporting
+    do {
+      let token = try await signInPost(
+        authMethod: authMethod,
+        endpointPath: endpointPath,
+        parameters: parameters,
+        session: tls12SignInSession)
+      await errorReporting.reportMessage(
+        "tls12_fallback_used",
+        ["auth_method": authMethod.rawValue, "tls12_fallback_outcome": "success"])
+      return token
+    } catch {
+      await errorReporting.reportMessage(
+        "tls12_fallback_used",
+        ["auth_method": authMethod.rawValue, "tls12_fallback_outcome": "failure"])
+      throw originalError
+    }
   }
 }
 
@@ -166,7 +211,7 @@ extension APIClient: DependencyKey {
         if let lastName {
           parameters["lastName"] = lastName
         }
-        return try await signInPost(
+        return try await signInPostWithTLS12Fallback(
           authMethod: .apple,
           endpointPath: "/v1/auth/apple/mobile/signup",
           parameters: parameters)
@@ -191,7 +236,7 @@ extension APIClient: DependencyKey {
           "originatesFromIOS": true,
         ]
 
-        return try await signInPost(
+        return try await signInPostWithTLS12Fallback(
           authMethod: .google,
           endpointPath: "/v1/auth/google/signin",
           parameters: parameters)

--- a/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
+++ b/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 4/23/26.
 //
 
+import Alamofire
 import Dependencies
 import DependenciesMacros
 import Foundation
@@ -106,6 +107,51 @@ struct SignInAPIError: Error, LocalizedError {
     }
     description += ": \(underlyingError.localizedDescription)"
     return description
+  }
+}
+
+enum SignInNetworkErrorClassifier {
+  static let networkErrorCodes: Set<Int> = [
+    NSURLErrorSecureConnectionFailed,
+    NSURLErrorNotConnectedToInternet,
+    NSURLErrorTimedOut,
+    NSURLErrorCannotConnectToHost,
+    NSURLErrorNetworkConnectionLost,
+  ]
+
+  static func isNetworkError(_ error: Error) -> Bool {
+    nsURLErrorCodes(in: error).contains { networkErrorCodes.contains($0) }
+  }
+
+  static func isSecureConnectionFailed(_ error: Error) -> Bool {
+    nsURLErrorCodes(in: error).contains(NSURLErrorSecureConnectionFailed)
+  }
+
+  private static func nsURLErrorCodes(in error: Error) -> [Int] {
+    walkErrors(error).compactMap { $0.domain == NSURLErrorDomain ? $0.code : nil }
+  }
+
+  private static func walkErrors(_ error: Error) -> [NSError] {
+    var collected: [NSError] = []
+    var queue: [Error] = [error]
+    var iterations = 0
+    while !queue.isEmpty, iterations < 16 {
+      let next = queue.removeFirst()
+      iterations += 1
+      let ns = next as NSError
+      collected.append(ns)
+      if let afError = next as? AFError, let underlying = afError.underlyingError {
+        queue.append(underlying)
+      }
+      if let signInError = next as? SignInAPIError {
+        queue.append(signInError.underlyingError)
+      }
+      if let underlying = ns.userInfo[NSUnderlyingErrorKey] as? Error {
+        queue.append(underlying)
+      }
+      queue.append(contentsOf: ns.underlyingErrors)
+    }
+    return collected
   }
 }
 

--- a/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
+++ b/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
@@ -140,13 +140,16 @@ enum SignInNetworkErrorClassifier {
       iterations += 1
       let ns = next as NSError
       collected.append(ns)
-      if let afError = next as? AFError, let underlying = afError.underlyingError {
-        queue.append(underlying)
-      }
-      if let signInError = next as? SignInAPIError {
+      // Branches are mutually exclusive so each error contributes its underlying exactly once:
+      // bridged AFError also exposes its underlying via NSUnderlyingErrorKey, and we don't
+      // want to spend two iteration-budget slots on the same hop.
+      if let afError = next as? AFError {
+        if let underlying = afError.underlyingError {
+          queue.append(underlying)
+        }
+      } else if let signInError = next as? SignInAPIError {
         queue.append(signInError.underlyingError)
-      }
-      if let underlying = ns.userInfo[NSUnderlyingErrorKey] as? Error {
+      } else if let underlying = ns.userInfo[NSUnderlyingErrorKey] as? Error {
         queue.append(underlying)
       }
       queue.append(contentsOf: ns.underlyingErrors)

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -82,9 +82,7 @@ class SignInPageModel: ViewModel {
           await analytics.track(.signInCompleted(method: .apple, userId: appleIDCredential.user))
         } catch {
           print("Sign in failed: \(error)")
-          presentedAlert = .signInError
-          await analytics.track(.signInFailed(method: .apple, error: error.localizedDescription))
-          await reportSignInError(error, authMethod: .apple, step: "api_call")
+          await handleSignInAPIFailure(error, authMethod: .apple, step: "api_call")
         }
       }
     case .failure(let error):
@@ -128,14 +126,19 @@ class SignInPageModel: ViewModel {
       if nsError.domain != kGIDSignInErrorDomain
         || nsError.code != GIDSignInError.canceled.rawValue
       {
-        presentedAlert = .signInError
-        await analytics.track(.signInFailed(method: .google, error: error.localizedDescription))
-        await reportSignInError(error, authMethod: .google, step: "google_sign_in_flow")
+        await handleSignInAPIFailure(error, authMethod: .google, step: "google_sign_in_flow")
       }
     }
   }
 
   // MARK: - Private Helpers
+
+  func handleSignInAPIFailure(_ error: Error, authMethod: AuthMethod, step: String) async {
+    presentedAlert =
+      SignInNetworkErrorClassifier.isNetworkError(error) ? .signInNetworkError : .signInError
+    await analytics.track(.signInFailed(method: authMethod, error: error.localizedDescription))
+    await reportSignInError(error, authMethod: authMethod, step: step)
+  }
 
   private func handleAppleAuthorizationFailure(_ error: any Error) {
     print(error)

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -131,14 +131,18 @@ class SignInPageModel: ViewModel {
     }
   }
 
-  // MARK: - Private Helpers
+  // MARK: - Internal Helpers
 
+  // Internal (not private) so SignInPageTests can drive the alert/analytics/reporting routing
+  // directly without needing to fabricate an ASAuthorization for the Apple .success branch.
   func handleSignInAPIFailure(_ error: Error, authMethod: AuthMethod, step: String) async {
     presentedAlert =
       SignInNetworkErrorClassifier.isNetworkError(error) ? .signInNetworkError : .signInError
     await analytics.track(.signInFailed(method: authMethod, error: error.localizedDescription))
     await reportSignInError(error, authMethod: authMethod, step: step)
   }
+
+  // MARK: - Private Helpers
 
   private func handleAppleAuthorizationFailure(_ error: any Error) {
     print(error)

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 1/22/25.
 //
 
+import Alamofire
 import AuthenticationServices
 import Dependencies
 import Sharing
@@ -168,6 +169,74 @@ final class SignInPageTests: XCTestCase {
     XCTAssertEqual(model.presentedAlert, .signInError)
   }
 
+  // MARK: - handleSignInAPIFailure Routing Tests
+
+  func testHandleSignInAPIFailureShowsNetworkAlertOnAppleSSLError() async {
+    let model = withDependencies {
+      $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
+      $0.analytics.track = { _ in }
+    } operation: {
+      SignInPageModel()
+    }
+
+    let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
+    let afError = AFError.sessionTaskFailed(error: underlying)
+
+    await model.handleSignInAPIFailure(afError, authMethod: .apple, step: "api_call")
+
+    XCTAssertEqual(model.presentedAlert, .signInNetworkError)
+    XCTAssertNotEqual(model.presentedAlert, .signInError)
+  }
+
+  func testHandleSignInAPIFailureShowsGenericAlertOnAppleUnknownError() async {
+    let model = withDependencies {
+      $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
+      $0.analytics.track = { _ in }
+    } operation: {
+      SignInPageModel()
+    }
+
+    let genericError = NSError(domain: "com.example.unknown", code: 42)
+
+    await model.handleSignInAPIFailure(genericError, authMethod: .apple, step: "api_call")
+
+    XCTAssertEqual(model.presentedAlert, .signInError)
+    XCTAssertEqual(model.presentedAlert?.title, "Sign-In Failed")
+  }
+
+  func testHandleSignInAPIFailureShowsNetworkAlertOnGoogleSSLError() async {
+    let model = withDependencies {
+      $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
+      $0.analytics.track = { _ in }
+    } operation: {
+      SignInPageModel()
+    }
+
+    let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
+    let afError = AFError.sessionTaskFailed(error: underlying)
+
+    await model.handleSignInAPIFailure(afError, authMethod: .google, step: "google_sign_in_flow")
+
+    XCTAssertEqual(model.presentedAlert, .signInNetworkError)
+  }
+
+  func testHandleSignInAPIFailureShowsGenericAlertOnGoogleUnknownError() async {
+    let model = withDependencies {
+      $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
+      $0.analytics.track = { _ in }
+    } operation: {
+      SignInPageModel()
+    }
+
+    let genericError = NSError(domain: "com.google.GIDSignIn", code: -4)
+
+    await model.handleSignInAPIFailure(
+      genericError, authMethod: .google, step: "google_sign_in_flow")
+
+    XCTAssertEqual(model.presentedAlert, .signInError)
+    XCTAssertEqual(model.presentedAlert?.title, "Sign-In Failed")
+  }
+
   // MARK: - Sign-in Error Reporting Context Tests
 
   func testSignInErrorReportIncludesNSErrorDomainAndCode() {
@@ -183,6 +252,73 @@ final class SignInPageTests: XCTestCase {
     XCTAssertEqual(report.tags["error_domain"], "com.google.GIDSignIn")
     XCTAssertEqual(report.tags["error_code"], "-4")
     XCTAssertEqual(report.contextKey, "sign_in")
+  }
+
+  // MARK: - SignInNetworkErrorClassifier Tests
+
+  func testClassifierMatchesSecureConnectionFailed() {
+    let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
+    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(error))
+    XCTAssertTrue(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
+  }
+
+  func testClassifierMatchesNotConnectedToInternet() {
+    let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
+    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(error))
+    XCTAssertFalse(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
+  }
+
+  func testClassifierMatchesTimedOutCannotConnectAndConnectionLost() {
+    for code in [
+      NSURLErrorTimedOut, NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost,
+    ] {
+      let error = NSError(domain: NSURLErrorDomain, code: code)
+      XCTAssertTrue(
+        SignInNetworkErrorClassifier.isNetworkError(error),
+        "Expected code \(code) to classify as network error")
+    }
+  }
+
+  func testClassifierRejectsUnrelatedDomain() {
+    let error = NSError(domain: "com.example.other", code: NSURLErrorSecureConnectionFailed)
+    XCTAssertFalse(SignInNetworkErrorClassifier.isNetworkError(error))
+    XCTAssertFalse(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
+  }
+
+  func testClassifierRejectsNSURLDomainWithUnrelatedCode() {
+    let error = NSError(domain: NSURLErrorDomain, code: -9999)
+    XCTAssertFalse(SignInNetworkErrorClassifier.isNetworkError(error))
+  }
+
+  func testClassifierUnwrapsAFErrorSessionTaskFailed() {
+    let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
+    let afError = AFError.sessionTaskFailed(error: underlying)
+    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(afError))
+    XCTAssertTrue(SignInNetworkErrorClassifier.isSecureConnectionFailed(afError))
+  }
+
+  func testClassifierUnwrapsSignInAPIErrorWrappingAFError() {
+    let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
+    let afError = AFError.sessionTaskFailed(error: underlying)
+    let signInError = SignInAPIError(
+      authMethod: .apple,
+      endpointPath: "/v1/auth/apple/mobile/signup",
+      statusCode: nil,
+      responseBody: nil,
+      underlyingError: afError)
+    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(signInError))
+    XCTAssertTrue(SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
+  }
+
+  func testClassifierRejectsSignInAPIErrorWrappingNonNetworkError() {
+    let signInError = SignInAPIError(
+      authMethod: .google,
+      endpointPath: "/v1/auth/google/signin",
+      statusCode: 500,
+      responseBody: nil,
+      underlyingError: NSError(domain: "decode", code: 7))
+    XCTAssertFalse(SignInNetworkErrorClassifier.isNetworkError(signInError))
+    XCTAssertFalse(SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
   }
 
   func testSignInErrorReportIncludesHTTPContextAndRedactsTokens() {

--- a/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
@@ -262,16 +262,26 @@ extension PlayolaAlert {
       dismissButton: .cancel(Text("OK")))
   }
 
+  static var signInNetworkError: PlayolaAlert {
+    let message =
+      "Your network is blocking the secure connection to Playola. Try turning "
+      + "off wifi and using cellular data, or switch to a different wifi "
+      + "network. (More info: https://support.apple.com/en-us/122756)"
+    return PlayolaAlert(
+      title: "Connection Issue",
+      message: message,
+      dismissButton: .cancel(Text("OK")))
+  }
+
   static var signInError: PlayolaAlert {
     let message =
-      "We have a rare bug on sign-in that only affects 1 out of every 1000 people. "
-      + "So sorry about this -- if you're up for it, please contact me at "
-      + "brian@playola.fm and we'll get you signed in and we'll send you a koozie "
-      + "or something. Sorry again!"
+      "Something went wrong on our end while signing you in. Please try again. "
+      + "If it keeps happening, contact us at brian@playola.fm and we'll help "
+      + "get you sorted."
     return PlayolaAlert(
-      title: "You win the lottery!",
+      title: "Sign-In Failed",
       message: message,
-      primaryButtonText: "Email Brian",
+      primaryButtonText: "Email Us",
       primaryAction: {
         guard let url = URL(string: "mailto:brian@playola.fm?subject=Sign-in%20issue") else {
           return


### PR DESCRIPTION
## Summary

Fixes Sentry issue [APPLE-IOS-Q](https://playola-radio.sentry.io/issues/APPLE-IOS-Q) (Alamofire `-1200 errSSLPeerProtocolVersion` on Apple sign-in). On iOS 26, the TLS 1.3 ClientHello with post-quantum hybrid key shares (~1.6 KB) is dropped by some users' middleboxes (antivirus SSL inspection, parental-control routers). Self-heal in three pieces:

- **TLS 1.2 fallback** — `signInViaApple` / `signInViaGoogle` now retry once on `errSSLPeerProtocolVersion` through a shared TLS-1.2-capped Alamofire `Session` (smaller ClientHello passes through). Reports a `tls12_fallback_used` Sentry event tagged with `auth_method` + `tls12_fallback_outcome`. If the retry also fails, the original error propagates.
- **Network-vs-app error routing** — sign-in catch blocks now use a new pure `SignInNetworkErrorClassifier` (walks the `AFError` / `SignInAPIError` / `NSError.underlyingErrors` chain for `NSURLErrorDomain` codes `-1200, -1009, -1001, -1004, -1005`) and present a new "Connection Issue" alert pointing to https://support.apple.com/en-us/122756 instead of the generic alert.
- **Generic alert copy** — replaced the "You win the lottery" copy with calmer team-voice text ("Sign-In Failed" / "Email Us") since the alert now only fires on truly unexplained failures.

## Test plan

- [ ] Run the test suite in Xcode — 8 classifier unit tests + 4 routing tests (Apple/Google × network/unknown) added in `SignInPageTests.swift`
- [ ] Manually verify sign-in still works on a normal network
- [ ] (Optional) Verify Connection Issue alert renders by simulating `-1200` (e.g. point a debug build at an https endpoint that drops the larger ClientHello)