### PR TITLE
Convert XCTest suites to swift-testing (Core, Models, Formatters)

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -38,13 +38,13 @@
     },
     {
       "id": "shared-state-in-tests",
-      "rule": "In tests, declare `@Shared` locally inside each test method with an initial value: `@Shared(.key) var key = initialValue`. Do NOT use class-level `@Shared` properties or `$shared.withLock` patterns anywhere in tests.",
+      "rule": "In tests, declare `@Shared` locally inside each test method with an initial value: `@Shared(.key) var key = initialValue`. Do NOT use class-level `@Shared` properties. `$shared.withLock` is permitted only when verifying production code that subscribes to `@Shared` and reacts to changes (use it to drive the change mid-test). For state setup or resets, use the per-test `= initialValue` pattern.",
       "scope": ["PlayolaRadio/**/*Tests.swift"],
       "severity": "high"
     },
     {
       "id": "test-class-main-actor",
-      "rule": "All test classes must be annotated with `@MainActor`: `@MainActor final class SomeTests: XCTestCase`.",
+      "rule": "Test types that touch MainActor-isolated code must be annotated with `@MainActor`. For XCTest: `@MainActor final class SomeTests: XCTestCase`. For swift-testing: `@MainActor struct SomeTests` (or `@MainActor @Suite struct ...`).",
       "scope": ["PlayolaRadio/**/*Tests.swift"],
       "severity": "medium"
     },

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -400,6 +400,7 @@
 		D3FEC80B2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */; };
 		D3FEC80C2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */; };
 		D3FEC80D2EDF689F00A33AE8 /* ChooseStationToBroadcastPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */; };
+		D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = D3FF74D42FA7CA760052D500 /* CustomDump */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
 /* End PBXBuildFile section */
 
@@ -686,6 +687,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D334827B2F9B1A83002CAC52 /* Sentry in Frameworks */,
+				D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1602,6 +1604,7 @@
 				D3916A652ECD229B00CAAD50 /* XCRemoteSwiftPackageReference "swift-identified-collections" */,
 				D3916A6A2ECD231200CAAD50 /* XCRemoteSwiftPackageReference "swift-sharing" */,
 				9E0939D453C04700B9C51BBD /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				D3FF74D32FA7CA760052D500 /* XCRemoteSwiftPackageReference "swift-custom-dump" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = D3536A022BFA4F49006942D6 /* Products */;
@@ -2786,6 +2789,14 @@
 				minimumVersion = 0.14.0;
 			};
 		};
+		D3FF74D32FA7CA760052D500 /* XCRemoteSwiftPackageReference "swift-custom-dump" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-custom-dump";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.5.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2931,6 +2942,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D3CE19012D3C825C0091B888 /* XCRemoteSwiftPackageReference "PlayolaPlayer" */;
 			productName = PlayolaPlayer;
+		};
+		D3FF74D42FA7CA760052D500 /* CustomDump */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D3FF74D32FA7CA760052D500 /* XCRemoteSwiftPackageReference "swift-custom-dump" */;
+			productName = CustomDump;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/PlayolaRadio/Core/API/APIClientTests.swift
+++ b/PlayolaRadio/Core/API/APIClientTests.swift
@@ -5,27 +5,29 @@
 //  Created by Brian D Keane on 12/31/25.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class APIClientTests: XCTestCase {
+struct APIClientTests {
 
   // MARK: - URL Encoding Tests
 
+  @Test
   func testS3KeyWithSlashIsProperlyEncodedForURLPath() {
     let s3Key = "station123/mock-uuid.m4a"
 
     // Using urlQueryAllowed does NOT encode "/" - this is the bug
     let badEncoding = s3Key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-    XCTAssertEqual(badEncoding, "station123/mock-uuid.m4a", "urlQueryAllowed doesn't encode slash")
+    #expect(badEncoding == "station123/mock-uuid.m4a", "urlQueryAllowed doesn't encode slash")
 
     // The correct encoding should encode "/" as %2F
     var allowedCharacters = CharacterSet.urlPathAllowed
     allowedCharacters.remove("/")
     let goodEncoding = s3Key.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
-    XCTAssertEqual(goodEncoding, "station123%2Fmock-uuid.m4a", "Slash should be encoded as %2F")
+    #expect(goodEncoding == "station123%2Fmock-uuid.m4a", "Slash should be encoded as %2F")
     func testVoicetrackStatusURLEncodesS3KeyWithSlashes() {
       let baseUrl = "https://api.example.com"
       let stationId = "station-123"
@@ -35,9 +37,8 @@ final class APIClientTests: XCTestCase {
         s3Key.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? s3Key
       let url = "\(baseUrl)/v1/stations/\(stationId)/voicetrack-status/\(encodedS3Key)"
 
-      XCTAssertEqual(
-        url,
-        "https://api.example.com/v1/stations/station-123/voicetrack-status/"
+      #expect(
+        url == "https://api.example.com/v1/stations/station-123/voicetrack-status/"
           + "voicetracks%2Fstation123%2Fabc%2Ddef%2D123%2Em4a"
       )
     }
@@ -48,7 +49,7 @@ final class APIClientTests: XCTestCase {
       let encodedWithQueryAllowed =
         s3Key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? s3Key
 
-      XCTAssertTrue(
+      #expect(
         encodedWithQueryAllowed.contains("/"),
         "urlQueryAllowed does NOT encode slashes - this causes 404 errors when used in URL paths"
       )
@@ -60,11 +61,11 @@ final class APIClientTests: XCTestCase {
       let encodedWithAlphanumerics =
         s3Key.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? s3Key
 
-      XCTAssertFalse(
-        encodedWithAlphanumerics.contains("/"),
+      #expect(
+        !encodedWithAlphanumerics.contains("/"),
         "alphanumerics should encode slashes"
       )
-      XCTAssertTrue(
+      #expect(
         encodedWithAlphanumerics.contains("%2F"),
         "Slashes should be encoded as %2F"
       )

--- a/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
@@ -10,6 +10,8 @@ import Testing
 
 @testable import PlayolaRadio
 
+// swiftlint:disable redundant_optional_initialization
+
 @MainActor
 struct AppRatingClientTests {
 
@@ -167,3 +169,5 @@ struct AppRatingClientTests {
     #expect(lastRatingPromptDismissDate != nil)
   }
 }
+
+// swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
@@ -6,152 +6,164 @@
 import Dependencies
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class AppRatingClientTests: XCTestCase {
-
-  override func setUp() {
-    super.setUp()
-    // Reset shared state before each test
-    @Shared(.appInstallDate) var appInstallDate: Date?
-    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String?
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date?
-
-    $appInstallDate.withLock { $0 = nil }
-    $lastRatingPromptVersion.withLock { $0 = nil }
-    $lastRatingPromptDismissDate.withLock { $0 = nil }
-  }
+struct AppRatingClientTests {
 
   // MARK: - shouldShowRatingPrompt Tests
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenListenTimeTooShort() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
     )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let thirtyMinutesMS = 30 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(thirtyMinutesMS))
+    #expect(!client.shouldShowRatingPrompt(thirtyMinutesMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenInstallTooRecent() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -3, to: Date()
     )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenNoInstallDate() {
-    @Shared(.appInstallDate) var appInstallDate: Date?
+    @Shared(.appInstallDate) var appInstallDate: Date? = nil
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenAlreadyShownThisVersion() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
     )
-    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion =
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? =
       Bundle.main.releaseVersionNumber
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenDismissedRecently() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
     )
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate = Calendar.current.date(
-      byAdding: .day, value: -3, to: Date()
-    )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? =
+      Calendar.current.date(byAdding: .day, value: -3, to: Date())
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsTrueWhenAllConditionsMet() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
     )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertTrue(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsTrueWhenDismissedOver7DaysAgo() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -20, to: Date()
     )
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate = Calendar.current.date(
-      byAdding: .day, value: -10, to: Date()
-    )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? =
+      Calendar.current.date(byAdding: .day, value: -10, to: Date())
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertTrue(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(client.shouldShowRatingPrompt(twoHoursMS))
   }
 
   // MARK: - recordInstallDateIfNeeded Tests
 
+  @Test
   func testRecordInstallDateOnlyRecordsOnce() {
-    @Shared(.appInstallDate) var appInstallDate: Date?
+    @Shared(.appInstallDate) var appInstallDate: Date? = nil
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
 
-    XCTAssertNil(appInstallDate)
+    #expect(appInstallDate == nil)
 
     client.recordInstallDateIfNeeded()
     let firstDate = appInstallDate
-    XCTAssertNotNil(firstDate)
+    #expect(firstDate != nil)
 
     // Wait a tiny bit and try again
     client.recordInstallDateIfNeeded()
-    XCTAssertEqual(appInstallDate, firstDate)
+    #expect(appInstallDate == firstDate)
   }
 
   // MARK: - markRatingPromptShown Tests
 
+  @Test
   func testMarkRatingPromptShownSetsVersionAndClearsDismissDate() {
-    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String?
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate = Date()
+    @Shared(.appInstallDate) var appInstallDate: Date? = nil
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = Date()
 
     let client = AppRatingClient.liveValue
     client.markRatingPromptShown()
 
-    XCTAssertEqual(lastRatingPromptVersion, Bundle.main.releaseVersionNumber)
-    XCTAssertNil(lastRatingPromptDismissDate)
+    #expect(lastRatingPromptVersion == Bundle.main.releaseVersionNumber)
+    #expect(lastRatingPromptDismissDate == nil)
   }
 
   // MARK: - markRatingPromptDismissed Tests
 
+  @Test
   func testMarkRatingPromptDismissedSetsDate() {
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date?
+    @Shared(.appInstallDate) var appInstallDate: Date? = nil
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
 
-    XCTAssertNil(lastRatingPromptDismissDate)
+    #expect(lastRatingPromptDismissDate == nil)
 
     client.markRatingPromptDismissed()
 
-    XCTAssertNotNil(lastRatingPromptDismissDate)
+    #expect(lastRatingPromptDismissDate != nil)
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -6,18 +6,20 @@
 //
 
 import Dependencies
+import Foundation
 import MediaPlayer
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class NowPlayingUpdaterTests: XCTestCase {
+struct NowPlayingUpdaterTests {
 
   // MARK: - Analytics Tests
 
-  func testTrackListeningSession_StartsSessionWhenTransitioningToPlaying() async {
+  @Test
+  func testTrackListeningSessionStartsSessionWhenTransitioningToPlaying() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -37,16 +39,18 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify session started event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .listeningSessionStarted(let stationInfo) = events.first {
-      XCTAssertEqual(stationInfo.id, station.id)
-      XCTAssertEqual(stationInfo.name, station.name)
+      #expect(stationInfo.id == station.id)
+      #expect(stationInfo.name == station.name)
     } else {
-      XCTFail("Expected listeningSessionStarted event, got: \(String(describing: events.first))")
+      Issue.record(
+        "Expected listeningSessionStarted event, got: \(String(describing: events.first))")
     }
   }
 
-  func testTrackListeningSession_EndsSessionWhenStoppingFromPlaying() async {
+  @Test
+  func testTrackListeningSessionEndsSessionWhenStoppingFromPlaying() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -75,17 +79,18 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify session ended event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .listeningSessionEnded(let stationInfo, let sessionLengthSec) = events.first {
-      XCTAssertEqual(stationInfo.id, station.id)
-      XCTAssertEqual(stationInfo.name, station.name)
-      XCTAssertGreaterThanOrEqual(sessionLengthSec, 0)
+      #expect(stationInfo.id == station.id)
+      #expect(stationInfo.name == station.name)
+      #expect(sessionLengthSec >= 0)
     } else {
-      XCTFail("Expected listeningSessionEnded event, got: \(String(describing: events.first))")
+      Issue.record("Expected listeningSessionEnded event, got: \(String(describing: events.first))")
     }
   }
 
-  func testTrackListeningSession_InitiatesSessionBeforeSwitch() async {
+  @Test
+  func testTrackListeningSessionInitiatesSessionBeforeSwitch() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station1 = AnyStation.mock
     let station2 = AnyStation.url(
@@ -118,9 +123,9 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify session was started
     let initialEvents = capturedEvents.value
-    XCTAssertEqual(initialEvents.count, 1, "Expected 1 event after starting session")
+    #expect(initialEvents.count == 1, "Expected 1 event after starting session")
     guard case .listeningSessionStarted = initialEvents.first else {
-      XCTFail("Expected listeningSessionStarted event after starting session")
+      Issue.record("Expected listeningSessionStarted event after starting session")
       return
     }
 
@@ -133,10 +138,11 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify switch generated events
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 3, "Station switch must generate exactly 3 events")
+    #expect(events.count == 3, "Station switch must generate exactly 3 events")
   }
 
-  func testTrackListeningSession_TracksStationSwitchEvents() async {
+  @Test
+  func testTrackListeningSessionTracksStationSwitchEvents() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station1 = AnyStation.mock
     let station2 = makeTestStation2()
@@ -164,7 +170,7 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify the three expected events
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 3, "Expected exactly 3 events when switching stations")
+    #expect(events.count == 3, "Expected exactly 3 events when switching stations")
     guard events.count == 3 else { return }
 
     verifySessionEndedEvent(events[0], expectedStationId: station1.id, eventIndex: 0)
@@ -173,7 +179,8 @@ final class NowPlayingUpdaterTests: XCTestCase {
     verifySessionStartedEvent(events[2], expectedStationId: station2.id, eventIndex: 2)
   }
 
-  func testTrackListeningSession_TracksPlaybackError() async {
+  @Test
+  func testTrackListeningSessionTracksPlaybackError() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
     let updater = withDependencies {
@@ -205,23 +212,24 @@ final class NowPlayingUpdaterTests: XCTestCase {
     // Verify events were tracked
     let events = capturedEvents.value
     guard events.count > 0 else {
-      XCTFail("Expected at least 1 event, got 0")
+      Issue.record("Expected at least 1 event, got 0")
       return
     }
 
     // When transitioning from playing to error, only session ended is tracked
     // The error case in the switch statement is only for non-playing to error transitions
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
 
     // Should be session ended
     if case .listeningSessionEnded = events[0] {
       // Expected
     } else {
-      XCTFail("Expected listeningSessionEnded event, got: \(events[0])")
+      Issue.record("Expected listeningSessionEnded event, got: \(events[0])")
     }
   }
 
-  func testTrackListeningSession_DoesNotStartMultipleSessions() async {
+  @Test
+  func testTrackListeningSessionDoesNotStartMultipleSessions() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -250,10 +258,11 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify no new session was started
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 0)
+    #expect(events.count == 0)
   }
 
-  func testTrackListeningSession_HandlesLoadingToPlayingTransition() async {
+  @Test
+  func testTrackListeningSessionHandlesLoadingToPlayingTransition() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -273,15 +282,17 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify session started
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .listeningSessionStarted(let stationInfo) = events.first {
-      XCTAssertEqual(stationInfo.id, station.id)
+      #expect(stationInfo.id == station.id)
     } else {
-      XCTFail("Expected listeningSessionStarted event, got: \(String(describing: events.first))")
+      Issue.record(
+        "Expected listeningSessionStarted event, got: \(String(describing: events.first))")
     }
   }
 
-  func testTrackListeningSession_DoesNotTrackSameStationSwitch() async {
+  @Test
+  func testTrackListeningSessionDoesNotTrackSameStationSwitch() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -310,12 +321,13 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify no events were tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 0)
+    #expect(events.count == 0)
   }
 
   // MARK: - Now Playing Title/Artist Tests
 
-  func testPopulatePlayingInfo_CommercialShowsPlayolaPaysAndStationName() {
+  @Test
+  func testPopulatePlayingInfoCommercialShowsPlayolaPaysAndStationName() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -335,11 +347,12 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "Playola Pays")
-    XCTAssertEqual(artist, "Test Station Name")
+    #expect(title == "Playola Pays")
+    #expect(artist == "Test Station Name")
   }
 
-  func testPopulatePlayingInfo_SongShowsTitleAndArtist() {
+  @Test
+  func testPopulatePlayingInfoSongShowsTitleAndArtist() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -359,11 +372,12 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "My Song Title")
-    XCTAssertEqual(artist, "My Song Artist")
+    #expect(title == "My Song Title")
+    #expect(artist == "My Song Artist")
   }
 
-  func testPopulatePlayingInfo_SongWithAiringShowsTitleAndArtist() {
+  @Test
+  func testPopulatePlayingInfoSongWithAiringShowsTitleAndArtist() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -386,11 +400,12 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "My Song Title")
-    XCTAssertEqual(artist, "My Song Artist")
+    #expect(title == "My Song Title")
+    #expect(artist == "My Song Artist")
   }
 
-  func testPopulatePlayingInfo_NonSongWithAiringShowsEpisodeTitleAndStationName() {
+  @Test
+  func testPopulatePlayingInfoNonSongWithAiringShowsEpisodeTitleAndStationName() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -413,11 +428,12 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "Episode Title")
-    XCTAssertEqual(artist, "Test Station Name")
+    #expect(title == "Episode Title")
+    #expect(artist == "Test Station Name")
   }
 
-  func testPopulatePlayingInfo_NonSongWithoutAiringShowsStationNameAndEmptyArtist() {
+  @Test
+  func testPopulatePlayingInfoNonSongWithoutAiringShowsStationNameAndEmptyArtist() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -437,8 +453,8 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "Test Station Name")
-    XCTAssertEqual(artist, "")
+    #expect(title == "Test Station Name")
+    #expect(artist == "")
   }
 
   // MARK: - Helper Methods
