### PR TITLE
Convert misc/components tests to swift-testing

### DIFF
--- a/PlayolaRadio/Extensions/Version+Comparison/VersionComparisonTests.swift
+++ b/PlayolaRadio/Extensions/Version+Comparison/VersionComparisonTests.swift
@@ -3,52 +3,62 @@
 //  PlayolaRadio
 //
 
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-class VersionComparisonTests: XCTestCase {
+struct VersionComparisonTests {
+  @Test
   func testEqualVersionsReturnsFalse() {
-    XCTAssertFalse(isVersion("1.0.0", lessThan: "1.0.0"))
+    #expect(!isVersion("1.0.0", lessThan: "1.0.0"))
   }
 
+  @Test
   func testLessThanMajorReturnsTrue() {
-    XCTAssertTrue(isVersion("1.0.0", lessThan: "2.0.0"))
+    #expect(isVersion("1.0.0", lessThan: "2.0.0"))
   }
 
+  @Test
   func testGreaterThanMajorReturnsFalse() {
-    XCTAssertFalse(isVersion("2.0.0", lessThan: "1.0.0"))
+    #expect(!isVersion("2.0.0", lessThan: "1.0.0"))
   }
 
+  @Test
   func testLessThanMinorReturnsTrue() {
-    XCTAssertTrue(isVersion("1.1.0", lessThan: "1.2.0"))
+    #expect(isVersion("1.1.0", lessThan: "1.2.0"))
   }
 
+  @Test
   func testGreaterThanMinorReturnsFalse() {
-    XCTAssertFalse(isVersion("1.2.0", lessThan: "1.1.0"))
+    #expect(!isVersion("1.2.0", lessThan: "1.1.0"))
   }
 
+  @Test
   func testLessThanPatchReturnsTrue() {
-    XCTAssertTrue(isVersion("1.0.1", lessThan: "1.0.2"))
+    #expect(isVersion("1.0.1", lessThan: "1.0.2"))
   }
 
+  @Test
   func testGreaterThanPatchReturnsFalse() {
-    XCTAssertFalse(isVersion("1.0.2", lessThan: "1.0.1"))
+    #expect(!isVersion("1.0.2", lessThan: "1.0.1"))
   }
 
+  @Test
   func testMissingPatchTreatedAsZero() {
-    XCTAssertFalse(isVersion("1.0", lessThan: "1.0.0"))
-    XCTAssertTrue(isVersion("1.0", lessThan: "1.0.1"))
+    #expect(!isVersion("1.0", lessThan: "1.0.0"))
+    #expect(isVersion("1.0", lessThan: "1.0.1"))
   }
 
+  @Test
   func testMissingPatchOnRequiredTreatedAsZero() {
-    XCTAssertFalse(isVersion("1.0.0", lessThan: "1.0"))
-    XCTAssertFalse(isVersion("1.0.1", lessThan: "1.0"))
+    #expect(!isVersion("1.0.0", lessThan: "1.0"))
+    #expect(!isVersion("1.0.1", lessThan: "1.0"))
   }
 
+  @Test
   func testTwoComponentVersions() {
-    XCTAssertTrue(isVersion("1.0", lessThan: "1.1"))
-    XCTAssertFalse(isVersion("1.1", lessThan: "1.0"))
+    #expect(isVersion("1.0", lessThan: "1.1"))
+    #expect(!isVersion("1.1", lessThan: "1.0"))
   }
 }

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -6,20 +6,17 @@
 //
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class ContactPageTests: XCTestCase {
-  override static func setUp() {
-    super.setUp()
-    @Shared(.auth) var auth
-  }
-
+struct ContactPageTests {
+  @Test
   func testOnLogOutTappedStopsPlayerAndClearsAllUserState() async {
     let audioBlock = AudioBlock.mock
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -49,22 +46,23 @@ final class ContactPageTests: XCTestCase {
       await ContactPageModel(stationPlayer: stationPlayerMock).onLogOutTapped()
     }
 
-    XCTAssertEqual(stationPlayerMock.stopCalledCount, 1)
-    XCTAssertEqual(unregisterCalls.value.count, 1)
-    XCTAssertEqual(unregisterCalls.value.first?.0, "test-jwt")
-    XCTAssertEqual(unregisterCalls.value.first?.1, "device-xyz")
-    XCTAssertEqual(resetCallCount.value, 1)
-    XCTAssertFalse(auth.isLoggedIn)
-    XCTAssertNil(registeredDeviceId)
-    XCTAssertTrue(userLikes.isEmpty)
-    XCTAssertTrue(pendingLikeOperations.isEmpty)
-    XCTAssertTrue(airings.isEmpty)
-    XCTAssertTrue(lastNotificationSentAt.isEmpty)
-    XCTAssertFalse(isBroadcaster)
-    XCTAssertNil(UserDefaults.standard.object(forKey: "analytics_session_paused_at"))
+    #expect(stationPlayerMock.stopCalledCount == 1)
+    #expect(unregisterCalls.value.count == 1)
+    #expect(unregisterCalls.value.first?.0 == "test-jwt")
+    #expect(unregisterCalls.value.first?.1 == "device-xyz")
+    #expect(resetCallCount.value == 1)
+    #expect(!auth.isLoggedIn)
+    #expect(registeredDeviceId == nil)
+    #expect(userLikes.isEmpty)
+    #expect(pendingLikeOperations.isEmpty)
+    #expect(airings.isEmpty)
+    #expect(lastNotificationSentAt.isEmpty)
+    #expect(!isBroadcaster)
+    #expect(UserDefaults.standard.object(forKey: "analytics_session_paused_at") == nil)
   }
 
-  func testNameDisplay_ReturnsFullNameWhenLoggedIn() {
+  @Test
+  func testNameDisplayReturnsFullNameWhenLoggedIn() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "Jane",
@@ -76,18 +74,20 @@ final class ContactPageTests: XCTestCase {
 
     let model = ContactPageModel()
 
-    XCTAssertEqual(model.name, "Jane Smith")
+    #expect(model.name == "Jane Smith")
   }
 
-  func testNameDisplay_ReturnsAnonymousWhenNotLoggedIn() {
+  @Test
+  func testNameDisplayReturnsAnonymousWhenNotLoggedIn() {
     @Shared(.auth) var auth = Auth()
 
     let model = ContactPageModel()
 
-    XCTAssertEqual(model.name, "Anonymous")
+    #expect(model.name == "Anonymous")
   }
 
-  func testEmailDisplay_ReturnsEmailWhenLoggedIn() {
+  @Test
+  func testEmailDisplayReturnsEmailWhenLoggedIn() {
     let loggedInUser = LoggedInUser(
       id: "456",
       firstName: "Bob",
@@ -99,59 +99,62 @@ final class ContactPageTests: XCTestCase {
 
     let model = ContactPageModel()
 
-    XCTAssertEqual(model.email, "bob@test.com")
+    #expect(model.email == "bob@test.com")
   }
 
-  func testEmailDisplay_ReturnsUnknownWhenNotLoggedIn() {
+  @Test
+  func testEmailDisplayReturnsUnknownWhenNotLoggedIn() {
     @Shared(.auth) var auth = Auth()
 
     let model = ContactPageModel()
 
-    XCTAssertEqual(model.email, "Unknown")
+    #expect(model.email == "Unknown")
   }
 
-  func testOnLikedSongsTapped_NavigatesToLikedSongsPage() {
+  @Test
+  func testOnLikedSongsTappedNavigatesToLikedSongsPage() {
     let model = ContactPageModel()
 
     // Verify initial navigation state
-    XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+    #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
 
     // Tap liked songs button
     model.onLikedSongsTapped()
 
     // Verify navigation occurred
-    XCTAssertEqual(model.mainContainerNavigationCoordinator.path.count, 1)
+    #expect(model.mainContainerNavigationCoordinator.path.count == 1)
 
     if case .likedSongsPage = model.mainContainerNavigationCoordinator.path.first {
       // Successfully navigated to liked songs page
     } else {
-      XCTFail("Expected navigation to liked songs page")
+      Issue.record("Expected navigation to liked songs page")
     }
   }
 
-  func testOnNotificationsTapped_NavigatesToNotificationsSettingsPage() {
+  @Test
+  func testOnNotificationsTappedNavigatesToNotificationsSettingsPage() {
     let model = ContactPageModel()
 
     // Verify initial navigation state
-    XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+    #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
 
     // Tap notifications button
     model.onNotificationsTapped()
 
     // Verify navigation occurred
-    XCTAssertEqual(model.mainContainerNavigationCoordinator.path.count, 1)
+    #expect(model.mainContainerNavigationCoordinator.path.count == 1)
 
     if case .notificationsSettingsPage = model.mainContainerNavigationCoordinator.path.first {
       // Successfully navigated to notifications settings page
     } else {
-      XCTFail("Expected navigation to notifications settings page")
+      Issue.record("Expected navigation to notifications settings page")
     }
   }
 
-  func testOnMyStationTapped_SwitchesToBroadcastMode() async {
+  @Test
+  func testOnMyStationTappedSwitchesToBroadcastMode() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     await withMainSerialExecutor {
-      @Shared(.auth) var auth
-      $auth.withLock { $0 = Auth(jwt: "test-jwt") }
       let mockStations = [Station.mockWith(id: "test-station-id")]
 
       await withDependencies {
@@ -162,31 +165,33 @@ final class ContactPageTests: XCTestCase {
 
         await model.onViewAppeared()
 
-        XCTAssertEqual(model.mainContainerNavigationCoordinator.appMode, .listening)
+        #expect(model.mainContainerNavigationCoordinator.appMode == .listening)
 
         await model.onMyStationTapped()
 
-        XCTAssertEqual(
-          model.mainContainerNavigationCoordinator.appMode,
-          .broadcasting(stationId: "test-station-id")
+        #expect(
+          model.mainContainerNavigationCoordinator.appMode
+            == .broadcasting(stationId: "test-station-id")
         )
-        XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+        #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
       }
     }
   }
 
   // MARK: - My Station Button Visibility Tests
 
-  func testMyStationButtonVisible_IsFalseInitially() {
+  @Test
+  func testMyStationButtonVisibleIsFalseInitially() {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
     let model = ContactPageModel()
 
-    XCTAssertFalse(model.myStationButtonVisible)
-    XCTAssertNil(model.stationIdToTransitionTo)
+    #expect(!model.myStationButtonVisible)
+    #expect(model.stationIdToTransitionTo == nil)
   }
 
-  func testMyStationButtonVisible_IsFalseWhenUserHasNoStations() async {
+  @Test
+  func testMyStationButtonVisibleIsFalseWhenUserHasNoStations() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
     await withDependencies {
@@ -196,12 +201,13 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertFalse(model.myStationButtonVisible)
-      XCTAssertNil(model.stationIdToTransitionTo)
+      #expect(!model.myStationButtonVisible)
+      #expect(model.stationIdToTransitionTo == nil)
     }
   }
 
-  func testMyStationButtonVisible_IsTrueWhenUserHasStations() async {
+  @Test
+  func testMyStationButtonVisibleIsTrueWhenUserHasStations() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-1", name: "First Station"),
@@ -215,12 +221,13 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertTrue(model.myStationButtonVisible)
-      XCTAssertEqual(model.stationIdToTransitionTo, "station-1")
+      #expect(model.myStationButtonVisible)
+      #expect(model.stationIdToTransitionTo == "station-1")
     }
   }
 
-  func testStationIdToTransitionTo_IsFirstStationId() async {
+  @Test
+  func testStationIdToTransitionToIsFirstStationId() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "first-station-id", name: "First Station"),
@@ -235,11 +242,12 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertEqual(model.stationIdToTransitionTo, "first-station-id")
+      #expect(model.stationIdToTransitionTo == "first-station-id")
     }
   }
 
-  func testOnMyStationTapped_WithSingleStation_SwitchesToBroadcastMode() async {
+  @Test
+  func testOnMyStationTappedWithSingleStationSwitchesToBroadcastMode() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "single-station-id", name: "My Only Station")
@@ -253,15 +261,16 @@ final class ContactPageTests: XCTestCase {
       await model.onViewAppeared()
       await model.onMyStationTapped()
 
-      XCTAssertEqual(
-        model.mainContainerNavigationCoordinator.appMode,
-        .broadcasting(stationId: "single-station-id")
+      #expect(
+        model.mainContainerNavigationCoordinator.appMode
+          == .broadcasting(stationId: "single-station-id")
       )
-      XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+      #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
     }
   }
 
-  func testOnMyStationTapped_WithMultipleStations_NavigatesToChooseStationPage() async {
+  @Test
+  func testOnMyStationTappedWithMultipleStationsNavigatesToChooseStationPage() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-1", name: "First Station"),
@@ -277,23 +286,24 @@ final class ContactPageTests: XCTestCase {
       await model.onViewAppeared()
       await model.onMyStationTapped()
 
-      XCTAssertEqual(model.mainContainerNavigationCoordinator.path.count, 1)
+      #expect(model.mainContainerNavigationCoordinator.path.count == 1)
 
       if case .chooseStationToBroadcastPage(let chooseModel) = model
         .mainContainerNavigationCoordinator
         .path.first
       {
-        XCTAssertEqual(chooseModel.stations.count, 3)
-        XCTAssertEqual(chooseModel.stations[0].id, "station-1")
-        XCTAssertEqual(chooseModel.stations[1].id, "station-2")
-        XCTAssertEqual(chooseModel.stations[2].id, "station-3")
+        #expect(chooseModel.stations.count == 3)
+        #expect(chooseModel.stations[0].id == "station-1")
+        #expect(chooseModel.stations[1].id == "station-2")
+        #expect(chooseModel.stations[2].id == "station-3")
       } else {
-        XCTFail("Expected navigation to choose station page")
+        Issue.record("Expected navigation to choose station page")
       }
     }
   }
 
-  func testOnMyStationTapped_WithTwoStations_NavigatesToChooseStationPage() async {
+  @Test
+  func testOnMyStationTappedWithTwoStationsNavigatesToChooseStationPage() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-a", name: "Station A"),
@@ -308,22 +318,23 @@ final class ContactPageTests: XCTestCase {
       await model.onViewAppeared()
       await model.onMyStationTapped()
 
-      XCTAssertEqual(model.mainContainerNavigationCoordinator.path.count, 1)
+      #expect(model.mainContainerNavigationCoordinator.path.count == 1)
 
       if case .chooseStationToBroadcastPage(let chooseModel) = model
         .mainContainerNavigationCoordinator
         .path.first
       {
-        XCTAssertEqual(chooseModel.stations.count, 2)
+        #expect(chooseModel.stations.count == 2)
       } else {
-        XCTFail("Expected navigation to choose station page")
+        Issue.record("Expected navigation to choose station page")
       }
     }
   }
 
   // MARK: - My Station Button Label Tests
 
-  func testMyStationButtonLabel_ReturnsSingularWhenOneStation() async {
+  @Test
+  func testMyStationButtonLabelReturnsSingularWhenOneStation() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [Station.mockWith(id: "station-1", name: "My Only Station")]
 
@@ -334,11 +345,12 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertEqual(model.myStationButtonLabel, "My Station")
+      #expect(model.myStationButtonLabel == "My Station")
     }
   }
 
-  func testMyStationButtonLabel_ReturnsPluralWhenMultipleStations() async {
+  @Test
+  func testMyStationButtonLabelReturnsPluralWhenMultipleStations() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-1", name: "First Station"),
@@ -352,13 +364,14 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertEqual(model.myStationButtonLabel, "My Stations")
+      #expect(model.myStationButtonLabel == "My Stations")
     }
   }
 
   // MARK: - Analytics Tests
 
-  func testOnMyStationTapped_WithSingleStation_TracksAnalyticsEvent() async {
+  @Test
+  func testOnMyStationTappedWithSingleStationTracksAnalyticsEvent() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStation = Station.mockWith(id: "my-station-id", name: "My Station")
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
@@ -381,11 +394,12 @@ final class ContactPageTests: XCTestCase {
         }
         return false
       }
-      XCTAssertTrue(hasViewedBroadcastEvent)
+      #expect(hasViewedBroadcastEvent)
     }
   }
 
-  func testOnMyStationTapped_WithMultipleStations_DoesNotTrackAnalyticsEvent() async {
+  @Test
+  func testOnMyStationTappedWithMultipleStationsDoesNotTrackAnalyticsEvent() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-1", name: "Station 1"),
@@ -411,12 +425,13 @@ final class ContactPageTests: XCTestCase {
         }
         return false
       }
-      XCTAssertFalse(hasViewedBroadcastEvent)
+      #expect(!hasViewedBroadcastEvent)
     }
   }
 
   // MARK: - Broadcast Mode Tests
 
+  @Test
   func testIsInBroadcastModeReturnsFalseWhenListening() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -424,9 +439,10 @@ final class ContactPageTests: XCTestCase {
 
     let model = ContactPageModel()
 
-    XCTAssertFalse(model.isInBroadcastMode)
+    #expect(!model.isInBroadcastMode)
   }
 
+  @Test
   func testIsInBroadcastModeReturnsTrueWhenBroadcasting() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -434,9 +450,10 @@ final class ContactPageTests: XCTestCase {
 
     let model = ContactPageModel()
 
-    XCTAssertTrue(model.isInBroadcastMode)
+    #expect(model.isInBroadcastMode)
   }
 
+  @Test
   func testSwitchToListeningModeSwitchesMode() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -445,9 +462,10 @@ final class ContactPageTests: XCTestCase {
     let model = ContactPageModel()
     model.switchToListeningMode()
 
-    XCTAssertEqual(coordinator.appMode, .listening)
+    #expect(coordinator.appMode == .listening)
   }
 
+  @Test
   func testLogoutResetsAppModeToListening() async {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -472,11 +490,12 @@ final class ContactPageTests: XCTestCase {
       await model.onLogOutTapped()
     }
 
-    XCTAssertEqual(coordinator.appMode, .listening)
+    #expect(coordinator.appMode == .listening)
   }
 
   // MARK: - Sign Out Edge Cases
 
+  @Test
   func testOnLogOutTappedSkipsServerCallWhenDeviceNotRegistered() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt-abc")
     @Shared(.registeredDeviceId) var registeredDeviceId = String?.none
@@ -493,10 +512,11 @@ final class ContactPageTests: XCTestCase {
       await model.onLogOutTapped()
     }
 
-    XCTAssertEqual(unregisterCallCount.value, 0)
-    XCTAssertFalse(auth.isLoggedIn)
+    #expect(unregisterCallCount.value == 0)
+    #expect(!auth.isLoggedIn)
   }
 
+  @Test
   func testOnLogOutTappedStillClearsLocalStateWhenServerCallFails() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt-abc")
     @Shared(.registeredDeviceId) var registeredDeviceId = "device-xyz"
@@ -511,10 +531,11 @@ final class ContactPageTests: XCTestCase {
       await model.onLogOutTapped()
     }
 
-    XCTAssertFalse(auth.isLoggedIn)
-    XCTAssertNil(registeredDeviceId)
+    #expect(!auth.isLoggedIn)
+    #expect(registeredDeviceId == nil)
   }
 
+  @Test
   func testMyStationButtonHiddenWhenInBroadcastMode() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.mainContainerNavigationCoordinator)
