### PR TITLE
Fix bump-build.sh version detection (don't rely on agvtool/Info.plist)

### DIFF
--- a/scripts/bump-build.sh
+++ b/scripts/bump-build.sh
@@ -28,7 +28,7 @@ git fetch origin --tags --quiet
 PBXPROJ="PlayolaRadio.xcodeproj/project.pbxproj"
 
 current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
-current_build=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+current_build=$(grep 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ' | sort -n | tail -1)
 
 if [ -z "$current_version" ]; then
   echo "Error: could not detect MARKETING_VERSION from $PBXPROJ" >&2

--- a/scripts/bump-build.sh
+++ b/scripts/bump-build.sh
@@ -25,8 +25,21 @@ fi
 git fetch origin main develop --quiet
 git fetch origin --tags --quiet
 
-current_version=$(agvtool what-marketing-version -terse1 | head -1)
-current_build=$(agvtool what-version -terse | sort -n | tail -1)
+PBXPROJ="PlayolaRadio.xcodeproj/project.pbxproj"
+
+current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+current_build=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+
+if [ -z "$current_version" ]; then
+  echo "Error: could not detect MARKETING_VERSION from $PBXPROJ" >&2
+  exit 1
+fi
+
+if ! [[ "$current_build" =~ ^[0-9]+$ ]]; then
+  echo "Error: could not detect a numeric CURRENT_PROJECT_VERSION from $PBXPROJ (got '$current_build')" >&2
+  exit 1
+fi
+
 new_build=$((current_build + 1))
 
 last_tag=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -59,8 +59,18 @@ esac
 PBXPROJ="PlayolaRadio.xcodeproj/project.pbxproj"
 
 # Get current version info
-current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed 's/.*= //' | sed 's/;.*//' | tr -d ' ')
-current_build=$(agvtool what-version -terse | sort -n | tail -1)
+current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+current_build=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+
+if [ -z "$current_version" ]; then
+  echo "Error: could not detect MARKETING_VERSION from $PBXPROJ" >&2
+  exit 1
+fi
+
+if ! [[ "$current_build" =~ ^[0-9]+$ ]]; then
+  echo "Error: could not detect a numeric CURRENT_PROJECT_VERSION from $PBXPROJ (got '$current_build')" >&2
+  exit 1
+fi
 
 # Calculate new version
 IFS='.' read -r major minor patch <<< "$current_version"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -60,7 +60,7 @@ PBXPROJ="PlayolaRadio.xcodeproj/project.pbxproj"
 
 # Get current version info
 current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
-current_build=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+current_build=$(grep 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ' | sort -n | tail -1)
 
 if [ -z "$current_version" ]; then
   echo "Error: could not detect MARKETING_VERSION from $PBXPROJ" >&2


### PR DESCRIPTION
## Summary

`scripts/bump-build.sh` was silently producing broken hotfix branch names and PR titles (e.g. `hotfix/-b84`, `Hotfix:  build 84` — note the missing version and double space, hit on #270).

The root cause: `agvtool what-marketing-version` reads `CFBundleShortVersionString` from `Info.plist`, but in this project both `PlayolaRadio/Info.plist` and `PlayolaRadio/Info-Staging.plist` have an empty `CFBundleShortVersionString`. The real marketing version lives in `MARKETING_VERSION` inside `PlayolaRadio.xcodeproj/project.pbxproj`. agvtool returned empty, the script kept going, and the branch/PR title came out malformed.

## Changes

- `scripts/bump-build.sh`: read `MARKETING_VERSION` and `CURRENT_PROJECT_VERSION` directly from `project.pbxproj` instead of using agvtool. Hard-fail when either value is missing or the build number is non-numeric.
- `scripts/release.sh`: same treatment for symmetry. The marketing version was already read from pbxproj here, but build number used the same fragile agvtool path. Both now fail loudly on bad input.

## Test plan

- [x] Ran the version-detection portion in isolation — produces `version=6.1.0`, `build=83`, `new_build=84`, `hotfix_branch=hotfix/6.1.0-b84`, PR title `Hotfix: 6.1.0 build 84`.
- [x] `bash -n` syntax check passes on both scripts.
- [ ] Next time we cut a hotfix or release, confirm the branch name and PR title come through correctly.