@@ -463,10 +479,10 @@ final class NowPlayingUpdaterTests: XCTestCase {
     _ event: AnalyticsEvent, expectedStationId: String, eventIndex: Int
   ) {
     guard case .listeningSessionEnded(let stationInfo, _) = event else {
-      XCTFail("Expected listeningSessionEnded event at index \(eventIndex), got: \(event)")
+      Issue.record("Expected listeningSessionEnded event at index \(eventIndex), got: \(event)")
       return
     }
-    XCTAssertEqual(stationInfo.id, expectedStationId)
+    #expect(stationInfo.id == expectedStationId)
   }
 
   private func verifySwitchedStationEvent(
@@ -477,22 +493,22 @@ final class NowPlayingUpdaterTests: XCTestCase {
   ) {
     guard case .switchedStation(let from, let to, let timeBeforeSwitchSec, let reason) = event
     else {
-      XCTFail("Expected switchedStation event at index \(eventIndex), got: \(event)")
+      Issue.record("Expected switchedStation event at index \(eventIndex), got: \(event)")
       return
     }
-    XCTAssertEqual(from.id, fromStationId)
-    XCTAssertEqual(to.id, toStationId)
-    XCTAssertGreaterThanOrEqual(timeBeforeSwitchSec, 0)
-    XCTAssertEqual(reason, .userInitiated)
+    #expect(from.id == fromStationId)
+    #expect(to.id == toStationId)
+    #expect(timeBeforeSwitchSec >= 0)
+    #expect(reason == .userInitiated)
   }
 
   private func verifySessionStartedEvent(
     _ event: AnalyticsEvent, expectedStationId: String, eventIndex: Int
   ) {
     guard case .listeningSessionStarted(let stationInfo) = event else {
-      XCTFail("Expected listeningSessionStarted event at index \(eventIndex), got: \(event)")
+      Issue.record("Expected listeningSessionStarted event at index \(eventIndex), got: \(event)")
       return
     }
-    XCTAssertEqual(stationInfo.id, expectedStationId)
+    #expect(stationInfo.id == expectedStationId)
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -5,18 +5,20 @@
 //  Created by Claude on 1/8/26.
 //
 
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class StationPlayerTests: XCTestCase {
+struct StationPlayerTests {
 
   // MARK: - seekNext Tests
 
+  @Test
   func testSeekNextPlaysNextStation() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -27,9 +29,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[1].id)
+    #expect(stationPlayer.currentStation?.id == stations[1].id)
   }
 
+  @Test
   func testSeekNextWrapsAroundFromLastToFirst() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -40,9 +43,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[0].id)
+    #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
+  @Test
   func testSeekNextWithNoCurrentStationPlaysFirst() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -52,9 +56,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[0].id)
+    #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
+  @Test
   func testSeekNextWithEmptyStationListDoesNothing() {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
@@ -63,11 +68,12 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertNil(stationPlayer.currentStation)
+    #expect(stationPlayer.currentStation == nil)
   }
 
   // MARK: - seekPrevious Tests
 
+  @Test
   func testSeekPreviousPlaysPreviousStation() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -78,9 +84,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekPrevious()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[0].id)
+    #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
+  @Test
   func testSeekPreviousWrapsAroundFromFirstToLast() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -91,9 +98,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekPrevious()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[2].id)
+    #expect(stationPlayer.currentStation?.id == stations[2].id)
   }
 
+  @Test
   func testSeekPreviousWithNoCurrentStationPlaysFirst() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -103,11 +111,12 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekPrevious()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[0].id)
+    #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
   // MARK: - Station Filtering Tests
 
+  @Test
   func testSeekOnlyUsesArtistListStations() {
     @Shared(.stationLists) var stationLists = makeArtistAndFmLists()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -119,9 +128,10 @@ final class StationPlayerTests: XCTestCase {
     stationPlayer.play(station: artistStations[0])
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, artistStations[1].id)
+    #expect(stationPlayer.currentStation?.id == artistStations[1].id)
   }
 