@@ -530,7 +551,7 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertFalse(model.myStationButtonVisible)
+      #expect(!model.myStationButtonVisible)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowTests.swift
@@ -6,15 +6,16 @@
 import Dependencies
 import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class EpisodeRowModelTests: XCTestCase {
+struct EpisodeRowModelTests {
 
   // MARK: - Tune In Text Tests (This Week)
 
+  @Test
   func testTuneInTextThisWeekShowsDayOnly() {
     let friday = createDate(year: 2026, month: 1, day: 16, hour: 14, minute: 20)
     let saturday = createDate(year: 2026, month: 1, day: 17, hour: 14, minute: 20)
@@ -25,9 +26,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: saturday))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Saturday at 2:20pm")
+    #expect(model.tuneInText == "Tune in Saturday at 2:20pm")
   }
 
+  @Test
   func testTuneInTextThisWeekDifferentTime() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let wednesday = createDate(year: 2026, month: 1, day: 14, hour: 16, minute: 0)
@@ -38,11 +40,12 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: wednesday))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Wednesday at 4:00pm")
+    #expect(model.tuneInText == "Tune in Wednesday at 4:00pm")
   }
 
   // MARK: - Tune In Text Tests (Next Week)
 
+  @Test
   func testTuneInTextNextWeekShowsNextPrefix() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let nextFriday = createDate(year: 2026, month: 1, day: 23, hour: 14, minute: 20)
