### PR TITLE
Apply Point-Free observable model patterns to view models

### DIFF
--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
@@ -49,6 +49,8 @@ class AskQuestionPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.audioPlayer) var audioPlayer
   @ObservationIgnored @Dependency(\.audioConverter) var audioConverter
   @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.continuousClock) var clock
+  @ObservationIgnored @Dependency(\.date.now) var now
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
@@ -166,32 +168,26 @@ class AskQuestionPageModel: ViewModel {
 
   // MARK: - Playback Actions
 
-  func playPauseTapped() {
-    Task {
-      if isPlaying {
-        await audioPlayer.pause()
-        stopPlaybackUpdates()
-        isPlaying = false
-      } else {
-        await audioPlayer.play()
-        startPlaybackUpdates()
-        isPlaying = true
-      }
+  func playPauseTapped() async {
+    if isPlaying {
+      await audioPlayer.pause()
+      stopPlaybackUpdates()
+      isPlaying = false
+    } else {
+      await audioPlayer.play()
+      startPlaybackUpdates()
+      isPlaying = true
     }
   }
 
-  func rewindTapped() {
-    Task {
-      await audioPlayer.seek(0)
-      playbackPosition = 0
-    }
+  func rewindTapped() async {
+    await audioPlayer.seek(0)
+    playbackPosition = 0
   }
 
-  func seekTo(_ time: TimeInterval) {
-    Task {
-      await audioPlayer.seek(time)
-      playbackPosition = time
-    }
+  func seekTo(_ time: TimeInterval) async {
+    await audioPlayer.seek(time)
+    playbackPosition = time
   }
 
   private func startPlaybackUpdates() {
@@ -216,13 +212,11 @@ class AskQuestionPageModel: ViewModel {
 
   // MARK: - Review Actions
 
-  func reRecordTapped() {
+  func reRecordTapped() async {
     stopPlaybackUpdates()
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     recordingURL = nil
     recordingDuration = 0
@@ -232,23 +226,21 @@ class AskQuestionPageModel: ViewModel {
     recordingPhase = .idle
   }
 
-  func cancelTapped() {
+  func cancelTapped() async {
     if recordingPhase == .review {
       presentedAlert = .discardRecordingConfirmation { [weak self] in
-        self?.confirmCancel()
+        Task { await self?.confirmCancel() }
       }
     } else {
-      confirmCancel()
+      await confirmCancel()
     }
   }
 
-  func confirmCancel() {
+  func confirmCancel() async {
     stopPlaybackUpdates()
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     resumeStationIfNeeded()
     mainContainerNavigationCoordinator.pop()
@@ -310,16 +302,16 @@ class AskQuestionPageModel: ViewModel {
   }
 
   private func waitForNormalization(jwt: String, s3Key: String) async throws {
-    let maxWaitTimeSeconds = 120
-    let pollIntervalSeconds: UInt64 = 2
-    let startTime = Date()
+    let maxWaitTime: TimeInterval = 120
+    let pollInterval: Duration = .seconds(2)
+    let startTime = now
 
-    while Date().timeIntervalSince(startTime) < Double(maxWaitTimeSeconds) {
+    while now.timeIntervalSince(startTime) < maxWaitTime {
       let status = try await api.getVoicetrackStatus(jwt, station.id, s3Key)
       if status.ready {
         return
       }
-      try await Task.sleep(nanoseconds: pollIntervalSeconds * 1_000_000_000)
+      try await clock.sleep(for: pollInterval)
     }
 
     throw AskQuestionError.normalizationTimeout

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
@@ -108,7 +108,7 @@ final class AskQuestionPageTests: XCTestCase {
 
   // MARK: - Re-record
 
-  func testReRecordTappedResetsToIdleState() {
+  func testReRecordTappedResetsToIdleState() async {
     let model = AskQuestionPageModel(station: .mock)
     model.recordingPhase = .review
     model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -116,7 +116,7 @@ final class AskQuestionPageTests: XCTestCase {
     model.playbackPosition = 5.0
     model.isPlaying = true
 
-    model.reRecordTapped()
+    await model.reRecordTapped()
 
     XCTAssertEqual(model.recordingPhase, .idle)
     XCTAssertNil(model.recordingURL)
@@ -127,35 +127,35 @@ final class AskQuestionPageTests: XCTestCase {
 
   // MARK: - Cancel
 
-  func testCancelTappedShowsConfirmationWhenInReview() {
+  func testCancelTappedShowsConfirmationWhenInReview() async {
     let model = AskQuestionPageModel(station: .mock)
     model.recordingPhase = .review
 
     XCTAssertNil(model.presentedAlert)
 
-    model.cancelTapped()
+    await model.cancelTapped()
 
     XCTAssertNotNil(model.presentedAlert)
     XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
   }
 
-  func testCancelTappedPopsNavigationWhenIdle() {
+  func testCancelTappedPopsNavigationWhenIdle() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
     let model = AskQuestionPageModel(station: .mock)
     coordinator.path = [.askQuestionPage(model)]
     model.recordingPhase = .idle
 
-    model.cancelTapped()
+    await model.cancelTapped()
 
     XCTAssertTrue(coordinator.path.isEmpty)
   }
 
-  func testConfirmCancelPopsNavigation() {
+  func testConfirmCancelPopsNavigation() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
     let model = AskQuestionPageModel(station: .mock)
     coordinator.path = [.askQuestionPage(model)]
 
-    model.confirmCancel()
+    await model.confirmCancel()
 
     XCTAssertTrue(coordinator.path.isEmpty)
   }
@@ -173,8 +173,7 @@ final class AskQuestionPageTests: XCTestCase {
       let model = AskQuestionPageModel(station: .mock)
       model.isPlaying = false
 
-      model.playPauseTapped()
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.playPauseTapped()
 
       XCTAssertTrue(playCalled.value)
       XCTAssertTrue(model.isPlaying)
@@ -190,8 +189,7 @@ final class AskQuestionPageTests: XCTestCase {
       let model = AskQuestionPageModel(station: .mock)
       model.isPlaying = true
 
-      model.playPauseTapped()
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.playPauseTapped()
 
       XCTAssertTrue(pauseCalled.value)
       XCTAssertFalse(model.isPlaying)
@@ -207,8 +205,7 @@ final class AskQuestionPageTests: XCTestCase {
       let model = AskQuestionPageModel(station: .mock)
       model.playbackPosition = 30.0
 
-      model.rewindTapped()
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.rewindTapped()
 
       XCTAssertEqual(seekTime.value, 0)
       XCTAssertEqual(model.playbackPosition, 0)
@@ -278,7 +275,7 @@ final class AskQuestionPageTests: XCTestCase {
       await model.viewAppeared()
       stationPlayerMock.callsToPlay = []
 
-      model.confirmCancel()
+      await model.confirmCancel()
 
       XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
       XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, playingStation.id)
@@ -298,7 +295,7 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      model.confirmCancel()
+      await model.confirmCancel()
 
       XCTAssertEqual(stationPlayerMock.callsToPlay.count, 0)
     }

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageView.swift
@@ -47,7 +47,7 @@ struct AskQuestionPageView: View {
       if !model.isUploading {
         ToolbarItem(placement: .navigationBarLeading) {
           Button("Cancel") {
-            model.cancelTapped()
+            Task { await model.cancelTapped() }
           }
           .foregroundColor(.white)
         }
@@ -162,7 +162,7 @@ struct AskQuestionPageView: View {
       }
     case .review:
       Button {
-        model.reRecordTapped()
+        Task { await model.reRecordTapped() }
       } label: {
         ZStack {
           Circle()
@@ -205,9 +205,9 @@ struct AskQuestionPageView: View {
         currentTime: model.playbackPosition,
         totalTime: model.recordingDuration,
         isPlaying: model.isPlaying,
-        onPlayPause: { model.playPauseTapped() },
-        onRewind: { model.rewindTapped() },
-        onSeek: { model.seekTo($0) }
+        onPlayPause: { Task { await model.playPauseTapped() } },
+        onRewind: { Task { await model.rewindTapped() } },
+        onSeek: { time in Task { await model.seekTo(time) } }
       )
       .disabled(model.isUploading)
       .opacity(model.isUploading ? 0.5 : 1)

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageModel.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageModel.swift
@@ -90,24 +90,10 @@ class BroadcastPageModel: ViewModel {
     self.stationId = stationId
     self.providedStationName = stationName
     super.init()
-
-    scheduleUpdateCancellable = NotificationCenter.default.publisher(
-      for: .scheduleUpdated
-    )
-    .compactMap { notification -> String? in
-      guard let id = notification.userInfo?["stationId"] as? String,
-        id == stationId
-      else { return nil }
-      return notification.userInfo?["editorName"] as? String
-    }
-    .sink { [weak self] editorName in
-      Task { [weak self] in
-        await self?.refreshScheduleFromRemote(editorName: editorName)
-      }
-    }
   }
 
   func viewAppeared() async {
+    startObservingScheduleUpdates()
     await analytics.track(
       .viewedBroadcastScreen(
         stationId: stationId,
@@ -117,6 +103,25 @@ class BroadcastPageModel: ViewModel {
     await withTaskGroup(of: Void.self) { group in
       group.addTask { await self.loadSchedule() }
       group.addTask { await self.loadStation() }
+    }
+  }
+
+  private func startObservingScheduleUpdates() {
+    guard scheduleUpdateCancellable == nil else { return }
+    let observedStationId = stationId
+    scheduleUpdateCancellable = NotificationCenter.default.publisher(
+      for: .scheduleUpdated
+    )
+    .compactMap { notification -> String? in
+      guard let id = notification.userInfo?["stationId"] as? String,
+        id == observedStationId
+      else { return nil }
+      return notification.userInfo?["editorName"] as? String
+    }
+    .sink { [weak self] editorName in
+      Task { [weak self] in
+        await self?.refreshScheduleFromRemote(editorName: editorName)
+      }
     }
   }
 
@@ -288,40 +293,36 @@ class BroadcastPageModel: ViewModel {
     stagingItems[index] = voicetrack
   }
 
-  func onAddSongTapped() {
-    Task {
-      await analytics.track(
-        .broadcastSongSearchTapped(
-          stationId: stationId,
-          stationName: navigationTitle,
-          userName: userName
-        ))
-    }
+  func onAddSongTapped() async {
+    await analytics.track(
+      .broadcastSongSearchTapped(
+        stationId: stationId,
+        stationName: navigationTitle,
+        userName: userName
+      ))
     let model = SongSearchPageModel(searchMode: .all)
     model.onDismiss = { [weak self] in
       self?.mainContainerNavigationCoordinator.presentedSheet = nil
     }
     model.onSongSelected = { [weak self] audioBlock in
-      self?.addSongToStaging(audioBlock)
+      Task { await self?.addSongToStaging(audioBlock) }
       self?.mainContainerNavigationCoordinator.presentedSheet = nil
     }
     songSearchPageModel = model
     mainContainerNavigationCoordinator.presentedSheet = .songSearchPage(model)
   }
 
-  func addSongToStaging(_ audioBlock: AudioBlock) {
+  func addSongToStaging(_ audioBlock: AudioBlock) async {
     guard !stagingItems.contains(where: { $0.stagingId == audioBlock.id }) else { return }
     stagingItems.append(audioBlock)
-    Task {
-      await analytics.track(
-        .broadcastSongAdded(
-          stationId: stationId,
-          stationName: navigationTitle,
-          userName: userName,
-          songTitle: audioBlock.title,
-          artistName: audioBlock.artist
-        ))
-    }
+    await analytics.track(
+      .broadcastSongAdded(
+        stationId: stationId,
+        stationName: navigationTitle,
+        userName: userName,
+        songTitle: audioBlock.title,
+        artistName: audioBlock.artist
+      ))
   }
 
   func onNotifyListenersTapped() {

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -442,22 +442,24 @@ final class BroadcastPageTests: XCTestCase {
   }
 
   func testOnAddSongTappedSongSelectedCallbackAddsSongToStaging() async {
-    @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator)
+      var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
-    let model = BroadcastPageModel(stationId: "test-station")
-    XCTAssertTrue(model.stagingItems.isEmpty)
+      let model = BroadcastPageModel(stationId: "test-station")
+      XCTAssertTrue(model.stagingItems.isEmpty)
 
-    await model.onAddSongTapped()
+      await model.onAddSongTapped()
 
-    let testSong = AudioBlock.mockWith(
-      id: "test-song-123", title: "Test Song", artist: "Test Artist")
-    model.songSearchPageModel?.onSongSelected?(testSong)
-    await Task.yield()
+      let testSong = AudioBlock.mockWith(
+        id: "test-song-123", title: "Test Song", artist: "Test Artist")
+      model.songSearchPageModel?.onSongSelected?(testSong)
+      await Task.yield()
 
-    XCTAssertEqual(model.stagingItems.count, 1)
-    XCTAssertEqual(model.stagingItems.first?.stagingId, "test-song-123")
-    XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
+      XCTAssertEqual(model.stagingItems.count, 1)
+      XCTAssertEqual(model.stagingItems.first?.stagingId, "test-song-123")
+      XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
+    }
   }
 
   func testOnAddSongTappedSongSelectedCallbackDismissesSheet() async {

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -412,7 +412,7 @@ final class BroadcastPageTests: XCTestCase {
     }
   }
 
-  func testOnAddSongTapped_PresentsSongSearchPageSheet() {
+  func testOnAddSongTapped_PresentsSongSearchPageSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
@@ -421,51 +421,51 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
     XCTAssertNil(model.songSearchPageModel)
 
-    model.onAddSongTapped()
+    await model.onAddSongTapped()
 
     XCTAssertNotNil(model.songSearchPageModel)
     if case .songSearchPage = mainContainerNavigationCoordinator.presentedSheet {
-      // Success - presented song search page sheet
     } else {
       XCTFail("Expected songSearchPage sheet presentation")
     }
   }
 
-  func testOnAddSongTappedUsesAllSearchMode() {
+  func testOnAddSongTappedUsesAllSearchMode() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     let model = BroadcastPageModel(stationId: "test-station")
 
-    model.onAddSongTapped()
+    await model.onAddSongTapped()
 
     XCTAssertEqual(model.songSearchPageModel?.searchMode, .all)
   }
 
-  func testOnAddSongTapped_SongSelectedCallbackAddsSongToStaging() {
+  func testOnAddSongTapped_SongSelectedCallbackAddsSongToStaging() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     let model = BroadcastPageModel(stationId: "test-station")
     XCTAssertTrue(model.stagingItems.isEmpty)
 
-    model.onAddSongTapped()
+    await model.onAddSongTapped()
 
     let testSong = AudioBlock.mockWith(
       id: "test-song-123", title: "Test Song", artist: "Test Artist")
     model.songSearchPageModel?.onSongSelected?(testSong)
+    await Task.yield()
 
     XCTAssertEqual(model.stagingItems.count, 1)
     XCTAssertEqual(model.stagingItems.first?.stagingId, "test-song-123")
     XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
   }
 
-  func testOnAddSongTapped_SongSelectedCallbackDismissesSheet() {
+  func testOnAddSongTapped_SongSelectedCallbackDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     let model = BroadcastPageModel(stationId: "test-station")
-    model.onAddSongTapped()
+    await model.onAddSongTapped()
 
     XCTAssertNotNil(mainContainerNavigationCoordinator.presentedSheet)
 
@@ -475,23 +475,23 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
   }
 
-  func testAddSongToStaging_DoesNotAddDuplicates() {
+  func testAddSongToStaging_DoesNotAddDuplicates() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let testSong = AudioBlock.mockWith(id: "test-song-123")
 
-    model.addSongToStaging(testSong)
-    model.addSongToStaging(testSong)
+    await model.addSongToStaging(testSong)
+    await model.addSongToStaging(testSong)
 
     XCTAssertEqual(model.stagingItems.count, 1)
   }
 
-  func testAddSongToStaging_AddsMultipleDifferentSongs() {
+  func testAddSongToStaging_AddsMultipleDifferentSongs() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let song1 = AudioBlock.mockWith(id: "song-1", title: "First Song")
     let song2 = AudioBlock.mockWith(id: "song-2", title: "Second Song")
 
-    model.addSongToStaging(song1)
-    model.addSongToStaging(song2)
+    await model.addSongToStaging(song1)
+    await model.addSongToStaging(song2)
 
     XCTAssertEqual(model.stagingItems.count, 2)
     XCTAssertEqual(model.stagingItems[0].stagingId, "song-1")
@@ -1638,7 +1638,7 @@ extension BroadcastPageTests {
         }
       } operation: {
         let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
-        model.onAddSongTapped()
+        await model.onAddSongTapped()
 
         await fulfillment(of: [searchTappedExpectation], timeout: 1.0)
 
@@ -1685,7 +1685,7 @@ extension BroadcastPageTests {
           title: "Test Song",
           artist: "Test Artist"
         )
-        model.addSongToStaging(audioBlock)
+        await model.addSongToStaging(audioBlock)
 
         await fulfillment(of: [songAddedExpectation], timeout: 1.0)
 

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -412,7 +412,7 @@ final class BroadcastPageTests: XCTestCase {
     }
   }
 
-  func testOnAddSongTapped_PresentsSongSearchPageSheet() async {
+  func testOnAddSongTappedPresentsSongSearchPageSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
@@ -441,7 +441,7 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertEqual(model.songSearchPageModel?.searchMode, .all)
   }
 
-  func testOnAddSongTapped_SongSelectedCallbackAddsSongToStaging() async {
+  func testOnAddSongTappedSongSelectedCallbackAddsSongToStaging() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
@@ -460,7 +460,7 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
   }
 
-  func testOnAddSongTapped_SongSelectedCallbackDismissesSheet() async {
+  func testOnAddSongTappedSongSelectedCallbackDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
@@ -475,7 +475,7 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
   }
 
-  func testAddSongToStaging_DoesNotAddDuplicates() async {
+  func testAddSongToStagingDoesNotAddDuplicates() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let testSong = AudioBlock.mockWith(id: "test-song-123")
 
@@ -485,7 +485,7 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertEqual(model.stagingItems.count, 1)
   }
 
-  func testAddSongToStaging_AddsMultipleDifferentSongs() async {
+  func testAddSongToStagingAddsMultipleDifferentSongs() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let song1 = AudioBlock.mockWith(id: "song-1", title: "First Song")
     let song2 = AudioBlock.mockWith(id: "song-2", title: "Second Song")

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
@@ -33,7 +33,7 @@ struct BroadcastPageView: View {
           BroadcastActionButton(
             icon: .asset("BroadcastAddSongIcon", width: 40, height: 40),
             label: "Add Song",
-            action: model.onAddSongTapped
+            action: { Task { await model.onAddSongTapped() } }
           )
 
           BroadcastActionButton(

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
@@ -100,7 +100,7 @@ struct LikedSongsPage: View {
     // Remove from data after animation completes
     Task { @MainActor in
       try? await Task.sleep(nanoseconds: 300_000_000)  // 0.3 seconds
-      model.removeSong(audioBlock)
+      model.removeSongTapped(audioBlock)
       removingAudioBlockIds.remove(audioBlock.id)
     }
   }

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageModel.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageModel.swift
@@ -11,6 +11,7 @@ class LikedSongsPageModel: ViewModel {
   // MARK: - Dependencies
 
   @ObservationIgnored @Dependency(\.likesManager) var likesManager: LikesManager
+  @ObservationIgnored @Dependency(\.date.now) var now
 
   // MARK: - Properties
 
@@ -50,7 +51,7 @@ class LikedSongsPageModel: ViewModel {
     presentedSongActionSheet = SongActionSheet(audioBlock: audioBlock, likedDate: likedDate)
   }
 
-  func removeSong(_ audioBlock: AudioBlock) {
+  func removeSongTapped(_ audioBlock: AudioBlock) {
     likesManager.unlike(audioBlock)
   }
 
@@ -66,7 +67,6 @@ class LikedSongsPageModel: ViewModel {
 
   private func formatSectionTitle(for date: Date) -> String {
     let calendar = Calendar.current
-    let now = Date()
 
     if calendar.isDate(date, equalTo: now, toGranularity: .weekOfYear) {
       return "Last Week"
@@ -79,7 +79,7 @@ class LikedSongsPageModel: ViewModel {
 
   private func parseSectionTitle(_ title: String) -> Date {
     if title == "Last Week" {
-      return Date()
+      return now
     } else {
       let formatter = DateFormatter()
       formatter.dateFormat = "MMMM yyyy"

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
@@ -31,6 +31,7 @@ final class LikedSongsPageTests: XCTestCase {
     let audioBlock2 = AudioBlock.mockWith(id: "different-id")
 
     withDependencies {
+      $0.date.now = Date()
       let likesManager = LikesManager()
       likesManager.like(audioBlock1)
       likesManager.like(audioBlock2)
@@ -61,6 +62,7 @@ final class LikedSongsPageTests: XCTestCase {
     let audioBlock = AudioBlock.mock
 
     withDependencies {
+      $0.date.now = Date()
       let likesManager = LikesManager()
       likesManager.like(audioBlock)
       $0.likesManager = likesManager

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
@@ -71,7 +71,7 @@ final class LikedSongsPageTests: XCTestCase {
       XCTAssertFalse(model.groupedLikedSongs.isEmpty)
 
       // Remove the song
-      model.removeSong(audioBlock)
+      model.removeSongTapped(audioBlock)
 
       // Verify song is no longer liked
       XCTAssertTrue(model.groupedLikedSongs.isEmpty)

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageModel.swift
@@ -56,6 +56,7 @@ class ListenerQuestionDetailPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.audioRecorder) var audioRecorder
   @ObservationIgnored @Dependency(\.voicetrackUploadService) var voicetrackUploadService
   @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.date.now) var now
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
@@ -101,7 +102,7 @@ class ListenerQuestionDetailPageModel: ViewModel {
   var timeAgoText: String {
     let formatter = RelativeDateTimeFormatter()
     formatter.unitsStyle = .full
-    return formatter.localizedString(for: question.createdAt, relativeTo: Date())
+    return formatter.localizedString(for: question.createdAt, relativeTo: now)
   }
 
   // MARK: - Question Playback Display

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -57,6 +57,8 @@ class MainContainerModel: ViewModel {
   var contactPageModel = ContactPageModel()
   var liveStationsPoller = LiveStationsPoller()
 
+  @ObservationIgnored private var toastObservationTask: Task<Void, Never>?
+
   // Broadcast mode models
   var broadcastPageModel: BroadcastPageModel?
   var libraryPageModel: LibraryPageModel?
@@ -323,14 +325,12 @@ class MainContainerModel: ViewModel {
   }
 
   func observeToasts() {
-    Task { @MainActor in
-      while true {
-        if let currentToast = await toast.currentToast() {
-          self.presentedToast = currentToast
-        } else {
-          self.presentedToast = nil
-        }
-        try? await Task.sleep(for: .milliseconds(100))
+    toastObservationTask?.cancel()
+    toastObservationTask = Task { [weak self] in
+      guard let stream = self?.toast.stream() else { return }
+      for await toast in stream {
+        guard !Task.isCancelled else { return }
+        self?.presentedToast = toast
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageModel.swift
@@ -16,6 +16,7 @@ class RecordIntroPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.audioRecorder) var audioRecorder
   @ObservationIgnored @Dependency(\.audioPlayer) var audioPlayer
   @ObservationIgnored @Dependency(\.introUploadService) var introUploadService
+  @ObservationIgnored @Dependency(\.continuousClock) var clock
 
   // MARK: - Shared State
 
@@ -171,41 +172,33 @@ class RecordIntroPageModel: ViewModel {
     }
   }
 
-  func onPlayPauseTapped() {
-    Task {
-      if isPlaying {
-        await audioPlayer.pause()
-        stopPlaybackUpdates()
-        isPlaying = false
-      } else {
-        await audioPlayer.play()
-        startPlaybackUpdates()
-        isPlaying = true
-      }
+  func onPlayPauseTapped() async {
+    if isPlaying {
+      await audioPlayer.pause()
+      stopPlaybackUpdates()
+      isPlaying = false
+    } else {
+      await audioPlayer.play()
+      startPlaybackUpdates()
+      isPlaying = true
     }
   }
 
-  func onRewindTapped() {
-    Task {
-      await audioPlayer.seek(0)
-      playbackPosition = 0
-    }
+  func onRewindTapped() async {
+    await audioPlayer.seek(0)
+    playbackPosition = 0
   }
 
-  func seekTo(_ time: TimeInterval) {
-    Task {
-      await audioPlayer.seek(time)
-      playbackPosition = time
-    }
+  func seekTo(_ time: TimeInterval) async {
+    await audioPlayer.seek(time)
+    playbackPosition = time
   }
 
-  func onReRecordTapped() {
+  func onReRecordTapped() async {
     stopPlaybackUpdates()
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     recordingURL = nil
     recordingDuration = 0
@@ -218,31 +211,29 @@ class RecordIntroPageModel: ViewModel {
   func onDiscardTapped() {
     stopPlaybackUpdates()
     presentedAlert = .discardRecordingConfirmation { [weak self] in
-      self?.confirmDiscard()
+      Task { await self?.confirmDiscard() }
     }
   }
 
-  func confirmDiscard() {
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+  func confirmDiscard() async {
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     mainContainerNavigationCoordinator.presentedSheet = nil
   }
 
-  func onAcceptRecordingTapped() {
+  func onAcceptRecordingTapped() async {
     guard recordingURL != nil else { return }
     stopPlaybackUpdates()
-    Task { await audioPlayer.stop() }
+    await audioPlayer.stop()
     isPlaying = false
-    startUpload()
+    await startUpload()
   }
 
-  func onRetryTapped() {
+  func onRetryTapped() async {
     uploadStatus = nil
-    startUpload()
+    await startUpload()
   }
 
   func onDoneTapped() {
@@ -251,30 +242,27 @@ class RecordIntroPageModel: ViewModel {
 
   // MARK: - Private Helpers
 
-  private func startUpload() {
+  private func startUpload() async {
     guard let url = recordingURL, let jwt = auth.jwt else { return }
     uploadStatus = .converting
-    Task {
-      do {
-        try await introUploadService.uploadIntro(
-          jwt,
-          url,
-          stationId,
-          songTitle,
-          audioBlockId
-        ) { [weak self] status in
-          self?.uploadStatus = status
-        }
-        uploadStatus = .completed
-        onUploadCompleted?()
-        try? await Task.sleep(for: .seconds(1))
-        mainContainerNavigationCoordinator.presentedSheet = nil
-      } catch {
-        if case .failed = uploadStatus {
-          // Status already set by the callback
-        } else {
-          uploadStatus = .failed(error.localizedDescription)
-        }
+    do {
+      try await introUploadService.uploadIntro(
+        jwt,
+        url,
+        stationId,
+        songTitle,
+        audioBlockId
+      ) { [weak self] status in
+        self?.uploadStatus = status
+      }
+      uploadStatus = .completed
+      onUploadCompleted?()
+      try? await clock.sleep(for: .seconds(1))
+      mainContainerNavigationCoordinator.presentedSheet = nil
+    } catch {
+      if case .failed = uploadStatus {
+      } else {
+        uploadStatus = .failed(error.localizedDescription)
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
@@ -170,7 +170,7 @@ final class RecordIntroPageTests: XCTestCase {
 
   // MARK: - Re-record
 
-  func testOnReRecordTappedResetsToIdleState() {
+  func testOnReRecordTappedResetsToIdleState() async {
     let model = makeModel()
     model.recordingPhase = .review
     model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -178,7 +178,7 @@ final class RecordIntroPageTests: XCTestCase {
     model.playbackPosition = 5.0
     model.isPlaying = true
 
-    model.onReRecordTapped()
+    await model.onReRecordTapped()
 
     XCTAssertEqual(model.recordingPhase, .idle)
     XCTAssertNil(model.recordingURL)
@@ -201,13 +201,13 @@ final class RecordIntroPageTests: XCTestCase {
     XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
   }
 
-  func testConfirmDiscardDismissesSheet() {
+  func testConfirmDiscardDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let model = makeModel()
     coordinator.presentedSheet = .recordIntroPage(model)
 
-    model.confirmDiscard()
+    await model.confirmDiscard()
 
     XCTAssertNil(coordinator.presentedSheet)
   }
@@ -221,6 +221,7 @@ final class RecordIntroPageTests: XCTestCase {
     await withMainSerialExecutor {
       await withDependencies {
         $0.audioPlayer.stop = {}
+        $0.continuousClock = ImmediateClock()
         $0.introUploadService.uploadIntro = { _, _, _, _, _, onStatus in
           uploadCalled.setValue(true)
           await onStatus(.completed)
@@ -230,8 +231,7 @@ final class RecordIntroPageTests: XCTestCase {
         model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
         model.recordingPhase = .review
 
-        model.onAcceptRecordingTapped()
-        await Task.yield()
+        await model.onAcceptRecordingTapped()
 
         XCTAssertNotNil(model.uploadStatus)
         XCTAssertTrue(uploadCalled.value)
@@ -239,11 +239,11 @@ final class RecordIntroPageTests: XCTestCase {
     }
   }
 
-  func testOnAcceptRecordingTappedDoesNothingWithoutURL() {
+  func testOnAcceptRecordingTappedDoesNothingWithoutURL() async {
     let model = makeModel()
     model.recordingURL = nil
 
-    model.onAcceptRecordingTapped()
+    await model.onAcceptRecordingTapped()
 
     XCTAssertNil(model.uploadStatus)
   }
@@ -290,6 +290,7 @@ final class RecordIntroPageTests: XCTestCase {
     await withMainSerialExecutor {
       await withDependencies {
         $0.audioPlayer.stop = {}
+        $0.continuousClock = ImmediateClock()
         $0.introUploadService.uploadIntro = { _, _, _, _, _, onStatus in
           uploadCallCount.withValue { $0 += 1 }
           await onStatus(.completed)
@@ -299,8 +300,7 @@ final class RecordIntroPageTests: XCTestCase {
         model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
         model.uploadStatus = .failed("First attempt failed")
 
-        model.onRetryTapped()
-        await Task.yield()
+        await model.onRetryTapped()
 
         XCTAssertEqual(uploadCallCount.value, 1)
       }
@@ -314,6 +314,7 @@ final class RecordIntroPageTests: XCTestCase {
     await withMainSerialExecutor {
       await withDependencies {
         $0.audioPlayer.stop = {}
+        $0.continuousClock = ImmediateClock()
         $0.introUploadService.uploadIntro = { _, _, _, _, _, onStatus in
           await onStatus(.completed)
         }
@@ -324,8 +325,7 @@ final class RecordIntroPageTests: XCTestCase {
           completedCalled.setValue(true)
         }
 
-        model.onAcceptRecordingTapped()
-        await Task.yield()
+        await model.onAcceptRecordingTapped()
 
         XCTAssertTrue(completedCalled.value)
         XCTAssertEqual(model.uploadStatus, .completed)

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
@@ -225,7 +225,7 @@ struct RecordIntroPageView: View {
       }
     case .review:
       Button {
-        model.onReRecordTapped()
+        Task { await model.onReRecordTapped() }
       } label: {
         ZStack {
           Circle()
@@ -283,9 +283,9 @@ struct RecordIntroPageView: View {
         currentTime: model.playbackPosition,
         totalTime: model.recordingDuration,
         isPlaying: model.isPlaying,
-        onPlayPause: { model.onPlayPauseTapped() },
-        onRewind: { model.onRewindTapped() },
-        onSeek: { model.seekTo($0) }
+        onPlayPause: { Task { await model.onPlayPauseTapped() } },
+        onRewind: { Task { await model.onRewindTapped() } },
+        onSeek: { time in Task { await model.seekTo(time) } }
       )
 
       HStack(spacing: 12) {
@@ -307,7 +307,7 @@ struct RecordIntroPageView: View {
         }
 
         Button {
-          model.onAcceptRecordingTapped()
+          Task { await model.onAcceptRecordingTapped() }
         } label: {
           HStack(spacing: 6) {
             Image(systemName: "checkmark")
@@ -351,7 +351,7 @@ struct RecordIntroPageView: View {
       if model.shouldShowRetryButton {
         HStack(spacing: 12) {
           Button {
-            model.confirmDiscard()
+            Task { await model.confirmDiscard() }
           } label: {
             HStack(spacing: 6) {
               Image(systemName: "trash")
@@ -368,7 +368,7 @@ struct RecordIntroPageView: View {
           }
 
           Button {
-            model.onRetryTapped()
+            Task { await model.onRetryTapped() }
           } label: {
             HStack(spacing: 6) {
               Image(systemName: "arrow.clockwise")

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
@@ -116,32 +116,26 @@ class RecordPageModel: ViewModel {
 
   // MARK: - Playback Actions
 
-  func onPlayPauseTapped() {
-    Task {
-      if isPlaying {
-        await audioPlayer.pause()
-        stopPlaybackUpdates()
-        isPlaying = false
-      } else {
-        await audioPlayer.play()
-        startPlaybackUpdates()
-        isPlaying = true
-      }
+  func onPlayPauseTapped() async {
+    if isPlaying {
+      await audioPlayer.pause()
+      stopPlaybackUpdates()
+      isPlaying = false
+    } else {
+      await audioPlayer.play()
+      startPlaybackUpdates()
+      isPlaying = true
     }
   }
 
-  func onRewindTapped() {
-    Task {
-      await audioPlayer.seek(0)
-      playbackPosition = 0
-    }
+  func onRewindTapped() async {
+    await audioPlayer.seek(0)
+    playbackPosition = 0
   }
 
-  func seekTo(_ time: TimeInterval) {
-    Task {
-      await audioPlayer.seek(time)
-      playbackPosition = time
-    }
+  func seekTo(_ time: TimeInterval) async {
+    await audioPlayer.seek(time)
+    playbackPosition = time
   }
 
   private func startPlaybackUpdates() {
@@ -166,13 +160,11 @@ class RecordPageModel: ViewModel {
 
   // MARK: - Review Actions
 
-  func onReRecordTapped() {
+  func onReRecordTapped() async {
     stopPlaybackUpdates()
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     recordingURL = nil
     recordingDuration = 0
@@ -185,26 +177,22 @@ class RecordPageModel: ViewModel {
   func onDiscardTapped() {
     stopPlaybackUpdates()
     presentedAlert = .discardRecordingConfirmation { [weak self] in
-      self?.confirmDiscard()
+      Task { await self?.confirmDiscard() }
     }
   }
 
-  func confirmDiscard() {
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+  func confirmDiscard() async {
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     mainContainerNavigationCoordinator.presentedSheet = nil
   }
 
-  func onAcceptRecordingTapped() {
+  func onAcceptRecordingTapped() async {
     guard let url = recordingURL else { return }
     mainContainerNavigationCoordinator.presentedSheet = nil
-    Task {
-      await onRecordingAccepted?(url)
-    }
+    await onRecordingAccepted?(url)
   }
 
   func onDoneTapped() {

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
@@ -171,7 +171,7 @@ final class RecordPageTests: XCTestCase {
 
   // MARK: - Re-record
 
-  func testOnReRecordTapped_ResetsToIdleState() async {
+  func testOnReRecordTappedResetsToIdleState() async {
     let model = RecordPageModel()
     model.recordingPhase = .review
     model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -202,7 +202,7 @@ final class RecordPageTests: XCTestCase {
     XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
   }
 
-  func testConfirmDiscard_DismissesSheet() async {
+  func testConfirmDiscardDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let model = RecordPageModel()
@@ -215,7 +215,7 @@ final class RecordPageTests: XCTestCase {
 
   // MARK: - Accept Recording
 
-  func testOnAcceptRecordingTapped_CallsCallbackAndDismisses() async {
+  func testOnAcceptRecordingTappedCallsCallbackAndDismisses() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let expectedURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -234,7 +234,7 @@ final class RecordPageTests: XCTestCase {
     XCTAssertEqual(receivedURL.value, expectedURL)
   }
 
-  func testOnAcceptRecordingTapped_DoesNothingWithoutURL() async {
+  func testOnAcceptRecordingTappedDoesNothingWithoutURL() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let callbackCalled = LockIsolated(false)
@@ -254,7 +254,7 @@ final class RecordPageTests: XCTestCase {
 
   // MARK: - Playback
 
-  func testOnPlayPauseTapped_PlaysWhenNotPlaying() async {
+  func testOnPlayPauseTappedPlaysWhenNotPlaying() async {
     let playCalled = LockIsolated(false)
 
     await withDependencies {
@@ -272,7 +272,7 @@ final class RecordPageTests: XCTestCase {
     }
   }
 
-  func testOnPlayPauseTapped_PausesWhenPlaying() async {
+  func testOnPlayPauseTappedPausesWhenPlaying() async {
     let pauseCalled = LockIsolated(false)
 
     await withDependencies {
@@ -288,7 +288,7 @@ final class RecordPageTests: XCTestCase {
     }
   }
 
-  func testOnRewindTapped_SeeksToZero() async {
+  func testOnRewindTappedSeeksToZero() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
     await withDependencies {
@@ -304,7 +304,7 @@ final class RecordPageTests: XCTestCase {
     }
   }
 
-  func testSeekTo_UpdatesPlaybackPosition() async {
+  func testSeekToUpdatesPlaybackPosition() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
     await withDependencies {

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
@@ -171,7 +171,7 @@ final class RecordPageTests: XCTestCase {
 
   // MARK: - Re-record
 
-  func testOnReRecordTapped_ResetsToIdleState() {
+  func testOnReRecordTapped_ResetsToIdleState() async {
     let model = RecordPageModel()
     model.recordingPhase = .review
     model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -179,7 +179,7 @@ final class RecordPageTests: XCTestCase {
     model.playbackPosition = 5.0
     model.isPlaying = true
 
-    model.onReRecordTapped()
+    await model.onReRecordTapped()
 
     XCTAssertEqual(model.recordingPhase, .idle)
     XCTAssertNil(model.recordingURL)
@@ -202,13 +202,13 @@ final class RecordPageTests: XCTestCase {
     XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
   }
 
-  func testConfirmDiscard_DismissesSheet() {
+  func testConfirmDiscard_DismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let model = RecordPageModel()
     coordinator.presentedSheet = .recordPage(model)
 
-    model.confirmDiscard()
+    await model.confirmDiscard()
 
     XCTAssertNil(coordinator.presentedSheet)
   }
@@ -219,23 +219,18 @@ final class RecordPageTests: XCTestCase {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let expectedURL = URL(fileURLWithPath: "/tmp/test.wav")
-    let callbackExpectation = XCTestExpectation(description: "onRecordingAccepted called")
     let receivedURL = LockIsolated<URL?>(nil)
 
     let model = RecordPageModel()
     model.recordingURL = expectedURL
     model.onRecordingAccepted = { url in
       receivedURL.setValue(url)
-      callbackExpectation.fulfill()
     }
     coordinator.presentedSheet = .recordPage(model)
 
-    model.onAcceptRecordingTapped()
+    await model.onAcceptRecordingTapped()
 
-    // Sheet dismisses immediately
     XCTAssertNil(coordinator.presentedSheet)
-
-    await fulfillment(of: [callbackExpectation], timeout: 1.0)
     XCTAssertEqual(receivedURL.value, expectedURL)
   }
 
@@ -251,10 +246,7 @@ final class RecordPageTests: XCTestCase {
     }
     coordinator.presentedSheet = .recordPage(model)
 
-    model.onAcceptRecordingTapped()
-
-    // Allow any spawned Task to complete
-    await Task.yield()
+    await model.onAcceptRecordingTapped()
 
     XCTAssertFalse(callbackCalled.value)
     XCTAssertNotNil(coordinator.presentedSheet)
@@ -273,9 +265,7 @@ final class RecordPageTests: XCTestCase {
       let model = RecordPageModel()
       model.isPlaying = false
 
-      model.onPlayPauseTapped()
-      // Allow Task to execute
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.onPlayPauseTapped()
 
       XCTAssertTrue(playCalled.value)
       XCTAssertTrue(model.isPlaying)
@@ -291,9 +281,7 @@ final class RecordPageTests: XCTestCase {
       let model = RecordPageModel()
       model.isPlaying = true
 
-      model.onPlayPauseTapped()
-      // Allow Task to execute
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.onPlayPauseTapped()
 
       XCTAssertTrue(pauseCalled.value)
       XCTAssertFalse(model.isPlaying)
@@ -309,9 +297,7 @@ final class RecordPageTests: XCTestCase {
       let model = RecordPageModel()
       model.playbackPosition = 30.0
 
-      model.onRewindTapped()
-      // Allow Task to execute
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.onRewindTapped()
 
       XCTAssertEqual(seekTime.value, 0)
       XCTAssertEqual(model.playbackPosition, 0)
@@ -327,9 +313,7 @@ final class RecordPageTests: XCTestCase {
       let model = RecordPageModel()
       model.recordingDuration = 60.0
 
-      model.seekTo(30.0)
-      // Allow Task to execute
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.seekTo(30.0)
 
       XCTAssertEqual(seekTime.value, 30.0)
       XCTAssertEqual(model.playbackPosition, 30.0)

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
@@ -142,7 +142,7 @@ struct RecordPageView: View {
       }
     case .review:
       Button {
-        model.onReRecordTapped()
+        Task { await model.onReRecordTapped() }
       } label: {
         ZStack {
           Circle()
@@ -186,9 +186,9 @@ struct RecordPageView: View {
           currentTime: model.playbackPosition,
           totalTime: model.recordingDuration,
           isPlaying: model.isPlaying,
-          onPlayPause: { model.onPlayPauseTapped() },
-          onRewind: { model.onRewindTapped() },
-          onSeek: { model.seekTo($0) }
+          onPlayPause: { Task { await model.onPlayPauseTapped() } },
+          onRewind: { Task { await model.onRewindTapped() } },
+          onSeek: { time in Task { await model.seekTo(time) } }
         )
 
         HStack(spacing: 12) {
@@ -210,9 +210,7 @@ struct RecordPageView: View {
           }
 
           Button {
-            Task {
-              model.onAcceptRecordingTapped()
-            }
+            Task { await model.onAcceptRecordingTapped() }
           } label: {
             HStack(spacing: 6) {
               Image(systemName: "checkmark")

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
@@ -9,13 +9,14 @@ import PlayolaPlayer
 
 @MainActor
 @Observable
-class EpisodeRowModel {
+class EpisodeRowModel: ViewModel {
   @ObservationIgnored @Dependency(\.date.now) var now
 
   let airing: Airing
 
   init(airing: Airing) {
     self.airing = airing
+    super.init()
   }
 
   var isUpcoming: Bool {

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
@@ -228,7 +228,8 @@ struct SubscriptionBadge: View {
                   createdAt: Date().addingTimeInterval(-86400 * 7)
                 )
               ),
-            ]
+            ],
+            now: Date()
           ),
           subscriptionStatus: .autoSubscribed
         )
@@ -253,7 +254,8 @@ struct SubscriptionBadge: View {
                   createdAt: Date()
                 )
               )
-            ]
+            ],
+            now: Date()
           ),
           subscriptionStatus: .subscribed
         )
@@ -285,7 +287,8 @@ struct SubscriptionBadge: View {
                   createdAt: Date().addingTimeInterval(-86400 * 30)
                 )
               ),
-            ]
+            ],
+            now: Date()
           ),
           subscriptionStatus: .notSubscribed
         )

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
@@ -145,7 +145,8 @@ final class SeriesCardModelTests: XCTestCase {
     ShowWithAirings(
       show: .mockWith(title: "Test Show"),
       station: stationId != nil ? .mockWith(id: stationId!) : nil,
-      airings: [.mockWith()]
+      airings: [.mockWith()],
+      now: Date()
     )
   }
 

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageModel.swift
@@ -52,42 +52,43 @@ class SeriesListPageModel: ViewModel {
   }
 
   private func groupAiringsByShow(_ airings: [Airing]) -> [ShowWithAirings] {
-    var showDict: [String: ShowWithAirings] = [:]
+    let currentTime = now
 
-    // Filter to only include airings that haven't ended yet
     let upcomingAirings = airings.filter { airing in
       let durationMS = airing.episode?.durationMS ?? 0
       let endTime = airing.airtime.addingTimeInterval(TimeInterval(durationMS) / 1000.0)
-      return endTime > now
+      return endTime > currentTime
     }
+
+    var airingsByShowId: [String: [Airing]] = [:]
+    var showsById: [String: Show] = [:]
+    var stationsByShowId: [String: Station?] = [:]
 
     for airing in upcomingAirings {
       guard let episode = airing.episode,
         let show = episode.show
       else { continue }
 
-      if var existing = showDict[show.id] {
-        existing.airings.append(airing)
-        showDict[show.id] = existing
-      } else {
-        showDict[show.id] = ShowWithAirings(
-          show: show,
-          station: airing.station,
-          airings: [airing]
-        )
+      airingsByShowId[show.id, default: []].append(airing)
+      showsById[show.id] = show
+      if stationsByShowId[show.id] == nil {
+        stationsByShowId[show.id] = airing.station
       }
     }
 
-    // Sort airings within each show by airtime
-    for (id, var showWithAirings) in showDict {
-      showWithAirings.airings.sort { $0.airtime < $1.airtime }
-      showDict[id] = showWithAirings
+    let shows = airingsByShowId.compactMap { showId, airings -> ShowWithAirings? in
+      guard let show = showsById[showId] else { return nil }
+      return ShowWithAirings(
+        show: show,
+        station: stationsByShowId[showId] ?? nil,
+        airings: airings.sorted { $0.airtime < $1.airtime },
+        now: currentTime
+      )
     }
 
-    return showDict.values
-      .sorted {
-        $0.nextAiring?.airtime ?? .distantFuture < $1.nextAiring?.airtime ?? .distantFuture
-      }
+    return shows.sorted {
+      $0.nextAiring?.airtime ?? .distantFuture < $1.nextAiring?.airtime ?? .distantFuture
+    }
   }
 }
 
@@ -96,19 +97,19 @@ class SeriesListPageModel: ViewModel {
 struct ShowWithAirings: Identifiable {
   let show: Show
   let station: Station?
-  var airings: [Airing]
+  let airings: [Airing]
+  let nextAiring: Airing?
+  let upcomingAiringsCount: Int
 
   var id: String { show.id }
 
-  var nextAiring: Airing? {
-    airings
-      .filter { $0.airtime > Date() }
-      .sorted { $0.airtime < $1.airtime }
-      .first
-  }
-
-  var upcomingAiringsCount: Int {
-    airings.filter { $0.airtime > Date() }.count
+  init(show: Show, station: Station?, airings: [Airing], now: Date) {
+    self.show = show
+    self.station = station
+    self.airings = airings
+    let upcoming = airings.filter { $0.airtime > now }
+    self.nextAiring = upcoming.sorted { $0.airtime < $1.airtime }.first
+    self.upcomingAiringsCount = upcoming.count
   }
 }
 

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
@@ -19,6 +19,7 @@ final class SeriesListPageModelTests: XCTestCase {
     let passedJwt = LockIsolated<String?>(nil)
 
     await withDependencies {
+      $0.date.now = Date()
       $0.api.getAirings = { jwt, _ in
         apiCalled.setValue(true)
         passedJwt.setValue(jwt)

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -45,10 +45,9 @@ class SignInPageModel: ViewModel {
     Task { await analytics.track(.signInStarted(method: .apple)) }
   }
 
-  func signInWithAppleCompleted(result: Result<ASAuthorization, any Error>) {
+  func signInWithAppleCompleted(result: Result<ASAuthorization, any Error>) async {
     switch result {
     case .success(let authorization):
-
       guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
         let identityTokenData = appleIDCredential.identityToken,
         let identityToken = String(data: identityTokenData, encoding: .utf8),
@@ -57,36 +56,32 @@ class SignInPageModel: ViewModel {
       else {
         print("Error decoding signin info from apple")
         presentedAlert = .signInError
-        Task {
-          await errorReporting.reportMessage(
-            "Error decoding sign-in info from Apple",
-            ["auth_method": "apple", "sign_in_step": "credential_decode"])
-        }
+        await errorReporting.reportMessage(
+          "Error decoding sign-in info from Apple",
+          ["auth_method": "apple", "sign_in_step": "credential_decode"])
         return
       }
 
       let email = appleIDCredential.email
 
-      Task {
-        do {
-          let firstName = appleIDCredential.fullName?.givenName ?? ""
-          let lastName = appleIDCredential.fullName?.familyName
-          let token = try await api.signInViaApple(
-            identityToken,
-            email,  // Now optional - can be nil
-            authCode,
-            firstName,
-            lastName)
-          $auth.withLock { $0 = Auth(jwtToken: token) }
-          appRating.recordInstallDateIfNeeded()
-          await analytics.track(.signInCompleted(method: .apple, userId: appleIDCredential.user))
-        } catch {
-          print("Sign in failed: \(error)")
-          await handleSignInAPIFailure(error, authMethod: .apple, step: "api_call")
-        }
+      do {
+        let firstName = appleIDCredential.fullName?.givenName ?? ""
+        let lastName = appleIDCredential.fullName?.familyName
+        let token = try await api.signInViaApple(
+          identityToken,
+          email,
+          authCode,
+          firstName,
+          lastName)
+        $auth.withLock { $0 = Auth(jwtToken: token) }
+        appRating.recordInstallDateIfNeeded()
+        await analytics.track(.signInCompleted(method: .apple, userId: appleIDCredential.user))
+      } catch {
+        print("Sign in failed: \(error)")
+        await handleSignInAPIFailure(error, authMethod: .apple, step: "api_call")
       }
     case .failure(let error):
-      handleAppleAuthorizationFailure(error)
+      await handleAppleAuthorizationFailure(error)
     }
   }
 
@@ -144,15 +139,13 @@ class SignInPageModel: ViewModel {
 
   // MARK: - Private Helpers
 
-  private func handleAppleAuthorizationFailure(_ error: any Error) {
+  private func handleAppleAuthorizationFailure(_ error: any Error) async {
     print(error)
     if let authError = error as? ASAuthorizationError, authError.code == .canceled {
       return
     }
     presentedAlert = .signInError
-    Task {
-      await reportSignInError(error, authMethod: .apple, step: "authorization_failure")
-    }
+    await reportSignInError(error, authMethod: .apple, step: "authorization_failure")
   }
 
   private func reportSignInError(_ error: Error, authMethod: AuthMethod, step: String) async {

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -94,33 +94,27 @@ final class SignInPageTests: XCTestCase {
     }
 
     let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
-    model.signInWithAppleCompleted(result: .failure(genericError))
-
-    await fulfillment(of: [expectation], timeout: 1.0)
+    await model.signInWithAppleCompleted(result: .failure(genericError))
 
     XCTAssertEqual(reportedErrors.value.count, 1, "Should call reportError exactly once")
     let tags = reportedErrors.value.first?.1 ?? [:]
     XCTAssertEqual(tags["auth_method"], "apple")
+    _ = expectation
   }
 
   func testSignInWithAppleCompletedDoesNotReportErrorOnUserCancel() async {
     let reportedErrors = LockIsolated<[(Error, [String: String])]>([])
-    let invertedExpectation = XCTestExpectation(description: "reportError must NOT be called")
-    invertedExpectation.isInverted = true
 
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { error, tags, _, _ in
         reportedErrors.withValue { $0.append((error, tags)) }
-        invertedExpectation.fulfill()
       }
     } operation: {
       SignInPageModel()
     }
 
     let cancelError = ASAuthorizationError(.canceled)
-    model.signInWithAppleCompleted(result: .failure(cancelError))
-
-    await fulfillment(of: [invertedExpectation], timeout: 0.2)
+    await model.signInWithAppleCompleted(result: .failure(cancelError))
 
     XCTAssertTrue(
       reportedErrors.value.isEmpty,
@@ -137,7 +131,7 @@ final class SignInPageTests: XCTestCase {
     }
 
     let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
-    model.signInWithAppleCompleted(result: .failure(genericError))
+    await model.signInWithAppleCompleted(result: .failure(genericError))
 
     XCTAssertEqual(model.presentedAlert, .signInError)
   }
@@ -150,7 +144,7 @@ final class SignInPageTests: XCTestCase {
     }
 
     let cancelError = ASAuthorizationError(.canceled)
-    model.signInWithAppleCompleted(result: .failure(cancelError))
+    await model.signInWithAppleCompleted(result: .failure(cancelError))
 
     XCTAssertNil(model.presentedAlert)
   }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -82,12 +82,10 @@ final class SignInPageTests: XCTestCase {
 
   func testSignInWithAppleCompletedReportsErrorOnAuthorizationFailure() async {
     let reportedErrors = LockIsolated<[(Error, [String: String])]>([])
-    let expectation = XCTestExpectation(description: "reportError called")
 
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { error, tags, _, _ in
         reportedErrors.withValue { $0.append((error, tags)) }
-        expectation.fulfill()
       }
     } operation: {
       SignInPageModel()
@@ -99,7 +97,6 @@ final class SignInPageTests: XCTestCase {
     XCTAssertEqual(reportedErrors.value.count, 1, "Should call reportError exactly once")
     let tags = reportedErrors.value.first?.1 ?? [:]
     XCTAssertEqual(tags["auth_method"], "apple")
-    _ = expectation
   }
 
   func testSignInWithAppleCompletedDoesNotReportErrorOnUserCancel() async {

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -61,7 +61,7 @@ struct SignInPage: View {
             SignInWithAppleButton(.signIn) { request in
               model.signInWithAppleButtonTapped(request: request)
             } onCompletion: { result in
-              model.signInWithAppleCompleted(result: result)
+              Task { await model.signInWithAppleCompleted(result: result) }
             }
             .signInWithAppleButtonStyle(.white)
             .frame(height: 56)

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageModel.swift
@@ -33,6 +33,7 @@ class SongSearchPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.date.now) var now
+  @ObservationIgnored @Dependency(\.uuid) var uuid
   @ObservationIgnored @Shared(.auth) var auth
 
   @ObservationIgnored private var debounceTask: Task<Void, Never>?
@@ -192,7 +193,7 @@ class SongSearchPageModel: ViewModel {
     else { return }
 
     let updatedSongRequest = SongRequest.mockWith(
-      requestId: UUID().uuidString,
+      requestId: uuid().uuidString,
       title: songRequest.title,
       artist: songRequest.artist,
       album: songRequest.album,

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
@@ -474,6 +474,7 @@ final class SongSearchPageTests: XCTestCase {
       await withDependencies {
         $0.continuousClock = clock
         $0.date = .constant(Date())
+        $0.uuid = .incrementing
         $0.api.searchSongs = { _, _ in [] }
         $0.api.searchSongRequests = { _, _ in mockSongRequests }
         $0.api.requestSong = { _, _ in }

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
@@ -35,9 +35,7 @@ class SupportPageModel: ViewModel {
 
   func onViewAppeared() async {
     guard let jwt = auth.jwt else { return }
-    startListeningForRefresh()
 
-    // If conversation is already set (e.g., from ConversationListPage), refresh messages
     if conversation != nil {
       await refreshMessages()
       isLoading = false
@@ -58,6 +56,12 @@ class SupportPageModel: ViewModel {
     }
 
     isLoading = false
+  }
+
+  func observeRefreshNotifications() async {
+    for await _ in NotificationCenter.default.notifications(named: .refreshSupportMessages) {
+      await refreshMessages()
+    }
   }
 
   private func markAsRead() async {
@@ -112,18 +116,6 @@ class SupportPageModel: ViewModel {
   func handleScenePhaseChange(_ phase: ScenePhase) async {
     guard phase == .active else { return }
     await refreshMessages()
-  }
-
-  func startListeningForRefresh() {
-    NotificationCenter.default.addObserver(
-      forName: .refreshSupportMessages,
-      object: nil,
-      queue: .main
-    ) { [weak self] _ in
-      Task { @MainActor in
-        await self?.refreshMessages()
-      }
-    }
   }
 }
 

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageView.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageView.swift
@@ -30,6 +30,9 @@ struct SupportPageView: View {
     .task {
       await model.onViewAppeared()
     }
+    .task {
+      await model.observeRefreshNotifications()
+    }
     .alert(item: $model.presentedAlert) { $0.alert }
     .onChange(of: scenePhase) { _, newPhase in
       Task { await model.handleScenePhaseChange(newPhase) }


### PR DESCRIPTION
## Summary
- Tightened task lifecycles: `MainContainerModel` consumes `toast.stream()` instead of polling; `SupportPageModel`'s notification listener now lives in a `.task`-scoped async sequence; `BroadcastPageModel` moves its `.scheduleUpdated` subscription out of `init` into `viewAppeared`.
- Replaced direct `Date()` / `UUID()` / `Task.sleep` with `@Dependency(\.date.now)`, `@Dependency(\.uuid)`, and `@Dependency(\.continuousClock)` across LikedSongs, ListenerQuestionDetail, SongSearch, AskQuestion, and SeriesList; `ShowWithAirings` now precomputes `nextAiring` / `upcomingAiringsCount` from an injected `now`.
- Converted `Task {}` blocks inside RecordPage/RecordIntroPage/AskQuestion/SignIn/Broadcast model methods to plain `async` methods, with views creating the `Task`; tests `await` directly instead of using `Task.sleep`.
- `EpisodeRowModel` now inherits from `ViewModel`; `LikedSongsPageModel.removeSong` renamed to `removeSongTapped`.

## Test plan
- [ ] Run the full test suite in Xcode (build verified via `xcodebuild build-for-testing`).
- [ ] Smoke-test recording flows (RecordPage, RecordIntroPage, AskQuestion) on simulator to confirm playback, discard, and accept paths still behave correctly.
- [ ] Verify Apple/Google sign-in still works end-to-end.
- [ ] Verify toasts still appear in MainContainer and the Broadcast schedule still refreshes when `.scheduleUpdated` fires.