+  @Test
   func testSeekSkipsInactiveStations() {
     @Shared(.stationLists) var stationLists = makeArtistListWithInactiveStation()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -132,9 +142,10 @@ final class StationPlayerTests: XCTestCase {
     stationPlayer.play(station: allStations[0])
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, allStations[2].id)
+    #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
 
+  @Test
   func testSeekSkipsComingSoonStationsWhenSecretsDisabled() {
     @Shared(.stationLists) var stationLists = makeArtistListWithComingSoonStation()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -145,9 +156,10 @@ final class StationPlayerTests: XCTestCase {
     stationPlayer.play(station: allStations[0])
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, allStations[2].id)
+    #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
 
+  @Test
   func testSeekIncludesComingSoonStationsWhenSecretsEnabled() {
     @Shared(.stationLists) var stationLists = makeArtistListWithComingSoonStation()
     @Shared(.showSecretStations) var showSecretStations = true
@@ -158,11 +170,12 @@ final class StationPlayerTests: XCTestCase {
     stationPlayer.play(station: allStations[0])
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, allStations[1].id)
+    #expect(stationPlayer.currentStation?.id == allStations[1].id)
   }
 
   // MARK: - seekableStations Tests
 
+  @Test
   func testSeekableStationsReturnsStationsFromArtistList() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -170,12 +183,13 @@ final class StationPlayerTests: XCTestCase {
     let stationPlayer = StationPlayer()
     let seekable = stationPlayer.seekableStations()
 
-    XCTAssertEqual(seekable.count, 3)
-    XCTAssertEqual(seekable[0].id, "station1")
-    XCTAssertEqual(seekable[1].id, "station2")
-    XCTAssertEqual(seekable[2].id, "station3")
+    #expect(seekable.count == 3)
+    #expect(seekable[0].id == "station1")
+    #expect(seekable[1].id == "station2")
+    #expect(seekable[2].id == "station3")
   }
 
+  @Test
   func testSeekableStationsReturnsEmptyWhenNoArtistList() {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
@@ -183,9 +197,10 @@ final class StationPlayerTests: XCTestCase {
     let stationPlayer = StationPlayer()
     let seekable = stationPlayer.seekableStations()
 
-    XCTAssertTrue(seekable.isEmpty)
+    #expect(seekable.isEmpty)
   }
 
+  @Test
   func testSeekableStationsFiltersInactiveStations() {
     @Shared(.stationLists) var stationLists = makeArtistListWithInactiveStation()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -193,11 +208,12 @@ final class StationPlayerTests: XCTestCase {
     let stationPlayer = StationPlayer()
     let seekable = stationPlayer.seekableStations()
 
-    XCTAssertEqual(seekable.count, 2)
-    XCTAssertEqual(seekable[0].id, "station1")
-    XCTAssertEqual(seekable[1].id, "station3")
+    #expect(seekable.count == 2)
+    #expect(seekable[0].id == "station1")
+    #expect(seekable[1].id == "station3")
   }
 
+  @Test
   func testSeekableStationsAccessesSharedState() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -205,19 +221,21 @@ final class StationPlayerTests: XCTestCase {
     let stationPlayer = StationPlayer()
 
     // Verify stationPlayer can see the shared state
-    XCTAssertEqual(stationPlayer.stationLists.count, 1, "StationPlayer should see 1 station list")
-    XCTAssertEqual(
-      stationPlayer.stationLists.first?.slug, "artist-list",
+    #expect(stationPlayer.stationLists.count == 1, "StationPlayer should see 1 station list")
+    #expect(
+      stationPlayer.stationLists.first?.slug == "artist-list",
       "StationPlayer should see artist-list slug")
   }
 
   // MARK: - isSeeking Flag Tests
 
+  @Test
   func testIsSeekingIsFalseByDefault() {
     let stationPlayer = StationPlayer()
-    XCTAssertFalse(stationPlayer.isSeeking)
+    #expect(!stationPlayer.isSeeking)
   }
 
+  @Test
   func testIsSeekingIsFalseAfterSeekNextCompletes() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -228,9 +246,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertFalse(stationPlayer.isSeeking, "isSeeking should be false after seek completes")
+    #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
 
+  @Test
   func testIsSeekingIsFalseAfterSeekPreviousCompletes() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -241,9 +260,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekPrevious()
 
-    XCTAssertFalse(stationPlayer.isSeeking, "isSeeking should be false after seek completes")
+    #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
 
+  @Test
   func testIsSeekingIsFalseWhenSeekHasNoStations() {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
@@ -252,7 +272,7 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertFalse(stationPlayer.isSeeking, "isSeeking should remain false when no stations")
+    #expect(!stationPlayer.isSeeking, "isSeeking should remain false when no stations")
   }
 
   // MARK: - Helper Methods

--- a/PlayolaRadio/Core/AudioRecording/IntroUploadServiceTests.swift
+++ b/PlayolaRadio/Core/AudioRecording/IntroUploadServiceTests.swift
@@ -5,16 +5,18 @@
 
 import ConcurrencyExtras
 import Dependencies
-import XCTest
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class IntroUploadServiceTests: XCTestCase {
+struct IntroUploadServiceTests {
 
   private let testStationId = "test-station-id"
   private let testSongTitle = "Bohemian Rhapsody"
 
+  @Test
   func testUploadIntroTransitionsThroughAllStatuses() async throws {
     let statusChanges = LockIsolated<[IntroUploadStatus]>([])
     let testURL = FileManager.default.temporaryDirectory.appendingPathComponent("test.wav")
@@ -44,16 +46,17 @@ final class IntroUploadServiceTests: XCTestCase {
     }
 
     let recordedStatuses = statusChanges.value
-    XCTAssertTrue(recordedStatuses.contains(.converting))
-    XCTAssertTrue(
+    #expect(recordedStatuses.contains(.converting))
+    #expect(
       recordedStatuses.contains(where: {
         if case .uploading = $0 { return true }
         return false
       }))
-    XCTAssertTrue(recordedStatuses.contains(.registering))
-    XCTAssertTrue(recordedStatuses.contains(.completed))
+    #expect(recordedStatuses.contains(.registering))
+    #expect(recordedStatuses.contains(.completed))
   }
 
+  @Test
   func testUploadIntroPassesCorrectStationIdAndFilename() async throws {
     let capturedStationId = LockIsolated<String?>(nil)
     let capturedFilename = LockIsolated<String?>(nil)
@@ -83,10 +86,11 @@ final class IntroUploadServiceTests: XCTestCase {
       "test-audio-block-id"
     ) { _ in }
 
-    XCTAssertEqual(capturedStationId.value, testStationId)
-    XCTAssertEqual(capturedFilename.value, "Bohemian Rhapsody.m4a")
+    #expect(capturedStationId.value == testStationId)
+    #expect(capturedFilename.value == "Bohemian Rhapsody.m4a")
   }
 
+  @Test
   func testUploadIntroPassesCorrectDataToCreateSourceTape() async throws {
     let capturedS3Key = LockIsolated<String?>(nil)
     let capturedName = LockIsolated<String?>(nil)
@@ -121,9 +125,9 @@ final class IntroUploadServiceTests: XCTestCase {
       "test-audio-block-id"
     ) { _ in }
 
-    XCTAssertEqual(capturedS3Key.value, "station/uuid-intro.m4a")
-    XCTAssertEqual(capturedName.value, "Bohemian Rhapsody")
-    XCTAssertEqual(capturedDurationMS.value, 15000)
-    XCTAssertEqual(capturedAudioBlockId.value, "test-audio-block-id")
+    #expect(capturedS3Key.value == "station/uuid-intro.m4a")
+    #expect(capturedName.value == "Bohemian Rhapsody")
+    #expect(capturedDurationMS.value == 15000)
+    #expect(capturedAudioBlockId.value == "test-audio-block-id")
   }
 }

--- a/PlayolaRadio/Core/AudioRecording/VoicetrackUploadServiceTests.swift
+++ b/PlayolaRadio/Core/AudioRecording/VoicetrackUploadServiceTests.swift
@@ -7,12 +7,13 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
-final class VoicetrackUploadServiceTests: XCTestCase {
+struct VoicetrackUploadServiceTests {
 
   // MARK: - Test Data
 
@@ -30,7 +31,8 @@ final class VoicetrackUploadServiceTests: XCTestCase {
 
   // MARK: - Normalization Polling Tests
 
-  func testProcessVoicetrack_handlesS3KeyWithSlash() async throws {
+  @Test
+  func testProcessVoicetrackHandlesS3KeyWithSlash() async throws {
     let capturedS3Key = LockIsolated<String?>(nil)
     let voicetrack = createTestVoicetrack()
     let s3KeyWithSlash = "station123/mock-uuid.m4a"
@@ -60,11 +62,12 @@ final class VoicetrackUploadServiceTests: XCTestCase {
       testJwtToken
     ) { _ in }
 
-    XCTAssertEqual(
-      capturedS3Key.value, s3KeyWithSlash, "s3Key with slash should be passed through correctly")
+    #expect(
+      capturedS3Key.value == s3KeyWithSlash, "s3Key with slash should be passed through correctly")
   }
 
-  func testProcessVoicetrack_transitionsThroughNormalizingStatus() async throws {
+  @Test
+  func testProcessVoicetrackTransitionsThroughNormalizingStatus() async throws {
     let statusChanges = LockIsolated<[LocalVoicetrackStatus]>([])
     let voicetrack = createTestVoicetrack()
 
@@ -96,7 +99,7 @@ final class VoicetrackUploadServiceTests: XCTestCase {
 
     let recordedStatuses = statusChanges.value
     // Verify that .normalizing status was reached
-    XCTAssertTrue(
+    #expect(
       recordedStatuses.contains(.normalizing),
       "Expected .normalizing status, got: \(recordedStatuses)"
     )
@@ -108,17 +111,18 @@ final class VoicetrackUploadServiceTests: XCTestCase {
     }),
       let normalizingIndex = recordedStatuses.firstIndex(of: .normalizing)
     {
-      XCTAssertLessThan(uploadingIndex, normalizingIndex)
+      #expect(uploadingIndex < normalizingIndex)
     }
 
     // Verify normalizing comes before finalizing
     if let normalizingIndex = recordedStatuses.firstIndex(of: .normalizing),
       let finalizingIndex = recordedStatuses.firstIndex(of: .finalizing)
     {
-      XCTAssertLessThan(normalizingIndex, finalizingIndex)
+      #expect(normalizingIndex < finalizingIndex)
     }
   }
 
+  @Test
   func testProcessVoicetrackPassesS3KeyWithSlashesToStatusCheck() async throws {
     let voicetrack = createTestVoicetrack()
     let s3KeyWithSlashes = "voicetracks/station123/abc-def-123.m4a"
@@ -149,6 +153,6 @@ final class VoicetrackUploadServiceTests: XCTestCase {
       testJwtToken
     ) { _ in }
 
-    XCTAssertEqual(capturedS3Key.value, s3KeyWithSlashes)
+    #expect(capturedS3Key.value == s3KeyWithSlashes)
   }
 }

--- a/PlayolaRadio/Core/Auth/PlayolaTokenProvider/PlayolaTokenProviderTests.swift
+++ b/PlayolaRadio/Core/Auth/PlayolaTokenProvider/PlayolaTokenProviderTests.swift
@@ -10,15 +10,15 @@
 import ConcurrencyExtras
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class PlayolaTokenProviderTests: XCTestCase {
+struct PlayolaTokenProviderTests {
 
   // Helper function to create valid JWT tokens for testing
-  func createTestJWT(
+  private func createTestJWT(
     id: String = "test-user-123",
     firstName: String = "Test",
     lastName: String? = "User",
@@ -58,27 +58,29 @@ final class PlayolaTokenProviderTests: XCTestCase {
 
   // MARK: - getCurrentToken Tests
 
-  func testGetCurrentToken_ReturnsNilWhenUserNotLoggedIn() async {
+  @Test
+  func testGetCurrentTokenReturnsNilWhenUserNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     let tokenProvider = PlayolaTokenProvider()
 
     let token = await tokenProvider.getCurrentToken()
 
-    XCTAssertNil(token)
+    #expect(token == nil)
   }
 
-  func testGetCurrentToken_ReturnsJWTWhenUserLoggedIn() async {
+  @Test
+  func testGetCurrentTokenReturnsJWTWhenUserLoggedIn() async {
     let expectedJWT = createTestJWT()
-    @Shared(.auth) var auth
-    $auth.withLock { $0 = Auth(jwtToken: expectedJWT) }
+    @Shared(.auth) var auth = Auth(jwtToken: expectedJWT)
     let tokenProvider = PlayolaTokenProvider()
 
     let token = await tokenProvider.getCurrentToken()
 
-    XCTAssertEqual(token, expectedJWT)
+    #expect(token == expectedJWT)
   }
 
-  func testGetCurrentToken_ReturnsNilAfterUserSignsOut() async {
+  @Test
+  func testGetCurrentTokenReturnsNilAfterUserSignsOut() async {
     let initialJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: initialJWT)
     let tokenProvider = PlayolaTokenProvider()
@@ -87,39 +89,42 @@ final class PlayolaTokenProviderTests: XCTestCase {
     $auth.withLock { $0 = Auth() }
 
     let token = await tokenProvider.getCurrentToken()
-    XCTAssertNil(token)
+    #expect(token == nil)
   }
 
   // MARK: - refreshToken Tests
 
-  func testRefreshToken_ReturnsNilWhenUserNotLoggedIn() async {
+  @Test
+  func testRefreshTokenReturnsNilWhenUserNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     let tokenProvider = PlayolaTokenProvider()
 
     let token = await tokenProvider.refreshToken()
 
-    XCTAssertNil(token)
+    #expect(token == nil)
   }
 
-  func testRefreshToken_ReturnsCurrentJWTWhenUserLoggedIn() async {
+  @Test
+  func testRefreshTokenReturnsCurrentJWTWhenUserLoggedIn() async {
     let expectedJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: expectedJWT)
     let tokenProvider = PlayolaTokenProvider()
 
     let token = await tokenProvider.refreshToken()
 
-    XCTAssertEqual(token, expectedJWT)
+    #expect(token == expectedJWT)
   }
 
   // MARK: - Reactive Authentication State Changes Tests
 
-  func testReactiveAuth_ImmediatelyReflectsAuthStateChanges() async {
+  @Test
+  func testReactiveAuthImmediatelyReflectsAuthStateChanges() async {
     @Shared(.auth) var auth = Auth()
     let tokenProvider = PlayolaTokenProvider()
 
     // Initially no token
     let initialToken = await tokenProvider.getCurrentToken()
-    XCTAssertNil(initialToken)
+    #expect(initialToken == nil)
 
     // User logs in
     let jwt = createTestJWT()
@@ -127,17 +132,18 @@ final class PlayolaTokenProviderTests: XCTestCase {
 
     // Token provider immediately reflects the change
     let newToken = await tokenProvider.getCurrentToken()
-    XCTAssertEqual(newToken, jwt)
+    #expect(newToken == jwt)
 
     // User logs out
     $auth.withLock { $0 = Auth() }
 
     // Token provider immediately reflects the logout
     let loggedOutToken = await tokenProvider.getCurrentToken()
-    XCTAssertNil(loggedOutToken)
+    #expect(loggedOutToken == nil)
   }
 
-  func testReactiveAuth_MultipleAuthStateChangesTracked() async {
+  @Test
+  func testReactiveAuthMultipleAuthStateChangesTracked() async {
     @Shared(.auth) var auth = Auth()
     let tokenProvider = PlayolaTokenProvider()
 
@@ -150,13 +156,13 @@ final class PlayolaTokenProviderTests: XCTestCase {
     for expectedToken in tokens {
       $auth.withLock { $0 = Auth(jwtToken: expectedToken) }
       let actualToken = await tokenProvider.getCurrentToken()
-      XCTAssertEqual(actualToken, expectedToken)
+      #expect(actualToken == expectedToken)
     }
 
     // Final logout
     $auth.withLock { $0 = Auth() }
     let finalToken = await tokenProvider.getCurrentToken()
-    XCTAssertNil(finalToken)
+    #expect(finalToken == nil)
   }
 }
 

--- a/PlayolaRadio/Core/Formatters/RRuleFormatterTests.swift
+++ b/PlayolaRadio/Core/Formatters/RRuleFormatterTests.swift
@@ -5,177 +5,196 @@
 //  Created by Claude on 1/8/26.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class RRuleFormatterTests: XCTestCase {
+struct RRuleFormatterTests {
   // MARK: - Single Day Tests
 
+  @Test
   func testFormatsWeeklyMondayAt4pm() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays at 4pm")
+    #expect(result == "Mondays at 4pm")
   }
 
+  @Test
   func testFormatsWeeklyTuesdayAt9am() {
     let rrule = "FREQ=WEEKLY;BYDAY=TU"
     let airtime = dateAt(hour: 9, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Tuesdays at 9am")
+    #expect(result == "Tuesdays at 9am")
   }
 
+  @Test
   func testFormatsWeeklyWednesdayAt830pm() {
     let rrule = "FREQ=WEEKLY;BYDAY=WE"
     let airtime = dateAt(hour: 20, minute: 30)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Wednesdays at 8:30pm")
+    #expect(result == "Wednesdays at 8:30pm")
   }
 
+  @Test
   func testFormatsWeeklyThursdayAtNoon() {
     let rrule = "FREQ=WEEKLY;BYDAY=TH"
     let airtime = dateAt(hour: 12, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Thursdays at 12pm")
+    #expect(result == "Thursdays at 12pm")
   }
 
+  @Test
   func testFormatsWeeklyFridayAt6pm() {
     let rrule = "FREQ=WEEKLY;BYDAY=FR"
     let airtime = dateAt(hour: 18, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Fridays at 6pm")
+    #expect(result == "Fridays at 6pm")
   }
 
+  @Test
   func testFormatsWeeklySaturdayAt10am() {
     let rrule = "FREQ=WEEKLY;BYDAY=SA"
     let airtime = dateAt(hour: 10, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Saturdays at 10am")
+    #expect(result == "Saturdays at 10am")
   }
 
+  @Test
   func testFormatsWeeklySundayAt7pm() {
     let rrule = "FREQ=WEEKLY;BYDAY=SU"
     let airtime = dateAt(hour: 19, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Sundays at 7pm")
+    #expect(result == "Sundays at 7pm")
   }
 
   // MARK: - Multiple Days Tests
 
+  @Test
   func testFormatsTwoDays() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO,WE"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays and Wednesdays at 4pm")
+    #expect(result == "Mondays and Wednesdays at 4pm")
   }
 
+  @Test
   func testFormatsThreeDays() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO,WE,FR"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays, Wednesdays, and Fridays at 4pm")
+    #expect(result == "Mondays, Wednesdays, and Fridays at 4pm")
   }
 
+  @Test
   func testFormatsWeekdays() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
     let airtime = dateAt(hour: 8, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Weekdays at 8am")
+    #expect(result == "Weekdays at 8am")
   }
 
+  @Test
   func testFormatsWeekends() {
     let rrule = "FREQ=WEEKLY;BYDAY=SA,SU"
     let airtime = dateAt(hour: 10, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Weekends at 10am")
+    #expect(result == "Weekends at 10am")
   }
 
+  @Test
   func testFormatsEveryDay() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU"
     let airtime = dateAt(hour: 20, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Every day at 8pm")
+    #expect(result == "Every day at 8pm")
   }
 
   // MARK: - Daily Frequency Tests
 
+  @Test
   func testFormatsDailyFrequency() {
     let rrule = "FREQ=DAILY"
     let airtime = dateAt(hour: 14, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Every day at 2pm")
+    #expect(result == "Every day at 2pm")
   }
 
   // MARK: - Edge Cases
 
+  @Test
   func testReturnsNilForInvalidRRule() {
     let rrule = "INVALID_RRULE"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertNil(result)
+    #expect(result == nil)
   }
 
+  @Test
   func testReturnsNilForEmptyRRule() {
     let rrule = ""
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertNil(result)
+    #expect(result == nil)
   }
 
+  @Test
   func testReturnsNilForNilRRule() {
     let result = RRuleFormatter.formatToPlainEnglish(rrule: nil, airtime: Date())
 
-    XCTAssertNil(result)
+    #expect(result == nil)
   }
 
+  @Test
   func testHandlesDaysInDifferentOrder() {
     let rrule = "FREQ=WEEKLY;BYDAY=FR,MO,WE"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays, Wednesdays, and Fridays at 4pm")
+    #expect(result == "Mondays, Wednesdays, and Fridays at 4pm")
   }
 
+  @Test
   func testHandlesLowercaseDays() {
     let rrule = "FREQ=WEEKLY;BYDAY=mo,we,fr"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays, Wednesdays, and Fridays at 4pm")
+    #expect(result == "Mondays, Wednesdays, and Fridays at 4pm")
   }
 
   // MARK: - Helpers

--- a/PlayolaRadio/Core/Likes/LikeOperationTests.swift
+++ b/PlayolaRadio/Core/Likes/LikeOperationTests.swift
@@ -5,12 +5,13 @@
 //  Created by Brian D Keane on 8/30/25.
 //
 
+import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
-final class LikeOperationTests: XCTestCase {
+struct LikeOperationTests {
 
   // MARK: - Test Data
 
@@ -18,22 +19,23 @@ final class LikeOperationTests: XCTestCase {
 
   // MARK: - Initialization Tests
 
-  func testInit_DefaultValues() {
+  @Test
+  func testInitDefaultValues() {
     let operation = LikeOperation(
       audioBlock: testAudioBlock,
       type: .like
     )
 
-    XCTAssertNotNil(operation.id)
-    XCTAssertEqual(operation.audioBlock.id, testAudioBlock.id)
-    XCTAssertEqual(operation.type, .like)
-    XCTAssertEqual(operation.retryCount, 0)
-    XCTAssertTrue(abs(operation.timestamp.timeIntervalSinceNow) < 1)  // Recent timestamp
+    #expect(operation.audioBlock.id == testAudioBlock.id)
+    #expect(operation.type == .like)
+    #expect(operation.retryCount == 0)
+    #expect(abs(operation.timestamp.timeIntervalSinceNow) < 1)
   }
 
-  func testInit_CustomValues() {
+  @Test
+  func testInitCustomValues() {
     let customId = UUID()
-    let customDate = Date(timeIntervalSinceNow: -3600)  // 1 hour ago
+    let customDate = Date(timeIntervalSinceNow: -3600)
 
     let operation = LikeOperation(
       id: customId,
@@ -43,14 +45,15 @@ final class LikeOperationTests: XCTestCase {
       retryCount: 2
     )
 
-    XCTAssertEqual(operation.id, customId)
-    XCTAssertEqual(operation.type, .unlike)
-    XCTAssertEqual(operation.timestamp, customDate)
-    XCTAssertEqual(operation.retryCount, 2)
+    #expect(operation.id == customId)
+    #expect(operation.type == .unlike)
+    #expect(operation.timestamp == customDate)
+    #expect(operation.retryCount == 2)
   }
 
   // MARK: - Retry Logic Tests
 
+  @Test
   func testIncrementingRetryCount() {
     let operation = LikeOperation(
       audioBlock: testAudioBlock,
@@ -60,13 +63,14 @@ final class LikeOperationTests: XCTestCase {
 
     let incrementedOperation = operation.incrementingRetryCount()
 
-    XCTAssertEqual(incrementedOperation.id, operation.id)
-    XCTAssertEqual(incrementedOperation.audioBlock.id, operation.audioBlock.id)
-    XCTAssertEqual(incrementedOperation.type, operation.type)
-    XCTAssertEqual(incrementedOperation.timestamp, operation.timestamp)
-    XCTAssertEqual(incrementedOperation.retryCount, 2)
+    #expect(incrementedOperation.id == operation.id)
+    #expect(incrementedOperation.audioBlock.id == operation.audioBlock.id)
+    #expect(incrementedOperation.type == operation.type)
+    #expect(incrementedOperation.timestamp == operation.timestamp)
+    #expect(incrementedOperation.retryCount == 2)
   }
 
+  @Test
   func testShouldRetry() {
     let operation0 = LikeOperation(audioBlock: testAudioBlock, type: .like, retryCount: 0)
     let operation1 = LikeOperation(audioBlock: testAudioBlock, type: .like, retryCount: 1)
@@ -74,15 +78,16 @@ final class LikeOperationTests: XCTestCase {
     let operation3 = LikeOperation(audioBlock: testAudioBlock, type: .like, retryCount: 3)
     let operation4 = LikeOperation(audioBlock: testAudioBlock, type: .like, retryCount: 4)
 
-    XCTAssertTrue(operation0.shouldRetry)
-    XCTAssertTrue(operation1.shouldRetry)
-    XCTAssertTrue(operation2.shouldRetry)
-    XCTAssertFalse(operation3.shouldRetry)  // Max retries = 3
-    XCTAssertFalse(operation4.shouldRetry)
+    #expect(operation0.shouldRetry)
+    #expect(operation1.shouldRetry)
+    #expect(operation2.shouldRetry)
+    #expect(!operation3.shouldRetry)
+    #expect(!operation4.shouldRetry)
   }
 
   // MARK: - Expiration Tests
 
+  @Test
   func testIsExpired() {
     let recentOperation = LikeOperation(
       audioBlock: testAudioBlock,
@@ -93,16 +98,17 @@ final class LikeOperationTests: XCTestCase {
     let oldOperation = LikeOperation(
       audioBlock: testAudioBlock,
       type: .like,
-      timestamp: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60)  // 8 days ago
+      timestamp: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60)
     )
 
-    XCTAssertFalse(recentOperation.isExpired)
-    XCTAssertTrue(oldOperation.isExpired)
+    #expect(!recentOperation.isExpired)
+    #expect(oldOperation.isExpired)
   }
 
   // MARK: - Equatable Tests
 
-  func testEquatable_Equal() {
+  @Test
+  func testEquatableEqual() {
     let id = UUID()
     let date = Date()
 
@@ -122,26 +128,29 @@ final class LikeOperationTests: XCTestCase {
       retryCount: 1
     )
 
-    XCTAssertEqual(operation1, operation2)
+    #expect(operation1 == operation2)
   }
 
-  func testEquatable_NotEqual_DifferentId() {
+  @Test
+  func testEquatableNotEqualDifferentId() {
     let operation1 = LikeOperation(audioBlock: testAudioBlock, type: .like)
     let operation2 = LikeOperation(audioBlock: testAudioBlock, type: .like)
 
-    XCTAssertNotEqual(operation1, operation2)  // Different IDs
+    #expect(operation1 != operation2)
   }
 
-  func testEquatable_NotEqual_DifferentType() {
+  @Test
+  func testEquatableNotEqualDifferentType() {
     let id = UUID()
     let operation1 = LikeOperation(id: id, audioBlock: testAudioBlock, type: .like)
     let operation2 = LikeOperation(id: id, audioBlock: testAudioBlock, type: .unlike)
 
-    XCTAssertNotEqual(operation1, operation2)
+    #expect(operation1 != operation2)
   }
 
   // MARK: - Codable Tests
 
+  @Test
   func testCodable() throws {
     let operation = LikeOperation(
       audioBlock: testAudioBlock,
@@ -149,27 +158,28 @@ final class LikeOperationTests: XCTestCase {
       retryCount: 2
     )
 
-    // Encode
     let encoder = JSONEncoder()
     let data = try encoder.encode(operation)
 
-    // Decode
     let decoder = JSONDecoder()
     let decodedOperation = try decoder.decode(LikeOperation.self, from: data)
 
-    // Verify
-    XCTAssertEqual(decodedOperation.id, operation.id)
-    XCTAssertEqual(decodedOperation.audioBlock.id, operation.audioBlock.id)
-    XCTAssertEqual(decodedOperation.audioBlock.title, operation.audioBlock.title)
-    XCTAssertEqual(decodedOperation.type, operation.type)
-    XCTAssertEqual(decodedOperation.retryCount, operation.retryCount)
-    XCTAssertEqual(
-      decodedOperation.timestamp.timeIntervalSince1970, operation.timestamp.timeIntervalSince1970,
-      accuracy: 0.001)
+    #expect(decodedOperation.id == operation.id)
+    #expect(decodedOperation.audioBlock.id == operation.audioBlock.id)
+    #expect(decodedOperation.audioBlock.title == operation.audioBlock.title)
+    #expect(decodedOperation.type == operation.type)
+    #expect(decodedOperation.retryCount == operation.retryCount)
+    #expect(
+      abs(
+        decodedOperation.timestamp.timeIntervalSince1970
+          - operation.timestamp.timeIntervalSince1970
+      ) < 0.001
+    )
   }
 
-  func testOperationType_RawValues() {
-    XCTAssertEqual(LikeOperation.OperationType.like.rawValue, "like")
-    XCTAssertEqual(LikeOperation.OperationType.unlike.rawValue, "unlike")
+  @Test
+  func testOperationTypeRawValues() {
+    #expect(LikeOperation.OperationType.like.rawValue == "like")
+    #expect(LikeOperation.OperationType.unlike.rawValue == "unlike")
   }
 }

--- a/PlayolaRadio/Core/Likes/LikesManagerTests.swift
+++ b/PlayolaRadio/Core/Likes/LikesManagerTests.swift
@@ -6,51 +6,54 @@
 //
 
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class LikesManagerTests: XCTestCase {
-
-  // MARK: - Setup
-
-  override func setUp() async throws {
-    try await super.setUp()
-    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
-    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
-    $userLikes.withLock { $0 = [:] }
-    $pendingOperations.withLock { $0 = [] }
-  }
+struct LikesManagerTests {
 
   // MARK: - Like Tests
 
-  func testLike_AddsToUserLikes() async {
+  @Test
+  func testLikeAddsToUserLikes() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
 
-    XCTAssertTrue(manager.isLiked(audioBlock.id))
-    XCTAssertEqual(manager.getLikedAudioBlock(audioBlock.id), audioBlock)
-    XCTAssertEqual(manager.allLikedAudioBlocks.count, 1)
-    XCTAssertEqual(manager.allLikedAudioBlocks.first, audioBlock)
+    #expect(manager.isLiked(audioBlock.id))
+    #expect(manager.getLikedAudioBlock(audioBlock.id) == audioBlock)
+    #expect(manager.allLikedAudioBlocks.count == 1)
+    #expect(manager.allLikedAudioBlocks.first == audioBlock)
   }
 
-  func testLike_CreatesPendingOperation() async {
+  @Test
+  func testLikeCreatesPendingOperation() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
 
-    XCTAssertEqual(manager.pendingOperations.count, 1)
-    XCTAssertEqual(manager.pendingOperations.first?.audioBlock, audioBlock)
-    XCTAssertEqual(manager.pendingOperations.first?.type, .like)
+    #expect(manager.pendingOperations.count == 1)
+    #expect(manager.pendingOperations.first?.audioBlock == audioBlock)
+    #expect(manager.pendingOperations.first?.type == .like)
   }
 
-  func testLike_CreatesUserSongLikeWithTimestamp() async {
+  @Test
+  func testLikeCreatesUserSongLikeWithTimestamp() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
     let beforeLike = Date()
@@ -58,39 +61,51 @@ final class LikesManagerTests: XCTestCase {
     manager.like(audioBlock)
 
     let timestamp = manager.getLikedTimestamp(audioBlock.id)
-    XCTAssertNotNil(timestamp)
-    XCTAssertTrue(timestamp! >= beforeLike)
-    XCTAssertTrue(timestamp! <= Date())
+    #expect(timestamp != nil)
+    #expect(timestamp! >= beforeLike)
+    #expect(timestamp! <= Date())
   }
 
-  func testLike_DoesNotDuplicateIfAlreadyLiked() async {
+  @Test
+  func testLikeDoesNotDuplicateIfAlreadyLiked() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
     manager.like(audioBlock)  // Try to like again
 
-    XCTAssertEqual(manager.allLikedAudioBlocks.count, 1)
-    XCTAssertEqual(manager.pendingOperations.count, 1)
+    #expect(manager.allLikedAudioBlocks.count == 1)
+    #expect(manager.pendingOperations.count == 1)
   }
 
   // MARK: - Unlike Tests
 
-  func testUnlike_RemovesFromUserLikes() async {
+  @Test
+  func testUnlikeRemovesFromUserLikes() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
-    XCTAssertTrue(manager.isLiked(audioBlock.id))
+    #expect(manager.isLiked(audioBlock.id))
 
     manager.unlike(audioBlock)
 
-    XCTAssertFalse(manager.isLiked(audioBlock.id))
-    XCTAssertNil(manager.getLikedAudioBlock(audioBlock.id))
-    XCTAssertEqual(manager.allLikedAudioBlocks.count, 0)
+    #expect(!manager.isLiked(audioBlock.id))
+    #expect(manager.getLikedAudioBlock(audioBlock.id) == nil)
+    #expect(manager.allLikedAudioBlocks.count == 0)
   }
 
-  func testUnlike_CreatesPendingOperation() async {
+  @Test
+  func testUnlikeCreatesPendingOperation() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
@@ -98,46 +113,62 @@ final class LikesManagerTests: XCTestCase {
 
     manager.unlike(audioBlock)
 
-    XCTAssertEqual(manager.pendingOperations.count, 2)
-    XCTAssertEqual(manager.pendingOperations.last?.audioBlock, audioBlock)
-    XCTAssertEqual(manager.pendingOperations.last?.type, .unlike)
+    #expect(manager.pendingOperations.count == 2)
+    #expect(manager.pendingOperations.last?.audioBlock == audioBlock)
+    #expect(manager.pendingOperations.last?.type == .unlike)
   }
 
-  func testUnlike_DoesNothingIfNotLiked() async {
+  @Test
+  func testUnlikeDoesNothingIfNotLiked() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.unlike(audioBlock)
 
-    XCTAssertEqual(manager.pendingOperations.count, 0)
+    #expect(manager.pendingOperations.count == 0)
   }
 
   // MARK: - Toggle Tests
 
-  func testToggleLike_LikesIfNotLiked() async {
+  @Test
+  func testToggleLikeLikesIfNotLiked() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.toggleLike(audioBlock)
 
-    XCTAssertTrue(manager.isLiked(audioBlock.id))
+    #expect(manager.isLiked(audioBlock.id))
   }
 
-  func testToggleLike_UnlikesIfLiked() async {
+  @Test
+  func testToggleLikeUnlikesIfLiked() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
-    XCTAssertTrue(manager.isLiked(audioBlock.id))
+    #expect(manager.isLiked(audioBlock.id))
 
     manager.toggleLike(audioBlock)
 
-    XCTAssertFalse(manager.isLiked(audioBlock.id))
+    #expect(!manager.isLiked(audioBlock.id))
   }
 
   // MARK: - Multiple Songs Tests
 
+  @Test
   func testMultipleLikes() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock1 = AudioBlock.mock
     let audioBlock2 = AudioBlock.mockWith(id: "different-id")
@@ -147,15 +178,19 @@ final class LikesManagerTests: XCTestCase {
     manager.like(audioBlock2)
     manager.like(audioBlock3)
 
-    XCTAssertEqual(manager.allLikedAudioBlocks.count, 3)
-    XCTAssertTrue(manager.isLiked(audioBlock1.id))
-    XCTAssertTrue(manager.isLiked(audioBlock2.id))
-    XCTAssertTrue(manager.isLiked(audioBlock3.id))
+    #expect(manager.allLikedAudioBlocks.count == 3)
+    #expect(manager.isLiked(audioBlock1.id))
+    #expect(manager.isLiked(audioBlock2.id))
+    #expect(manager.isLiked(audioBlock3.id))
   }
 
   // MARK: - Cleanup Tests
 
+  @Test
   func testCleanupExpiredOperations() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
@@ -173,13 +208,17 @@ final class LikesManagerTests: XCTestCase {
 
     manager.cleanupExpiredOperations()
 
-    XCTAssertEqual(manager.pendingOperations.count, 1)
-    XCTAssertEqual(manager.pendingOperations.first, recentOp)
+    #expect(manager.pendingOperations.count == 1)
+    #expect(manager.pendingOperations.first == recentOp)
   }
 
   // MARK: - Persistence Tests
 
+  @Test
   func testPersistenceBetweenInstances() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let audioBlock = AudioBlock.mock
 
     let manager1 = LikesManager()
@@ -187,8 +226,8 @@ final class LikesManagerTests: XCTestCase {
 
     let manager2 = LikesManager()
 
-    XCTAssertTrue(manager2.isLiked(audioBlock.id))
-    XCTAssertEqual(manager2.allLikedAudioBlocks.count, 1)
-    XCTAssertEqual(manager2.pendingOperations.count, 1)
+    #expect(manager2.isLiked(audioBlock.id))
+    #expect(manager2.allLikedAudioBlocks.count == 1)
+    #expect(manager2.pendingOperations.count == 1)
   }
 }

--- a/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
+++ b/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
@@ -5,31 +5,16 @@
 //  Created by Brian D Keane on 7/23/25.
 //
 
-import Combine
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 // swiftlint:disable redundant_optional_initialization
 
 @MainActor
-final class ListeningTrackerTests: XCTestCase {
-
-  private var cancellables = Set<AnyCancellable>()
-
-  override func setUp() {
-    super.setUp()
-    cancellables.removeAll()
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
-  }
-
-  override func tearDown() {
-    super.tearDown()
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
-    cancellables.removeAll()
-  }
+struct ListeningTrackerTests {
 
   func createMockRewardsProfile(totalTimeListenedMS: Int = 0) -> RewardsProfile {
     return RewardsProfile(
@@ -52,16 +37,22 @@ final class ListeningTrackerTests: XCTestCase {
 
   // MARK: - Initialization Tests
 
-  func testInit_WithEmptyLocalSessions() {
+  @Test
+  func testInitWithEmptyLocalSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile()
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 0)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertEqual(tracker.rewardsProfile.totalTimeListenedMS, 0)
+    #expect(tracker.localListeningSessions.count == 0)
+    #expect(!tracker.isListening)
+    #expect(tracker.rewardsProfile.totalTimeListenedMS == 0)
   }
 
-  func testInit_WithExistingLocalSessions() {
+  @Test
+  func testInitWithExistingLocalSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile()
     let existingSessions = [
       LocalListeningSession(
@@ -70,20 +61,26 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
   }
 
   // MARK: - isListening Tests
 
-  func testIsListening_ReturnsFalseWhenNoSessions() {
+  @Test
+  func testIsListeningReturnsFalseWhenNoSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile()
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertFalse(tracker.isListening)
+    #expect(!tracker.isListening)
   }
 
-  func testIsListening_ReturnsFalseWhenLastSessionEnded() {
+  @Test
+  func testIsListeningReturnsFalseWhenLastSessionEnded() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile()
     let existingSessions = [
       LocalListeningSession(
@@ -92,10 +89,11 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertFalse(tracker.isListening)
+    #expect(!tracker.isListening)
   }
 
-  func testIsListening_ReturnsTrueWhenLastSessionNotEnded() {
+  @Test
+  func testIsListeningReturnsTrueWhenLastSessionNotEnded() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -108,19 +106,25 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.isListening)
   }
 
   // MARK: - totalListenTimeMS Tests
 
-  func testTotalListenTimeMS_WithOnlyServerTime() {
+  @Test
+  func testTotalListenTimeMSWithOnlyServerTime() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile(totalTimeListenedMS: 5000)
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.totalListenTimeMS, 5000)
+    #expect(tracker.totalListenTimeMS == 5000)
   }
 
-  func testTotalListenTimeMS_WithOnlyLocalSessions() {
+  @Test
+  func testTotalListenTimeMSWithOnlyLocalSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile(totalTimeListenedMS: 0)
     let startTime = Date()
     let endTime = startTime.addingTimeInterval(10)  // 10 seconds = 10000ms
@@ -130,10 +134,13 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertEqual(tracker.totalListenTimeMS, 10000)
+    #expect(tracker.totalListenTimeMS == 10000)
   }
 
-  func testTotalListenTimeMS_WithBothServerAndLocalTime() {
+  @Test
+  func testTotalListenTimeMSWithBothServerAndLocalTime() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile(totalTimeListenedMS: 5000)
     let startTime = Date()
     let endTime = startTime.addingTimeInterval(10)  // 10 seconds = 10000ms
@@ -143,10 +150,13 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertEqual(tracker.totalListenTimeMS, 15000)
+    #expect(tracker.totalListenTimeMS == 15000)
   }
 
-  func testTotalListenTimeMS_WithMultipleLocalSessions() {
+  @Test
+  func testTotalListenTimeMSWithMultipleLocalSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile(totalTimeListenedMS: 1000)
     let baseTime = Date()
     let existingSessions = [
@@ -159,32 +169,34 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertEqual(tracker.totalListenTimeMS, 9000)  // 1000 + 5000 + 3000
+    #expect(tracker.totalListenTimeMS == 9000)  // 1000 + 5000 + 3000
   }
 
   // MARK: - Playback State Change Tests
 
-  func testPlaybackStateChange_StartsNewSessionWhenPlayingStarted() {
+  @Test
+  func testPlaybackStateChangeStartsNewSessionWhenPlayingStarted() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
     // Create tracker with initial stopped state
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 0)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 0)
+    #expect(!tracker.isListening)
 
     // Update the shared state synchronously
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .playing(AnyStation.mock)) }
 
     // The publisher should have already fired synchronously
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.startTime)
-    XCTAssertNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.startTime != nil)
+    #expect(tracker.localListeningSessions.last?.endTime == nil)
   }
 
-  func testPlaybackStateChange_EndsSessionWhenPlaybackStopped() {
+  @Test
+  func testPlaybackStateChangeEndsSessionWhenPlaybackStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -194,19 +206,20 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
     // Verify initial state
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate playback stopping
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .stopped) }
 
     // The publisher should have already fired synchronously
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.endTime != nil)
   }
 
-  func testPlaybackStateChange_DoesNotStartDuplicateSessionWhenAlreadyPlaying() {
+  @Test
+  func testPlaybackStateChangeDoesNotStartDuplicateSessionWhenAlreadyPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -215,18 +228,19 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate another playing state (should not create new session)
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .playing(AnyStation.mock)) }
 
     // Should still have only one session
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
   }
 
-  func testPlaybackStateChange_HandlesLoadingStateAsNonPlaying() {
+  @Test
+  func testPlaybackStateChangeHandlesLoadingStateAsNonPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -235,18 +249,19 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate loading state (should end session)
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .loading(AnyStation.mock)) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.endTime != nil)
   }
 
-  func testPlaybackStateChange_HandlesErrorStateAsNonPlaying() {
+  @Test
+  func testPlaybackStateChangeHandlesErrorStateAsNonPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -255,18 +270,19 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate error state (should end session)
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .error) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.endTime != nil)
   }
 
-  func testPlaybackStateChange_HandlesNilNowPlayingAsNonPlaying() {
+  @Test
+  func testPlaybackStateChangeHandlesNilNowPlayingAsNonPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -275,20 +291,21 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate nil nowPlaying (should end session)
     $nowPlaying.withLock { $0 = nil }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.endTime != nil)
   }
 
   // MARK: - Edge Cases
 
-  func testPlaybackStateChange_DoesNotEndSessionWhenNoSessionsExist() {
+  @Test
+  func testPlaybackStateChangeDoesNotEndSessionWhenNoSessionsExist() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -297,10 +314,11 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 0)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 0)
+    #expect(!tracker.isListening)
   }
 
+  @Test
   func testMultiplePlaybackStateChanges() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
@@ -309,31 +327,32 @@ final class ListeningTrackerTests: XCTestCase {
     // Start playing
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .playing(AnyStation.mock)) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Stop playing
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .stopped) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
 
     // Start playing again
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .playing(AnyStation.mock)) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 2)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 2)
+    #expect(tracker.isListening)
 
     // Stop playing again
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .stopped) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 2)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 2)
+    #expect(!tracker.isListening)
   }
 
   // MARK: - Real-time Session Duration Test
 
-  func testSessionDuration_CalculatesCorrectly() {
+  @Test
+  func testSessionDurationCalculatesCorrectly() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -343,26 +362,26 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
     // Verify session started
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Get the start time
     let startTime = tracker.localListeningSessions.first?.startTime
-    XCTAssertNotNil(startTime)
+    #expect(startTime != nil)
 
     // Stop playing
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .stopped) }
 
     // Verify session ended
-    XCTAssertFalse(tracker.isListening)
+    #expect(!tracker.isListening)
     let endTime = tracker.localListeningSessions.first?.endTime
-    XCTAssertNotNil(endTime)
+    #expect(endTime != nil)
 
     // The duration should be very small since we're testing synchronously
     if let start = startTime, let end = endTime {
       let duration = end.timeIntervalSince(start)
-      XCTAssertLessThan(duration, 1.0)  // Should be less than 1 second
-      XCTAssertGreaterThanOrEqual(duration, 0)  // Should be non-negative
+      #expect(duration < 1.0)  // Should be less than 1 second
+      #expect(duration >= 0)  // Should be non-negative
     }
   }
 }

--- a/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinatorTests.swift
@@ -6,26 +6,19 @@
 //
 
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class MainContainerNavigationCoordinatorTests: XCTestCase {
-
-  // MARK: - Setup
-
-  override func setUp() async throws {
-    try await super.setUp()
-    // Clear any shared state
-    @Shared(.activeTab) var activeTab: MainContainerModel.ActiveTab = .home
-    $activeTab.withLock { $0 = .home }
-  }
+struct MainContainerNavigationCoordinatorTests {
 
   // MARK: - navigateToLikedSongs Tests
 
-  func testNavigateToLikedSongs_WithSheetAndDifferentTab() async {
+  @Test
+  func testNavigateToLikedSongsWithSheetAndDifferentTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -38,18 +31,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Should have completed both transitions and pushed liked songs page
-      XCTAssertNil(coordinator.presentedSheet)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.presentedSheet == nil)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
-  func testNavigateToLikedSongs_WithSheetButCorrectTab() async {
+  @Test
+  func testNavigateToLikedSongsWithSheetButCorrectTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -62,18 +56,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Should have dismissed sheet, kept same tab, and pushed liked songs page
-      XCTAssertNil(coordinator.presentedSheet)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.presentedSheet == nil)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
-  func testNavigateToLikedSongs_WithDifferentTabButNoSheet() async {
+  @Test
+  func testNavigateToLikedSongsWithDifferentTabButNoSheet() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -86,17 +81,18 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Should have changed tab and pushed liked songs page
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
-  func testNavigateToLikedSongs_NoSheetAndCorrectTab() async {
+  @Test
+  func testNavigateToLikedSongsNoSheetAndCorrectTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -109,19 +105,20 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Should have pushed liked songs page
-      XCTAssertEqual(coordinator.path.count, 1)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertNil(coordinator.presentedSheet)
+      #expect(coordinator.path.count == 1)
+      #expect(activeTab == .profile)
+      #expect(coordinator.presentedSheet == nil)
 
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
-  func testNavigateToLikedSongs_CreatesLikedSongsPageModel() async {
+  @Test
+  func testNavigateToLikedSongsCreatesLikedSongsPageModel() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -136,18 +133,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Verify that a LikedSongsPageModel was created
-      XCTAssertEqual(coordinator.path.count, 1)
-      if case .likedSongsPage(let model) = coordinator.path.first {
-        XCTAssertNotNil(model)
+      #expect(coordinator.path.count == 1)
+      if case .likedSongsPage = coordinator.path.first {
+        // Success
       } else {
-        XCTFail("Expected likedSongsPage with model to be pushed")
+        Issue.record("Expected likedSongsPage with model to be pushed")
       }
     }
   }
 
   // MARK: - navigateToSupport Tests
 
-  func testNavigateToSupport_WithSheetAndDifferentTab() async {
+  @Test
+  func testNavigateToSupportWithSheetAndDifferentTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -160,18 +158,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertNil(coordinator.presentedSheet)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.presentedSheet == nil)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }
 
-  func testNavigateToSupport_WithSheetButCorrectTab() async {
+  @Test
+  func testNavigateToSupportWithSheetButCorrectTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -184,18 +183,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertNil(coordinator.presentedSheet)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.presentedSheet == nil)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }
 
-  func testNavigateToSupport_WithDifferentTabButNoSheet() async {
+  @Test
+  func testNavigateToSupportWithDifferentTabButNoSheet() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -208,17 +208,18 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }
 
-  func testNavigateToSupport_NoSheetAndCorrectTab() async {
+  @Test
+  func testNavigateToSupportNoSheetAndCorrectTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -231,19 +232,20 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertEqual(coordinator.path.count, 1)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertNil(coordinator.presentedSheet)
+      #expect(coordinator.path.count == 1)
+      #expect(activeTab == .profile)
+      #expect(coordinator.presentedSheet == nil)
 
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }
 
-  func testNavigateToSupport_UsesProvidedModel() async {
+  @Test
+  func testNavigateToSupportUsesProvidedModel() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -256,38 +258,41 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.path.count == 1)
       if case .supportPage(let model) = coordinator.path.first {
-        XCTAssertTrue(model === supportModel)
+        #expect(model === supportModel)
       } else {
-        XCTFail("Expected supportPage with the provided model to be pushed")
+        Issue.record("Expected supportPage with the provided model to be pushed")
       }
     }
   }
 
   // MARK: - switchToBroadcastMode Tests
 
+  @Test
   func testSwitchToBroadcastModeSetsAppModeAndClearsPath() {
     let coordinator = MainContainerNavigationCoordinator()
     coordinator.path = [.editProfilePage(EditProfilePageModel())]
 
     coordinator.switchToBroadcastMode(stationId: "station-123")
 
-    XCTAssertEqual(coordinator.appMode, .broadcasting(stationId: "station-123"))
-    XCTAssertTrue(coordinator.path.isEmpty)
+    #expect(coordinator.appMode == .broadcasting(stationId: "station-123"))
+    #expect(coordinator.path.isEmpty)
   }
 
+  @Test
   func testSwitchToBroadcastModeFromListeningMode() {
     let coordinator = MainContainerNavigationCoordinator()
-    XCTAssertEqual(coordinator.appMode, .listening)
+    #expect(coordinator.appMode == .listening)
 
     coordinator.switchToBroadcastMode(stationId: "my-station")
 
-    XCTAssertEqual(coordinator.appMode, .broadcasting(stationId: "my-station"))
+    #expect(coordinator.appMode == .broadcasting(stationId: "my-station"))
   }
 
   // MARK: - switchToListeningMode Tests
 
+  @Test
   func testSwitchToListeningModeSetsAppModeAndClearsPath() {
     let coordinator = MainContainerNavigationCoordinator()
     coordinator.appMode = .broadcasting(stationId: "station-123")
@@ -295,21 +300,23 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
 
     coordinator.switchToListeningMode()
 
-    XCTAssertEqual(coordinator.appMode, .listening)
-    XCTAssertTrue(coordinator.path.isEmpty)
+    #expect(coordinator.appMode == .listening)
+    #expect(coordinator.path.isEmpty)
   }
 
+  @Test
   func testSwitchToListeningModeFromBroadcastMode() {
     let coordinator = MainContainerNavigationCoordinator()
     coordinator.appMode = .broadcasting(stationId: "station-123")
 
     coordinator.switchToListeningMode()
 
-    XCTAssertEqual(coordinator.appMode, .listening)
+    #expect(coordinator.appMode == .listening)
   }
 
   // MARK: - navigateToLikedSongs from Broadcast Mode Tests
 
+  @Test
   func testNavigateToLikedSongsSwitchesToListeningModeFirst() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
@@ -322,18 +329,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
 
       await coordinator.navigateToLikedSongs()
 
-      XCTAssertEqual(coordinator.appMode, .listening)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.appMode == .listening)
+      #expect(coordinator.path.count == 1)
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
   // MARK: - navigateToSupport from Broadcast Mode Tests
 
+  @Test
   func testNavigateToSupportSwitchesToListeningModeFirst() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
@@ -347,12 +355,12 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertEqual(coordinator.appMode, .listening)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.appMode == .listening)
+      #expect(coordinator.path.count == 1)
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -7,16 +7,18 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class PushNotificationsTests: XCTestCase {
+struct PushNotificationsTests {
 
   // MARK: - registerForRemoteNotifications
 
+  @Test
   func testRegisterForRemoteNotificationsRequestsAuthorization() async throws {
     let authorizationRequested = LockIsolated(false)
 
@@ -31,9 +33,10 @@ final class PushNotificationsTests: XCTestCase {
       _ = try await pushNotifications.requestAuthorization()
     }
 
-    XCTAssertTrue(authorizationRequested.value)
+    #expect(authorizationRequested.value)
   }
 
+  @Test
   func testRegisterForRemoteNotificationsCallsUIApplicationRegister() async throws {
     let registerCalled = LockIsolated(false)
 
@@ -46,20 +49,22 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.registerForRemoteNotifications()
     }
 
-    XCTAssertTrue(registerCalled.value)
+    #expect(registerCalled.value)
   }
 
   // MARK: - Device Token Handling
 
+  @Test
   func testDeviceTokenConvertedToHexString() {
     let tokenBytes: [UInt8] = [0xAB, 0xCD, 0xEF, 0x12, 0x34, 0x56, 0x78, 0x90]
     let tokenData = Data(tokenBytes)
 
     let hexString = tokenData.map { String(format: "%02x", $0) }.joined()
 
-    XCTAssertEqual(hexString, "abcdef1234567890")
+    #expect(hexString == "abcdef1234567890")
   }
 
+  @Test
   func testHandleDeviceTokenCallsAPIWhenLoggedIn() async throws {
     let capturedToken = LockIsolated<String?>(nil)
     let capturedPlatform = LockIsolated<String?>(nil)
@@ -78,13 +83,14 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleDeviceToken(tokenData)
     }
 
-    XCTAssertEqual(capturedToken.value, "abcdef12")
-    XCTAssertEqual(capturedPlatform.value, "ios")
-    XCTAssertEqual(capturedAppVersion.value, "1.0.0")
+    #expect(capturedToken.value == "abcdef12")
+    #expect(capturedPlatform.value == "ios")
+    #expect(capturedAppVersion.value == "1.0.0")
   }
 
   // MARK: - Notification Payload Parsing
 
+  @Test
   func testParseNotificationPayloadExtractsStationId() {
     let userInfo: [String: any Sendable] = [
       "stationId": "test-station-123"
@@ -92,19 +98,21 @@ final class PushNotificationsTests: XCTestCase {
 
     let stationId = NotificationPayload.stationId(from: userInfo)
 
-    XCTAssertEqual(stationId, "test-station-123")
+    #expect(stationId == "test-station-123")
   }
 
+  @Test
   func testParseNotificationPayloadReturnsNilWhenNoStationId() {
     let userInfo: [String: any Sendable] = [:]
 
     let stationId = NotificationPayload.stationId(from: userInfo)
 
-    XCTAssertNil(stationId)
+    #expect(stationId == nil)
   }
 
   // MARK: - Notification Response Handling
 
+  @Test
   func testHandleNotificationResponsePlaysStation() async {
     let playedStationId = LockIsolated<String?>(nil)
 
@@ -120,11 +128,12 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleNotificationTap(userInfo)
     }
 
-    XCTAssertEqual(playedStationId.value, "station-abc")
+    #expect(playedStationId.value == "station-abc")
   }
 
   // MARK: - Support Notification Badge Handling
 
+  @Test
   func testHandleSupportNotificationBadgeSetsCountFromPayload() async {
     @Shared(.unreadSupportCount) var unreadSupportCount = 0
     let capturedBadgeCount = LockIsolated<Int?>(nil)
@@ -141,10 +150,11 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleSupportNotificationBadge(badgeFromPayload: 5)
     }
 
-    XCTAssertEqual(unreadSupportCount, 5)
-    XCTAssertEqual(capturedBadgeCount.value, 5)
+    #expect(unreadSupportCount == 5)
+    #expect(capturedBadgeCount.value == 5)
   }
 
+  @Test
   func testHandleSupportNotificationBadgeIncrementsWhenNoPayload() async {
     @Shared(.unreadSupportCount) var unreadSupportCount = 2
     let capturedBadgeCount = LockIsolated<Int?>(nil)
@@ -161,10 +171,11 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleSupportNotificationBadge(badgeFromPayload: nil)
     }
 
-    XCTAssertEqual(unreadSupportCount, 3)
-    XCTAssertEqual(capturedBadgeCount.value, 3)
+    #expect(unreadSupportCount == 3)
+    #expect(capturedBadgeCount.value == 3)
   }
 
+  @Test
   func testClearSupportBadgeSetsCountToZero() async {
     @Shared(.unreadSupportCount) var unreadSupportCount = 5
     let capturedBadgeCount = LockIsolated<Int?>(nil)
@@ -181,12 +192,13 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.clearSupportBadge()
     }
 
-    XCTAssertEqual(unreadSupportCount, 0)
-    XCTAssertEqual(capturedBadgeCount.value, 0)
+    #expect(unreadSupportCount == 0)
+    #expect(capturedBadgeCount.value == 0)
   }
 
   // MARK: - Support Message Notification Tap
 
+  @Test
   func testHandleNotificationTapPostsRefreshWhenSupportMessageAndOnSupportPage() async {
     @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
       MainContainerNavigationCoordinator()
@@ -212,6 +224,6 @@ final class PushNotificationsTests: XCTestCase {
     ]
     await PushNotificationsClient.liveValue.handleNotificationTap(userInfo)
 
-    XCTAssertTrue(refreshNotificationPosted.value)
+    #expect(refreshNotificationPosted.value)
   }
 }

--- a/PlayolaRadio/Core/Toast/ToastClientTests.swift
+++ b/PlayolaRadio/Core/Toast/ToastClientTests.swift
@@ -7,16 +7,18 @@
 
 import ConcurrencyExtras
 import Dependencies
-import XCTest
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class ToastClientTests: XCTestCase {
+struct ToastClientTests {
 
   // MARK: - Basic Show/Dismiss
 
-  func testShow_SetsCurrentToast() async {
+  @Test
+  func testShowSetsCurrentToast() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -30,12 +32,13 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast)
 
       let currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Test message")
-      XCTAssertEqual(currentToast?.buttonTitle, "OK")
+      #expect(currentToast?.message == "Test message")
+      #expect(currentToast?.buttonTitle == "OK")
     }
   }
 
-  func testDismiss_ClearsCurrentToast() async {
+  @Test
+  func testDismissClearsCurrentToast() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -48,18 +51,19 @@ final class ToastClientTests: XCTestCase {
 
       await client.show(toast)
       let currentToast = await client.currentToast()
-      XCTAssertNotNil(currentToast)
+      #expect(currentToast != nil)
 
       await client.dismiss()
 
       let dismissedToast = await client.currentToast()
-      XCTAssertNil(dismissedToast)
+      #expect(dismissedToast == nil)
     }
   }
 
   // MARK: - Queue Management
 
-  func testShow_QueuesMultipleToasts() async {
+  @Test
+  func testShowQueuesMultipleToasts() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -78,16 +82,17 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast2)
 
       let currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "First toast")
+      #expect(currentToast?.message == "First toast")
 
       await client.dismiss()
 
       let nextToast = await client.currentToast()
-      XCTAssertEqual(nextToast?.message, "Second toast")
+      #expect(nextToast?.message == "Second toast")
     }
   }
 
-  func testQueue_ShowsToastsInOrder() async {
+  @Test
+  func testQueueShowsToastsInOrder() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -102,25 +107,26 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast3)
 
       var currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "First")
+      #expect(currentToast?.message == "First")
 
       await client.dismiss()
       currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Second")
+      #expect(currentToast?.message == "Second")
 
       await client.dismiss()
       currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Third")
+      #expect(currentToast?.message == "Third")
 
       await client.dismiss()
       currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
     }
   }
 
   // MARK: - Auto-dismiss
 
-  func testAutoDismiss_AfterSpecifiedDuration() async {
+  @Test
+  func testAutoDismissAfterSpecifiedDuration() async {
     let clock = TestClock()
 
     await withDependencies {
@@ -137,19 +143,20 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast)
 
       var currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Test message")
+      #expect(currentToast?.message == "Test message")
 
       await clock.advance(by: .seconds(1.0))
       currentToast = await client.currentToast()
-      XCTAssertNotNil(currentToast)
+      #expect(currentToast != nil)
 
       await clock.advance(by: .seconds(1.5))
       currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
     }
   }
 
-  func testAutoDismiss_ShowsNextToastInQueue() async {
+  @Test
+  func testAutoDismissShowsNextToastInQueue() async {
     let clock = TestClock()
 
     await withDependencies {
@@ -172,18 +179,19 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast2)
 
       var currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "First toast")
+      #expect(currentToast?.message == "First toast")
 
       await clock.advance(by: .seconds(1.5))
 
       currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Second toast")
+      #expect(currentToast?.message == "Second toast")
     }
   }
 
   // MARK: - Manual Dismiss
 
-  func testManualDismiss_CancelsAutoDismissTimer() async {
+  @Test
+  func testManualDismissCancelsAutoDismissTimer() async {
     let clock = TestClock()
 
     await withDependencies {
@@ -200,21 +208,22 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast)
 
       var currentToast = await client.currentToast()
-      XCTAssertNotNil(currentToast)
+      #expect(currentToast != nil)
 
       await client.dismiss()
 
       currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
 
       // Ensure timer was cancelled - toast shouldn't resurrect
       await clock.advance(by: .seconds(5.0))
       currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
     }
   }
 
-  func testManualDismiss_ShowsNextToastInQueue() async {
+  @Test
+  func testManualDismissShowsNextToastInQueue() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -234,18 +243,19 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast2)
 
       var currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "First toast")
+      #expect(currentToast?.message == "First toast")
 
       await client.dismiss()
 
       currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Second toast")
+      #expect(currentToast?.message == "Second toast")
     }
   }
 
   // MARK: - Concurrent Access
 