@@ -53,9 +56,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: nextFriday))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in next Friday at 2:20pm")
+    #expect(model.tuneInText == "Tune in next Friday at 2:20pm")
   }
 
+  @Test
   func testTuneInTextNextWeekDifferentDay() {
     let friday = createDate(year: 2026, month: 1, day: 16, hour: 9, minute: 0)
     let nextTuesday = createDate(year: 2026, month: 1, day: 20, hour: 19, minute: 30)
@@ -66,11 +70,12 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: nextTuesday))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in next Tuesday at 7:30pm")
+    #expect(model.tuneInText == "Tune in next Tuesday at 7:30pm")
   }
 
   // MARK: - Tune In Text Tests (Beyond Next Week)
 
+  @Test
   func testTuneInTextBeyondNextWeekShowsDayAndDate() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 3, hour: 14, minute: 20)
@@ -81,9 +86,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Tuesday the 3rd at 2:20pm")
+    #expect(model.tuneInText == "Tune in Tuesday the 3rd at 2:20pm")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinalSt() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 1, hour: 10, minute: 0)
@@ -94,9 +100,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Sunday the 1st at 10:00am")
+    #expect(model.tuneInText == "Tune in Sunday the 1st at 10:00am")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinalNd() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 2, hour: 15, minute: 45)
@@ -107,9 +114,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Monday the 2nd at 3:45pm")
+    #expect(model.tuneInText == "Tune in Monday the 2nd at 3:45pm")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinalTh() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 11, hour: 20, minute: 0)
@@ -120,9 +128,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Wednesday the 11th at 8:00pm")
+    #expect(model.tuneInText == "Tune in Wednesday the 11th at 8:00pm")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinal12th() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 12, hour: 12, minute: 0)
@@ -133,9 +142,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Thursday the 12th at 12:00pm")
+    #expect(model.tuneInText == "Tune in Thursday the 12th at 12:00pm")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinal13th() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 13, hour: 9, minute: 30)
@@ -146,9 +156,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Friday the 13th at 9:30am")
+    #expect(model.tuneInText == "Tune in Friday the 13th at 9:30am")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinal21st() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 21, hour: 18, minute: 0)
@@ -159,7 +170,7 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Saturday the 21st at 6:00pm")
+    #expect(model.tuneInText == "Tune in Saturday the 21st at 6:00pm")
   }
 
   // MARK: - Helper

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
@@ -5,14 +5,16 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SeriesCardModelTests: XCTestCase {
+struct SeriesCardModelTests {
+  @Test
   func testRemindMeTappedCallsSubscribeAPI() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let subscribeCalled = LockIsolated(false)
@@ -32,11 +34,12 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertTrue(subscribeCalled.value)
-      XCTAssertEqual(subscribedStationId.value, "station-123")
+      #expect(subscribeCalled.value)
+      #expect(subscribedStationId.value == "station-123")
     }
   }
 
+  @Test
   func testRemindMeTappedUpdatesStatusToSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -52,10 +55,11 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertEqual(model.subscriptionStatus, .subscribed)
+      #expect(model.subscriptionStatus == .subscribed)
     }
   }
 
+  @Test
   func testRemindMeTappedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -71,10 +75,11 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
+  @Test
   func testRemindMeTappedDoesNotCallAPIWithoutJWT() async {
     @Shared(.auth) var auth = Auth(jwt: nil)
     let subscribeCalled = LockIsolated(false)
@@ -92,10 +97,11 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertFalse(subscribeCalled.value)
+      #expect(!subscribeCalled.value)
     }
   }
 
+  @Test
   func testRemindMeTappedDoesNotCallAPIWithoutStation() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let subscribeCalled = LockIsolated(false)
@@ -113,10 +119,11 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertFalse(subscribeCalled.value)
+      #expect(!subscribeCalled.value)
     }
   }
 
+  @Test
   func testRemindMeTappedSetsIsSubscribingDuringRequest() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let wasSubscribingDuringCall = LockIsolated(false)
@@ -134,8 +141,8 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertTrue(wasSubscribingDuringCall.value)
-      XCTAssertFalse(model.isSubscribing)
+      #expect(wasSubscribingDuringCall.value)
+      #expect(!model.isSubscribing)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
@@ -5,14 +5,16 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SeriesListPageModelTests: XCTestCase {
+struct SeriesListPageModelTests {
+  @Test
   func testViewAppearedCallsGetAiringsAPI() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let apiCalled = LockIsolated(false)
@@ -30,11 +32,12 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertTrue(apiCalled.value)
-      XCTAssertEqual(passedJwt.value, "test-jwt")
+      #expect(apiCalled.value)
+      #expect(passedJwt.value == "test-jwt")
     }
   }
 
+  @Test
   func testViewAppearedPopulatesShowsGroupedByShow() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let now = Date()
@@ -67,14 +70,15 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.shows.count, 2)
+      #expect(model.shows.count == 2)
       let show1Group = model.shows.first { $0.show.id == "show-1" }
       let show2Group = model.shows.first { $0.show.id == "show-2" }
-      XCTAssertEqual(show1Group?.airings.count, 2)
-      XCTAssertEqual(show2Group?.airings.count, 1)
+      #expect(show1Group?.airings.count == 2)
+      #expect(show2Group?.airings.count == 1)
     }
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -87,10 +91,11 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
+  @Test
   func testViewAppearedDoesNotCallAPIWithoutJWT() async {
     @Shared(.auth) var auth = Auth(jwt: nil)
     let apiCalled = LockIsolated(false)
@@ -105,10 +110,11 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(apiCalled.value)
+      #expect(!apiCalled.value)
     }
   }
 
+  @Test
   func testViewAppearedFiltersOutEndedAirings() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let now = Date()
@@ -143,12 +149,12 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.shows.count, 1)
+      #expect(model.shows.count == 1)
       let showGroup = model.shows.first
-      XCTAssertEqual(showGroup?.airings.count, 2)
-      XCTAssertTrue(showGroup?.airings.contains { $0.id == "live-airing" } ?? false)
-      XCTAssertTrue(showGroup?.airings.contains { $0.id == "upcoming-airing" } ?? false)
-      XCTAssertFalse(showGroup?.airings.contains { $0.id == "ended-airing" } ?? true)
+      #expect(showGroup?.airings.count == 2)
+      #expect(showGroup?.airings.contains { $0.id == "live-airing" } ?? false)
+      #expect(showGroup?.airings.contains { $0.id == "upcoming-airing" } ?? false)
+      #expect(!(showGroup?.airings.contains { $0.id == "ended-airing" } ?? true))
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
@@ -5,15 +5,17 @@
 //  Created by Brian D Keane on 9/26/25.
 //
 
+import Foundation
 import PlayolaPlayer
 import Sharing
 import SwiftUI
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class StationListStationRowTests: XCTestCase {
+struct StationListStationRowTests {
+  @Test
   func testModelInitializationFromStation() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let stationList = StationList.mocks.first { !$0.visibleStationItems.isEmpty }!
@@ -22,12 +24,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, station.name)
-    XCTAssertEqual(model.subtitleText, station.stationName)
-    XCTAssertEqual(model.subtitleColor, Color.white)
-    XCTAssertEqual(model.imageUrl, station.imageUrl ?? station.processedImageURL())
+    #expect(model.titleText == station.name)
+    #expect(model.subtitleText == station.stationName)
+    #expect(model.subtitleColor == Color.white)
+    #expect(model.imageUrl == station.imageUrl ?? station.processedImageURL())
   }
 
+  @Test
   func testComingSoonItemShowsComingSoonWhenSecretsHidden() {
     @Shared(.showSecretStations) var showSecretStations: Bool = false
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -51,13 +54,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, comingSoonStation.curatorName)
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
-    XCTAssertEqual(
-      model.imageUrl, comingSoonStation.imageUrl)
+    #expect(model.titleText == comingSoonStation.curatorName)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
+    #expect(model.imageUrl == comingSoonStation.imageUrl)
   }
 
+  @Test
   func testComingSoonItemShowsComingSoonWhenSecretsShowingAndInactive() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -81,13 +84,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, comingSoonStation.curatorName)
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
-    XCTAssertEqual(
-      model.imageUrl, comingSoonStation.imageUrl)
+    #expect(model.titleText == comingSoonStation.curatorName)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
+    #expect(model.imageUrl == comingSoonStation.imageUrl)
   }
 
+  @Test
   func testComingSoonItemShowsNormallyWhenSecretsShowingAndActive() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -111,13 +114,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, comingSoonStation.curatorName)
-    XCTAssertEqual(model.subtitleText, comingSoonStation.name)
-    XCTAssertEqual(model.subtitleColor, Color.white)
-    XCTAssertEqual(
-      model.imageUrl, comingSoonStation.imageUrl)
+    #expect(model.titleText == comingSoonStation.curatorName)
+    #expect(model.subtitleText == comingSoonStation.name)
+    #expect(model.subtitleColor == Color.white)
+    #expect(model.imageUrl == comingSoonStation.imageUrl)
   }
 
+  @Test
   func testComingSoonItemShowsDateWhenItExists() {
     @Shared(.showSecretStations) var showSecretStations: Bool = false
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -142,13 +145,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, comingSoonStation.curatorName)
-    XCTAssertEqual(model.subtitleText, "Coming Dec 25th")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
-    XCTAssertEqual(
-      model.imageUrl, comingSoonStation.imageUrl)
+    #expect(model.titleText == comingSoonStation.curatorName)
+    #expect(model.subtitleText == "Coming Dec 25th")
+    #expect(model.subtitleColor == Color.playolaRed)
+    #expect(model.imageUrl == comingSoonStation.imageUrl)
   }
 
+  @Test
   func testComingSoonDateFormattingUsesUTCTimezone() {
     @Shared(.showSecretStations) var showSecretStations: Bool = false
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -181,9 +184,10 @@ final class StationListStationRowTests: XCTestCase {
     let model = StationListStationRowModel(item: item)
 
     // Should show Dec 25th (the UTC date), not Dec 24th (what it would be in US timezones)
-    XCTAssertEqual(model.subtitleText, "Coming Dec 25th")
+    #expect(model.subtitleText == "Coming Dec 25th")
   }
 
+  @Test
   func testInactiveVisibleStationShowsComingSoonWhenSecretsHidden() {
     @Shared(.showSecretStations) var showSecretStations: Bool = false
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -207,10 +211,11 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
   }
 
+  @Test
   func testInactiveVisibleStationShowsComingSoonWhenSecretsShowing() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -234,10 +239,11 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
   }
 
+  @Test
   func testInactiveUrlStationShowsComingSoonWhenSecretsShowing() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let inactiveUrlStation = UrlStation(
@@ -262,12 +268,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
   }
 
   // MARK: - Live Sort Priority Tests
 