-  func testConcurrentShow_SafelyQueuesAllToasts() async {
+  @Test
+  func testConcurrentShowSafelyQueuesAllToasts() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -264,28 +274,27 @@ final class ToastClientTests: XCTestCase {
       await show3
 
       let currentToast = await client.currentToast()
-      XCTAssertNotNil(currentToast)
-      XCTAssertTrue(
-        ["Toast 1", "Toast 2", "Toast 3"].contains(currentToast?.message)
-      )
+      #expect(currentToast != nil)
+      #expect(["Toast 1", "Toast 2", "Toast 3"].contains(currentToast?.message))
 
       await client.dismiss()
       let secondToast = await client.currentToast()
-      XCTAssertNotNil(secondToast)
+      #expect(secondToast != nil)
 
       await client.dismiss()
       let thirdToast = await client.currentToast()
-      XCTAssertNotNil(thirdToast)
+      #expect(thirdToast != nil)
 
       await client.dismiss()
       let finalToast = await client.currentToast()
-      XCTAssertNil(finalToast)
+      #expect(finalToast == nil)
     }
   }
 
   // MARK: - Toast Actions
 
-  func testToastAction_ExecutesWhenInvoked() {
+  @Test
+  func testToastActionExecutesWhenInvoked() {
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -301,13 +310,14 @@ final class ToastClientTests: XCTestCase {
 
       toast.action?()
 
-      XCTAssertTrue(actionExecuted.value)
+      #expect(actionExecuted.value)
     }
   }
 
   // MARK: - Edge Cases
 
-  func testDismiss_WhenNoCurrentToast_DoesNothing() async {
+  @Test
+  func testDismissWhenNoCurrentToastDoesNothing() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -316,11 +326,12 @@ final class ToastClientTests: XCTestCase {
       await client.dismiss()
 
       let currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
     }
   }
 
-  func testShow_WithZeroDuration_StillShowsToast() async {
+  @Test
+  func testShowWithZeroDurationStillShowsToast() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -335,7 +346,7 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast)
 
       let currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Zero duration")
+      #expect(currentToast?.message == "Zero duration")
     }
   }
 }