+  @Test
   func testLiveSortPriorityReturnsZeroForVoicetracking() {
     let station = Station.mockWith(id: "live-station")
     let item = APIStationItem(
@@ -282,9 +289,10 @@ final class StationListStationRowTests: XCTestCase {
 
     let priority = item.liveSortPriority(liveStations)
 
-    XCTAssertEqual(priority, 0)
+    #expect(priority == 0)
   }
 
+  @Test
   func testLiveSortPriorityReturnsOneForShowAiring() {
     let station = Station.mockWith(id: "show-station")
     let item = APIStationItem(
@@ -299,9 +307,10 @@ final class StationListStationRowTests: XCTestCase {
 
     let priority = item.liveSortPriority(liveStations)
 
-    XCTAssertEqual(priority, 1)
+    #expect(priority == 1)
   }
 
+  @Test
   func testLiveSortPriorityReturnsTwoForNotLive() {
     let station = Station.mockWith(id: "not-live-station")
     let item = APIStationItem(
@@ -314,11 +323,12 @@ final class StationListStationRowTests: XCTestCase {
 
     let priority = item.liveSortPriority(liveStations)
 
-    XCTAssertEqual(priority, 2)
+    #expect(priority == 2)
   }
 
   // MARK: - Live Status in Row Model Tests
 
+  @Test
   func testRowModelStoresLiveStatus() {
     let station = Station.mockWith(id: "live-station")
     let item = APIStationItem(
@@ -330,9 +340,10 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item, liveStatus: .voicetracking)
 
-    XCTAssertEqual(model.liveStatus, .voicetracking)
+    #expect(model.liveStatus == .voicetracking)
   }
 
+  @Test
   func testRowModelLiveStatusDefaultsToNil() {
     let station = Station.mockWith(id: "station")
     let item = APIStationItem(
@@ -344,6 +355,6 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertNil(model.liveStatus)
+    #expect(model.liveStatus == nil)
   }
 }

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
@@ -10,12 +10,12 @@ import Dependencies
 import Foundation
 import Sharing
 import SwiftUI
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SupportPageTests: XCTestCase {
+struct SupportPageTests {
   private func makeConversation(id: String) -> Conversation {
     Conversation(
       id: id,
@@ -43,6 +43,7 @@ final class SupportPageTests: XCTestCase {
     )
   }
 
+  @Test
   func testOnViewAppearedLoadsConversationAndMessages() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -88,17 +89,18 @@ final class SupportPageTests: XCTestCase {
       SupportPageModel()
     }
 
-    XCTAssertTrue(model.isLoading)
-    XCTAssertTrue(model.messages.isEmpty)
+    #expect(model.isLoading)
+    #expect(model.messages.isEmpty)
 
     await model.onViewAppeared()
 
-    XCTAssertFalse(model.isLoading)
-    XCTAssertEqual(model.conversation?.id, "conv-1")
-    XCTAssertEqual(model.messages.count, 1)
-    XCTAssertTrue(model.hasExistingMessages)
+    #expect(!model.isLoading)
+    #expect(model.conversation?.id == "conv-1")
+    #expect(model.messages.count == 1)
+    #expect(model.hasExistingMessages)
   }
 
+  @Test
   func testHasExistingMessagesReturnsFalseWhenEmpty() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -134,9 +136,10 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertFalse(model.hasExistingMessages)
+    #expect(!model.hasExistingMessages)
   }
 
+  @Test
   func testSendMessageAppendsToMessages() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -184,28 +187,30 @@ final class SupportPageTests: XCTestCase {
     await model.onViewAppeared()
     model.newMessage = "Test message"
 
-    XCTAssertTrue(model.canSend)
+    #expect(model.canSend)
 
     await model.sendMessage()
 
-    XCTAssertEqual(model.messages.count, 1)
-    XCTAssertEqual(model.messages.first?.message, "Test message")
-    XCTAssertTrue(model.newMessage.isEmpty)
+    #expect(model.messages.count == 1)
+    #expect(model.messages.first?.message == "Test message")
+    #expect(model.newMessage.isEmpty)
   }
 
+  @Test
   func testCanSendReturnsFalseWhenMessageEmpty() {
     let model = SupportPageModel()
 
     model.newMessage = ""
-    XCTAssertFalse(model.canSend)
+    #expect(!model.canSend)
 
     model.newMessage = "   "
-    XCTAssertFalse(model.canSend)
+    #expect(!model.canSend)
 
     model.newMessage = "Hello"
-    XCTAssertTrue(model.canSend)
+    #expect(model.canSend)
   }
 
+  @Test
   func testOnViewAppearedDoesNotOverwritePresetConversation() async {
     // Regression test: When navigating from ConversationListPage, the model
     // already has a conversation set. onViewAppeared should NOT overwrite it.
@@ -244,11 +249,12 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertEqual(model.conversation?.id, "preset-conv-id")
-    XCTAssertFalse(getSupportConversationCalled.value)
-    XCTAssertFalse(model.isLoading)
+    #expect(model.conversation?.id == "preset-conv-id")
+    #expect(!getSupportConversationCalled.value)
+    #expect(!model.isLoading)
   }
 
+  @Test
   func testOnViewAppearedRefreshesMessagesWhenConversationAlreadySet() async {
     // Regression test: When navigating to support page with conversation already set,
     // onViewAppeared should still refresh the messages to get any new ones.
@@ -290,12 +296,13 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertTrue(getConversationMessagesCalled.value)
-    XCTAssertEqual(model.messages.count, 2)
-    XCTAssertEqual(model.messages.last?.message, "New message")
-    XCTAssertFalse(model.isLoading)
+    #expect(getConversationMessagesCalled.value)
+    #expect(model.messages.count == 2)
+    #expect(model.messages.last?.message == "New message")
+    #expect(!model.isLoading)
   }
 
+  @Test
   func testHandleScenePhaseChangeRefreshesMessagesWhenActive() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -328,11 +335,12 @@ final class SupportPageTests: XCTestCase {
 
     await model.handleScenePhaseChange(.active)
 
-    XCTAssertTrue(getConversationMessagesCalled.value)
-    XCTAssertEqual(model.messages.count, 1)
-    XCTAssertEqual(model.messages.first?.message, "New reply")
+    #expect(getConversationMessagesCalled.value)
+    #expect(model.messages.count == 1)
+    #expect(model.messages.first?.message == "New reply")
   }
 
+  @Test
   func testOnViewAppearedDoesNotCreateConversationWhenGetReturnsNil() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -367,15 +375,16 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertFalse(
-      createCalled.value, "Should not create a conversation just from viewing the page")
-    XCTAssertFalse(getMessagesCalled.value, "No conversation = no messages to fetch")
-    XCTAssertNil(model.conversation)
-    XCTAssertTrue(model.messages.isEmpty)
-    XCTAssertFalse(model.isLoading)
-    XCTAssertNil(model.presentedAlert)
+    #expect(
+      !createCalled.value, "Should not create a conversation just from viewing the page")
+    #expect(!getMessagesCalled.value, "No conversation = no messages to fetch")
+    #expect(model.conversation == nil)
+    #expect(model.messages.isEmpty)
+    #expect(!model.isLoading)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testSendMessageCreatesConversationWhenNoneExists() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -405,8 +414,8 @@ final class SupportPageTests: XCTestCase {
           conversation: createdConversation, unreadCount: 0)
       }
       $0.api.sendConversationMessage = { _, conversationId, text in
-        XCTAssertEqual(conversationId, "lazy-conv")
-        XCTAssertEqual(text, "Hi there")
+        #expect(conversationId == "lazy-conv")
+        #expect(text == "Hi there")
         return sentMessage
       }
       $0.api.getConversationMessages = { _, _ in [] }
@@ -415,18 +424,19 @@ final class SupportPageTests: XCTestCase {
     }
 
     await model.onViewAppeared()
-    XCTAssertNil(model.conversation)
+    #expect(model.conversation == nil)
 
     model.newMessage = "Hi there"
     await model.sendMessage()
 
-    XCTAssertTrue(createCalled.value)
-    XCTAssertEqual(model.conversation?.id, "lazy-conv")
-    XCTAssertEqual(model.messages.count, 1)
-    XCTAssertEqual(model.messages.first?.message, "Hi there")
-    XCTAssertTrue(model.newMessage.isEmpty)
+    #expect(createCalled.value)
+    #expect(model.conversation?.id == "lazy-conv")
+    #expect(model.messages.count == 1)
+    #expect(model.messages.first?.message == "Hi there")
+    #expect(model.newMessage.isEmpty)
   }
 
+  @Test
   func testSendMessageRestoresMessageAndShowsAlertWhenCreateFails() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -466,13 +476,14 @@ final class SupportPageTests: XCTestCase {
     model.newMessage = "Hello"
     await model.sendMessage()
 
-    XCTAssertFalse(sendCalled.value, "Should not call send when create fails")
-    XCTAssertNil(model.conversation)
-    XCTAssertEqual(model.newMessage, "Hello", "newMessage should be restored")
-    XCTAssertEqual(model.presentedAlert, .errorSendingMessage)
-    XCTAssertFalse(model.isSending)
+    #expect(!sendCalled.value, "Should not call send when create fails")
+    #expect(model.conversation == nil)
+    #expect(model.newMessage == "Hello", "newMessage should be restored")
+    #expect(model.presentedAlert == .errorSendingMessage)
+    #expect(!model.isSending)
   }
 
+  @Test
   func testOnViewAppearedUsesExistingConversationFromGet() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -504,10 +515,11 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertFalse(createCalled.value)
-    XCTAssertEqual(model.conversation?.id, "existing-conv")
+    #expect(!createCalled.value)
+    #expect(model.conversation?.id == "existing-conv")
   }
 
+  @Test
   func testHandleScenePhaseChangeDoesNothingWhenNotActive() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -533,9 +545,9 @@ final class SupportPageTests: XCTestCase {
     model.conversation = conversation
 
     await model.handleScenePhaseChange(.background)
-    XCTAssertFalse(getConversationMessagesCalled.value)
+    #expect(!getConversationMessagesCalled.value)
 
     await model.handleScenePhaseChange(.inactive)
-    XCTAssertFalse(getConversationMessagesCalled.value)
+    #expect(!getConversationMessagesCalled.value)
   }
 }

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
@@ -9,24 +9,14 @@ import Combine
 import Dependencies
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 // swiftlint:disable redundant_optional_initialization
 
 @MainActor
-final class ListeningTimeTileModelTests: XCTestCase {
-
-  override func setUp() {
-    super.setUp()
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
-  }
-
-  override func tearDown() {
-    super.tearDown()
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
-  }
+struct ListeningTimeTileModelTests {
 
   func createMockListeningTracker(totalTimeMS: Int) -> ListeningTracker {
     let rewardsProfile = RewardsProfile(
@@ -39,65 +29,76 @@ final class ListeningTimeTileModelTests: XCTestCase {
 
   // MARK: - Display String Formatting Tests
 
-  func testListeningTimeDisplayString_FormatsZeroTime() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsZeroTime() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 0
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "00h 00m 00s")
+      #expect(model.listeningTimeDisplayString == "00h 00m 00s")
     }
   }
 
-  func testListeningTimeDisplayString_FormatsSeconds() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsSeconds() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 45000  // 45 seconds
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "00h 00m 45s")
+      #expect(model.listeningTimeDisplayString == "00h 00m 45s")
     }
   }
 
-  func testListeningTimeDisplayString_FormatsMinutes() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsMinutes() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 150000  // 2 minutes 30 seconds
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "00h 02m 30s")
+      #expect(model.listeningTimeDisplayString == "00h 02m 30s")
     }
   }
 
-  func testListeningTimeDisplayString_FormatsHours() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsHours() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 7_382_000  // 2 hours 3 minutes 2 seconds
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "02h 03m 02s")
+      #expect(model.listeningTimeDisplayString == "02h 03m 02s")
     }
   }
 
-  func testListeningTimeDisplayString_FormatsLargeHours() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsLargeHours() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 360_000_000  // 100 hours
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "100h 00m 00s")
+      #expect(model.listeningTimeDisplayString == "100h 00m 00s")
     }
   }
 
   // MARK: - View Lifecycle Tests
 
-  func testViewAppeared_UpdatesFromListeningTracker() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+  @Test
+  func testViewAppearedUpdatesFromListeningTracker() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -105,7 +106,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
       ListeningTimeTileModel()
     }
 
-    XCTAssertEqual(model.totalListeningTime, 0)
+    #expect(model.totalListeningTime == 0)
 
     let tracker = createMockListeningTracker(totalTimeMS: 5000)
     $listeningTracker.withLock { $0 = tracker }
@@ -114,13 +115,14 @@ final class ListeningTimeTileModelTests: XCTestCase {
 
     // The initial update should happen immediately
     await clock.advance(by: .seconds(1))
-    XCTAssertEqual(model.totalListeningTime, 5000)
+    #expect(model.totalListeningTime == 5000)
 
     model.viewDisappeared()
   }
 
-  func testViewAppeared_HandlesNilTracker() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+  @Test
+  func testViewAppearedHandlesNilTracker() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -131,13 +133,14 @@ final class ListeningTimeTileModelTests: XCTestCase {
     model.viewAppeared()
 
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 0)
+    #expect(model.totalListeningTime == 0)
 
     model.viewDisappeared()
   }
 
-  func testViewDisappeared_CancelsRefreshTask() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+  @Test
+  func testViewDisappearedCancelsRefreshTask() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -151,7 +154,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
     model.viewAppeared()
 
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 1000)
+    #expect(model.totalListeningTime == 1000)
 
     model.viewDisappeared()
 
@@ -166,11 +169,12 @@ final class ListeningTimeTileModelTests: XCTestCase {
     await clock.advance(by: .seconds(1))
 
     // Should still be 1000 since task was cancelled
-    XCTAssertEqual(model.totalListeningTime, 1000)
+    #expect(model.totalListeningTime == 1000)
   }
 
-  func testMultipleViewAppeared_CancelsPreviousTask() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+  @Test
+  func testMultipleViewAppearedCancelsPreviousTask() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -184,7 +188,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
     // First viewAppeared
     model.viewAppeared()
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 1000)
+    #expect(model.totalListeningTime == 1000)
 
     // Second viewAppeared (should cancel first task)
     let session1 = LocalListeningSession(
@@ -204,7 +208,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
 
     model.viewAppeared()
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 11000)  // 1000 + 10000
+    #expect(model.totalListeningTime == 11000)  // 1000 + 10000
 
     // Advance clock to verify only one task is running
     let session2 = LocalListeningSession(
@@ -225,13 +229,14 @@ final class ListeningTimeTileModelTests: XCTestCase {
     // Allow shared state to propagate before advancing clock
     await Task.yield()
     await clock.advance(by: .seconds(1))
-    XCTAssertEqual(model.totalListeningTime, 16000)  // 1000 + 10000 + 5000
+    #expect(model.totalListeningTime == 16000)  // 1000 + 10000 + 5000
 
     model.viewDisappeared()
   }
 
+  @Test
   func testConcurrentUpdates() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -245,7 +250,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
     model.viewAppeared()
 
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 0)
+    #expect(model.totalListeningTime == 0)
 
     // Simulate rapid updates by adding sessions
     var sessions: [LocalListeningSession] = []
@@ -269,14 +274,15 @@ final class ListeningTimeTileModelTests: XCTestCase {
       // Allow shared state to propagate before advancing clock
       await Task.yield()
       await clock.advance(by: .seconds(1))
-      XCTAssertEqual(model.totalListeningTime, index * 1000)
+      #expect(model.totalListeningTime == index * 1000)
     }
 
     model.viewDisappeared()
   }
 
+  @Test
   func testIntegrationWithRealTimeTracking() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -298,8 +304,8 @@ final class ListeningTimeTileModelTests: XCTestCase {
 
     // Initial state: 10 seconds from server
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 10000)
-    XCTAssertEqual(model.listeningTimeDisplayString, "00h 00m 10s")
+    #expect(model.totalListeningTime == 10000)
+    #expect(model.listeningTimeDisplayString == "00h 00m 10s")
 
     // Advance 5 seconds - the listening session should add time
     await clock.advance(by: .seconds(5))