--- a/PlayolaRadio/Models/SongSeed/SongSeedTests.swift
+++ b/PlayolaRadio/Models/SongSeed/SongSeedTests.swift
@@ -5,12 +5,15 @@
 //  Created by Brian D Keane on 12/15/25.
 //
 
-import XCTest
+import CustomDump
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
-final class SongRequestTests: XCTestCase {
+struct SongRequestTests {
 
+  @Test
   func testSongRequestDecodesFromJSON() throws {
     let jsonString = """
       {
@@ -30,19 +33,10 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertEqual(songRequest.title, "Like a Rolling Stone")
-    XCTAssertEqual(songRequest.artist, "Bob Dylan")
-    XCTAssertEqual(songRequest.album, "Highway 61 Revisited")
-    XCTAssertEqual(songRequest.durationMS, 369600)
-    XCTAssertEqual(songRequest.popularity, 78)
-    XCTAssertEqual(songRequest.releaseDate, "1965-08-30")
-    XCTAssertEqual(songRequest.isrc, "USSM16500213")
-    XCTAssertEqual(songRequest.appleId, "1440806768")
-    XCTAssertEqual(songRequest.spotifyId, "3AhXZa8sUQht0UEdBJgpGc")
-    XCTAssertEqual(songRequest.imageUrl, URL(string: "https://i.scdn.co/image/test"))
-    XCTAssertNil(songRequest.requestId)
+    expectNoDifference(songRequest, SongRequest.mockWith())
   }
 
+  @Test
   func testSongRequestDecodesWithRequestId() throws {
     let jsonString = """
       {
@@ -63,9 +57,10 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertEqual(songRequest.requestId, "request-abc-123")
+    #expect(songRequest.requestId == "request-abc-123")
   }
 
+  @Test
   func testSongRequestDecodesWithNullImageUrl() throws {
     let jsonString = """
       {
@@ -84,9 +79,10 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertNil(songRequest.imageUrl)
+    #expect(songRequest.imageUrl == nil)
   }
 
+  @Test
   func testSongRequestDecodesWithMissingImageUrl() throws {
     let jsonString = """
       {
@@ -104,9 +100,10 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertNil(songRequest.imageUrl)
+    #expect(songRequest.imageUrl == nil)
   }
 
+  @Test
   func testSongRequestDecodesWithNullOptionalFields() throws {
     let jsonString = """
       {
@@ -122,12 +119,13 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertNil(songRequest.popularity)
-    XCTAssertNil(songRequest.isrc)
-    XCTAssertNil(songRequest.spotifyId)
-    XCTAssertNil(songRequest.imageUrl)
+    #expect(songRequest.popularity == nil)
+    #expect(songRequest.isrc == nil)
+    #expect(songRequest.spotifyId == nil)
+    #expect(songRequest.imageUrl == nil)
   }
 
+  @Test
   func testSongRequestMockWithReturnsValidInstance() {
     let songRequest = SongRequest.mockWith(
       title: "Custom Title",
@@ -135,14 +133,15 @@ final class SongRequestTests: XCTestCase {
       appleId: "custom-apple-id"
     )
 
-    XCTAssertEqual(songRequest.title, "Custom Title")
-    XCTAssertEqual(songRequest.artist, "Custom Artist")
-    XCTAssertEqual(songRequest.appleId, "custom-apple-id")
+    #expect(songRequest.title == "Custom Title")
+    #expect(songRequest.artist == "Custom Artist")
+    #expect(songRequest.appleId == "custom-apple-id")
   }
 
+  @Test
   func testSongRequestIdentifiableUsesAppleIdAsId() {
     let songRequest = SongRequest.mockWith(appleId: "unique-apple-id")
 
-    XCTAssertEqual(songRequest.id, "unique-apple-id")
+    #expect(songRequest.id == "unique-apple-id")
   }
 }

--- a/PlayolaRadio/Models/StagingItem/StagingItemTests.swift
+++ b/PlayolaRadio/Models/StagingItem/StagingItemTests.swift
@@ -5,17 +5,19 @@
 //  Created by Brian D Keane on 12/15/25.
 //
 
+import Foundation
 import PlayolaPlayer
 import SwiftUI
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
-final class StagingItemTests: XCTestCase {
+struct StagingItemTests {
 
   // MARK: - LocalVoicetrack Conformance Tests
 
-  func testLocalVoicetrack_StagingId_ReturnsUUIDString() {
+  @Test
+  func testLocalVoicetrackStagingIdReturnsUUIDString() {
     let id = UUID()
     let voicetrack = LocalVoicetrack(
       id: id,
@@ -23,117 +25,129 @@ final class StagingItemTests: XCTestCase {
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.stagingId, id.uuidString)
+    #expect(voicetrack.stagingId == id.uuidString)
   }
 
-  func testLocalVoicetrack_TitleText_ReturnsTitle() {
+  @Test
+  func testLocalVoicetrackTitleTextReturnsTitle() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       title: "Voice Track 10:00am"
     )
 
-    XCTAssertEqual(voicetrack.titleText, "Voice Track 10:00am")
+    #expect(voicetrack.titleText == "Voice Track 10:00am")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenConverting_ReturnsConverting() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenConvertingReturnsConverting() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .converting,
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Converting...")
+    #expect(voicetrack.subtitleText == "Converting...")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenUploading_ReturnsProgress() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenUploadingReturnsProgress() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .uploading(progress: 0.5),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Uploading 50%")
+    #expect(voicetrack.subtitleText == "Uploading 50%")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenFinalizing_ReturnsFinalizing() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenFinalizingReturnsFinalizing() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .finalizing,
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Finalizing...")
+    #expect(voicetrack.subtitleText == "Finalizing...")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenCompleted_ReturnsReady() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenCompletedReturnsReady() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .completed,
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Ready")
+    #expect(voicetrack.subtitleText == "Ready")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenFailed_ReturnsErrorMessage() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenFailedReturnsErrorMessage() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .failed(error: "Upload failed"),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Upload failed")
+    #expect(voicetrack.subtitleText == "Upload failed")
   }
 
-  func testLocalVoicetrack_SubtitleColor_WhenCompleted_ReturnsGreen() {
+  @Test
+  func testLocalVoicetrackSubtitleColorWhenCompletedReturnsGreen() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .completed,
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleColor, .green)
+    #expect(voicetrack.subtitleColor == .green)
   }
 
-  func testLocalVoicetrack_SubtitleColor_WhenFailed_ReturnsRed() {
+  @Test
+  func testLocalVoicetrackSubtitleColorWhenFailedReturnsRed() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .failed(error: "Error"),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleColor, .playolaRed)
+    #expect(voicetrack.subtitleColor == .playolaRed)
   }
 
-  func testLocalVoicetrack_SubtitleColor_WhenProcessing_ReturnsGray() {
+  @Test
+  func testLocalVoicetrackSubtitleColorWhenProcessingReturnsGray() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .uploading(progress: 0.5),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleColor, .playolaGray)
+    #expect(voicetrack.subtitleColor == .playolaGray)
   }
 
-  func testLocalVoicetrack_AlbumImageUrl_ReturnsNil() {
+  @Test
+  func testLocalVoicetrackAlbumImageUrlReturnsNil() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       title: "Test"
     )
 
-    XCTAssertNil(voicetrack.albumImageUrl)
+    #expect(voicetrack.albumImageUrl == nil)
   }
 
-  func testLocalVoicetrack_Icon_ReturnsMicFill() {
+  @Test
+  func testLocalVoicetrackIconReturnsMicFill() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.icon, "mic.fill")
+    #expect(voicetrack.icon == "mic.fill")
   }
 
-  func testLocalVoicetrack_IsReady_WhenCompleted_ReturnsTrue() {
+  @Test
+  func testLocalVoicetrackIsReadyWhenCompletedReturnsTrue() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .completed,
@@ -141,20 +155,22 @@ final class StagingItemTests: XCTestCase {
       audioBlockId: "audio-block-123"
     )
 
-    XCTAssertTrue(voicetrack.isReady)
+    #expect(voicetrack.isReady)
   }
 
-  func testLocalVoicetrack_IsReady_WhenProcessing_ReturnsFalse() {
+  @Test
+  func testLocalVoicetrackIsReadyWhenProcessingReturnsFalse() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .uploading(progress: 0.5),
       title: "Test"
     )
 
-    XCTAssertFalse(voicetrack.isReady)
+    #expect(!voicetrack.isReady)
   }
 
-  func testLocalVoicetrack_IsReady_WhenCompletedButNoAudioBlockId_ReturnsFalse() {
+  @Test
+  func testLocalVoicetrackIsReadyWhenCompletedButNoAudioBlockIdReturnsFalse() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .completed,
@@ -162,63 +178,72 @@ final class StagingItemTests: XCTestCase {
       audioBlockId: nil
     )
 
-    XCTAssertFalse(voicetrack.isReady)
+    #expect(!voicetrack.isReady)
   }
 
   // MARK: - AudioBlock Conformance Tests
 
-  func testAudioBlock_StagingId_ReturnsId() {
+  @Test
+  func testAudioBlockStagingIdReturnsId() {
     let audioBlock = AudioBlock.mockWith(id: "song-123")
 
-    XCTAssertEqual(audioBlock.stagingId, "song-123")
+    #expect(audioBlock.stagingId == "song-123")
   }
 
-  func testAudioBlock_TitleText_ReturnsTitle() {
+  @Test
+  func testAudioBlockTitleTextReturnsTitle() {
     let audioBlock = AudioBlock.mockWith(title: "Blowin' in the Wind")
 
-    XCTAssertEqual(audioBlock.titleText, "Blowin' in the Wind")
+    #expect(audioBlock.titleText == "Blowin' in the Wind")
   }
 
-  func testAudioBlock_SubtitleText_ReturnsArtist() {
+  @Test
+  func testAudioBlockSubtitleTextReturnsArtist() {
     let audioBlock = AudioBlock.mockWith(artist: "Bob Dylan")
 
-    XCTAssertEqual(audioBlock.subtitleText, "Bob Dylan")
+    #expect(audioBlock.subtitleText == "Bob Dylan")
   }
 
-  func testAudioBlock_SubtitleColor_ReturnsGray() {
+  @Test
+  func testAudioBlockSubtitleColorReturnsGray() {
     let audioBlock = AudioBlock.mockWith()
 
-    XCTAssertEqual(audioBlock.subtitleColor, .playolaGray)
+    #expect(audioBlock.subtitleColor == .playolaGray)
   }
 
-  func testAudioBlock_AlbumImageUrl_ReturnsImageUrl() {
+  @Test
+  func testAudioBlockAlbumImageUrlReturnsImageUrl() {
     let imageUrl = URL(string: "https://example.com/album.jpg")!
     let audioBlock = AudioBlock.mockWith(imageUrl: imageUrl)
 
-    XCTAssertEqual(audioBlock.albumImageUrl, imageUrl)
+    #expect(audioBlock.albumImageUrl == imageUrl)
   }
 
-  func testAudioBlock_Icon_ReturnsNil() {
+  @Test
+  func testAudioBlockIconReturnsNil() {
     let audioBlock = AudioBlock.mockWith()
 
-    XCTAssertNil(audioBlock.icon)
+    #expect(audioBlock.icon == nil)
   }
 
-  func testAudioBlock_AudioBlockId_ReturnsId() {
+  @Test
+  func testAudioBlockAudioBlockIdReturnsId() {
     let audioBlock = AudioBlock.mockWith(id: "song-456")
 
-    XCTAssertEqual(audioBlock.audioBlockId, "song-456")
+    #expect(audioBlock.audioBlockId == "song-456")
   }
 
-  func testAudioBlock_IsReady_ReturnsTrue() {
+  @Test
+  func testAudioBlockIsReadyReturnsTrue() {
     let audioBlock = AudioBlock.mockWith()
 
-    XCTAssertTrue(audioBlock.isReady)
+    #expect(audioBlock.isReady)
   }
 
-  func testAudioBlock_IsProcessing_ReturnsFalse() {
+  @Test
+  func testAudioBlockIsProcessingReturnsFalse() {
     let audioBlock = AudioBlock.mockWith()
 
-    XCTAssertFalse(audioBlock.isProcessing)
+    #expect(!audioBlock.isProcessing)
   }
 }


### PR DESCRIPTION
## Summary
- Convert 16 XCTest files (Core, Models, Formatters) to swift-testing: \`final class FooTests: XCTestCase\` → \`struct FooTests\`, \`func testFoo()\` → \`@Test\`, \`XCTAssert*\` → \`#expect\`/\`Issue.record\`. Test names cleaned to camelCase per project convention.
- Add the swift-custom-dump SPM package to the test target only and use \`expectNoDifference\` where it meaningfully shortens whole-struct round-trip assertions.
- For files whose XCTest \`setUp()\` only zeroed @Shared state, the per-test \`@Shared\` declarations now own the reset (per CLAUDE.md). Reactive tests that need mid-test mutation still use \`\$shared.withLock\`, which is the only way to mutate the shared store from a test.

## Test plan
- [ ] All 142 converted tests pass: combined \`xcodebuild test\` on iPhone 16 Pro / iOS 18.6 reported \`** TEST SUCCEEDED **\` for the 16 affected suites.
- [ ] Spot-check XcodeGen / project.pbxproj diff: CustomDump is linked to the \`PlayolaRadioTests\` target only, never to the main app.