@@ -308,7 +314,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
     // Note: Due to the way ListeningTracker calculates time,
     // we might need to be flexible with exact timing
     let expectedTime = model.totalListeningTime
-    XCTAssertGreaterThanOrEqual(expectedTime, 10000)
+    #expect(expectedTime >= 10000)
 
     model.viewDisappeared()
   }

--- a/PlayolaRadio/Views/Reusable Components/NewFeatureTile/NewFeatureTileTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/NewFeatureTile/NewFeatureTileTests.swift
@@ -3,13 +3,14 @@
 //  PlayolaRadio
 //
 
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class NewFeatureTileModelTests: XCTestCase {
+struct NewFeatureTileModelTests {
 
+  @Test
   func testOnButtonTappedCallsButtonAction() async {
     var actionCalled = false
 
@@ -20,6 +21,6 @@ final class NewFeatureTileModelTests: XCTestCase {
 
     await model.onButtonTapped()
 
-    XCTAssertTrue(actionCalled)
+    #expect(actionCalled)
   }
 }

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
@@ -13,6 +13,8 @@ import Testing
 
 @testable import PlayolaRadio
 
+// swiftlint:disable redundant_optional_initialization
+
 @MainActor
 struct SmallPlayerTests {
 
@@ -302,3 +304,5 @@ struct SmallPlayerTests {
     #expect(smallPlayer.artworkURL == testImageUrl)
   }
 }
+
+// swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
@@ -6,52 +6,51 @@
 //
 
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SmallPlayerTests: XCTestCase {
-
-  override func setUp() {
-    super.setUp()
-    // Clear shared state before each test
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
-    $nowPlaying.withLock { $0 = nil }
-  }
+struct SmallPlayerTests {
 
   // MARK: - Main Title Tests
 
-  func testMainTitle_ReturnsStationNameWhenAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testMainTitleReturnsStationNameWhenAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock { $0 = NowPlaying(currentStation: mockStation) }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
+    #expect(smallPlayer.mainTitle == mockStation.name)
   }
 
-  func testMainTitle_ReturnsEmptyStringWhenNoStation() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testMainTitleReturnsEmptyStringWhenNoStation() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
 
     $nowPlaying.withLock { $0 = NowPlaying() }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, "")
+    #expect(smallPlayer.mainTitle == "")
   }
 
-  func testMainTitle_ReturnsEmptyStringWhenNowPlayingIsNil() {
+  @Test
+  func testMainTitleReturnsEmptyStringWhenNowPlayingIsNil() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, "")
+    #expect(smallPlayer.mainTitle == "")
   }
 
   // MARK: - Secondary Title Tests
 
-  func testSecondaryTitle_ReturnsArtistAndTitleWhenAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsArtistAndTitleWhenAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -63,21 +62,23 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Test Artist - Test Song")
+    #expect(smallPlayer.secondaryTitle == "Test Artist - Test Song")
   }
 
-  func testSecondaryTitle_ReturnsStationDescWhenNoArtistTitle() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsStationDescWhenNoArtistTitle() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock { $0 = NowPlaying(currentStation: mockStation) }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, mockStation.description)
+    #expect(smallPlayer.secondaryTitle == mockStation.description)
   }
 
-  func testSecondaryTitle_ReturnsLoadingWhenPlaybackStatusIsLoading() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsLoadingWhenPlaybackStatusIsLoading() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -88,11 +89,12 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Loading...")
+    #expect(smallPlayer.secondaryTitle == "Loading...")
   }
 
-  func testSecondaryTitle_ReturnsLoadingWhenLoadingEvenWithTrackInfo() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsLoadingWhenLoadingEvenWithTrackInfo() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -105,11 +107,12 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Loading...")
+    #expect(smallPlayer.secondaryTitle == "Loading...")
   }
 
-  func testSecondaryTitle_ReturnsStationDescWhenOnlyArtistAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsStationDescWhenOnlyArtistAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -120,11 +123,12 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, mockStation.description)
+    #expect(smallPlayer.secondaryTitle == mockStation.description)
   }
 
-  func testSecondaryTitle_ReturnsStationDescWhenOnlyTitleAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsStationDescWhenOnlyTitleAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -135,22 +139,24 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, mockStation.description)
+    #expect(smallPlayer.secondaryTitle == mockStation.description)
   }
 
-  func testSecondaryTitle_ReturnsEmptyStringWhenNothingAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsEmptyStringWhenNothingAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
 
     $nowPlaying.withLock { $0 = NowPlaying() }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, "")
+    #expect(smallPlayer.secondaryTitle == "")
   }
 
   // MARK: - Artwork URL Tests
 
-  func testArtworkURL_ReturnsAlbumArtworkWhenAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testArtworkURLReturnsAlbumArtworkWhenAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let testURL = URL(string: "https://example.com/album.jpg")!
     let mockStation = AnyStation.mock
 
@@ -162,45 +168,50 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.artworkURL, testURL)
+    #expect(smallPlayer.artworkURL == testURL)
   }
 
-  func testArtworkURL_ReturnsStationImageWhenNoAlbumArtwork() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testArtworkURLReturnsStationImageWhenNoAlbumArtwork() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock { $0 = NowPlaying(currentStation: mockStation) }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.artworkURL, mockStation.processedImageURL())
+    #expect(smallPlayer.artworkURL == mockStation.processedImageURL())
   }
 
-  func testArtworkURL_ReturnsFallbackWhenNothingAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testArtworkURLReturnsFallbackWhenNothingAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
 
     $nowPlaying.withLock { $0 = NowPlaying() }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.artworkURL, URL(string: "https://example.com")!)
+    #expect(smallPlayer.artworkURL == URL(string: "https://example.com")!)
   }
 
-  func testArtworkURL_ReturnsFallbackWhenNowPlayingIsNil() {
+  @Test
+  func testArtworkURLReturnsFallbackWhenNowPlayingIsNil() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.artworkURL, URL(string: "https://example.com")!)
+    #expect(smallPlayer.artworkURL == URL(string: "https://example.com")!)
   }
 
   // MARK: - State Change Tests
 
-  func testSmallPlayer_UpdatesWhenNowPlayingChanges() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSmallPlayerUpdatesWhenNowPlayingChanges() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     // Initial state - no track info
     $nowPlaying.withLock { $0 = NowPlaying(currentStation: mockStation) }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, mockStation.description)
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == mockStation.description)
 
     // Update with artist/title - should now show track info
     $nowPlaying.withLock {
@@ -211,19 +222,20 @@ final class SmallPlayerTests: XCTestCase {
       )
     }
 
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, "New Artist - New Song")
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == "New Artist - New Song")
   }
 
-  func testSmallPlayer_HandlesNilToDataTransition() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSmallPlayerHandlesNilToDataTransition() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     let smallPlayer = SmallPlayer()
 
     // Initially nil
-    XCTAssertEqual(smallPlayer.mainTitle, "")
-    XCTAssertEqual(smallPlayer.secondaryTitle, "")
+    #expect(smallPlayer.mainTitle == "")
+    #expect(smallPlayer.secondaryTitle == "")
 
     // Set data
     $nowPlaying.withLock {
@@ -234,12 +246,13 @@ final class SmallPlayerTests: XCTestCase {
       )
     }
 
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Test Artist - Test Song")
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == "Test Artist - Test Song")
   }
 
-  func testSmallPlayer_HandlesDataToNilTransition() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSmallPlayerHandlesDataToNilTransition() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     // Start with data
@@ -252,20 +265,21 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Test Artist - Test Song")
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == "Test Artist - Test Song")
 
     // Clear data
     $nowPlaying.withLock { $0 = nil }
 
-    XCTAssertEqual(smallPlayer.mainTitle, "")
-    XCTAssertEqual(smallPlayer.secondaryTitle, "")
+    #expect(smallPlayer.mainTitle == "")
+    #expect(smallPlayer.secondaryTitle == "")
   }
 
   // MARK: - Integration Tests with Spin Data
 
-  func testSmallPlayer_DisplaysSpinDataCorrectly() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSmallPlayerDisplaysSpinDataCorrectly() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
     let mockSpin = Spin.mock
     let testArtist = "Test Artist"
@@ -283,8 +297,8 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, "\(testArtist) - \(testTitle)")
-    XCTAssertEqual(smallPlayer.artworkURL, testImageUrl)
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == "\(testArtist) - \(testTitle)")
+    #expect(smallPlayer.artworkURL == testImageUrl)
   }
 }

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
@@ -6,15 +6,17 @@
 //
 
 import Dependencies
+import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SongDrawerTests: XCTestCase {
+struct SongDrawerTests {
 
-  func testOpenSpotify_WithSpotifyId_OpensCorrectURL() {
+  @Test
+  func testOpenSpotifyWithSpotifyIdOpensCorrectURL() {
     let audioBlock = AudioBlock.mockWith(spotifyId: "4iV5W9uYEdYUVa79Axb7Rh")
     var dismissCalled = false
 
@@ -28,10 +30,11 @@ final class SongDrawerTests: XCTestCase {
     // This test verifies the logic flow and that dismiss is called
     model.openSpotify()
 
-    XCTAssertTrue(dismissCalled, "Should call onDismiss after attempting to open Spotify")
+    #expect(dismissCalled, "Should call onDismiss after attempting to open Spotify")
   }
 
-  func testOpenSpotify_WithoutSpotifyId_JustDismisses() {
+  @Test
+  func testOpenSpotifyWithoutSpotifyIdJustDismisses() {
     let audioBlock = AudioBlock.mockWith(spotifyId: nil)
     var dismissCalled = false
 
@@ -43,10 +46,11 @@ final class SongDrawerTests: XCTestCase {
 
     model.openSpotify()
 
-    XCTAssertTrue(dismissCalled, "Should call onDismiss when no Spotify ID is available")
+    #expect(dismissCalled, "Should call onDismiss when no Spotify ID is available")
   }
 
-  func testOpenAppleMusic_OpensSearchURL() {
+  @Test
+  func testOpenAppleMusicOpensSearchURL() {
     let audioBlock = AudioBlock.mockWith(
       title: "Test Song",
       artist: "Test Artist"
@@ -61,10 +65,11 @@ final class SongDrawerTests: XCTestCase {
 
     model.openAppleMusic()
 
-    XCTAssertTrue(dismissCalled, "Should call onDismiss after attempting to open Apple Music")
+    #expect(dismissCalled, "Should call onDismiss after attempting to open Apple Music")
   }
 
-  func testOpenAppleMusic_HandlesSpecialCharacters() {
+  @Test
+  func testOpenAppleMusicHandlesSpecialCharacters() {
     let audioBlock = AudioBlock.mockWith(
       title: "Song & Title",
       artist: "Artist @ Name"
@@ -80,10 +85,11 @@ final class SongDrawerTests: XCTestCase {
     // Should not crash with special characters and should call dismiss
     model.openAppleMusic()
 
-    XCTAssertTrue(dismissCalled, "Should handle URL encoding and call onDismiss")
+    #expect(dismissCalled, "Should handle URL encoding and call onDismiss")
   }
 
-  func testShouldShowSpotify_TrueWhenSpotifyIdExists() {
+  @Test
+  func testShouldShowSpotifyTrueWhenSpotifyIdExists() {
     let audioBlock = AudioBlock.mockWith(spotifyId: "4iV5W9uYEdYUVa79Axb7Rh")
     let model = SongDrawerModel(
       audioBlock: audioBlock,
@@ -91,10 +97,11 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertTrue(model.shouldShowSpotify)
+    #expect(model.shouldShowSpotify)
   }
 
-  func testShouldShowSpotify_FalseWhenSpotifyIdIsNil() {
+  @Test
+  func testShouldShowSpotifyFalseWhenSpotifyIdIsNil() {
     let audioBlock = AudioBlock.mockWith(spotifyId: nil)
     let model = SongDrawerModel(
       audioBlock: audioBlock,
@@ -102,10 +109,11 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertFalse(model.shouldShowSpotify)
+    #expect(!model.shouldShowSpotify)
   }
 
-  func testShouldShowAppleMusic_TrueWhenTitleAndArtistExist() {
+  @Test
+  func testShouldShowAppleMusicTrueWhenTitleAndArtistExist() {
     let audioBlock = AudioBlock.mockWith(
       title: "Test Song",
       artist: "Test Artist"
@@ -116,10 +124,11 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertTrue(model.shouldShowAppleMusic)
+    #expect(model.shouldShowAppleMusic)
   }
 
-  func testShouldShowAppleMusic_FalseWhenTitleOrArtistEmpty() {
+  @Test
+  func testShouldShowAppleMusicFalseWhenTitleOrArtistEmpty() {
     let audioBlockEmptyTitle = AudioBlock.mockWith(
       title: "",
       artist: "Test Artist"
@@ -130,7 +139,7 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertFalse(modelEmptyTitle.shouldShowAppleMusic)
+    #expect(!modelEmptyTitle.shouldShowAppleMusic)
 
     let audioBlockEmptyArtist = AudioBlock.mockWith(
       title: "Test Song",
@@ -142,10 +151,11 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertFalse(modelEmptyArtist.shouldShowAppleMusic)
+    #expect(!modelEmptyArtist.shouldShowAppleMusic)
   }
 
-  func testRemoveFromLikedSongs_UnlikesAndDismisses() async {
+  @Test
+  func testRemoveFromLikedSongsUnlikesAndDismisses() async {
     let audioBlock = AudioBlock.mock
     var dismissCalled = false
 
@@ -162,17 +172,18 @@ final class SongDrawerTests: XCTestCase {
       )
 
       // Verify it's liked initially
-      XCTAssertTrue(model.likesManager.isLiked(audioBlock.id))
+      #expect(model.likesManager.isLiked(audioBlock.id))
 
       model.removeFromLikedSongs()
 
       // Verify it's been unliked and dismiss was called
-      XCTAssertFalse(model.likesManager.isLiked(audioBlock.id))
-      XCTAssertTrue(dismissCalled)
+      #expect(!model.likesManager.isLiked(audioBlock.id))
+      #expect(dismissCalled)
     }
   }
 
-  func testRemoveFromLikedSongs_WithOnRemoveCallback() async {
+  @Test
+  func testRemoveFromLikedSongsWithOnRemoveCallback() async {
     let audioBlock = AudioBlock.mock
     var dismissCalled = false
     var onRemoveCalled = false
@@ -196,13 +207,13 @@ final class SongDrawerTests: XCTestCase {
       model.removeFromLikedSongs()
 
       // Verify the onRemove callback was called with correct audio block
-      XCTAssertTrue(onRemoveCalled, "Should call onRemove callback")
-      XCTAssertEqual(
-        removedAudioBlock?.id, audioBlock.id, "Should pass correct audioBlock to onRemove")
-      XCTAssertTrue(dismissCalled, "Should call onDismiss")
+      #expect(onRemoveCalled, "Should call onRemove callback")
+      #expect(
+        removedAudioBlock?.id == audioBlock.id, "Should pass correct audioBlock to onRemove")
+      #expect(dismissCalled, "Should call onDismiss")
 
       // Verify song is still liked (since onRemove callback handles the removal)
-      XCTAssertTrue(
+      #expect(
         model.likesManager.isLiked(audioBlock.id),
         "Song should still be liked when using onRemove callback"
       )


### PR DESCRIPTION
Converts 11 remaining XCTest files (component, page, and extension tests) to swift-testing, matching the pattern established in PR #278. All 124 tests across the 11 suites pass.

Per-test `@Shared` declarations replace shared `setUp` reset blocks per project convention; `XCTFail` cases become `Issue.record`; method names rewritten to camelCase without underscores.