### PR TITLE
Convert browse/playback page tests to swift-testing

### DIFF
--- a/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageTests.swift
@@ -3,13 +3,15 @@
 //  PlayolaRadio
 //
 
+import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class ChooseStationPageTests: XCTestCase {
+struct ChooseStationPageTests {
+  @Test
   func testInitStoresStations() {
     let stations = [
       Station.mockWith(id: "station-1", name: "First Station"),
@@ -22,12 +24,13 @@ final class ChooseStationPageTests: XCTestCase {
       onStationSelected: { selectedStation = $0 }
     )
 
-    XCTAssertEqual(model.stations.count, 2)
-    XCTAssertEqual(model.stations[0].id, "station-1")
-    XCTAssertEqual(model.stations[1].id, "station-2")
-    XCTAssertNil(selectedStation)
+    #expect(model.stations.count == 2)
+    #expect(model.stations[0].id == "station-1")
+    #expect(model.stations[1].id == "station-2")
+    #expect(selectedStation == nil)
   }
 
+  @Test
   func testSortedStationsSortsByCuratorName() {
     let stations = [
       Station.mockWith(id: "station-z", curatorName: "Zack"),
@@ -40,11 +43,12 @@ final class ChooseStationPageTests: XCTestCase {
       onStationSelected: { _ in }
     )
 
-    XCTAssertEqual(model.sortedStations[0].curatorName, "Alice")
-    XCTAssertEqual(model.sortedStations[1].curatorName, "Mike")
-    XCTAssertEqual(model.sortedStations[2].curatorName, "Zack")
+    #expect(model.sortedStations[0].curatorName == "Alice")
+    #expect(model.sortedStations[1].curatorName == "Mike")
+    #expect(model.sortedStations[2].curatorName == "Zack")
   }
 
+  @Test
   func testSortedStationsFiltersOutInactiveStations() {
     let stations = [
       Station.mockWith(id: "active-1", curatorName: "Alice", active: true),
@@ -58,13 +62,14 @@ final class ChooseStationPageTests: XCTestCase {
       onStationSelected: { _ in }
     )
 
-    XCTAssertEqual(model.sortedStations.count, 3)
-    XCTAssertFalse(model.sortedStations.contains { $0.id == "inactive-1" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "active-1" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "active-2" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "nil-active" })
+    #expect(model.sortedStations.count == 3)
+    #expect(!model.sortedStations.contains { $0.id == "inactive-1" })
+    #expect(model.sortedStations.contains { $0.id == "active-1" })
+    #expect(model.sortedStations.contains { $0.id == "active-2" })
+    #expect(model.sortedStations.contains { $0.id == "nil-active" })
   }
 
+  @Test
   func testStationTappedCallsCallback() {
     let station = Station.mockWith(id: "station-123", curatorName: "Test Curator")
     var selectedStation: Station?
@@ -76,16 +81,17 @@ final class ChooseStationPageTests: XCTestCase {
 
     model.stationTapped(station)
 
-    XCTAssertEqual(selectedStation?.id, "station-123")
+    #expect(selectedStation?.id == "station-123")
   }
 
+  @Test
   func testEmptyStationsList() {
     let model = ChooseStationPageModel(
       stations: [],
       onStationSelected: { _ in }
     )
 
-    XCTAssertTrue(model.stations.isEmpty)
-    XCTAssertTrue(model.sortedStations.isEmpty)
+    #expect(model.stations.isEmpty)
+    #expect(model.sortedStations.isEmpty)
   }
 }

--- a/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
@@ -62,6 +62,9 @@ struct ChooseStationToBroadcastPageTests {
 
   @Test
   func testStationSelectedSwitchesToBroadcastMode() {
+    @Shared(.mainContainerNavigationCoordinator)
+    var coordinator = MainContainerNavigationCoordinator()
+
     let stations = [
       Station.mockWith(id: "station-1", name: "First Station"),
       Station.mockWith(id: "station-2", name: "Second Station"),

--- a/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
@@ -6,15 +6,17 @@
 //
 
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class ChooseStationToBroadcastPageTests: XCTestCase {
-  func testInit_StoresStationsList() {
+struct ChooseStationToBroadcastPageTests {
+  @Test
+  func testInitStoresStationsList() {
     let stations = [
       Station.mockWith(id: "station-1", name: "First Station"),
       Station.mockWith(id: "station-2", name: "Second Station"),
@@ -22,18 +24,20 @@ final class ChooseStationToBroadcastPageTests: XCTestCase {
 
     let model = ChooseStationToBroadcastPageModel(stations: stations)
 
-    XCTAssertEqual(model.stations.count, 2)
-    XCTAssertEqual(model.stations[0].id, "station-1")
-    XCTAssertEqual(model.stations[1].id, "station-2")
+    #expect(model.stations.count == 2)
+    #expect(model.stations[0].id == "station-1")
+    #expect(model.stations[1].id == "station-2")
   }
 
-  func testInit_WithEmptyStationsList() {
+  @Test
+  func testInitWithEmptyStationsList() {
     let model = ChooseStationToBroadcastPageModel(stations: [])
 
-    XCTAssertTrue(model.stations.isEmpty)
+    #expect(model.stations.isEmpty)
   }
 
-  func testStations_AreSortedByCuratorName() {
+  @Test
+  func testStationsAreSortedByCuratorName() {
     let stations = [
       Station.mockWith(id: "station-z", name: "Z Station", curatorName: "Zack"),
       Station.mockWith(id: "station-a", name: "A Station", curatorName: "Alice"),
@@ -42,20 +46,22 @@ final class ChooseStationToBroadcastPageTests: XCTestCase {
 
     let model = ChooseStationToBroadcastPageModel(stations: stations)
 
-    XCTAssertEqual(model.sortedStations[0].curatorName, "Alice")
-    XCTAssertEqual(model.sortedStations[1].curatorName, "Mike")
-    XCTAssertEqual(model.sortedStations[2].curatorName, "Zack")
+    #expect(model.sortedStations[0].curatorName == "Alice")
+    #expect(model.sortedStations[1].curatorName == "Mike")
+    #expect(model.sortedStations[2].curatorName == "Zack")
   }
 
-  func testDisplayName_ReturnsCuratorNameDashName() {
+  @Test
+  func testDisplayNameReturnsCuratorNameDashName() {
     let station = Station.mockWith(id: "test", name: "Cool Station", curatorName: "DJ Awesome")
 
     let model = ChooseStationToBroadcastPageModel(stations: [station])
 
-    XCTAssertEqual(model.displayName(for: station), "DJ Awesome - Cool Station")
+    #expect(model.displayName(for: station) == "DJ Awesome - Cool Station")
   }
 
-  func testStationSelected_SwitchesToBroadcastMode() {
+  @Test
+  func testStationSelectedSwitchesToBroadcastMode() {
     let stations = [
       Station.mockWith(id: "station-1", name: "First Station"),
       Station.mockWith(id: "station-2", name: "Second Station"),
@@ -63,18 +69,18 @@ final class ChooseStationToBroadcastPageTests: XCTestCase {
 
     let model = ChooseStationToBroadcastPageModel(stations: stations)
 
-    XCTAssertEqual(model.mainContainerNavigationCoordinator.appMode, .listening)
+    #expect(model.mainContainerNavigationCoordinator.appMode == .listening)
 
     model.stationSelected(stations[1])
 
-    XCTAssertEqual(
-      model.mainContainerNavigationCoordinator.appMode,
-      .broadcasting(stationId: "station-2")
-    )
-    XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+    #expect(
+      model.mainContainerNavigationCoordinator.appMode
+        == .broadcasting(stationId: "station-2"))
+    #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
   }
 
-  func testSortedStations_FiltersOutInactiveStations() {
+  @Test
+  func testSortedStationsFiltersOutInactiveStations() {
     let stations = [
       Station.mockWith(id: "active-1", name: "Active Station", curatorName: "Alice", active: true),
       Station.mockWith(
@@ -87,10 +93,10 @@ final class ChooseStationToBroadcastPageTests: XCTestCase {
 
     let model = ChooseStationToBroadcastPageModel(stations: stations)
 
-    XCTAssertEqual(model.sortedStations.count, 3)
-    XCTAssertFalse(model.sortedStations.contains { $0.id == "inactive-1" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "active-1" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "active-2" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "nil-active" })
+    #expect(model.sortedStations.count == 3)
+    #expect(!model.sortedStations.contains { $0.id == "inactive-1" })
+    #expect(model.sortedStations.contains { $0.id == "active-1" })
+    #expect(model.sortedStations.contains { $0.id == "active-2" })
+    #expect(model.sortedStations.contains { $0.id == "nil-active" })
   }
 }

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -5,8 +5,6 @@
 //  Created by Brian D Keane on 6/10/25.
 //
 
-// swiftlint:disable force_try
-
 import ConcurrencyExtras
 import Dependencies
 import Foundation
@@ -682,5 +680,3 @@ struct HomePageTests {
   }
 
 }
-
-// swiftlint:enable force_try

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -9,29 +9,71 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
+// Helper function to create valid JWT tokens for testing
+private func createTestJWT(
+  id: String = "test-user-123",
+  firstName: String = "John",
+  lastName: String? = "Doe",
+  email: String = "john@example.com",
+  profileImageUrl: String? = nil,
+  role: String = "user"
+) -> String {
+  let header = ["alg": "HS256", "typ": "JWT"]
+  var payload: [String: Any] = [
+    "id": id,
+    "firstName": firstName,
+    "email": email,
+    "role": role,
+  ]
+  if let lastName = lastName {
+    payload["lastName"] = lastName
+  }
+  if let profileImageUrl = profileImageUrl {
+    payload["profileImageUrl"] = profileImageUrl
+  }
+
+  let headerData = try! JSONSerialization.data(withJSONObject: header)
+  let payloadData = try! JSONSerialization.data(withJSONObject: payload)
+
+  let headerString = headerData.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+
+  let payloadString = payloadData.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+
+  return "\(headerString).\(payloadString).fake_signature"
+}
+
 @MainActor
-final class HomePageTests: XCTestCase {
+struct HomePageTests {
   // MARK: - ViewAppeared Tests
 
-  func testViewAppeared_PopulatesForYouStationsBasedOnInitialValueOfSharedStationLists() async {
+  @Test
+  func testViewAppearedPopulatesForYouStationsBasedOnInitialValueOfSharedStationLists() async {
     @Shared(.stationLists) var stationLists = StationList.mocks
     let artistStations = stationLists.first {
       $0.slug == StationList.artistListSlug
     }
-    XCTAssertNotNil(artistStations)
+    #expect(artistStations != nil)
     let model = HomePageModel()
     await model.viewAppeared()
-    XCTAssertEqual(model.forYouStations.elements, artistStations!.stations)
+    #expect(model.forYouStations.elements == artistStations!.stations)
   }
 
-  func testViewAppeared_RepopulatesForYouStationsWhenSharedStationListsChanges() async {
+  @Test
+  func testViewAppearedRepopulatesForYouStationsWhenSharedStationListsChanges() async {
     @Shared(.stationLists) var stationLists = StationList.mocks
     let artistStations = stationLists.first {
       $0.slug == StationList.artistListSlug
@@ -39,14 +81,14 @@ final class HomePageTests: XCTestCase {
     let inDevelopmentStations = stationLists.first {
       $0.id == StationList.inDevelopmentListId
     }
-    XCTAssertNotNil(artistStations)
-    XCTAssertNotNil(inDevelopmentStations)
-    XCTAssertNotEqual(artistStations!.stations, inDevelopmentStations!.stations)
+    #expect(artistStations != nil)
+    #expect(inDevelopmentStations != nil)
+    #expect(artistStations!.stations != inDevelopmentStations!.stations)
 
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.elements, artistStations!.stations)
+    #expect(model.forYouStations.elements == artistStations!.stations)
 
     $stationLists.withLock {
       $0 = IdentifiedArray(
@@ -80,11 +122,12 @@ final class HomePageTests: XCTestCase {
         ])
     }
 
-    XCTAssertEqual(model.forYouStations.elements.count, 1)
-    XCTAssertEqual(model.forYouStations.elements.first?.id, "different-station")
+    #expect(model.forYouStations.elements.count == 1)
+    #expect(model.forYouStations.elements.first?.id == "different-station")
   }
 
-  func testViewAppeared_ExcludesComingSoonStationsFromForYouList() async {
+  @Test
+  func testViewAppearedExcludesComingSoonStationsFromForYouList() async {
     let visibleStation = Station.mockWith(
       id: "visible-station", name: "Visible Station", curatorName: "DJ Visible")
     let artistList = StationList.mockArtistList(items: [
@@ -98,11 +141,12 @@ final class HomePageTests: XCTestCase {
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.count, 1)
-    XCTAssertEqual(model.forYouStations.first?.id, visibleStation.id)
-    XCTAssertNil(model.forYouStations[id: "coming-soon-station"])
+    #expect(model.forYouStations.count == 1)
+    #expect(model.forYouStations.first?.id == visibleStation.id)
+    #expect(model.forYouStations[id: "coming-soon-station"] == nil)
   }
 
+  @Test
   func testShowSecretStationsIncludesActiveComingSoonStations() async {
     let visibleStation = Station.mockWith(id: "visible-station", curatorName: "DJ Visible")
     let comingSoonStation = Station.mockWith(id: "coming-soon-station", curatorName: "DJ Soon")
@@ -117,15 +161,16 @@ final class HomePageTests: XCTestCase {
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.count, 1)
-    XCTAssertNil(model.forYouStations[id: comingSoonStation.id])
+    #expect(model.forYouStations.count == 1)
+    #expect(model.forYouStations[id: comingSoonStation.id] == nil)
 
     $showSecretStations.withLock { $0 = true }
 
-    XCTAssertNotNil(model.forYouStations[id: comingSoonStation.id])
-    XCTAssertEqual(model.forYouStations.count, 2)
+    #expect(model.forYouStations[id: comingSoonStation.id] != nil)
+    #expect(model.forYouStations.count == 2)
   }
 
+  @Test
   func testShowSecretStationsStillHidesInactiveComingSoonStations() async {
     let visibleStation = Station.mockWith(id: "visible-station", curatorName: "DJ Visible")
     let inactiveStation = Station.mockWith(
@@ -141,22 +186,25 @@ final class HomePageTests: XCTestCase {
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.count, 1)
-    XCTAssertNil(model.forYouStations[id: inactiveStation.id])
+    #expect(model.forYouStations.count == 1)
+    #expect(model.forYouStations[id: inactiveStation.id] == nil)
   }
 
+  @Test
   func testStationListItemVisibilityDecodesKnownValue() throws {
     let jsonData = Data("\"coming-soon\"".utf8)
     let visibility = try JSONDecoder().decode(StationListItemVisibility.self, from: jsonData)
-    XCTAssertEqual(visibility, .comingSoon)
+    #expect(visibility == .comingSoon)
   }
 
+  @Test
   func testStationListItemVisibilityDecodesUnknownValueAsUnknown() throws {
     let jsonData = Data("\"future-release\"".utf8)
     let visibility = try JSONDecoder().decode(StationListItemVisibility.self, from: jsonData)
-    XCTAssertEqual(visibility, .unknown)
+    #expect(visibility == .unknown)
   }
 
+  @Test
   func testStationListStationsFiltersByVisibility() {
     let visiblePlayola = Station.mockWith(id: "visible-playola")
     let unknownPlayola = Station.mockWith(id: "unknown-playola")
@@ -175,124 +223,91 @@ final class HomePageTests: XCTestCase {
     )
 
     let visibleItems = list.stationItems(includeHidden: false)
-    XCTAssertEqual(visibleItems.map(\.visibility), [.visible, .comingSoon, .unknown])
+    #expect(visibleItems.map(\.visibility) == [.visible, .comingSoon, .unknown])
 
     let visibleStations = visibleItems.map { $0.anyStation }
-    XCTAssertEqual(visibleStations.count, 3)
+    #expect(visibleStations.count == 3)
     if case .playola(let station) = visibleStations[0] {
-      XCTAssertEqual(station.id, visiblePlayola.id)
+      #expect(station.id == visiblePlayola.id)
     } else {
-      XCTFail("Expected first visible station to be playola")
+      Issue.record("Expected first visible station to be playola")
     }
 
     if case .url(let station) = visibleStations[1] {
-      XCTAssertEqual(station.id, comingSoonUrl.id)
+      #expect(station.id == comingSoonUrl.id)
     } else {
-      XCTFail("Expected second visible station to be coming soon url station")
+      Issue.record("Expected second visible station to be coming soon url station")
     }
 
     if case .playola(let station) = visibleStations[2] {
-      XCTAssertEqual(station.id, unknownPlayola.id)
+      #expect(station.id == unknownPlayola.id)
     } else {
-      XCTFail("Expected second visible station to be playola")
+      Issue.record("Expected second visible station to be playola")
     }
 
     let allItemsIncludingHidden = list.stationItems(includeHidden: true)
     let comingSoonItems = allItemsIncludingHidden.filter { $0.visibility == .comingSoon }
-    XCTAssertEqual(comingSoonItems.count, 1)
-    XCTAssertEqual(comingSoonItems.first?.urlStation?.id, comingSoonUrl.id)
+    #expect(comingSoonItems.count == 1)
+    #expect(comingSoonItems.first?.urlStation?.id == comingSoonUrl.id)
 
     let hiddenItems = allItemsIncludingHidden.filter { $0.visibility == .hidden }
-    XCTAssertEqual(hiddenItems.count, 1)
-    XCTAssertEqual(hiddenItems.first?.urlStation?.id, hiddenUrl.id)
+    #expect(hiddenItems.count == 1)
+    #expect(hiddenItems.first?.urlStation?.id == hiddenUrl.id)
   }
 
   // MARK: - Welcome Message Tests
 
-  func testWelcomeMessage_ShowsGenericWelcomeMessageWhenNoUserIsLoggedIn() {
+  @Test
+  func testWelcomeMessageShowsGenericWelcomeMessageWhenNoUserIsLoggedIn() {
     @Shared(.auth) var auth = Auth()
     let model = HomePageModel()
-    XCTAssertEqual(model.welcomeMessage, "Welcome to Playola")
+    #expect(model.welcomeMessage == "Welcome to Playola")
   }
 
-  // Helper function to create valid JWT tokens for testing
-  static func createTestJWT(
-    id: String = "test-user-123",
-    firstName: String = "John",
-    lastName: String? = "Doe",
-    email: String = "john@example.com",
-    profileImageUrl: String? = nil,
-    role: String = "user"
-  ) -> String {
-    let header = ["alg": "HS256", "typ": "JWT"]
-    var payload: [String: Any] = [
-      "id": id,
-      "firstName": firstName,
-      "email": email,
-      "role": role,
-    ]
-    if let lastName = lastName {
-      payload["lastName"] = lastName
-    }
-    if let profileImageUrl = profileImageUrl {
-      payload["profileImageUrl"] = profileImageUrl
-    }
-
-    let headerData = try! JSONSerialization.data(withJSONObject: header)
-    let payloadData = try! JSONSerialization.data(withJSONObject: payload)
-
-    let headerString = headerData.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-
-    let payloadString = payloadData.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-
-    return "\(headerString).\(payloadString).fake_signature"
-  }
-
-  func testWelcomeMessage_ShowsPersonalizedWelcomeMessageWhenUserIsLoggedIn() {
-    let mockJWT = HomePageTests.createTestJWT(firstName: "John")
+  @Test
+  func testWelcomeMessageShowsPersonalizedWelcomeMessageWhenUserIsLoggedIn() {
+    let mockJWT = createTestJWT(firstName: "John")
     @Shared(.auth) var auth = Auth(jwtToken: mockJWT)
     let model = HomePageModel()
-    XCTAssertEqual(model.welcomeMessage, "Welcome, John")
+    #expect(model.welcomeMessage == "Welcome, John")
   }
 
-  func testWelcomeMessage_UpdatesWelcomeMessageWhenAuthChanges() {
+  @Test
+  func testWelcomeMessageUpdatesWelcomeMessageWhenAuthChanges() {
     @Shared(.auth) var auth = Auth()
     let model = HomePageModel()
-    XCTAssertEqual(model.welcomeMessage, "Welcome to Playola")
+    #expect(model.welcomeMessage == "Welcome to Playola")
 
-    let mockJWT = HomePageTests.createTestJWT(firstName: "John")
+    let mockJWT = createTestJWT(firstName: "John")
     $auth.withLock { $0 = Auth(jwtToken: mockJWT) }
-    XCTAssertEqual(model.welcomeMessage, "Welcome, John")
+    #expect(model.welcomeMessage == "Welcome, John")
   }
 
   // MARK: - Tapping The P Tests
 
-  func testTappingTheP_TurnsOnTheSecretStations() {
+  @Test
+  func testTappingThePTurnsOnTheSecretStations() {
     let homePage = HomePageModel()
-    XCTAssertFalse(homePage.showSecretStations)
+    #expect(!homePage.showSecretStations)
     homePage.playolaIconTapped10Times()
-    XCTAssertTrue(homePage.showSecretStations)
-    XCTAssertEqual(homePage.presentedAlert, .secretStationsTurnedOnAlert)
+    #expect(homePage.showSecretStations)
+    #expect(homePage.presentedAlert == .secretStationsTurnedOnAlert)
   }
 
-  func testTappingTheP_HidesTheSecretStations() {
+  @Test
+  func testTappingThePHidesTheSecretStations() {
     @Shared(.showSecretStations) var showSecretStations = true
     let homePage = HomePageModel()
-    XCTAssertTrue(homePage.showSecretStations)
+    #expect(homePage.showSecretStations)
     homePage.playolaIconTapped10Times()
-    XCTAssertFalse(homePage.showSecretStations)
-    XCTAssertEqual(homePage.presentedAlert, .secretStationsHiddenAlert)
+    #expect(!homePage.showSecretStations)
+    #expect(homePage.presentedAlert == .secretStationsHiddenAlert)
   }
 
   // MARK: - Listening Tile Navigation Tests
 
-  func testListeningTile_NavigationToRewardsTracksAnalytics() async {
+  @Test
+  func testListeningTileNavigationToRewardsTracksAnalytics() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     @Shared(.activeTab) var activeTab = MainContainerModel.ActiveTab.home
 
@@ -304,21 +319,19 @@ final class HomePageTests: XCTestCase {
       HomePageModel()
     }
 
-    // Call the button action on the listening tile model
     await homePageModel.listeningTimeTileModel.buttonAction?()
 
-    // Verify navigation happened
-    XCTAssertEqual(activeTab, .rewards)
+    #expect(activeTab == .rewards)
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
-    XCTAssertEqual(events.first, .navigatedToRewardsFromListeningTile)
+    #expect(events.count == 1)
+    #expect(events.first == .navigatedToRewardsFromListeningTile)
   }
 
   // MARK: - Player Interaction Tests
 
-  func testPlayerInteraction_PlaysAStationWhenItIsTapped() async {
+  @Test
+  func testPlayerInteractionPlaysAStationWhenItIsTapped() async {
     let stationPlayerMock: StationPlayerMock = .mockStoppedPlayer()
     let station: AnyStation = .mock
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
@@ -333,21 +346,21 @@ final class HomePageTests: XCTestCase {
 
     await homePageModel.stationTapped(station)
 
-    XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
-    XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, station.id)
+    #expect(stationPlayerMock.callsToPlay.count == 1)
+    #expect(stationPlayerMock.callsToPlay.first?.id == station.id)
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .startedStation(let stationInfo, let entryPoint) = events.first {
-      XCTAssertEqual(stationInfo.id, station.id)
-      XCTAssertEqual(stationInfo.name, station.name)
-      XCTAssertEqual(entryPoint, "home_recommendations")
+      #expect(stationInfo.id == station.id)
+      #expect(stationInfo.name == station.name)
+      #expect(entryPoint == "home_recommendations")
     } else {
-      XCTFail("Expected startedStation event, got: \(String(describing: events.first))")
+      Issue.record("Expected startedStation event, got: \(String(describing: events.first))")
     }
   }
 
+  @Test
   func testShowSecretStationsToggleUpdatesForYouStations() async {
     let artistList = StationList.mockArtistList(items: [
       .mockWith(sortOrder: 0, visibility: .visible, station: .mockWith(id: "visible-playola")),
@@ -359,17 +372,18 @@ final class HomePageTests: XCTestCase {
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.count, 1)
+    #expect(model.forYouStations.count == 1)
 
     $showSecretStations.withLock { $0 = true }
-    XCTAssertEqual(model.forYouStations.count, 2)
+    #expect(model.forYouStations.count == 2)
 
     $showSecretStations.withLock { $0 = false }
-    XCTAssertEqual(model.forYouStations.count, 1)
+    #expect(model.forYouStations.count == 1)
   }
 
   // MARK: - Scheduled Shows Tests
 
+  @Test
   func testViewAppearedSetsHasScheduledShowsToTrueWhenAiringsExist() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let now = Date()
@@ -388,10 +402,11 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertTrue(model.hasScheduledShows)
+      #expect(model.hasScheduledShows)
     }
   }
 
+  @Test
   func testViewAppearedSetsHasScheduledShowsToFalseWhenNoAirings() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -402,10 +417,11 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(model.hasScheduledShows)
+      #expect(!model.hasScheduledShows)
     }
   }
 
+  @Test
   func testViewAppearedSetsHasScheduledShowsToFalseOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -418,10 +434,11 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(model.hasScheduledShows)
+      #expect(!model.hasScheduledShows)
     }
   }
 
+  @Test
   func testScheduledShowsTileNavigatesToSeriesListPage() async {
     @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
       MainContainerNavigationCoordinator()
@@ -430,15 +447,16 @@ final class HomePageTests: XCTestCase {
 
     await model.scheduledShowsTileModel.buttonAction?()
 
-    XCTAssertEqual(navigationCoordinator.path.count, 1)
+    #expect(navigationCoordinator.path.count == 1)
     if case .seriesListPage = navigationCoordinator.path.first {
       // Success
     } else {
-      XCTFail(
+      Issue.record(
         "Expected seriesListPage, got: \(String(describing: navigationCoordinator.path.first))")
     }
   }
 
+  @Test
   func testViewAppearedSetsHasScheduledShowsToFalseWhenAllAiringsEnded() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let now = Date()
@@ -464,12 +482,13 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(model.hasScheduledShows)
+      #expect(!model.hasScheduledShows)
     }
   }
 
   // MARK: - Listener Question Airing Tests
 
+  @Test
   func testViewAppearedSetsUpcomingQuestionAiringWhenAiringsExist() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let futureDate = Date().addingTimeInterval(2 * 24 * 60 * 60)
@@ -486,12 +505,13 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNotNil(model.upcomingQuestionAiring)
-      XCTAssertEqual(model.upcomingQuestionAiring?.id, expectedAiring.id)
-      XCTAssertTrue(model.hasUpcomingQuestionAiring)
+      #expect(model.upcomingQuestionAiring != nil)
+      #expect(model.upcomingQuestionAiring?.id == expectedAiring.id)
+      #expect(model.hasUpcomingQuestionAiring)
     }
   }
 
+  @Test
   func testViewAppearedSetsUpcomingQuestionAiringToNilWhenNoAirings() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -502,11 +522,12 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNil(model.upcomingQuestionAiring)
-      XCTAssertFalse(model.hasUpcomingQuestionAiring)
+      #expect(model.upcomingQuestionAiring == nil)
+      #expect(!model.hasUpcomingQuestionAiring)
     }
   }
 
+  @Test
   func testViewAppearedSetsUpcomingQuestionAiringToNilOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -519,11 +540,12 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNil(model.upcomingQuestionAiring)
-      XCTAssertFalse(model.hasUpcomingQuestionAiring)
+      #expect(model.upcomingQuestionAiring == nil)
+      #expect(!model.hasUpcomingQuestionAiring)
     }
   }
 
+  @Test
   func testViewAppearedDoesNotCheckAiringsWhenNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     let apiCalled = LockIsolated(false)
@@ -538,11 +560,12 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(apiCalled.value)
-      XCTAssertNil(model.upcomingQuestionAiring)
+      #expect(!apiCalled.value)
+      #expect(model.upcomingQuestionAiring == nil)
     }
   }
 
+  @Test
   func testQuestionAiringTileShowsStationNameAndAirtime() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let futureDate = Date().addingTimeInterval(2 * 24 * 60 * 60)
@@ -558,8 +581,8 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.questionAiringTileModel.content, "You're On Air Soon!")
-      XCTAssertTrue(
+      #expect(model.questionAiringTileModel.content == "You're On Air Soon!")
+      #expect(
         model.questionAiringTileModel.paragraph!.contains("DJ Awesome picked your question!"))
     }
   }
@@ -568,6 +591,7 @@ final class HomePageTests: XCTestCase {
 
   private static let appStoreUrl = "https://apps.apple.com/us/app/playola-radio/id6480465361"
 
+  @Test
   func testQuestionAiringShareButtonPresentsShareSheetWithAppStoreUrl() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
@@ -588,14 +612,15 @@ final class HomePageTests: XCTestCase {
       await model.questionAiringTileModel.buttonAction?()
 
       if case .share(let shareModel) = navigationCoordinator.presentedSheet {
-        XCTAssertTrue(shareModel.items[0].contains("Jason Eady's radio station"))
-        XCTAssertEqual(shareModel.items[1], Self.appStoreUrl)
+        #expect(shareModel.items[0].contains("Jason Eady's radio station"))
+        #expect(shareModel.items[1] == Self.appStoreUrl)
       } else {
-        XCTFail("Expected share sheet to be presented")
+        Issue.record("Expected share sheet to be presented")
       }
     }
   }
 
+  @Test
   func testQuestionAiringShareButtonUsesGenericMessageWhenNoCuratorName() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
@@ -616,16 +641,17 @@ final class HomePageTests: XCTestCase {
       await model.questionAiringTileModel.buttonAction?()
 
       if case .share(let shareModel) = navigationCoordinator.presentedSheet {
-        XCTAssertTrue(shareModel.items[0].contains("an internet radio station"))
-        XCTAssertEqual(shareModel.items[1], Self.appStoreUrl)
+        #expect(shareModel.items[0].contains("an internet radio station"))
+        #expect(shareModel.items[1] == Self.appStoreUrl)
       } else {
-        XCTFail("Expected share sheet to be presented")
+        Issue.record("Expected share sheet to be presented")
       }
     }
   }
 
   // MARK: - Invite Friends Tile Tests
 
+  @Test
   func testCanInviteFriendsIsTrueWhenUserHasTwoOrMoreHours() {
     let rewardsProfile = RewardsProfile(
       totalTimeListenedMS: 2 * 60 * 60 * 1000,  // 2 hours
@@ -637,9 +663,10 @@ final class HomePageTests: XCTestCase {
 
     let model = HomePageModel()
 
-    XCTAssertTrue(model.canInviteFriends)
+    #expect(model.canInviteFriends)
   }
 
+  @Test
   func testCanInviteFriendsIsFalseWhenUserHasLessThanTwoHours() {
     let rewardsProfile = RewardsProfile(
       totalTimeListenedMS: 1 * 60 * 60 * 1000,  // 1 hour
@@ -651,26 +678,29 @@ final class HomePageTests: XCTestCase {
 
     let model = HomePageModel()
 
-    XCTAssertFalse(model.canInviteFriends)
+    #expect(!model.canInviteFriends)
   }
 
+  @Test
   func testCanInviteFriendsIsFalseWhenListeningTrackerIsNil() {
     @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
 
     let model = HomePageModel()
 
-    XCTAssertFalse(model.canInviteFriends)
+    #expect(!model.canInviteFriends)
   }
 
+  @Test
   func testInviteFriendsTileHasCorrectContent() {
     let model = HomePageModel()
 
-    XCTAssertEqual(model.inviteFriendsTileModel.label, "Power Listener Reward")
-    XCTAssertEqual(model.inviteFriendsTileModel.content, "Invite Your Friends")
-    XCTAssertEqual(model.inviteFriendsTileModel.buttonText, "Invite")
-    XCTAssertNotNil(model.inviteFriendsTileModel.paragraph)
+    #expect(model.inviteFriendsTileModel.label == "Power Listener Reward")
+    #expect(model.inviteFriendsTileModel.content == "Invite Your Friends")
+    #expect(model.inviteFriendsTileModel.buttonText == "Invite")
+    #expect(model.inviteFriendsTileModel.paragraph != nil)
   }
 
+  @Test
   func testInviteFriendsTilePresentsShareSheetWithAppStoreUrl() async {
     @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
       MainContainerNavigationCoordinator()
@@ -680,10 +710,10 @@ final class HomePageTests: XCTestCase {
     await model.inviteFriendsTileModel.buttonAction?()
 
     if case .share(let shareModel) = navigationCoordinator.presentedSheet {
-      XCTAssertEqual(shareModel.items.count, 1)
-      XCTAssertEqual(shareModel.items[0], Self.appStoreUrl)
+      #expect(shareModel.items.count == 1)
+      #expect(shareModel.items[0] == Self.appStoreUrl)
     } else {
-      XCTFail("Expected share sheet to be presented")
+      Issue.record("Expected share sheet to be presented")
     }
   }
 

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -17,44 +17,8 @@ import Testing
 
 @testable import PlayolaRadio
 
-// Helper function to create valid JWT tokens for testing
-private func createTestJWT(
-  id: String = "test-user-123",
-  firstName: String = "John",
-  lastName: String? = "Doe",
-  email: String = "john@example.com",
-  profileImageUrl: String? = nil,
-  role: String = "user"
-) -> String {
-  let header = ["alg": "HS256", "typ": "JWT"]
-  var payload: [String: Any] = [
-    "id": id,
-    "firstName": firstName,
-    "email": email,
-    "role": role,
-  ]
-  if let lastName = lastName {
-    payload["lastName"] = lastName
-  }
-  if let profileImageUrl = profileImageUrl {
-    payload["profileImageUrl"] = profileImageUrl
-  }
-
-  let headerData = try! JSONSerialization.data(withJSONObject: header)
-  let payloadData = try! JSONSerialization.data(withJSONObject: payload)
-
-  let headerString = headerData.base64EncodedString()
-    .replacingOccurrences(of: "+", with: "-")
-    .replacingOccurrences(of: "/", with: "_")
-    .replacingOccurrences(of: "=", with: "")
-
-  let payloadString = payloadData.base64EncodedString()
-    .replacingOccurrences(of: "+", with: "-")
-    .replacingOccurrences(of: "/", with: "_")
-    .replacingOccurrences(of: "=", with: "")
-
-  return "\(headerString).\(payloadString).fake_signature"
-}
+// `createTestJWT` is defined in MainContainerTests.swift and shared
+// across the test target.
 
 @MainActor
 struct HomePageTests {

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
@@ -661,7 +661,7 @@ struct LibraryPageTests {
   @Test
   func testAddSongButtonTappedPresentsSongSearchPageSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     withModel { model in
       #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
@@ -711,7 +711,7 @@ struct LibraryPageTests {
   @Test
   func testAddSongButtonTappedOnAddedToLibraryCallbackDismissesSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     withModel { model in
       model.addSongButtonTapped()
@@ -727,7 +727,7 @@ struct LibraryPageTests {
   @Test
   func testAddSongButtonTappedOnDismissCallbackDismissesSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     withModel { model in
       model.addSongButtonTapped()
@@ -797,7 +797,7 @@ struct LibraryPageTests {
   @Test
   func testRecordIntroButtonTappedPresentsRecordIntroSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     withModel { model in
       let song = LibrarySong.mockWith(id: "song-1", title: "Test Song", artist: "Test Artist")

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
@@ -5,13 +5,14 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class LibraryPageTests: XCTestCase {
+struct LibraryPageTests {
   // MARK: - Helpers
 
   private func withModel(
@@ -50,38 +51,44 @@ final class LibraryPageTests: XCTestCase {
 
   // MARK: - Initial State Tests
 
+  @Test
   func testInitialStateLibrarySongsAreEmpty() {
     withModel { model in
-      XCTAssertTrue(model.librarySongs.isEmpty)
+      #expect(model.librarySongs.isEmpty)
     }
   }
 
+  @Test
   func testInitialStateLibraryRequestsAreEmpty() {
     withModel { model in
-      XCTAssertTrue(model.libraryRequests.isEmpty)
+      #expect(model.libraryRequests.isEmpty)
     }
   }
 
+  @Test
   func testInitialStateIsNotLoading() {
     withModel { model in
-      XCTAssertFalse(model.isLoading)
+      #expect(!model.isLoading)
     }
   }
 
+  @Test
   func testInitialStateSearchTextIsEmpty() {
     withModel { model in
-      XCTAssertEqual(model.searchText, "")
+      #expect(model.searchText == "")
     }
   }
 
+  @Test
   func testNavigationTitle() {
     withModel { model in
-      XCTAssertEqual(model.navigationTitle, "Library")
+      #expect(model.navigationTitle == "Library")
     }
   }
 
   // MARK: - View Appeared Tests
 
+  @Test
   func testViewAppearedFetchesLibrarySongs() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Song One"),
@@ -89,12 +96,13 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(songs: mockSongs) { model in
-      XCTAssertEqual(model.librarySongs.count, 2)
-      XCTAssertEqual(model.librarySongs[0].id, "song-1")
-      XCTAssertEqual(model.librarySongs[1].id, "song-2")
+      #expect(model.librarySongs.count == 2)
+      #expect(model.librarySongs[0].id == "song-1")
+      #expect(model.librarySongs[1].id == "song-2")
     }
   }
 
+  @Test
   func testViewAppearedFetchesLibraryRequests() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", title: "Request One"),
@@ -102,12 +110,13 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertEqual(model.libraryRequests.count, 2)
-      XCTAssertEqual(model.libraryRequests[0].id, "request-1")
-      XCTAssertEqual(model.libraryRequests[1].id, "request-2")
+      #expect(model.libraryRequests.count == 2)
+      #expect(model.libraryRequests[0].id == "request-1")
+      #expect(model.libraryRequests[1].id == "request-2")
     }
   }
 
+  @Test
   func testViewAppearedPassesCorrectStationId() async {
     let capturedStationId = LockIsolated<String?>(nil)
 
@@ -120,11 +129,12 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { _ in
-        XCTAssertEqual(capturedStationId.value, "my-station-123")
+        #expect(capturedStationId.value == "my-station-123")
       }
     )
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     await withLoadedModel(
       configure: {
@@ -133,14 +143,15 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertNotNil(model.presentedAlert)
-        XCTAssertEqual(model.presentedAlert?.title, "Error")
+        #expect(model.presentedAlert != nil)
+        #expect(model.presentedAlert?.title == "Error")
       }
     )
   }
 
   // MARK: - Search/Filter Tests
 
+  @Test
   func testFilteredSongsReturnsAllWhenSearchTextIsEmpty() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Alpha", artist: "Artist A"),
@@ -149,10 +160,11 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = ""
-      XCTAssertEqual(model.filteredSongs.count, 2)
+      #expect(model.filteredSongs.count == 2)
     }
   }
 
+  @Test
   func testFilteredSongsFiltersByTitle() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Bohemian Rhapsody", artist: "Queen"),
@@ -161,11 +173,12 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = "Bohemian"
-      XCTAssertEqual(model.filteredSongs.count, 1)
-      XCTAssertEqual(model.filteredSongs[0].title, "Bohemian Rhapsody")
+      #expect(model.filteredSongs.count == 1)
+      #expect(model.filteredSongs[0].title == "Bohemian Rhapsody")
     }
   }
 
+  @Test
   func testFilteredSongsFiltersByArtist() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Bohemian Rhapsody", artist: "Queen"),
@@ -174,11 +187,12 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = "Eagles"
-      XCTAssertEqual(model.filteredSongs.count, 1)
-      XCTAssertEqual(model.filteredSongs[0].artist, "Eagles")
+      #expect(model.filteredSongs.count == 1)
+      #expect(model.filteredSongs[0].artist == "Eagles")
     }
   }
 
+  @Test
   func testFilteredSongsIsCaseInsensitive() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Bohemian Rhapsody", artist: "Queen")
@@ -186,12 +200,13 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = "QUEEN"
-      XCTAssertEqual(model.filteredSongs.count, 1)
+      #expect(model.filteredSongs.count == 1)
     }
   }
 
   // MARK: - Request Filtering Tests
 
+  @Test
   func testPendingRequestsReturnsOnlyPendingRequests() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .pending),
@@ -200,11 +215,12 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertEqual(model.pendingRequests.count, 1)
-      XCTAssertEqual(model.pendingRequests[0].id, "request-1")
+      #expect(model.pendingRequests.count == 1)
+      #expect(model.pendingRequests[0].id == "request-1")
     }
   }
 
+  @Test
   func testFulfilledRequestsReturnsOnlyCompletedRequests() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .pending),
@@ -213,31 +229,34 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertEqual(model.fulfilledRequests.count, 1)
-      XCTAssertEqual(model.fulfilledRequests[0].id, "request-2")
+      #expect(model.fulfilledRequests.count == 1)
+      #expect(model.fulfilledRequests[0].id == "request-2")
     }
   }
 
+  @Test
   func testHasActiveRequestsReturnsTrueWhenPendingExists() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .pending)
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertTrue(model.hasActiveRequests)
+      #expect(model.hasActiveRequests)
     }
   }
 
+  @Test
   func testHasActiveRequestsReturnsTrueWhenFulfilledExists() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .completed)
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertTrue(model.hasActiveRequests)
+      #expect(model.hasActiveRequests)
     }
   }
 
+  @Test
   func testHasActiveRequestsReturnsFalseWhenAllDismissed() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .dismissed),
@@ -245,12 +264,13 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertFalse(model.hasActiveRequests)
+      #expect(!model.hasActiveRequests)
     }
   }
 
   // MARK: - Remove Song Tests
 
+  @Test
   func testRemoveSongButtonTappedCreatesRemoveRequest() async {
     let capturedAudioBlockId = LockIsolated<String?>(nil)
     let mockSong = LibrarySong.mockWith(id: "song-to-remove")
@@ -265,11 +285,12 @@ final class LibraryPageTests: XCTestCase {
       },
       perform: { model in
         await model.removeSongButtonTapped(mockSong)
-        XCTAssertEqual(capturedAudioBlockId.value, "song-to-remove")
+        #expect(capturedAudioBlockId.value == "song-to-remove")
       }
     )
   }
 
+  @Test
   func testRemoveSongButtonTappedAddsRequestToList() async {
     let mockSong = LibrarySong.mockWith(id: "song-to-remove", title: "Song to Remove")
     let mockRequest = StationLibraryRequest.mockWith(
@@ -285,16 +306,17 @@ final class LibraryPageTests: XCTestCase {
         $0.api.createRemoveLibraryRequest = { _, _, _ in mockRequest }
       },
       perform: { model in
-        XCTAssertEqual(model.libraryRequests.count, 0)
+        #expect(model.libraryRequests.count == 0)
         await model.removeSongButtonTapped(mockSong)
-        XCTAssertEqual(model.libraryRequests.count, 1)
-        XCTAssertEqual(model.libraryRequests[0].id, "new-request")
+        #expect(model.libraryRequests.count == 1)
+        #expect(model.libraryRequests[0].id == "new-request")
       }
     )
   }
 
   // MARK: - Pending Request Check Tests
 
+  @Test
   func testHasPendingRequestReturnsTrueForSongWithPendingRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
     let mockRequest = StationLibraryRequest.mockWith(
@@ -304,28 +326,31 @@ final class LibraryPageTests: XCTestCase {
     )
 
     await withLoadedModel(songs: [mockSong], requests: [mockRequest]) { model in
-      XCTAssertTrue(model.hasPendingRequest(for: mockSong))
+      #expect(model.hasPendingRequest(for: mockSong))
     }
   }
 
+  @Test
   func testHasPendingRequestReturnsFalseForSongWithoutRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     await withLoadedModel(songs: [mockSong]) { model in
-      XCTAssertFalse(model.hasPendingRequest(for: mockSong))
+      #expect(!model.hasPendingRequest(for: mockSong))
     }
   }
 
   // MARK: - Processing Removal Tests
 
+  @Test
   func testIsProcessingRemovalReturnsFalseInitially() {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     withModel { model in
-      XCTAssertFalse(model.isProcessingRemoval(for: mockSong))
+      #expect(!model.isProcessingRemoval(for: mockSong))
     }
   }
 
+  @Test
   func testIsProcessingRemovalReturnsFalseAfterCompletion() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
@@ -337,15 +362,16 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertFalse(model.isProcessingRemoval(for: mockSong))
+        #expect(!model.isProcessingRemoval(for: mockSong))
         await model.removeSongButtonTapped(mockSong)
-        XCTAssertFalse(model.isProcessingRemoval(for: mockSong))
+        #expect(!model.isProcessingRemoval(for: mockSong))
       }
     )
   }
 
   // MARK: - Dismiss Request Tests
 
+  @Test
   func testDismissRequestButtonTappedCallsAPI() async {
     let capturedRequestId = LockIsolated<String?>(nil)
     let mockRequest = StationLibraryRequest.mockWith(id: "request-to-dismiss", status: .completed)
@@ -360,11 +386,12 @@ final class LibraryPageTests: XCTestCase {
       },
       perform: { model in
         await model.dismissRequestButtonTapped(mockRequest)
-        XCTAssertEqual(capturedRequestId.value, "request-to-dismiss")
+        #expect(capturedRequestId.value == "request-to-dismiss")
       }
     )
   }
 
+  @Test
   func testDismissRequestButtonTappedUpdatesRequestInList() async {
     let mockRequest = StationLibraryRequest.mockWith(id: "request-1", status: .completed)
 
@@ -376,15 +403,16 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertEqual(model.fulfilledRequests.count, 1)
+        #expect(model.fulfilledRequests.count == 1)
         await model.dismissRequestButtonTapped(mockRequest)
-        XCTAssertEqual(model.fulfilledRequests.count, 0)
+        #expect(model.fulfilledRequests.count == 0)
       }
     )
   }
 
   // MARK: - Refresh Tests
 
+  @Test
   func testRefreshPulledDownReloadsData() async {
     let fetchCount = LockIsolated(0)
 
@@ -396,15 +424,16 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertEqual(fetchCount.value, 1)
+        #expect(fetchCount.value == 1)
         await model.refreshPulledDown()
-        XCTAssertEqual(fetchCount.value, 2)
+        #expect(fetchCount.value == 2)
       }
     )
   }
 
   // MARK: - View Helper Tests
 
+  @Test
   func testSongsSectionHeaderIncludesCount() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1"),
@@ -413,10 +442,11 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(songs: mockSongs) { model in
-      XCTAssertEqual(model.songsSectionHeader, "SONGS (3)")
+      #expect(model.songsSectionHeader == "SONGS (3)")
     }
   }
 
+  @Test
   func testSongsSectionHeaderReflectsFilteredCount() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Alpha", artist: "Artist A"),
@@ -426,95 +456,107 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = "Artist A"
-      XCTAssertEqual(model.songsSectionHeader, "SONGS (2)")
+      #expect(model.songsSectionHeader == "SONGS (2)")
     }
   }
 
+  @Test
   func testRequestTypeLabelReturnsAddForAddRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(type: .add)
-      XCTAssertEqual(model.requestTypeLabel(for: request), "Add")
+      #expect(model.requestTypeLabel(for: request) == "Add")
     }
   }
 
+  @Test
   func testRequestTypeLabelReturnsRemoveForRemoveRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(type: .remove)
-      XCTAssertEqual(model.requestTypeLabel(for: request), "Remove")
+      #expect(model.requestTypeLabel(for: request) == "Remove")
     }
   }
 
+  @Test
   func testRequestTypeColorReturnsSuccessForAddRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(type: .add)
-      XCTAssertEqual(model.requestTypeColor(for: request), .success)
+      #expect(model.requestTypeColor(for: request) == .success)
     }
   }
 
+  @Test
   func testRequestTypeColorReturnsWarningForRemoveRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(type: .remove)
-      XCTAssertEqual(model.requestTypeColor(for: request), .warning)
+      #expect(model.requestTypeColor(for: request) == .warning)
     }
   }
 
+  @Test
   func testRequestStatusLabelReturnsCapitalizedStatus() {
     withModel { model in
       let pendingRequest = StationLibraryRequest.mockWith(status: .pending)
-      XCTAssertEqual(model.requestStatusLabel(for: pendingRequest), "Pending")
+      #expect(model.requestStatusLabel(for: pendingRequest) == "Pending")
 
       let completedRequest = StationLibraryRequest.mockWith(status: .completed)
-      XCTAssertEqual(model.requestStatusLabel(for: completedRequest), "Completed")
+      #expect(model.requestStatusLabel(for: completedRequest) == "Completed")
 
       let dismissedRequest = StationLibraryRequest.mockWith(status: .dismissed)
-      XCTAssertEqual(model.requestStatusLabel(for: dismissedRequest), "Dismissed")
+      #expect(model.requestStatusLabel(for: dismissedRequest) == "Dismissed")
     }
   }
 
+  @Test
   func testCanDismissRequestReturnsTrueForCompletedRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .completed)
-      XCTAssertTrue(model.canDismissRequest(request))
+      #expect(model.canDismissRequest(request))
     }
   }
 
+  @Test
   func testCanDismissRequestReturnsFalseForPendingRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .pending)
-      XCTAssertFalse(model.canDismissRequest(request))
+      #expect(!model.canDismissRequest(request))
     }
   }
 
+  @Test
   func testCanDismissRequestReturnsFalseForDismissedRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .dismissed)
-      XCTAssertFalse(model.canDismissRequest(request))
+      #expect(!model.canDismissRequest(request))
     }
   }
 
+  @Test
   func testCanCancelRequestReturnsTrueForPendingRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .pending)
-      XCTAssertTrue(model.canCancelRequest(request))
+      #expect(model.canCancelRequest(request))
     }
   }
 
+  @Test
   func testCanCancelRequestReturnsFalseForCompletedRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .completed)
-      XCTAssertFalse(model.canCancelRequest(request))
+      #expect(!model.canCancelRequest(request))
     }
   }
 
+  @Test
   func testCanCancelRequestReturnsFalseForDismissedRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .dismissed)
-      XCTAssertFalse(model.canCancelRequest(request))
+      #expect(!model.canCancelRequest(request))
     }
   }
 
   // MARK: - Pending Request Helper Tests
 
+  @Test
   func testPendingRequestReturnsRequestForSongWithPendingRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
     let mockRequest = StationLibraryRequest.mockWith(
@@ -526,20 +568,22 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: [mockSong], requests: [mockRequest]) { model in
       let result = model.pendingRequest(for: mockSong)
-      XCTAssertNotNil(result)
-      XCTAssertEqual(result?.id, "pending-request-1")
+      #expect(result != nil)
+      #expect(result?.id == "pending-request-1")
     }
   }
 
+  @Test
   func testPendingRequestReturnsNilForSongWithoutPendingRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     await withLoadedModel(songs: [mockSong]) { model in
       let result = model.pendingRequest(for: mockSong)
-      XCTAssertNil(result)
+      #expect(result == nil)
     }
   }
 
+  @Test
   func testPendingRequestReturnsNilForSongWithCompletedRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
     let mockRequest = StationLibraryRequest.mockWith(
@@ -550,12 +594,13 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: [mockSong], requests: [mockRequest]) { model in
       let result = model.pendingRequest(for: mockSong)
-      XCTAssertNil(result)
+      #expect(result == nil)
     }
   }
 
   // MARK: - Cancel Request Tests
 
+  @Test
   func testCancelRequestButtonTappedCallsAPI() async {
     let capturedRequestId = LockIsolated<String?>(nil)
     let mockRequest = StationLibraryRequest.mockWith(id: "request-to-cancel", status: .pending)
@@ -569,11 +614,12 @@ final class LibraryPageTests: XCTestCase {
       },
       perform: { model in
         await model.cancelRequestButtonTapped(mockRequest)
-        XCTAssertEqual(capturedRequestId.value, "request-to-cancel")
+        #expect(capturedRequestId.value == "request-to-cancel")
       }
     )
   }
 
+  @Test
   func testCancelRequestButtonTappedRemovesRequestFromList() async {
     let mockRequest = StationLibraryRequest.mockWith(id: "request-1", status: .pending)
 
@@ -583,13 +629,14 @@ final class LibraryPageTests: XCTestCase {
         $0.api.cancelStationLibraryRequest = { _, _, _ in }
       },
       perform: { model in
-        XCTAssertEqual(model.libraryRequests.count, 1)
+        #expect(model.libraryRequests.count == 1)
         await model.cancelRequestButtonTapped(mockRequest)
-        XCTAssertEqual(model.libraryRequests.count, 0)
+        #expect(model.libraryRequests.count == 0)
       }
     )
   }
 
+  @Test
   func testCancelRequestButtonTappedShowsAlertOnError() async {
     let mockRequest = StationLibraryRequest.mockWith(id: "request-1", status: .pending)
 
@@ -601,99 +648,107 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertNil(model.presentedAlert)
+        #expect(model.presentedAlert == nil)
         await model.cancelRequestButtonTapped(mockRequest)
-        XCTAssertNotNil(model.presentedAlert)
-        XCTAssertEqual(model.presentedAlert?.title, "Error")
+        #expect(model.presentedAlert != nil)
+        #expect(model.presentedAlert?.title == "Error")
       }
     )
   }
 
   // MARK: - Add Song Button Tests
 
+  @Test
   func testAddSongButtonTappedPresentsSongSearchPageSheet() {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     withModel { model in
-      XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
-      XCTAssertNil(model.songSearchPageModel)
+      #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
+      #expect(model.songSearchPageModel == nil)
 
       model.addSongButtonTapped()
 
-      XCTAssertNotNil(model.songSearchPageModel)
+      #expect(model.songSearchPageModel != nil)
       if case .songSearchPage = mainContainerNavigationCoordinator.presentedSheet {
         // Success
       } else {
-        XCTFail("Expected songSearchPage sheet presentation")
+        Issue.record("Expected songSearchPage sheet presentation")
       }
     }
   }
 
+  @Test
   func testAddSongButtonTappedUsesSeedsOnlySearchMode() {
     withModel { model in
       model.addSongButtonTapped()
-      XCTAssertEqual(model.songSearchPageModel?.searchMode, .seedsOnly)
+      #expect(model.songSearchPageModel?.searchMode == .seedsOnly)
     }
   }
 
+  @Test
   func testAddSongButtonTappedPassesStationId() {
     withModel(stationId: "my-station-456") { model in
       model.addSongButtonTapped()
-      XCTAssertEqual(model.songSearchPageModel?.stationId, "my-station-456")
+      #expect(model.songSearchPageModel?.stationId == "my-station-456")
     }
   }
 
+  @Test
   func testAddSongButtonTappedOnAddedToLibraryCallbackAddsRequestToList() {
     withModel { model in
       model.addSongButtonTapped()
-      XCTAssertTrue(model.libraryRequests.isEmpty)
+      #expect(model.libraryRequests.isEmpty)
 
       let mockRequest = StationLibraryRequest.mockWith(id: "new-add-request", type: .add)
       model.songSearchPageModel?.onAddedToLibrary?(mockRequest)
 
-      XCTAssertEqual(model.libraryRequests.count, 1)
-      XCTAssertEqual(model.libraryRequests[0].id, "new-add-request")
+      #expect(model.libraryRequests.count == 1)
+      #expect(model.libraryRequests[0].id == "new-add-request")
     }
   }
 
+  @Test
   func testAddSongButtonTappedOnAddedToLibraryCallbackDismissesSheet() {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     withModel { model in
       model.addSongButtonTapped()
-      XCTAssertNotNil(mainContainerNavigationCoordinator.presentedSheet)
+      #expect(mainContainerNavigationCoordinator.presentedSheet != nil)
 
       let mockRequest = StationLibraryRequest.mockWith(id: "new-add-request", type: .add)
       model.songSearchPageModel?.onAddedToLibrary?(mockRequest)
 
-      XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
+      #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
     }
   }
 
+  @Test
   func testAddSongButtonTappedOnDismissCallbackDismissesSheet() {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     withModel { model in
       model.addSongButtonTapped()
-      XCTAssertNotNil(mainContainerNavigationCoordinator.presentedSheet)
+      #expect(mainContainerNavigationCoordinator.presentedSheet != nil)
 
       model.songSearchPageModel?.onDismiss?()
 
-      XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
+      #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
     }
   }
 
   // MARK: - Song Intro Tests
 
+  @Test
   func testInitialStateSongIdsWithSongIntrosIsEmpty() {
     withModel { model in
-      XCTAssertTrue(model.songIdsWithSongIntros.isEmpty)
+      #expect(model.songIdsWithSongIntros.isEmpty)
     }
   }
 
+  @Test
   func testViewAppearedPopulatesSongIdsWithSongIntros() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1"),
@@ -707,11 +762,12 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertEqual(model.songIdsWithSongIntros, Set(["song-1"]))
+        #expect(model.songIdsWithSongIntros == Set(["song-1"]))
       }
     )
   }
 
+  @Test
   func testHasSongIntroReturnsTrueForSongWithIntro() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
@@ -722,21 +778,23 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertTrue(model.hasSongIntro(for: mockSong))
+        #expect(model.hasSongIntro(for: mockSong))
       }
     )
   }
 
+  @Test
   func testHasSongIntroReturnsFalseForSongWithoutIntro() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     await withLoadedModel(songs: [mockSong]) { model in
-      XCTAssertFalse(model.hasSongIntro(for: mockSong))
+      #expect(!model.hasSongIntro(for: mockSong))
     }
   }
 
   // MARK: - Intro Upload Tests
 
+  @Test
   func testRecordIntroButtonTappedPresentsRecordIntroSheet() {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
@@ -749,18 +807,19 @@ final class LibraryPageTests: XCTestCase {
       if case .recordIntroPage = mainContainerNavigationCoordinator.presentedSheet {
         // Success
       } else {
-        XCTFail("Expected recordIntroPage sheet")
+        Issue.record("Expected recordIntroPage sheet")
       }
     }
   }
 
+  @Test
   func testHasSongIntroReturnsTrueForLocallyUploadedIntro() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     await withLoadedModel(songs: [mockSong]) { model in
-      XCTAssertFalse(model.hasSongIntro(for: mockSong))
+      #expect(!model.hasSongIntro(for: mockSong))
       model.uploadedIntroSongIds.insert("song-1")
-      XCTAssertTrue(model.hasSongIntro(for: mockSong))
+      #expect(model.hasSongIntro(for: mockSong))
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
@@ -1,32 +1,32 @@
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class LikedSongsPageTests: XCTestCase {
-
-  override func setUp() async throws {
-    try await super.setUp()
+struct LikedSongsPageTests {
+  @Test
+  func testGroupedLikedSongsEmptyWhenNoLikes() {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
-    $userLikes.withLock { $0 = [:] }
-    $pendingOperations.withLock { $0 = [] }
-  }
 
-  func testGroupedLikedSongs_EmptyWhenNoLikes() {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
       let model = LikedSongsPageModel()
 
-      XCTAssertTrue(model.groupedLikedSongs.isEmpty)
+      #expect(model.groupedLikedSongs.isEmpty)
     }
   }
 
-  func testGroupedLikedSongs_GroupsBySectionTitle() async {
+  @Test
+  func testGroupedLikedSongsGroupsBySectionTitle() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let audioBlock1 = AudioBlock.mock
     let audioBlock2 = AudioBlock.mockWith(id: "different-id")
 
@@ -39,12 +39,16 @@ final class LikedSongsPageTests: XCTestCase {
     } operation: {
       let model = LikedSongsPageModel()
 
-      XCTAssertFalse(model.groupedLikedSongs.isEmpty)
-      XCTAssertEqual(model.groupedLikedSongs.first?.1.count, 2)
+      #expect(!model.groupedLikedSongs.isEmpty)
+      #expect(model.groupedLikedSongs.first?.1.count == 2)
     }
   }
 
+  @Test
   func testFormatTimestamp() {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
@@ -53,12 +57,16 @@ final class LikedSongsPageTests: XCTestCase {
 
       let result = model.formatTimestamp(for: testDate)
 
-      XCTAssertFalse(result.isEmpty)
-      XCTAssertTrue(result.contains("at"))
+      #expect(!result.isEmpty)
+      #expect(result.contains("at"))
     }
   }
 
+  @Test
   func testRemoveSong() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let audioBlock = AudioBlock.mock
 
     withDependencies {
@@ -69,14 +77,11 @@ final class LikedSongsPageTests: XCTestCase {
     } operation: {
       let model = LikedSongsPageModel()
 
-      // Verify song is initially liked
-      XCTAssertFalse(model.groupedLikedSongs.isEmpty)
+      #expect(!model.groupedLikedSongs.isEmpty)
 
-      // Remove the song
       model.removeSongTapped(audioBlock)
 
-      // Verify song is no longer liked
-      XCTAssertTrue(model.groupedLikedSongs.isEmpty)
+      #expect(model.groupedLikedSongs.isEmpty)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -304,6 +304,9 @@ struct MainContainerTests {
 
   @Test
   func testProcessNewStationStateDoesNotPresentSheetForOtherStates() {
+    @Shared(.mainContainerNavigationCoordinator)
+    var coordinator = MainContainerNavigationCoordinator()
+
     let stationPlayerMock = StationPlayerMock()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -17,8 +17,9 @@ import Testing
 
 @testable import PlayolaRadio
 
-// Helper function to create valid JWT tokens for testing
-private func createTestJWT(
+// Helper function to create valid JWT tokens for testing.
+// Module-internal (not file-private) so HomePageTests can reuse it.
+func createTestJWT(
   id: String = "test-user-123",
   firstName: String = "Test",
   lastName: String? = "User",
@@ -787,42 +788,49 @@ struct MainContainerTests {
       let markShownCalled = LockIsolated(false)
       let markDismissedCalled = LockIsolated(false)
 
-      await confirmation("feedbackSheetPresented tracked") { feedbackSheetConfirmation in
-        let mainContainerModel = withDependencies {
-          $0.api.getStations = { [] }
-          $0.pushNotifications.registerForRemoteNotifications = {}
-          $0.appRating.shouldShowRatingPrompt = { _ in true }
-          $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
-          $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
-          $0.analytics.track = { @Sendable event in
-            capturedEvents.withValue { $0.append(event) }
-            if event == .feedbackSheetPresented { feedbackSheetConfirmation() }
-          }
-        } operation: {
-          MainContainerModel()
+      let mainContainerModel = withDependencies {
+        $0.api.getStations = { [] }
+        $0.pushNotifications.registerForRemoteNotifications = {}
+        $0.appRating.shouldShowRatingPrompt = { _ in true }
+        $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
+        $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
+        $0.analytics.track = { @Sendable event in
+          capturedEvents.withValue { $0.append(event) }
         }
+      } operation: {
+        MainContainerModel()
+      }
 
-        mainContainerModel.checkAndShowRatingPromptIfNeeded()
-        await mainContainerModel.presentedAlert?.secondaryAction?()
+      mainContainerModel.checkAndShowRatingPromptIfNeeded()
+      await mainContainerModel.presentedAlert?.secondaryAction?()
 
-        // showFeedbackSheet() spawns a Task that awaits analytics.track
-        // before presenting the sheet — yield enough times for it to drain.
-        for _ in 0..<10 { await Task.yield() }
-
-        #expect(markShownCalled.value)
-        #expect(
-          markDismissedCalled.value,
-          "Not really should also set dismiss date for 7-day cooldown")
-        #expect(capturedEvents.value.contains { $0 == .ratingPromptNotEnjoying })
-        #expect(
-          mainContainerModel.presentedAlert == nil,
-          "Alert should be dismissed before showing feedback sheet")
-        guard
-          case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet
-        else {
-          Issue.record("Expected feedback sheet to be presented")
-          return
+      // Drain the spawned Task in showFeedbackSheet() — it awaits
+      // analytics.track and then assigns presentedSheet. Polling on the
+      // observable end-state (presentedSheet being .feedbackSheet) is
+      // resilient to changes in the number of internal async hops.
+      for _ in 0..<50 {
+        if case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator
+          .presentedSheet
+        {
+          break
         }
+        await Task.yield()
+      }
+
+      #expect(markShownCalled.value)
+      #expect(
+        markDismissedCalled.value,
+        "Not really should also set dismiss date for 7-day cooldown")
+      #expect(capturedEvents.value.contains { $0 == .ratingPromptNotEnjoying })
+      #expect(capturedEvents.value.contains { $0 == .feedbackSheetPresented })
+      #expect(
+        mainContainerModel.presentedAlert == nil,
+        "Alert should be dismissed before showing feedback sheet")
+      guard
+        case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet
+      else {
+        Issue.record("Expected feedback sheet to be presented")
+        return
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -7,58 +7,60 @@
 
 // swiftlint:disable force_try
 
+import ConcurrencyExtras
 import Dependencies
 import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
-@MainActor
-final class MainContainerTests: XCTestCase {
-  // Helper function to create valid JWT tokens for testing
-  static func createTestJWT(
-    id: String = "test-user-123",
-    firstName: String = "Test",
-    lastName: String? = "User",
-    email: String = "test@example.com",
-    profileImageUrl: String? = nil,
-    role: String = "user"
-  ) -> String {
-    let header = ["alg": "HS256", "typ": "JWT"]
-    var payload: [String: Any] = [
-      "id": id,
-      "firstName": firstName,
-      "email": email,
-      "role": role,
-    ]
-    if let lastName = lastName {
-      payload["lastName"] = lastName
-    }
-    if let profileImageUrl = profileImageUrl {
-      payload["profileImageUrl"] = profileImageUrl
-    }
-
-    let headerData = try! JSONSerialization.data(withJSONObject: header)
-    let payloadData = try! JSONSerialization.data(withJSONObject: payload)
-
-    let headerString = headerData.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-
-    let payloadString = payloadData.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-
-    return "\(headerString).\(payloadString).fake_signature"
+// Helper function to create valid JWT tokens for testing
+private func createTestJWT(
+  id: String = "test-user-123",
+  firstName: String = "Test",
+  lastName: String? = "User",
+  email: String = "test@example.com",
+  profileImageUrl: String? = nil,
+  role: String = "user"
+) -> String {
+  let header = ["alg": "HS256", "typ": "JWT"]
+  var payload: [String: Any] = [
+    "id": id,
+    "firstName": firstName,
+    "email": email,
+    "role": role,
+  ]
+  if let lastName = lastName {
+    payload["lastName"] = lastName
+  }
+  if let profileImageUrl = profileImageUrl {
+    payload["profileImageUrl"] = profileImageUrl
   }
 
+  let headerData = try! JSONSerialization.data(withJSONObject: header)
+  let payloadData = try! JSONSerialization.data(withJSONObject: payload)
+
+  let headerString = headerData.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+
+  let payloadString = payloadData.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+
+  return "\(headerString).\(payloadString).fake_signature"
+}
+
+@MainActor
+struct MainContainerTests {
   // MARK: - ViewAppeared Tests
 
+  @Test
   func testViewAppearedRegistersForRemoteNotifications() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     let registerForRemoteNotificationsCalled = LockIsolated(false)
@@ -73,10 +75,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertTrue(registerForRemoteNotificationsCalled.value)
+    #expect(registerForRemoteNotificationsCalled.value)
   }
 
-  func testViewAppeared_CorrectlyRetrievesStationListsWhenApiIsSuccessful() async {
+  @Test
+  func testViewAppearedCorrectlyRetrievesStationListsWhenApiIsSuccessful() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     let getStationsCallCount = LockIsolated(0)
@@ -92,12 +95,13 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertEqual(getStationsCallCount.value, 1)
-    XCTAssertEqual(stationLists, StationList.mocks)
-    XCTAssertTrue(stationListsLoaded)
+    #expect(getStationsCallCount.value == 1)
+    #expect(stationLists == StationList.mocks)
+    #expect(stationListsLoaded)
   }
 
-  func testViewAppeared_DisplaysAnErrorAlertOnApiError() async {
+  @Test
+  func testViewAppearedDisplaysAnErrorAlertOnApiError() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     struct TestError: Error {
@@ -119,22 +123,22 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertEqual(mainContainerModel.presentedAlert, .errorLoadingStations)
-    XCTAssertFalse(stationListsLoaded)
+    #expect(mainContainerModel.presentedAlert == .errorLoadingStations)
+    #expect(!stationListsLoaded)
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .apiError(let endpoint, let error) = events.first {
-      XCTAssertEqual(endpoint, "getStations")
-      XCTAssertTrue(
+      #expect(endpoint == "getStations")
+      #expect(
         error.contains("TestError"), "Expected error to contain 'TestError', got: \(error)")
     } else {
-      XCTFail("Expected apiError event, got: \(String(describing: events.first))")
+      Issue.record("Expected apiError event, got: \(String(describing: events.first))")
     }
   }
 
-  func testViewAppeared_ExitsEarlyWhenStationListsAlreadyLoaded() async {
+  @Test
+  func testViewAppearedExitsEarlyWhenStationListsAlreadyLoaded() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = true
     let getStationsCallCount = LockIsolated(0)
 
@@ -149,11 +153,12 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertEqual(getStationsCallCount.value, 0)
+    #expect(getStationsCallCount.value == 0)
   }
 
+  @Test
   func testViewAppearedLoadsAiringsWhenLoggedIn() async {
-    let testJWT = MainContainerTests.createTestJWT()
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
@@ -177,13 +182,14 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.viewAppeared()
 
-    XCTAssertEqual(getAiringsCallCount.value, 1)
-    XCTAssertEqual(airings.count, 2)
+    #expect(getAiringsCallCount.value == 1)
+    #expect(airings.count == 2)
   }
 
   // MARK: - Small Player Properties Tests
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenPlaying() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenPlaying() async {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
 
     let mainContainerModel = withDependencies {
@@ -194,10 +200,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertTrue(mainContainerModel.shouldShowSmallPlayer)
+    #expect(mainContainerModel.shouldShowSmallPlayer)
   }
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenLoading() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenLoading() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .loading(.mock))
 
@@ -209,10 +216,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertTrue(mainContainerModel.shouldShowSmallPlayer)
+    #expect(mainContainerModel.shouldShowSmallPlayer)
   }
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenStopped() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenStopped() async {
     let stationPlayerMock = StationPlayerMock.mockStoppedPlayer()
 
     let mainContainerModel = withDependencies {
@@ -223,10 +231,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertFalse(mainContainerModel.shouldShowSmallPlayer)
+    #expect(!mainContainerModel.shouldShowSmallPlayer)
   }
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenError() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenError() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .error)
 
@@ -238,10 +247,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertFalse(mainContainerModel.shouldShowSmallPlayer)
+    #expect(!mainContainerModel.shouldShowSmallPlayer)
   }
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenStartingNewStation() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenStartingNewStation() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .startingNewStation(.mock))
 
@@ -253,159 +263,148 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertTrue(mainContainerModel.shouldShowSmallPlayer)
+    #expect(mainContainerModel.shouldShowSmallPlayer)
   }
 
   // MARK: - Small Player Actions Tests
 
-  func testSmallPlayerActions_OnSmallPlayerTapped() {
+  @Test
+  func testSmallPlayerActionsOnSmallPlayerTapped() {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 
     mainContainerModel.onSmallPlayerTapped()
 
-    XCTAssertNotNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet != nil)
     if case .player = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet {
       // Test passes
     } else {
-      XCTFail("Expected player sheet to be presented")
+      Issue.record("Expected player sheet to be presented")
     }
   }
 
   // MARK: - Process New Station State Tests
 
-  func testProcessNewStationState_PresentsPlayerSheetWhenStartingNewStation() {
+  @Test
+  func testProcessNewStationStatePresentsPlayerSheetWhenStartingNewStation() {
     let stationPlayerMock = StationPlayerMock()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 
     let newState = StationPlayer.State(playbackStatus: .startingNewStation(.mock))
     mainContainerModel.processNewStationState(newState)
 
-    XCTAssertNotNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet != nil)
     if case .player = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet {
       // Test passes
     } else {
-      XCTFail("Expected player sheet to be presented")
+      Issue.record("Expected player sheet to be presented")
     }
   }
 
-  func testProcessNewStationState_DoesNotPresentSheetForOtherStates() {
+  @Test
+  func testProcessNewStationStateDoesNotPresentSheetForOtherStates() {
     let stationPlayerMock = StationPlayerMock()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 
     let playingState = StationPlayer.State(playbackStatus: .playing(.mock))
     mainContainerModel.processNewStationState(playingState)
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
 
     let stoppedState = StationPlayer.State(playbackStatus: .stopped)
     mainContainerModel.processNewStationState(stoppedState)
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
 
     let loadingState = StationPlayer.State(playbackStatus: .loading(.mock))
     mainContainerModel.processNewStationState(loadingState)
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
 
     let errorState = StationPlayer.State(playbackStatus: .error)
     mainContainerModel.processNewStationState(errorState)
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
   }
 
   // MARK: - Dismiss Button Tests
 
-  func testDismissButton_PlayerPageOnDismissClearsPresentedSheet() {
-    // @Shared(.mainContainerNavigationCoordinator)
-    // var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
-    //
+  @Test
+  func testDismissButtonPlayerPageOnDismissClearsPresentedSheet() {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 
-    // Trigger the presentation of the player sheet
     mainContainerModel.onSmallPlayerTapped()
 
-    // Verify the sheet is presented
-    XCTAssertNotNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet != nil)
 
-    // Extract the PlayerPageModel from the presented sheet
     guard
       case .player(let playerPageModel) = mainContainerModel.mainContainerNavigationCoordinator
         .presentedSheet
     else {
-      XCTFail("Expected player sheet to be presented")
+      Issue.record("Expected player sheet to be presented")
       return
     }
 
-    // Call the onDismiss callback
     playerPageModel.onDismiss?()
 
-    // Verify the sheet is now nil
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
   }
 
   // MARK: - Playola Station Player Configuration Tests
 
-  func testPlayolaStationPlayer_ConfiguresPlayolaStationPlayerOnInit() async {
-    let testJWT = MainContainerTests.createTestJWT()
+  @Test
+  func testPlayolaStationPlayerConfiguresPlayolaStationPlayerOnInit() async {
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
-    // When MainContainerModel is created (user is logged in),
-    // it should configure PlayolaStationPlayer with authentication
-    let mainContainerModel = MainContainerModel()
-
-    XCTAssertNotNil(mainContainerModel, "MainContainerModel should be created successfully")
+    _ = MainContainerModel()
   }
 
-  func testPlayolaStationPlayer_UsesAuthenticatedSessionReporting() async {
-    let testJWT = MainContainerTests.createTestJWT()
+  @Test
+  func testPlayolaStationPlayerUsesAuthenticatedSessionReporting() async {
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
-    // MainContainerModel creation should configure PlayolaStationPlayer
-    // to use JWT tokens for session reporting
     _ = MainContainerModel()
 
-    XCTAssertTrue(auth.isLoggedIn)
-    XCTAssertEqual(auth.jwt, testJWT)
+    #expect(auth.isLoggedIn)
+    #expect(auth.jwt == testJWT)
   }
 
   // MARK: - Authentication State Lifecycle Tests
 
-  func testAuthStateLifecycle_MainContainerExistsOnlyWhenAuthenticated() async {
-    let testJWT = MainContainerTests.createTestJWT()
+  @Test
+  func testAuthStateLifecycleMainContainerExistsOnlyWhenAuthenticated() async {
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
-    // User is logged in - MainContainer can be created
-    XCTAssertTrue(auth.isLoggedIn)
-    let mainContainerModel = MainContainerModel()
-    XCTAssertNotNil(mainContainerModel)
+    #expect(auth.isLoggedIn)
+    _ = MainContainerModel()
 
-    // When user signs out, ContentView will destroy MainContainer
-    // and show SignInPage instead - this is handled by ContentView logic
     $auth.withLock { $0 = Auth() }
-    XCTAssertFalse(auth.isLoggedIn)
+    #expect(!auth.isLoggedIn)
   }
 
-  func testAuthStateLifecycle_MultipleLoginSessionsGetFreshConfig() async {
+  @Test
+  func testAuthStateLifecycleMultipleLoginSessionsGetFreshConfig() async {
     @Shared(.auth) var auth = Auth()
 
-    // First login session
-    let firstJWT = MainContainerTests.createTestJWT(
+    let firstJWT = createTestJWT(
       id: "user1", firstName: "First", lastName: "User")
     $auth.withLock { $0 = Auth(jwtToken: firstJWT) }
     _ = MainContainerModel()
-    XCTAssertEqual(auth.jwt, firstJWT)
+    #expect(auth.jwt == firstJWT)
 
-    // User logs out, logs back in with new token
     $auth.withLock { $0 = Auth() }
-    let secondJWT = MainContainerTests.createTestJWT(
+    let secondJWT = createTestJWT(
       id: "user2", firstName: "Second", lastName: "User")
     $auth.withLock { $0 = Auth(jwtToken: secondJWT) }
     _ = MainContainerModel()
-    XCTAssertEqual(auth.jwt, secondJWT)
+    #expect(auth.jwt == secondJWT)
   }
 
   // MARK: - Refresh On Foreground Tests
 
+  @Test
   func testRefreshOnForegroundRefreshesStationListsAndAirings() async {
-    let testJWT = MainContainerTests.createTestJWT()
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
@@ -432,14 +431,15 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.refreshOnForeground()
 
-    XCTAssertEqual(getStationsCallCount.value, 1)
-    XCTAssertEqual(getAiringsCallCount.value, 1)
-    XCTAssertEqual(stationLists, StationList.mocks)
-    XCTAssertEqual(airings.count, 2)
-    XCTAssertEqual(airings[id: "airing1"]?.id, "airing1")
-    XCTAssertEqual(airings[id: "airing2"]?.id, "airing2")
+    #expect(getStationsCallCount.value == 1)
+    #expect(getAiringsCallCount.value == 1)
+    #expect(stationLists == StationList.mocks)
+    #expect(airings.count == 2)
+    #expect(airings[id: "airing1"]?.id == "airing1")
+    #expect(airings[id: "airing2"]?.id == "airing2")
   }
 
+  @Test
   func testRefreshOnForegroundSkipsAiringsWhenNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
@@ -463,14 +463,15 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.refreshOnForeground()
 
-    XCTAssertEqual(getStationsCallCount.value, 1)
-    XCTAssertEqual(getAiringsCallCount.value, 0)
-    XCTAssertEqual(stationLists, StationList.mocks)
-    XCTAssertTrue(airings.isEmpty)
+    #expect(getStationsCallCount.value == 1)
+    #expect(getAiringsCallCount.value == 0)
+    #expect(stationLists == StationList.mocks)
+    #expect(airings.isEmpty)
   }
 
-  func testRefreshOnForeground_TracksAnalyticsOnStationsError() async {
-    let testJWT = MainContainerTests.createTestJWT()
+  @Test
+  func testRefreshOnForegroundTracksAnalyticsOnStationsError() async {
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
     struct TestError: Error {
@@ -494,7 +495,7 @@ final class MainContainerTests: XCTestCase {
     await mainContainerModel.refreshOnForeground()
 
     let events = capturedEvents.value
-    XCTAssertTrue(
+    #expect(
       events.contains { event in
         if case .apiError(let endpoint, _) = event {
           return endpoint == "getStations"
@@ -503,8 +504,9 @@ final class MainContainerTests: XCTestCase {
       })
   }
 
+  @Test
   func testRefreshOnForegroundRefreshesUnreadSupportCount() async {
-    let testJWT = MainContainerTests.createTestJWT()
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
     @Shared(.unreadSupportCount) var unreadSupportCount = 0
 
@@ -535,12 +537,13 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.refreshOnForeground()
 
-    XCTAssertEqual(getSupportConversationCallCount.value, 1)
-    XCTAssertEqual(unreadSupportCount, 3)
+    #expect(getSupportConversationCallCount.value == 1)
+    #expect(unreadSupportCount == 3)
   }
 
+  @Test
   func testRefreshOnForegroundTracksAnalyticsOnAiringsError() async {
-    let testJWT = MainContainerTests.createTestJWT()
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
     struct TestError: Error {
@@ -564,7 +567,7 @@ final class MainContainerTests: XCTestCase {
     await mainContainerModel.refreshOnForeground()
 
     let events = capturedEvents.value
-    XCTAssertTrue(
+    #expect(
       events.contains { event in
         if case .apiError(let endpoint, _) = event {
           return endpoint == "getAirings"
@@ -572,8 +575,10 @@ final class MainContainerTests: XCTestCase {
         return false
       })
   }
+
   // MARK: - Rating Prompt Tests
 
+  @Test
   func testCheckRatingPromptShowsAlertWhenEligible() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -597,10 +602,11 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertNotNil(mainContainerModel.presentedAlert)
-    XCTAssertEqual(mainContainerModel.presentedAlert?.title, "Are you enjoying Playola Radio?")
+    #expect(mainContainerModel.presentedAlert != nil)
+    #expect(mainContainerModel.presentedAlert?.title == "Are you enjoying Playola Radio?")
   }
 
+  @Test
   func testCheckRatingPromptDoesNotShowWhenNotEligible() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -3, to: Date()
@@ -623,9 +629,10 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertNil(mainContainerModel.presentedAlert)
+    #expect(mainContainerModel.presentedAlert == nil)
   }
 
+  @Test
   func testCheckRatingPromptOnlyChecksOncePerSession() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -656,9 +663,10 @@ final class MainContainerTests: XCTestCase {
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertEqual(shouldShowCallCount.value, 1)
+    #expect(shouldShowCallCount.value == 1)
   }
 
+  @Test
   func testCheckRatingPromptDoesNotShowWhenNoListeningTracker() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -680,10 +688,11 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertFalse(shouldShowCalled.value)
-    XCTAssertNil(mainContainerModel.presentedAlert)
+    #expect(!shouldShowCalled.value)
+    #expect(mainContainerModel.presentedAlert == nil)
   }
 
+  @Test
   func testTabChangeChecksRatingPrompt() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -711,13 +720,13 @@ final class MainContainerTests: XCTestCase {
       MainContainerModel(stationPlayer: stationPlayerMock)
     }
 
-    // Simulate tab change - this is what onChange(of: model.activeTab) responds to
     $activeTab.withLock { $0 = .stationsList }
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertTrue(shouldShowCalled.value)
+    #expect(shouldShowCalled.value)
   }
 
+  @Test
   func testRatingPromptEnjoyingTracksAnalyticsAndRequestsReview() async {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -750,17 +759,17 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    // Simulate tapping "Yes!"
     await mainContainerModel.presentedAlert?.primaryAction?()
 
-    XCTAssertTrue(markShownCalled.value)
-    XCTAssertTrue(requestReviewCalled.value)
-    XCTAssertTrue(capturedEvents.value.contains { $0 == .ratingPromptEnjoying })
+    #expect(markShownCalled.value)
+    #expect(requestReviewCalled.value)
+    #expect(capturedEvents.value.contains { $0 == .ratingPromptEnjoying })
   }
 
+  @Test
   func testRatingPromptNotEnjoyingTracksAnalyticsAndShowsFeedback() async {
     await withMainSerialExecutor {
-      let testJWT = MainContainerTests.createTestJWT()
+      let testJWT = createTestJWT()
       @Shared(.auth) var auth = Auth(jwtToken: testJWT)
       @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
         byAdding: .day, value: -10, to: Date()
@@ -777,43 +786,48 @@ final class MainContainerTests: XCTestCase {
       let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
       let markShownCalled = LockIsolated(false)
       let markDismissedCalled = LockIsolated(false)
-      let feedbackSheetExpectation = XCTestExpectation(
-        description: "feedbackSheetPresented tracked")
 
-      let mainContainerModel = withDependencies {
-        $0.api.getStations = { [] }
-        $0.pushNotifications.registerForRemoteNotifications = {}
-        $0.appRating.shouldShowRatingPrompt = { _ in true }
-        $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
-        $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
-        $0.analytics.track = { @Sendable event in
-          capturedEvents.withValue { $0.append(event) }
-          if event == .feedbackSheetPresented { feedbackSheetExpectation.fulfill() }
+      await confirmation("feedbackSheetPresented tracked") { feedbackSheetConfirmation in
+        let mainContainerModel = withDependencies {
+          $0.api.getStations = { [] }
+          $0.pushNotifications.registerForRemoteNotifications = {}
+          $0.appRating.shouldShowRatingPrompt = { _ in true }
+          $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
+          $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
+          $0.analytics.track = { @Sendable event in
+            capturedEvents.withValue { $0.append(event) }
+            if event == .feedbackSheetPresented { feedbackSheetConfirmation() }
+          }
+        } operation: {
+          MainContainerModel()
         }
-      } operation: {
-        MainContainerModel()
-      }
 
-      mainContainerModel.checkAndShowRatingPromptIfNeeded()
-      await mainContainerModel.presentedAlert?.secondaryAction?()
-      await fulfillment(of: [feedbackSheetExpectation], timeout: 1.0)
+        mainContainerModel.checkAndShowRatingPromptIfNeeded()
+        await mainContainerModel.presentedAlert?.secondaryAction?()
 
-      XCTAssertTrue(markShownCalled.value)
-      XCTAssertTrue(
-        markDismissedCalled.value, "Not really should also set dismiss date for 7-day cooldown")
-      XCTAssertTrue(capturedEvents.value.contains { $0 == .ratingPromptNotEnjoying })
-      XCTAssertNil(
-        mainContainerModel.presentedAlert, "Alert should be dismissed before showing feedback sheet"
-      )
-      guard
-        case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet
-      else {
-        XCTFail("Expected feedback sheet to be presented")
-        return
+        // showFeedbackSheet() spawns a Task that awaits analytics.track
+        // before presenting the sheet — yield enough times for it to drain.
+        for _ in 0..<10 { await Task.yield() }
+
+        #expect(markShownCalled.value)
+        #expect(
+          markDismissedCalled.value,
+          "Not really should also set dismiss date for 7-day cooldown")
+        #expect(capturedEvents.value.contains { $0 == .ratingPromptNotEnjoying })
+        #expect(
+          mainContainerModel.presentedAlert == nil,
+          "Alert should be dismissed before showing feedback sheet")
+        guard
+          case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet
+        else {
+          Issue.record("Expected feedback sheet to be presented")
+          return
+        }
       }
     }
   }
 
+  @Test
   func testRatingPromptDismissedTracksAnalyticsAndMarksDismissed() async {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -844,15 +858,15 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    // Simulate tapping "Not now"
     await mainContainerModel.presentedAlert?.tertiaryAction?()
 
-    XCTAssertTrue(markDismissedCalled.value)
-    XCTAssertTrue(capturedEvents.value.contains { $0 == .ratingPromptDismissed })
+    #expect(markDismissedCalled.value)
+    #expect(capturedEvents.value.contains { $0 == .ratingPromptDismissed })
   }
 
   // MARK: - Mode-Aware Properties Tests
 
+  @Test
   func testIsInBroadcastModeReturnsFalseWhenListening() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -860,9 +874,10 @@ final class MainContainerTests: XCTestCase {
 
     let mainContainerModel = MainContainerModel()
 
-    XCTAssertFalse(mainContainerModel.isInBroadcastMode)
+    #expect(!mainContainerModel.isInBroadcastMode)
   }
 
+  @Test
   func testIsInBroadcastModeReturnsTrueWhenBroadcasting() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -870,9 +885,10 @@ final class MainContainerTests: XCTestCase {
 
     let mainContainerModel = MainContainerModel()
 
-    XCTAssertTrue(mainContainerModel.isInBroadcastMode)
+    #expect(mainContainerModel.isInBroadcastMode)
   }
 
+  @Test
   func testBroadcastStationIdReturnsNilWhenListening() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -880,9 +896,10 @@ final class MainContainerTests: XCTestCase {
 
     let mainContainerModel = MainContainerModel()
 
-    XCTAssertNil(mainContainerModel.broadcastStationId)
+    #expect(mainContainerModel.broadcastStationId == nil)
   }
 
+  @Test
   func testBroadcastStationIdReturnsStationIdWhenBroadcasting() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -890,23 +907,25 @@ final class MainContainerTests: XCTestCase {
 
     let mainContainerModel = MainContainerModel()
 
-    XCTAssertEqual(mainContainerModel.broadcastStationId, "station-123")
+    #expect(mainContainerModel.broadcastStationId == "station-123")
   }
 
+  @Test
   func testEnsureBroadcastModelsCreatesBroadcastPageModel() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
     coordinator.appMode = .broadcasting(stationId: "station-123")
 
     let mainContainerModel = MainContainerModel()
-    XCTAssertNil(mainContainerModel.broadcastPageModel)
+    #expect(mainContainerModel.broadcastPageModel == nil)
 
     mainContainerModel.ensureBroadcastModels()
 
-    XCTAssertNotNil(mainContainerModel.broadcastPageModel)
-    XCTAssertEqual(mainContainerModel.broadcastPageModel?.stationId, "station-123")
+    #expect(mainContainerModel.broadcastPageModel != nil)
+    #expect(mainContainerModel.broadcastPageModel?.stationId == "station-123")
   }
 
+  @Test
   func testEnsureBroadcastModelsDoesNothingWhenListening() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -915,9 +934,10 @@ final class MainContainerTests: XCTestCase {
     let mainContainerModel = MainContainerModel()
     mainContainerModel.ensureBroadcastModels()
 
-    XCTAssertNil(mainContainerModel.broadcastPageModel)
+    #expect(mainContainerModel.broadcastPageModel == nil)
   }
 
+  @Test
   func testEnsureBroadcastModelsRecreatesModelsWhenStationIdChanges() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -927,13 +947,13 @@ final class MainContainerTests: XCTestCase {
     mainContainerModel.ensureBroadcastModels()
 
     let originalModel = mainContainerModel.broadcastPageModel
-    XCTAssertEqual(originalModel?.stationId, "station-123")
+    #expect(originalModel?.stationId == "station-123")
 
     coordinator.appMode = .broadcasting(stationId: "station-456")
     mainContainerModel.ensureBroadcastModels()
 
-    XCTAssertEqual(mainContainerModel.broadcastPageModel?.stationId, "station-456")
-    XCTAssertFalse(mainContainerModel.broadcastPageModel === originalModel)
+    #expect(mainContainerModel.broadcastPageModel?.stationId == "station-456")
+    #expect(!(mainContainerModel.broadcastPageModel === originalModel))
   }
 }
 // swiftlint:enable force_try

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -803,19 +803,7 @@ struct MainContainerTests {
 
       mainContainerModel.checkAndShowRatingPromptIfNeeded()
       await mainContainerModel.presentedAlert?.secondaryAction?()
-
-      // Drain the spawned Task in showFeedbackSheet() — it awaits
-      // analytics.track and then assigns presentedSheet. Polling on the
-      // observable end-state (presentedSheet being .feedbackSheet) is
-      // resilient to changes in the number of internal async hops.
-      for _ in 0..<50 {
-        if case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator
-          .presentedSheet
-        {
-          break
-        }
-        await Task.yield()
-      }
+      await waitForFeedbackSheet(on: mainContainerModel.mainContainerNavigationCoordinator)
 
       #expect(markShownCalled.value)
       #expect(
@@ -962,6 +950,18 @@ struct MainContainerTests {
 
     #expect(mainContainerModel.broadcastPageModel?.stationId == "station-456")
     #expect(!(mainContainerModel.broadcastPageModel === originalModel))
+  }
+}
+
+// Drain the fire-and-forget Task in MainContainerModel.showFeedbackSheet()
+// (it awaits analytics.track then assigns presentedSheet). Polling on the
+// observable end-state is resilient to changes in the number of internal
+// async hops.
+@MainActor
+private func waitForFeedbackSheet(on coordinator: MainContainerNavigationCoordinator) async {
+  for _ in 0..<50 {
+    if case .feedbackSheet = coordinator.presentedSheet { return }
+    await Task.yield()
   }
 }
 // swiftlint:enable force_try

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -10,59 +10,63 @@ import FRadioPlayer
 import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class PlayerPageTests: XCTestCase {
+struct PlayerPageTests {
   // MARK: - viewAppeared Tests
 
-  func testViewAppeared_PopulatesCorrectlyWhenLoadingNoProgress() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenLoadingNoProgress() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
-    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Station Loading...")
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenLoadingWithProgress() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenLoadingWithProgress() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station, 0.42))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
-    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
-    XCTAssertEqual(model.loadingPercentage, 0.42)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Station Loading...")
+    #expect(model.loadingPercentage == 0.42)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenSomethingIsPlaying() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenSomethingIsPlaying() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       artistPlaying: "Rachel Loy", titlePlaying: "Selfie", station: station)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Selfie - Rachel Loy")
-    XCTAssertEqual(model.stationArtUrl, station.imageUrl)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Selfie - Rachel Loy")
+    #expect(model.stationArtUrl == station.imageUrl)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenSomethingIsPlayingWithAudioBlock() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenSomethingIsPlayingWithAudioBlock() {
     let station = AnyStation.mock
     let audioBlock = AudioBlock.mockWith(title: "Selfie", artist: "Rachel Loy", type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
@@ -70,12 +74,13 @@ final class PlayerPageTests: XCTestCase {
       artistPlaying: "Rachel Loy", titlePlaying: "Selfie", spin: spin, station: station)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Selfie - Rachel Loy")
-    XCTAssertEqual(model.stationArtUrl, station.imageUrl)
-    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+    #expect(model.nowPlayingText == "Selfie - Rachel Loy")
+    #expect(model.stationArtUrl == station.imageUrl)
+    #expect(model.playolaAudioBlockPlaying == audioBlock)
   }
 
-  func testViewAppeared_PopulatesRelatedTextPrioritizingTheAudioBlockTranscription() {
+  @Test
+  func testViewAppearedPopulatesRelatedTextPrioritizingTheAudioBlockTranscription() {
     let transcription = "This is the transcription"
     let audioBlock = AudioBlock.mockWith(type: "song", transcription: transcription)
     let relatedTexts = [
@@ -86,12 +91,13 @@ final class PlayerPageTests: XCTestCase {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.relatedText?.title, "Why I chose this song")
-    XCTAssertEqual(model.relatedText?.body, transcription)
-    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+    #expect(model.relatedText?.title == "Why I chose this song")
+    #expect(model.relatedText?.body == transcription)
+    #expect(model.playolaAudioBlockPlaying == audioBlock)
   }
 
-  func testViewAppeared_PopulatesRelatedTextWhenRelatedTextButNoTranscription() {
+  @Test
+  func testViewAppearedPopulatesRelatedTextWhenRelatedTextButNoTranscription() {
     let audioBlock = AudioBlock.mockWith(type: "song", transcription: nil)
     let relatedTexts = [
       RelatedText(title: "title1", body: "body1"),
@@ -101,49 +107,53 @@ final class PlayerPageTests: XCTestCase {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertNotNil(model.relatedText)
-    XCTAssertTrue(model.relatedText == relatedTexts[0] || model.relatedText == relatedTexts[1])
-    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+    #expect(model.relatedText != nil)
+    #expect(model.relatedText == relatedTexts[0] || model.relatedText == relatedTexts[1])
+    #expect(model.playolaAudioBlockPlaying == audioBlock)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenStopped() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "")
-    XCTAssertNil(model.albumArtUrl)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "")
+    #expect(model.albumArtUrl == nil)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenError() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenError() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .error)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Error Playing Station")
-    XCTAssertEqual(model.primaryNavBarTitle, "")
-    XCTAssertEqual(model.secondaryNavBarTitle, "")
-    XCTAssertNil(model.albumArtUrl)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Error Playing Station")
+    #expect(model.primaryNavBarTitle == "")
+    #expect(model.secondaryNavBarTitle == "")
+    #expect(model.albumArtUrl == nil)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenStartingNewStation() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenStartingNewStation() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
-    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
-    XCTAssertEqual(model.loadingPercentage, 0.0)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Station Loading...")
+    #expect(model.loadingPercentage == 0.0)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenStartingNewStationWithAudioBlock() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenStartingNewStationWithAudioBlock() {
     let station = AnyStation.mock
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
@@ -151,18 +161,19 @@ final class PlayerPageTests: XCTestCase {
       spin: spin, station: station, status: .startingNewStation(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
-    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
-    XCTAssertEqual(model.loadingPercentage, 0.0)
-    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+    #expect(model.nowPlayingText == "Station Loading...")
+    #expect(model.loadingPercentage == 0.0)
+    #expect(model.playolaAudioBlockPlaying == audioBlock)
   }
 
-  func testRelatedText_ReturnsConsistentValueForSameSpin() {
+  @Test
+  func testRelatedTextReturnsConsistentValueForSameSpin() {
     let audioBlock = AudioBlock.mockWith(type: "song", transcription: nil)
     let relatedTexts = [
       RelatedText(title: "title1", body: "body1"),
@@ -173,25 +184,27 @@ final class PlayerPageTests: XCTestCase {
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
     let firstResult = model.relatedText
-    XCTAssertNotNil(firstResult)
-    XCTAssertEqual(firstResult, model.relatedText)
-    XCTAssertEqual(firstResult, model.relatedText)
+    #expect(firstResult != nil)
+    #expect(firstResult == model.relatedText)
+    #expect(firstResult == model.relatedText)
   }
 
   // MARK: - playPauseButtonTapped Tests
 
-  func testPlayPauseButtonTapped_StopsWhenPlaying() {
+  @Test
+  func testPlayPauseButtonTappedStopsWhenPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()
     let spy = StationPlayerMock()
     let model = PlayerPageModel(stationPlayer: spy)
 
     model.playPauseButtonTapped()
 
-    XCTAssertEqual(spy.stopCalledCount, 1)
-    XCTAssertEqual(spy.callsToPlay.count, 0)
+    #expect(spy.stopCalledCount == 1)
+    #expect(spy.callsToPlay.count == 0)
   }
 
-  func testPlayPauseButtonTapped_DismissesWhenStopButtonPressed() {
+  @Test
+  func testPlayPauseButtonTappedDismissesWhenStopButtonPressed() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()
     let spy = StationPlayerMock()
     var dismissCalled = false
@@ -199,13 +212,14 @@ final class PlayerPageTests: XCTestCase {
 
     model.playPauseButtonTapped()
 
-    XCTAssertEqual(spy.stopCalledCount, 1)
-    XCTAssertTrue(dismissCalled)
+    #expect(spy.stopCalledCount == 1)
+    #expect(dismissCalled)
   }
 
   // MARK: - scenePhaseChanged Tests
 
-  func testScenePhaseChanged_DismissesWhenActiveAndPlayerStopped() {
+  @Test
+  func testScenePhaseChangedDismissesWhenActiveAndPlayerStopped() {
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
@@ -214,10 +228,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertTrue(dismissCalled)
+    #expect(dismissCalled)
   }
 
-  func testScenePhaseChanged_DismissesWhenActiveAndPlayerError() {
+  @Test
+  func testScenePhaseChangedDismissesWhenActiveAndPlayerError() {
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .error)
 
@@ -226,10 +241,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertTrue(dismissCalled)
+    #expect(dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenActiveAndPlayerPlaying() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenActiveAndPlayerPlaying() {
     let station = AnyStation.mock
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .playing(station))
@@ -239,10 +255,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenActiveAndPlayerLoading() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenActiveAndPlayerLoading() {
     let station = AnyStation.mock
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .loading(station))
@@ -252,10 +269,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenActiveAndPlayerStartingNewStation() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenActiveAndPlayerStartingNewStation() {
     let station = AnyStation.mock
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .startingNewStation(station))
@@ -265,10 +283,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenBackgroundPhase() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenBackgroundPhase() {
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
@@ -277,10 +296,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .background)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenInactivePhase() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenInactivePhase() {
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
@@ -289,21 +309,23 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .inactive)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
   // MARK: - Heart State Tests
 
-  func testHeartState_HiddenWhenNotPlayingPlayolaSong() {
+  @Test
+  func testHeartStateHiddenWhenNotPlayingPlayolaSong() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()  // No spin
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.heartState, .hidden)
-    XCTAssertEqual(model.heartState.imageName, "")
-    XCTAssertEqual(model.heartState.imageColorHex, "")
+    #expect(model.heartState == .hidden)
+    #expect(model.heartState.imageName == "")
+    #expect(model.heartState.imageColorHex == "")
   }
 
-  func testHeartState_EmptyWhenPlayingUnlikedSong() async {
+  @Test
+  func testHeartStateEmptyWhenPlayingUnlikedSong() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -313,13 +335,14 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .empty)
-      XCTAssertEqual(model.heartState.imageName, "heart")
-      XCTAssertEqual(model.heartState.imageColorHex, "#BABABA")
+      #expect(model.heartState == .empty)
+      #expect(model.heartState.imageName == "heart")
+      #expect(model.heartState.imageColorHex == "#BABABA")
     }
   }
 
-  func testHeartState_FilledWhenPlayingLikedSong() async {
+  @Test
+  func testHeartStateFilledWhenPlayingLikedSong() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -331,15 +354,16 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .filled)
-      XCTAssertEqual(model.heartState.imageName, "heart.fill")
-      XCTAssertEqual(model.heartState.imageColorHex, "#EF6962")
+      #expect(model.heartState == .filled)
+      #expect(model.heartState.imageName == "heart.fill")
+      #expect(model.heartState.imageColorHex == "#EF6962")
     }
   }
 
   // MARK: - Heart Button Tap Tests
 
-  func testHeartButtonTapped_DoesNothingWhenNoAudioBlock() async {
+  @Test
+  func testHeartButtonTappedDoesNothingWhenNoAudioBlock() async {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()  // No spin
 
     withDependencies {
@@ -347,11 +371,12 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
       model.heartButtonTapped()
-      XCTAssertEqual(model.likesManager.allLikedAudioBlocks.count, 0)
+      #expect(model.likesManager.allLikedAudioBlocks.count == 0)
     }
   }
 
-  func testHeartButtonTapped_LikesUnlikedSong() async {
+  @Test
+  func testHeartButtonTappedLikesUnlikedSong() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -361,16 +386,17 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .empty)
+      #expect(model.heartState == .empty)
       model.heartButtonTapped()
 
-      XCTAssertEqual(model.heartState, .filled)
-      XCTAssertTrue(model.likesManager.isLiked(audioBlock.id))
-      XCTAssertEqual(model.likesManager.allLikedAudioBlocks.count, 1)
+      #expect(model.heartState == .filled)
+      #expect(model.likesManager.isLiked(audioBlock.id))
+      #expect(model.likesManager.allLikedAudioBlocks.count == 1)
     }
   }
 
-  func testHeartButtonTapped_UnlikesLikedSong() async {
+  @Test
+  func testHeartButtonTappedUnlikesLikedSong() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -382,16 +408,17 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .filled)
+      #expect(model.heartState == .filled)
       model.heartButtonTapped()
 
-      XCTAssertEqual(model.heartState, .empty)
-      XCTAssertFalse(model.likesManager.isLiked(audioBlock.id))
-      XCTAssertEqual(model.likesManager.allLikedAudioBlocks.count, 0)
+      #expect(model.heartState == .empty)
+      #expect(!model.likesManager.isLiked(audioBlock.id))
+      #expect(model.likesManager.allLikedAudioBlocks.count == 0)
     }
   }
 
-  func testHeartButtonTapped_CreatesPendingOperation() async {
+  @Test
+  func testHeartButtonTappedCreatesPendingOperation() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -402,15 +429,16 @@ final class PlayerPageTests: XCTestCase {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
       model.heartButtonTapped()
 
-      XCTAssertEqual(model.likesManager.pendingOperations.count, 1)
-      XCTAssertEqual(model.likesManager.pendingOperations.first?.type, .like)
-      XCTAssertEqual(model.likesManager.pendingOperations.first?.audioBlock.id, audioBlock.id)
+      #expect(model.likesManager.pendingOperations.count == 1)
+      #expect(model.likesManager.pendingOperations.first?.type == .like)
+      #expect(model.likesManager.pendingOperations.first?.audioBlock.id == audioBlock.id)
     }
   }
 
   // MARK: - Button Visibility Tests (Type-based)
 
-  func testHeartState_HiddenWhenPlayingNonSongAudioBlock() async {
+  @Test
+  func testHeartStateHiddenWhenPlayingNonSongAudioBlock() async {
     let commercialBlock = AudioBlock.mockWith(type: "commercial")
     let spin = Spin.mockWith(audioBlock: commercialBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -420,13 +448,14 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .hidden)
-      XCTAssertEqual(model.heartState.imageName, "")
-      XCTAssertEqual(model.heartState.imageColorHex, "")
+      #expect(model.heartState == .hidden)
+      #expect(model.heartState.imageName == "")
+      #expect(model.heartState.imageColorHex == "")
     }
   }
 
-  func testHeartState_VisibleWhenPlayingSongAudioBlock() async {
+  @Test
+  func testHeartStateVisibleWhenPlayingSongAudioBlock() async {
     let songBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: songBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -436,13 +465,14 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .empty)
-      XCTAssertEqual(model.heartState.imageName, "heart")
-      XCTAssertEqual(model.heartState.imageColorHex, "#BABABA")
+      #expect(model.heartState == .empty)
+      #expect(model.heartState.imageName == "heart")
+      #expect(model.heartState.imageColorHex == "#BABABA")
     }
   }
 
-  func testHeartButtonTapped_DoesNothingWhenPlayingNonSongAudioBlock() async {
+  @Test
+  func testHeartButtonTappedDoesNothingWhenPlayingNonSongAudioBlock() async {
     let commercialBlock = AudioBlock.mockWith(type: "commercial")
     let spin = Spin.mockWith(audioBlock: commercialBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -453,104 +483,114 @@ final class PlayerPageTests: XCTestCase {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
       model.heartButtonTapped()
 
-      XCTAssertEqual(model.likesManager.allLikedAudioBlocks.count, 0)
-      XCTAssertEqual(model.likesManager.pendingOperations.count, 0)
+      #expect(model.likesManager.allLikedAudioBlocks.count == 0)
+      #expect(model.likesManager.pendingOperations.count == 0)
     }
   }
 
   // MARK: - Navigation Bar Title Tests
 
-  func testNavBarTitles_PlayolaStationLoading() {
+  @Test
+  func testNavBarTitlesPlayolaStationLoading() {
     let station = AnyStation.mockPlayola(name: "Test Radio Show", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "Test Curator")
-    XCTAssertEqual(model.secondaryNavBarTitle, "Test Radio Show")
+    #expect(model.primaryNavBarTitle == "Test Curator")
+    #expect(model.secondaryNavBarTitle == "Test Radio Show")
   }
 
-  func testNavBarTitles_PlayolaStationStartingNewStation() {
+  @Test
+  func testNavBarTitlesPlayolaStationStartingNewStation() {
     let station = AnyStation.mockPlayola(name: "Another Radio Show", curatorName: "Another Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "Another Curator")
-    XCTAssertEqual(model.secondaryNavBarTitle, "Another Radio Show")
+    #expect(model.primaryNavBarTitle == "Another Curator")
+    #expect(model.secondaryNavBarTitle == "Another Radio Show")
   }
 
-  func testNavBarTitles_UrlStationLoading() {
+  @Test
+  func testNavBarTitlesUrlStationLoading() {
     let station = AnyStation.mockUrl(name: "Test FM", location: "Test City, TX")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "Test FM")
-    XCTAssertEqual(model.secondaryNavBarTitle, "Test City, TX")
+    #expect(model.primaryNavBarTitle == "Test FM")
+    #expect(model.secondaryNavBarTitle == "Test City, TX")
   }
 
-  func testNavBarTitles_UrlStationStartingNewStation() {
+  @Test
+  func testNavBarTitlesUrlStationStartingNewStation() {
     let station = AnyStation.mockUrl(name: "Another FM", location: "Another City, CA")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "Another FM")
-    XCTAssertEqual(model.secondaryNavBarTitle, "Another City, CA")
+    #expect(model.primaryNavBarTitle == "Another FM")
+    #expect(model.secondaryNavBarTitle == "Another City, CA")
   }
 
-  func testNavBarTitles_UrlStationWithoutLocation() {
+  @Test
+  func testNavBarTitlesUrlStationWithoutLocation() {
     let station = AnyStation.mockUrl(name: "No Location FM", location: "")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "No Location FM")
-    XCTAssertEqual(model.secondaryNavBarTitle, "")
+    #expect(model.primaryNavBarTitle == "No Location FM")
+    #expect(model.secondaryNavBarTitle == "")
   }
 
-  func testNavBarTitles_WhenPlaying() {
+  @Test
+  func testNavBarTitlesWhenPlaying() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
   }
 
-  func testNavBarTitles_EmptyWhenStopped() {
+  @Test
+  func testNavBarTitlesEmptyWhenStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "")
-    XCTAssertEqual(model.secondaryNavBarTitle, "")
+    #expect(model.primaryNavBarTitle == "")
+    #expect(model.secondaryNavBarTitle == "")
   }
 
   // MARK: - Now Playing Text Tests
 
+  @Test
   func testNowPlayingTextShowsPlayolaPaysForCommercial() {
     let commercialBlock = AudioBlock.mockWith(type: "commercial")
     let spin = Spin.mockWith(audioBlock: commercialBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Playola Pays")
+    #expect(model.nowPlayingText == "Playola Pays")
   }
 
+  @Test
   func testNowPlayingTextShowsTitleArtistForSong() {
     let songBlock = AudioBlock.mockWith(title: "Test Song", artist: "Test Artist", type: "song")
     let spin = Spin.mockWith(audioBlock: songBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Test Song - Test Artist")
+    #expect(model.nowPlayingText == "Test Song - Test Artist")
   }
 
+  @Test
   func testNowPlayingTextShowsTitleArtistForSongEvenWithAiring() {
     let songBlock = AudioBlock.mockWith(
       title: "Airing Song",
@@ -566,9 +606,10 @@ final class PlayerPageTests: XCTestCase {
 
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Airing Song - Airing Artist")
+    #expect(model.nowPlayingText == "Airing Song - Airing Artist")
   }
 
+  @Test
   func testNowPlayingTextShowsEpisodeTitleForNonSongWithAiring() {
     let voiceTrackBlock = AudioBlock.mockWith(type: "voicetrack")
     let airing = Airing.mockWith(
@@ -580,9 +621,10 @@ final class PlayerPageTests: XCTestCase {
 
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "My Cool Episode")
+    #expect(model.nowPlayingText == "My Cool Episode")
   }
 
+  @Test
   func testNowPlayingTextShowsStationNameForNonSongWithoutAiring() {
     let station = AnyStation.mockPlayola(name: "Test Station Name")
     let voiceTrackBlock = AudioBlock.mockWith(type: "voicetrack")
@@ -592,43 +634,49 @@ final class PlayerPageTests: XCTestCase {
 
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Test Station Name")
+    #expect(model.nowPlayingText == "Test Station Name")
   }
 
   // MARK: - Ask Question Tests
 
+  @Test
   func testCanAskQuestionTrueForPlayolaStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockPlayola())
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertTrue(model.canAskQuestion)
+    #expect(model.canAskQuestion)
   }
 
+  @Test
   func testCanAskQuestionFalseForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertFalse(model.canAskQuestion)
+    #expect(!model.canAskQuestion)
   }
 
+  @Test
   func testCanAskQuestionFalseWhenNoStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertFalse(model.canAskQuestion)
+    #expect(!model.canAskQuestion)
   }
 
+  @Test
   func testCurrentPlayolaStationReturnsStationForPlayolaStation() {
     let station = AnyStation.mockPlayola(id: "test-id", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertEqual(model.currentPlayolaStation?.id, "test-id")
-    XCTAssertEqual(model.currentPlayolaStation?.curatorName, "Test Curator")
+    #expect(model.currentPlayolaStation?.id == "test-id")
+    #expect(model.currentPlayolaStation?.curatorName == "Test Curator")
   }
 
+  @Test
   func testCurrentPlayolaStationReturnsNilForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertNil(model.currentPlayolaStation)
+    #expect(model.currentPlayolaStation == nil)
   }
 
+  @Test
   func testAskQuestionButtonTappedNavigatesToAskQuestionPageAndDismisses() {
     let station = AnyStation.mockPlayola(id: "test-id", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
@@ -641,16 +689,17 @@ final class PlayerPageTests: XCTestCase {
 
     model.askQuestionButtonTapped()
 
-    XCTAssertEqual(navCoordinator.path.count, 1)
+    #expect(navCoordinator.path.count == 1)
     if case .askQuestionPage(let askModel) = navCoordinator.path.first {
-      XCTAssertEqual(askModel.station.id, "test-id")
-      XCTAssertEqual(askModel.curatorName, "Test Curator")
+      #expect(askModel.station.id == "test-id")
+      #expect(askModel.curatorName == "Test Curator")
     } else {
-      XCTFail("Expected askQuestionPage in navigation path")
+      Issue.record("Expected askQuestionPage in navigation path")
     }
-    XCTAssertTrue(dismissCalled)
+    #expect(dismissCalled)
   }
 
+  @Test
   func testAskQuestionButtonTappedDoesNothingForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
     @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
@@ -659,6 +708,6 @@ final class PlayerPageTests: XCTestCase {
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
     model.askQuestionButtonTapped()
 
-    XCTAssertTrue(navCoordinator.path.isEmpty)
+    #expect(navCoordinator.path.isEmpty)
   }
 }

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
@@ -8,14 +8,16 @@
 import Clocks
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SongSearchPageTests: XCTestCase {
+struct SongSearchPageTests {
+  @Test
   func testOnCancelTappedCallsOnDismissCallback() {
     var dismissCalled = false
 
@@ -27,40 +29,44 @@ final class SongSearchPageTests: XCTestCase {
 
       model.onCancelTapped()
 
-      XCTAssertTrue(dismissCalled)
+      #expect(dismissCalled)
     }
   }
 
+  @Test
   func testInitialStateSearchTextIsEmpty() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertEqual(model.searchText, "")
+      #expect(model.searchText == "")
     }
   }
 
+  @Test
   func testInitialStateIsNotSearching() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertFalse(model.isSearching)
+      #expect(!model.isSearching)
     }
   }
 
+  @Test
   func testInitialStateSearchResultsAreEmpty() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertTrue(model.searchResults.isEmpty)
+      #expect(model.searchResults.isEmpty)
     }
   }
 
+  @Test
   func testOnSelectSongCallsOnSongSelectedCallback() {
     var selectedSong: AudioBlock?
 
@@ -73,11 +79,12 @@ final class SongSearchPageTests: XCTestCase {
 
       model.onSelectSong(testAudioBlock)
 
-      XCTAssertEqual(selectedSong?.id, "test-song-id")
-      XCTAssertEqual(selectedSong?.title, "Test Song")
+      #expect(selectedSong?.id == "test-song-id")
+      #expect(selectedSong?.title == "Test Song")
     }
   }
 
+  @Test
   func testPerformSearchUpdatesSearchResults() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -97,13 +104,14 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(model.searchResults.count, 2)
-        XCTAssertEqual(model.searchResults[0].id, "song-1")
-        XCTAssertEqual(model.searchResults[1].id, "song-2")
+        #expect(model.searchResults.count == 2)
+        #expect(model.searchResults[0].id == "song-1")
+        #expect(model.searchResults[1].id == "song-2")
       }
     }
   }
 
+  @Test
   func testPerformSearchClearsResultsWhenQueryIsEmpty() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -118,15 +126,16 @@ final class SongSearchPageTests: XCTestCase {
 
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
-        XCTAssertEqual(model.searchResults.count, 1)
+        #expect(model.searchResults.count == 1)
 
         model.searchText = ""
         await clock.advance(by: .milliseconds(300))
-        XCTAssertTrue(model.searchResults.isEmpty)
+        #expect(model.searchResults.isEmpty)
       }
     }
   }
 
+  @Test
   func testPerformSearchShowsAlertOnError() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -140,17 +149,18 @@ final class SongSearchPageTests: XCTestCase {
         }
       } operation: {
         let model = SongSearchPageModel()
-        XCTAssertNil(model.presentedAlert)
+        #expect(model.presentedAlert == nil)
 
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertNotNil(model.presentedAlert)
-        XCTAssertEqual(model.presentedAlert?.title, "Search Error")
+        #expect(model.presentedAlert != nil)
+        #expect(model.presentedAlert?.title == "Search Error")
       }
     }
   }
 
+  @Test
   func testPerformSearchShowsAlertWhenNotAuthenticated() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -161,17 +171,18 @@ final class SongSearchPageTests: XCTestCase {
         $0.date = .constant(Date())
       } operation: {
         let model = SongSearchPageModel()
-        XCTAssertNil(model.presentedAlert)
+        #expect(model.presentedAlert == nil)
 
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertNotNil(model.presentedAlert)
-        XCTAssertEqual(model.presentedAlert?.title, "Not Signed In")
+        #expect(model.presentedAlert != nil)
+        #expect(model.presentedAlert?.title == "Not Signed In")
       }
     }
   }
 
+  @Test
   func testPerformSearchPassesCorrectKeywordsToAPI() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -191,11 +202,12 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(capturedKeywords.value, "Bob Dylan")
+        #expect(capturedKeywords.value == "Bob Dylan")
       }
     }
   }
 
+  @Test
   func testPerformSearchTrimsWhitespace() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -215,11 +227,12 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(capturedKeywords.value, "Bob Dylan")
+        #expect(capturedKeywords.value == "Bob Dylan")
       }
     }
   }
 
+  @Test
   func testDebounceOnlySearchesOnceForRapidChanges() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -243,11 +256,12 @@ final class SongSearchPageTests: XCTestCase {
         model.searchText = "Bob"
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(searchCount.value, 1)
+        #expect(searchCount.value == 1)
       }
     }
   }
 
+  @Test
   func testDebounceDoesNotSearchBeforeDebounceTime() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -267,27 +281,29 @@ final class SongSearchPageTests: XCTestCase {
         model.searchText = "test"
         await clock.advance(by: .milliseconds(200))
 
-        XCTAssertEqual(searchCount.value, 0)
+        #expect(searchCount.value == 0)
 
         await clock.advance(by: .milliseconds(100))
 
-        XCTAssertEqual(searchCount.value, 1)
+        #expect(searchCount.value == 1)
       }
     }
   }
 
   // MARK: - Song Request Tests
 
+  @Test
   func testInitialStateSongRequestResultsAreEmpty() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertTrue(model.songRequestResults.isEmpty)
+      #expect(model.songRequestResults.isEmpty)
     }
   }
 
+  @Test
   func testPerformSearchUpdatesSongRequestResults() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -308,13 +324,14 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(model.songRequestResults.count, 2)
-        XCTAssertEqual(model.songRequestResults[0].appleId, "apple-1")
-        XCTAssertEqual(model.songRequestResults[1].appleId, "apple-2")
+        #expect(model.songRequestResults.count == 2)
+        #expect(model.songRequestResults[0].appleId == "apple-1")
+        #expect(model.songRequestResults[1].appleId == "apple-2")
       }
     }
   }
 
+  @Test
   func testPerformSearchSearchesBothSourcesSimultaneously() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -339,12 +356,13 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertTrue(songsSearchCalled.value)
-        XCTAssertTrue(songRequestsSearchCalled.value)
+        #expect(songsSearchCalled.value)
+        #expect(songRequestsSearchCalled.value)
       }
     }
   }
 
+  @Test
   func testPerformSearchClearsSongRequestResultsWhenQueryIsEmpty() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -360,15 +378,16 @@ final class SongSearchPageTests: XCTestCase {
 
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
-        XCTAssertEqual(model.songRequestResults.count, 1)
+        #expect(model.songRequestResults.count == 1)
 
         model.searchText = ""
         await clock.advance(by: .milliseconds(300))
-        XCTAssertTrue(model.songRequestResults.isEmpty)
+        #expect(model.songRequestResults.isEmpty)
       }
     }
   }
 
+  @Test
   func testOnRequestSongCallsOnSongRequestedCallback() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     var requestedSongRequest: SongRequest?
@@ -384,11 +403,12 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onRequestSong(testSongRequest)
 
-      XCTAssertEqual(requestedSongRequest?.appleId, "test-apple-id")
-      XCTAssertEqual(requestedSongRequest?.title, "Test Request")
+      #expect(requestedSongRequest?.appleId == "test-apple-id")
+      #expect(requestedSongRequest?.title == "Test Request")
     }
   }
 
+  @Test
   func testPerformSearchSongRequestErrorDoesNotAffectSongResults() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -408,31 +428,34 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(model.searchResults.count, 1)
-        XCTAssertTrue(model.songRequestResults.isEmpty)
+        #expect(model.searchResults.count == 1)
+        #expect(model.songRequestResults.isEmpty)
       }
     }
   }
 
   // MARK: - SongRequest Status Tests
 
+  @Test
   func testSongRequestWithNoRequestIdHasUnrequestedStatus() {
     let songRequest = SongRequest.mockWith(requestId: nil)
 
-    XCTAssertEqual(songRequest.requestStatus, .unrequested)
-    XCTAssertFalse(songRequest.requestStatus.isRequested)
-    XCTAssertNil(songRequest.requestStatus.displayText)
+    #expect(songRequest.requestStatus == .unrequested)
+    #expect(!songRequest.requestStatus.isRequested)
+    #expect(songRequest.requestStatus.displayText == nil)
   }
 
+  @Test
   func testSongRequestWithRequestIdAndCreatedAtHasRequestedStatus() {
     let requestDate = Date(timeIntervalSince1970: 1_000_000)
     let songRequest = SongRequest.mockWith(requestId: "request-123", createdAt: requestDate)
 
-    XCTAssertEqual(songRequest.requestStatus, .requested(requestDate))
-    XCTAssertTrue(songRequest.requestStatus.isRequested)
-    XCTAssertEqual(songRequest.requestStatus.requestedDate, requestDate)
+    #expect(songRequest.requestStatus == .requested(requestDate))
+    #expect(songRequest.requestStatus.isRequested)
+    #expect(songRequest.requestStatus.requestedDate == requestDate)
   }
 
+  @Test
   func testSongRequestRequestedStatusDisplaysFormattedDate() {
     var calendar = Calendar(identifier: .gregorian)
     calendar.timeZone = TimeZone.current
@@ -440,9 +463,10 @@ final class SongSearchPageTests: XCTestCase {
     let requestDate = calendar.date(from: components)!
     let songRequest = SongRequest.mockWith(requestId: "request-123", createdAt: requestDate)
 
-    XCTAssertEqual(songRequest.requestStatus.displayText, "Requested 9/14")
+    #expect(songRequest.requestStatus.displayText == "Requested 9/14")
   }
 
+  @Test
   func testOnRequestSongCallsAPIWithAppleId() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let capturedSongRequest = LockIsolated<SongRequest?>(nil)
@@ -458,10 +482,11 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onRequestSong(testSongRequest)
 
-      XCTAssertEqual(capturedSongRequest.value?.appleId, "test-apple-123")
+      #expect(capturedSongRequest.value?.appleId == "test-apple-123")
     }
   }
 
+  @Test
   func testOnRequestSongUpdatesSongRequestToRequested() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -483,15 +508,16 @@ final class SongSearchPageTests: XCTestCase {
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertFalse(model.songRequestResults[0].requestStatus.isRequested)
+        #expect(!model.songRequestResults[0].requestStatus.isRequested)
 
         await model.onRequestSong(model.songRequestResults[0])
 
-        XCTAssertTrue(model.songRequestResults[0].requestStatus.isRequested)
+        #expect(model.songRequestResults[0].requestStatus.isRequested)
       }
     }
   }
 
+  @Test
   func testOnRequestSongShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -504,46 +530,50 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel()
       let testSongRequest = SongRequest.mockWith(appleId: "test-apple-123")
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.onRequestSong(testSongRequest)
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
   // MARK: - Search Mode Tests
 
+  @Test
   func testDefaultSearchModeIsAll() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertEqual(model.searchMode, .all)
+      #expect(model.searchMode == .all)
     }
   }
 
+  @Test
   func testInitWithSearchModeLibraryOnly() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel(searchMode: .libraryOnly)
 
-      XCTAssertEqual(model.searchMode, .libraryOnly)
+      #expect(model.searchMode == .libraryOnly)
     }
   }
 
+  @Test
   func testInitWithSearchModeSeedsOnly() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel(searchMode: .seedsOnly)
 
-      XCTAssertEqual(model.searchMode, .seedsOnly)
+      #expect(model.searchMode == .seedsOnly)
     }
   }
 
+  @Test
   func testLibraryOnlyModeOnlySearchesSongs() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -568,12 +598,13 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertTrue(songsSearchCalled.value)
-        XCTAssertFalse(songRequestsSearchCalled.value)
+        #expect(songsSearchCalled.value)
+        #expect(!songRequestsSearchCalled.value)
       }
     }
   }
 
+  @Test
   func testSeedsOnlyModeOnlySearchesSongRequests() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -598,24 +629,26 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertFalse(songsSearchCalled.value)
-        XCTAssertTrue(songRequestsSearchCalled.value)
+        #expect(!songsSearchCalled.value)
+        #expect(songRequestsSearchCalled.value)
       }
     }
   }
 
   // MARK: - Library Add Mode Tests
 
+  @Test
   func testIsLibraryAddModeReturnsFalseByDefault() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertFalse(model.isLibraryAddMode)
+      #expect(!model.isLibraryAddMode)
     }
   }
 
+  @Test
   func testIsLibraryAddModeReturnsTrueWhenCallbackSet() {
     withDependencies {
       $0.date = .constant(Date())
@@ -623,20 +656,22 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel()
       model.onAddedToLibrary = { _ in }
 
-      XCTAssertTrue(model.isLibraryAddMode)
+      #expect(model.isLibraryAddMode)
     }
   }
 
+  @Test
   func testSongSeedsSectionHeaderReturnsRequestHeaderByDefault() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertEqual(model.songSeedsSectionHeader, "AVAILABLE SOON BY REQUEST")
+      #expect(model.songSeedsSectionHeader == "AVAILABLE SOON BY REQUEST")
     }
   }
 
+  @Test
   func testSongSeedsSectionHeaderReturnsAppleMusicHeaderWhenLibraryAddMode() {
     withDependencies {
       $0.date = .constant(Date())
@@ -644,12 +679,13 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel()
       model.onAddedToLibrary = { _ in }
 
-      XCTAssertEqual(model.songSeedsSectionHeader, "APPLE MUSIC")
+      #expect(model.songSeedsSectionHeader == "APPLE MUSIC")
     }
   }
 
   // MARK: - Add Song to Library Tests
 
+  @Test
   func testOnAddSongToLibraryCallsAPIWithCorrectParameters() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let capturedStationId = LockIsolated<String?>(nil)
@@ -674,15 +710,16 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertEqual(capturedStationId.value, "station-123")
-      XCTAssertEqual(capturedBody.value?.appleId, "apple-456")
-      XCTAssertEqual(capturedBody.value?.title, "Test Song")
-      XCTAssertEqual(capturedBody.value?.artist, "Test Artist")
-      XCTAssertEqual(capturedBody.value?.album, "Test Album")
-      XCTAssertEqual(capturedBody.value?.imageUrl, "https://example.com/image.jpg")
+      #expect(capturedStationId.value == "station-123")
+      #expect(capturedBody.value?.appleId == "apple-456")
+      #expect(capturedBody.value?.title == "Test Song")
+      #expect(capturedBody.value?.artist == "Test Artist")
+      #expect(capturedBody.value?.album == "Test Album")
+      #expect(capturedBody.value?.imageUrl == "https://example.com/image.jpg")
     }
   }
 
+  @Test
   func testOnAddSongToLibraryCallsOnAddedToLibraryCallback() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     var addedRequest: StationLibraryRequest?
@@ -698,10 +735,11 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertEqual(addedRequest?.id, "new-request")
+      #expect(addedRequest?.id == "new-request")
     }
   }
 
+  @Test
   func testOnAddSongToLibraryShowsAlertWhenNotAuthenticated() async {
     @Shared(.auth) var auth = Auth()
 
@@ -711,15 +749,16 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel(searchMode: .seedsOnly, stationId: "station-123")
       let testSongRequest = SongRequest.mockWith(appleId: "apple-456")
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Not Signed In")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Not Signed In")
     }
   }
 
+  @Test
   func testOnAddSongToLibraryShowsAlertWhenStationIdMissing() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -729,15 +768,16 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel(searchMode: .seedsOnly, stationId: nil)
       let testSongRequest = SongRequest.mockWith(appleId: "apple-456")
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Add Failed")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Add Failed")
     }
   }
 
+  @Test
   func testOnAddSongToLibraryShowsAlertOnAPIError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -750,17 +790,18 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel(searchMode: .seedsOnly, stationId: "station-123")
       let testSongRequest = SongRequest.mockWith(appleId: "apple-456")
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Add Failed")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Add Failed")
     }
   }
 
   // MARK: - Processing Add State Tests
 
+  @Test
   func testIsProcessingAddReturnsFalseInitially() {
     withDependencies {
       $0.date = .constant(Date())
@@ -768,10 +809,11 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel()
       let testSongRequest = SongRequest.mockWith(appleId: "apple-456")
 
-      XCTAssertFalse(model.isProcessingAdd(for: testSongRequest))
+      #expect(!model.isProcessingAdd(for: testSongRequest))
     }
   }
 
+  @Test
   func testIsProcessingAddReturnsFalseAfterCompletion() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -784,10 +826,11 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertFalse(model.isProcessingAdd(for: testSongRequest))
+      #expect(!model.isProcessingAdd(for: testSongRequest))
     }
   }
 
+  @Test
   func testIsProcessingAddReturnsFalseAfterError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -802,7 +845,7 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertFalse(model.isProcessingAdd(for: testSongRequest))
+      #expect(!model.isProcessingAdd(for: testSongRequest))
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -5,54 +5,59 @@
 //  Created by Brian D Keane on 6/13/25.
 //
 
+import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class StationListPageTests: XCTestCase {
+struct StationListPageTests {
   // MARK: - View Appeared Tests
 
-  func testViewAppeared_PopulatesFromInitialSharedStationLists() async {
+  @Test
+  func testViewAppearedPopulatesFromInitialSharedStationLists() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.stationLists) var stationLists = StationList.mocks
     let expectedVisibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
     let model = StationListModel()
     await model.viewAppeared()
-    XCTAssertEqual(model.stationListsForDisplay, expectedVisibleLists)
-    XCTAssertEqual(model.segmentTitles, ["All"] + expectedVisibleLists.map { $0.title })
-    XCTAssertEqual(model.selectedSegment, "All")
+    #expect(model.stationListsForDisplay == expectedVisibleLists)
+    #expect(model.segmentTitles == ["All"] + expectedVisibleLists.map { $0.title })
+    #expect(model.selectedSegment == "All")
   }
 
   // MARK: - Segment Selection Tests
 
-  func testSegmentSelection_FiltersWhenSegmentSelected() async {
+  @Test
+  func testSegmentSelectionFiltersWhenSegmentSelected() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.stationLists) var stationLists = StationList.mocks
     let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
     guard let firstList = visibleLists.first else {
-      XCTFail("StationList.mocks should have at least one non-development list")
+      Issue.record("StationList.mocks should have at least one non-development list")
       return
     }
     let model = StationListModel()
     await model.viewAppeared()
     await model.segmentSelected(firstList.title)
-    XCTAssertEqual(model.selectedSegment, firstList.title)
-    XCTAssertEqual(model.stationListsForDisplay, [firstList])
+    #expect(model.selectedSegment == firstList.title)
+    #expect(model.stationListsForDisplay == [firstList])
   }
 
   // MARK: - Shared stationLists Updates Tests
 
-  func testSharedStationListsUpdates_KeepsSelectedSegmentWhenStillPresent() async {
+  @Test
+  func testSharedStationListsUpdatesKeepsSelectedSegmentWhenStillPresent() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.stationLists) var stationLists = StationList.mocks
     let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
     guard let targetList = visibleLists.first else {
-      XCTFail("StationList.mocks should have at least one non-development list")
+      Issue.record("StationList.mocks should have at least one non-development list")
       return
     }
 
@@ -78,17 +83,18 @@ final class StationListPageTests: XCTestCase {
       )
     }
 
-    XCTAssertEqual(model.selectedSegment, targetList.title)
-    XCTAssertEqual(model.stationListsForDisplay.count, 1)
-    XCTAssertEqual(model.stationListsForDisplay.first?.title, targetList.title)
+    #expect(model.selectedSegment == targetList.title)
+    #expect(model.stationListsForDisplay.count == 1)
+    #expect(model.stationListsForDisplay.first?.title == targetList.title)
   }
 
-  func testSharedStationListsUpdates_ResetsSelectedSegmentWhenSegmentMissing() async {
+  @Test
+  func testSharedStationListsUpdatesResetsSelectedSegmentWhenSegmentMissing() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.stationLists) var stationLists = StationList.mocks
     let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
     guard let targetList = visibleLists.first else {
-      XCTFail("StationList.mocks should have at least one non-development list")
+      Issue.record("StationList.mocks should have at least one non-development list")
       return
     }
 
@@ -120,23 +126,25 @@ final class StationListPageTests: XCTestCase {
     let expectedVisibleAfterUpdate = stationLists.filter {
       $0.id != StationList.inDevelopmentListId
     }
-    XCTAssertEqual(model.selectedSegment, "All")
-    XCTAssertEqual(model.stationListsForDisplay, expectedVisibleAfterUpdate)
+    #expect(model.selectedSegment == "All")
+    #expect(model.stationListsForDisplay == expectedVisibleAfterUpdate)
   }
 
-  func testViewAppeared_IncludesHiddenListsWhenSecretsEnabled() async {
+  @Test
+  func testViewAppearedIncludesHiddenListsWhenSecretsEnabled() async {
     @Shared(.showSecretStations) var showSecretStations = true
     @Shared(.stationLists) var stationLists = StationList.mocks
     let model = StationListModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.stationListsForDisplay, stationLists)
-    XCTAssertEqual(model.segmentTitles, ["All"] + stationLists.map { $0.title })
+    #expect(model.stationListsForDisplay == stationLists)
+    #expect(model.segmentTitles == ["All"] + stationLists.map { $0.title })
   }
 
   // MARK: - Player Interaction Tests
 
-  func testPlayerInteraction_PlaysAStationWhenItIsTapped() async {
+  @Test
+  func testPlayerInteractionPlaysAStationWhenItIsTapped() async {
     let stationPlayerMock: StationPlayerMock = .mockStoppedPlayer()
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
@@ -150,11 +158,12 @@ final class StationListPageTests: XCTestCase {
 
     await stationListModel.stationSelected(item)
 
-    XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
-    XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, item.anyStation.id)
+    #expect(stationPlayerMock.callsToPlay.count == 1)
+    #expect(stationPlayerMock.callsToPlay.first?.id == item.anyStation.id)
     assertPlayedEvents(capturedEvents.value, stationId: item.anyStation.id)
   }
 
+  @Test
   func testComingSoonStationDoesNotPlayWhenSecretsHidden() async {
     @Shared(.showSecretStations) var showSecretStations = false
 
@@ -188,10 +197,11 @@ final class StationListPageTests: XCTestCase {
 
     await stationListModel.stationSelected(comingSoonItem)
 
-    XCTAssertTrue(stationPlayerMock.callsToPlay.isEmpty)
-    XCTAssertTrue(capturedEvents.value.isEmpty)
+    #expect(stationPlayerMock.callsToPlay.isEmpty)
+    #expect(capturedEvents.value.isEmpty)
   }
 
+  @Test
   func testComingSoonStationPlaysWhenSecretsShown() async {
     @Shared(.showSecretStations) var showSecretStations = true
 
@@ -225,23 +235,24 @@ final class StationListPageTests: XCTestCase {
 
     await stationListModel.stationSelected(comingSoonItem)
 
-    XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
-    XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, comingSoonItem.anyStation.id)
+    #expect(stationPlayerMock.callsToPlay.count == 1)
+    #expect(stationPlayerMock.callsToPlay.first?.id == comingSoonItem.anyStation.id)
 
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 2)
+    #expect(events.count == 2)
     if case .tappedStationCard(let stationInfo, _, _) = events[0] {
-      XCTAssertEqual(stationInfo.id, comingSoonItem.anyStation.id)
+      #expect(stationInfo.id == comingSoonItem.anyStation.id)
     } else {
-      XCTFail("Expected tappedStationCard event")
+      Issue.record("Expected tappedStationCard event")
     }
     if case .startedStation(let stationInfo, _) = events[1] {
-      XCTAssertEqual(stationInfo.id, comingSoonItem.anyStation.id)
+      #expect(stationInfo.id == comingSoonItem.anyStation.id)
     } else {
-      XCTFail("Expected startedStation event")
+      Issue.record("Expected startedStation event")
     }
   }
 
+  @Test
   func testInactiveStationDoesNotPlay() async {
     @Shared(.showSecretStations) var showSecretStations = true
 
@@ -275,12 +286,13 @@ final class StationListPageTests: XCTestCase {
 
     await stationListModel.stationSelected(inactiveItem)
 
-    XCTAssertTrue(stationPlayerMock.callsToPlay.isEmpty)
-    XCTAssertTrue(capturedEvents.value.isEmpty)
+    #expect(stationPlayerMock.callsToPlay.isEmpty)
+    #expect(capturedEvents.value.isEmpty)
   }
 
   // MARK: - Hidden Station Filtering
 
+  @Test
   func testHiddenStationsFilteredWhenSecretsOff() async {
     @Shared(.showSecretStations) var showSecretStations = false
     let now = Date()
@@ -329,10 +341,11 @@ final class StationListPageTests: XCTestCase {
     let includeHidden = model.showSecretStations || !secretList.hidden
     let filteredItems = secretList.stationItems(includeHidden: includeHidden)
 
-    XCTAssertEqual(filteredItems.count, 1)
-    XCTAssertEqual(filteredItems.first?.visibility, .visible)
+    #expect(filteredItems.count == 1)
+    #expect(filteredItems.first?.visibility == .visible)
   }
 
+  @Test
   func testHiddenStationsIncludedWhenSecretsOn() async {
     @Shared(.showSecretStations) var showSecretStations = true
     let now = Date()
@@ -381,12 +394,13 @@ final class StationListPageTests: XCTestCase {
     let includeHidden = model.showSecretStations || !secretList.hidden
     let filteredItems = secretList.stationItems(includeHidden: includeHidden)
 
-    XCTAssertEqual(filteredItems.count, 2)
-    XCTAssertEqual(filteredItems.last?.visibility, .hidden)
+    #expect(filteredItems.count == 2)
+    #expect(filteredItems.last?.visibility == .hidden)
   }
 
   // MARK: - Live Station Tests
 
+  @Test
   func testLiveStatusForStationReturnsNilWhenNotLive() async {
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
 
@@ -395,9 +409,10 @@ final class StationListPageTests: XCTestCase {
 
     let status = model.liveStatusForStation("some-station-id")
 
-    XCTAssertNil(status)
+    #expect(status == nil)
   }
 
+  @Test
   func testLiveStatusForStationReturnsVoicetrackingStatus() async {
     let station = Station.mockWith(id: "live-station")
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = [
@@ -409,9 +424,10 @@ final class StationListPageTests: XCTestCase {
 
     let status = model.liveStatusForStation("live-station")
 
-    XCTAssertEqual(status, .voicetracking)
+    #expect(status == .voicetracking)
   }
 
+  @Test
   func testLiveStatusForStationReturnsShowAiringStatus() async {
     let station = Station.mockWith(id: "show-station")
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = [
@@ -423,9 +439,10 @@ final class StationListPageTests: XCTestCase {
 
     let status = model.liveStatusForStation("show-station")
 
-    XCTAssertEqual(status, .showAiring)
+    #expect(status == .showAiring)
   }
 
+  @Test
   func testSortedStationItemsPutsLiveStationsFirst() async {
     @Shared(.showSecretStations) var showSecretStations = false
     let now = Date()
@@ -458,10 +475,11 @@ final class StationListPageTests: XCTestCase {
 
     let sortedItems = model.sortedStationItems(for: list)
 
-    XCTAssertEqual(sortedItems.count, 3)
-    XCTAssertEqual(sortedItems[0].anyStation.id, "station-2")
+    #expect(sortedItems.count == 3)
+    #expect(sortedItems[0].anyStation.id == "station-2")
   }
 
+  @Test
   func testSortedStationItemsPutsVoicetrackingBeforeShowAiring() async {
     @Shared(.showSecretStations) var showSecretStations = false
     let now = Date()
@@ -495,12 +513,13 @@ final class StationListPageTests: XCTestCase {
 
     let sortedItems = model.sortedStationItems(for: list)
 
-    XCTAssertEqual(sortedItems.count, 3)
-    XCTAssertEqual(sortedItems[0].anyStation.id, "station-3")  // voicetracking first
-    XCTAssertEqual(sortedItems[1].anyStation.id, "station-1")  // showAiring second
-    XCTAssertEqual(sortedItems[2].anyStation.id, "station-2")  // not live last
+    #expect(sortedItems.count == 3)
+    #expect(sortedItems[0].anyStation.id == "station-3")  // voicetracking first
+    #expect(sortedItems[1].anyStation.id == "station-1")  // showAiring second
+    #expect(sortedItems[2].anyStation.id == "station-2")  // not live last
   }
 
+  @Test
   func testSortedStationItemsPreservesOrderWhenNoLiveStations() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -528,13 +547,14 @@ final class StationListPageTests: XCTestCase {
 
     let sortedItems = model.sortedStationItems(for: list)
 
-    XCTAssertEqual(sortedItems.count, 2)
-    XCTAssertEqual(sortedItems[0].anyStation.id, "station-1")
-    XCTAssertEqual(sortedItems[1].anyStation.id, "station-2")
+    #expect(sortedItems.count == 2)
+    #expect(sortedItems[0].anyStation.id == "station-1")
+    #expect(sortedItems[1].anyStation.id == "station-2")
   }
 
   // MARK: - Search Tests
 
+  @Test
   func testSearchByCuratorNameFiltersStations() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -554,10 +574,11 @@ final class StationListPageTests: XCTestCase {
     model.searchText = "Alice"
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 1)
-    XCTAssertEqual(items.first?.anyStation.id, "s1")
+    #expect(items.count == 1)
+    #expect(items.first?.anyStation.id == "s1")
   }
 
+  @Test
   func testSearchByStationNameFiltersStations() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -577,10 +598,11 @@ final class StationListPageTests: XCTestCase {
     model.searchText = "Moondog"
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 1)
-    XCTAssertEqual(items.first?.anyStation.id, "s1")
+    #expect(items.count == 1)
+    #expect(items.first?.anyStation.id == "s1")
   }
 
+  @Test
   func testSearchIsCaseInsensitive() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -598,10 +620,11 @@ final class StationListPageTests: XCTestCase {
     model.searchText = "alice"
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 1)
-    XCTAssertEqual(items.first?.anyStation.id, "s1")
+    #expect(items.count == 1)
+    #expect(items.first?.anyStation.id == "s1")
   }
 
+  @Test
   func testEmptySearchTextShowsAllStations() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -621,9 +644,10 @@ final class StationListPageTests: XCTestCase {
     model.searchText = ""
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 2)
+    #expect(items.count == 2)
   }
 
+  @Test
   func testIsShowingNoResultsTrueWhenSearchHasNoMatches() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -640,9 +664,10 @@ final class StationListPageTests: XCTestCase {
 
     model.searchText = "xyznonexistent"
 
-    XCTAssertTrue(model.isShowingNoResults)
+    #expect(model.isShowingNoResults)
   }
 
+  @Test
   func testIsShowingNoResultsFalseWhenSearchTextEmpty() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -659,9 +684,10 @@ final class StationListPageTests: XCTestCase {
 
     model.searchText = ""
 
-    XCTAssertFalse(model.isShowingNoResults)
+    #expect(!model.isShowingNoResults)
   }
 
+  @Test
   func testSearchWorksWithinSelectedSegment() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -692,12 +718,13 @@ final class StationListPageTests: XCTestCase {
     await model.segmentSelected("Hip Hop")
     model.searchText = "Alice"
 
-    XCTAssertEqual(model.stationListsForDisplay.count, 1)
+    #expect(model.stationListsForDisplay.count == 1)
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 1)
-    XCTAssertEqual(items.first?.anyStation.id, "s1")
+    #expect(items.count == 1)
+    #expect(items.first?.anyStation.id == "s1")
   }
 
+  @Test
   func testSearchTextClearedOnSegmentSwitch() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -723,12 +750,13 @@ final class StationListPageTests: XCTestCase {
     await model.viewAppeared()
 
     model.searchText = "Alice"
-    XCTAssertEqual(model.searchText, "Alice")
+    #expect(model.searchText == "Alice")
 
     await model.segmentSelected("Jazz")
-    XCTAssertEqual(model.searchText, "")
+    #expect(model.searchText == "")
   }
 
+  @Test
   func testSearchMatchesEitherCuratorNameOrStationName() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -750,10 +778,10 @@ final class StationListPageTests: XCTestCase {
     model.searchText = "Moondog"
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 2)
+    #expect(items.count == 2)
     let ids = items.map { $0.anyStation.id }
-    XCTAssertTrue(ids.contains("s1"))
-    XCTAssertTrue(ids.contains("s2"))
+    #expect(ids.contains("s1"))
+    #expect(ids.contains("s2"))
   }
 }
 
@@ -761,30 +789,34 @@ private func assertPlayedEvents(
   _ events: [AnalyticsEvent],
   stationId: String
 ) {
-  XCTAssertEqual(events.count, 2)
+  #expect(events.count == 2)
 
   guard let firstEvent = events.first else {
-    return XCTFail("Expected tappedStationCard event, but events were empty")
+    Issue.record("Expected tappedStationCard event, but events were empty")
+    return
   }
   guard
     case .tappedStationCard(let stationInfo, let position, let totalStations) = firstEvent
   else {
-    return XCTFail("Expected tappedStationCard event, got: \(String(describing: firstEvent))")
+    Issue.record("Expected tappedStationCard event, got: \(String(describing: firstEvent))")
+    return
   }
-  XCTAssertEqual(stationInfo.id, stationId)
-  XCTAssertEqual(position, 0)
-  XCTAssertEqual(totalStations, 1)
+  #expect(stationInfo.id == stationId)
+  #expect(position == 0)
+  #expect(totalStations == 1)
 
   guard let secondEvent = events.dropFirst().first else {
-    return XCTFail("Expected startedStation event, but only found one event")
+    Issue.record("Expected startedStation event, but only found one event")
+    return
   }
   guard
     case .startedStation(let startedInfo, let entryPoint) = secondEvent
   else {
-    return XCTFail("Expected startedStation event, got: \(String(describing: secondEvent))")
+    Issue.record("Expected startedStation event, got: \(String(describing: secondEvent))")
+    return
   }
-  XCTAssertEqual(startedInfo.id, stationId)
-  XCTAssertEqual(entryPoint, "station_list")
+  #expect(startedInfo.id == stationId)
+  #expect(entryPoint == "station_list")
 }
 
 private func makeComingSoonItem(active: Bool, date: Date) -> APIStationItem {
@@ -858,8 +890,9 @@ private func makeStationListModel(
 // MARK: - Notification Permission Prompt Tests
 
 @MainActor
-final class StationListNotificationPromptTests: XCTestCase {
+struct StationListNotificationPromptTests {
 
+  @Test
   func testViewAppearedShowsNotificationAlertOnFirstVisit() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
 
@@ -872,10 +905,11 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Stay in the Loop?")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Stay in the Loop?")
   }
 
+  @Test
   func testViewAppearedDoesNotShowAlertIfAlreadyAsked() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = true
 
@@ -888,9 +922,10 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testNotificationAlertYesTappedRequestsPermission() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
     let authorizationRequested = LockIsolated(false)
@@ -910,12 +945,13 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.notificationAlertYesTapped()
 
-    XCTAssertTrue(authorizationRequested.value)
-    XCTAssertTrue(registrationCalled.value)
-    XCTAssertTrue(hasAsked)
-    XCTAssertNil(model.presentedAlert)
+    #expect(authorizationRequested.value)
+    #expect(registrationCalled.value)
+    #expect(hasAsked)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testNotificationAlertNoTappedSetsHasAskedWithoutRequesting() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
     let authorizationRequested = LockIsolated(false)
@@ -932,11 +968,12 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.notificationAlertNoTapped()
 
-    XCTAssertFalse(authorizationRequested.value)
-    XCTAssertTrue(hasAsked)
-    XCTAssertNil(model.presentedAlert)
+    #expect(!authorizationRequested.value)
+    #expect(hasAsked)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testNotificationAlertDoesNotRegisterIfPermissionDenied() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
     let registrationCalled = LockIsolated(false)
@@ -954,7 +991,7 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.notificationAlertYesTapped()
 
-    XCTAssertFalse(registrationCalled.value)
-    XCTAssertTrue(hasAsked)
+    #expect(!registrationCalled.value)
+    #expect(hasAsked)
   }
 }

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
@@ -5,14 +5,16 @@
 //  Created by Brian D Keane on 3/10/26.
 //
 
+import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class StationSuggestionPageTests: XCTestCase {
+struct StationSuggestionPageTests {
 
   // MARK: - Test Data
 
@@ -64,25 +66,28 @@ final class StationSuggestionPageTests: XCTestCase {
 
   // MARK: - View Appeared Tests
 
+  @Test
   func testViewAppearedFetchesSuggestions() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel()
 
     await model.viewAppeared()
 
-    XCTAssertEqual(model.suggestions.count, 3)
-    XCTAssertEqual(model.suggestions.first?.artistName, "Bri Bagwell")
+    #expect(model.suggestions.count == 3)
+    #expect(model.suggestions.first?.artistName == "Bri Bagwell")
   }
 
+  @Test
   func testViewAppearedDoesNothingWithoutAuth() async {
     @Shared(.auth) var auth = Auth()
     let model = makeModel()
 
     await model.viewAppeared()
 
-    XCTAssertTrue(model.suggestions.isEmpty)
+    #expect(model.suggestions.isEmpty)
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel(onGetSuggestions: { _, _ in
@@ -91,12 +96,13 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Error")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Error")
   }
 
   // MARK: - Search Tests
 
+  @Test
   func testSearchTextChangedFetchesWithQuery() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedSearches = LockIsolated<[String?]>([])
@@ -109,9 +115,10 @@ final class StationSuggestionPageTests: XCTestCase {
     await model.searchTextChanged()
 
     let searches = capturedSearches.value
-    XCTAssertEqual(searches.last, "Charley")
+    #expect(searches.last == "Charley")
   }
 
+  @Test
   func testSearchTextChangedSendsNilForEmptyQuery() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedSearches = LockIsolated<[String?]>([])
@@ -124,9 +131,10 @@ final class StationSuggestionPageTests: XCTestCase {
     await model.searchTextChanged()
 
     let searches = capturedSearches.value
-    XCTAssertNil(searches.last ?? nil)
+    #expect((searches.last ?? nil) == nil)
   }
 
+  @Test
   func testClearSearchTappedResetsTextAndFetches() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedSearches = LockIsolated<[String?]>([])
@@ -138,13 +146,14 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "Charley"
     await model.clearSearchTapped()
 
-    XCTAssertEqual(model.searchText, "")
-    XCTAssertNil(capturedSearches.value.last ?? nil)
-    XCTAssertEqual(model.suggestions.count, 3)
+    #expect(model.searchText == "")
+    #expect((capturedSearches.value.last ?? nil) == nil)
+    #expect(model.suggestions.count == 3)
   }
 
   // MARK: - Vote Tests
 
+  @Test
   func testVoteTappedCallsVoteForUnvotedSuggestion() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedVoteIds = LockIsolated<[String]>([])
@@ -158,9 +167,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertEqual(capturedVoteIds.value, ["s2"])
+    #expect(capturedVoteIds.value == ["s2"])
   }
 
+  @Test
   func testVoteTappedCallsRemoveVoteForVotedSuggestion() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedRemoveIds = LockIsolated<[String]>([])
@@ -174,9 +184,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(votedSuggestion)
 
-    XCTAssertEqual(capturedRemoveIds.value, ["s1"])
+    #expect(capturedRemoveIds.value == ["s1"])
   }
 
+  @Test
   func testVoteTappedRefetchesSuggestionsAfterSuccess() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let fetchCount = LockIsolated(0)
@@ -191,9 +202,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertGreaterThanOrEqual(fetchCount.value, 1)
+    #expect(fetchCount.value >= 1)
   }
 
+  @Test
   func testVoteTappedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
@@ -206,10 +218,11 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Error")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Error")
   }
 
+  @Test
   func testVoteTappedDoesNothingWithoutAuth() async {
     @Shared(.auth) var auth = Auth()
     let capturedVoteIds = LockIsolated<[String]>([])
@@ -223,11 +236,12 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(suggestion)
 
-    XCTAssertTrue(capturedVoteIds.value.isEmpty)
+    #expect(capturedVoteIds.value.isEmpty)
   }
 
   // MARK: - Suggest Tests
 
+  @Test
   func testSuggestTappedCreatesAndClearsSearch() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedNames = LockIsolated<[String]>([])
@@ -241,10 +255,11 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "Tyler Childers"
     await model.suggestTapped()
 
-    XCTAssertEqual(capturedNames.value, ["Tyler Childers"])
-    XCTAssertEqual(model.searchText, "")
+    #expect(capturedNames.value == ["Tyler Childers"])
+    #expect(model.searchText == "")
   }
 
+  @Test
   func testSuggestTappedTrimsWhitespace() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedNames = LockIsolated<[String]>([])
@@ -258,9 +273,10 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "  Tyler Childers  "
     await model.suggestTapped()
 
-    XCTAssertEqual(capturedNames.value, ["Tyler Childers"])
+    #expect(capturedNames.value == ["Tyler Childers"])
   }
 
+  @Test
   func testSuggestTappedDoesNothingForEmptySearch() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedNames = LockIsolated<[String]>([])
@@ -274,9 +290,10 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "   "
     await model.suggestTapped()
 
-    XCTAssertTrue(capturedNames.value.isEmpty)
+    #expect(capturedNames.value.isEmpty)
   }
 
+  @Test
   func testSuggestTappedDoesNothingWithoutAuth() async {
     @Shared(.auth) var auth = Auth()
     let capturedNames = LockIsolated<[String]>([])
@@ -290,9 +307,10 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "Tyler Childers"
     await model.suggestTapped()
 
-    XCTAssertTrue(capturedNames.value.isEmpty)
+    #expect(capturedNames.value.isEmpty)
   }
 
+  @Test
   func testSuggestTappedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel(onCreate: { _, _ in
@@ -302,112 +320,125 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "Tyler Childers"
     await model.suggestTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Error")
-    XCTAssertEqual(model.searchText, "Tyler Childers")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Error")
+    #expect(model.searchText == "Tyler Childers")
   }
 
   // MARK: - View Helper Tests
 
+  @Test
   func testShowSuggestButtonTrueWhenSearchDoesNotMatchExisting() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.searchText = "Tyler Childers"
 
-    XCTAssertTrue(model.showSuggestButton)
+    #expect(model.showSuggestButton)
   }
 
+  @Test
   func testShowSuggestButtonFalseWhenSearchMatchesExistingCaseInsensitive() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.searchText = "bri bagwell"
 
-    XCTAssertFalse(model.showSuggestButton)
+    #expect(!model.showSuggestButton)
   }
 
+  @Test
   func testShowSuggestButtonFalseWhenSearchIsEmpty() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.searchText = ""
 
-    XCTAssertFalse(model.showSuggestButton)
+    #expect(!model.showSuggestButton)
   }
 
+  @Test
   func testShowSuggestButtonFalseWhenSearchIsWhitespace() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.searchText = "   "
 
-    XCTAssertFalse(model.showSuggestButton)
+    #expect(!model.showSuggestButton)
   }
 
+  @Test
   func testShowEmptyStateTrueWhenNotLoadingAndEmpty() {
     let model = makeModel()
     model.suggestions = []
     model.isLoading = false
 
-    XCTAssertTrue(model.showEmptyState)
+    #expect(model.showEmptyState)
   }
 
+  @Test
   func testShowEmptyStateFalseWhenLoading() {
     let model = makeModel()
     model.suggestions = []
     model.isLoading = true
 
-    XCTAssertFalse(model.showEmptyState)
+    #expect(!model.showEmptyState)
   }
 
+  @Test
   func testShowEmptyStateFalseWhenSuggestionsExist() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.isLoading = false
 
-    XCTAssertFalse(model.showEmptyState)
+    #expect(!model.showEmptyState)
   }
 
+  @Test
   func testEmptyMessageShowsDefaultWhenSearchEmpty() {
     let model = makeModel()
     model.searchText = ""
 
-    XCTAssertEqual(model.emptyMessage, model.emptyStateMessage)
+    #expect(model.emptyMessage == model.emptyStateMessage)
   }
 
+  @Test
   func testEmptyMessageShowsSearchMessageWhenSearchActive() {
     let model = makeModel()
     model.searchText = "Nobody"
 
-    XCTAssertEqual(model.emptyMessage, model.emptySearchMessage)
+    #expect(model.emptyMessage == model.emptySearchMessage)
   }
 
+  @Test
   func testVoteButtonTextShowsVotedWhenHasVoted() {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
       voteCount: 5, hasVoted: true, createdAt: Date(), updatedAt: Date())
 
-    XCTAssertEqual(model.voteButtonText(suggestion), "Voted")
+    #expect(model.voteButtonText(suggestion) == "Voted")
   }
 
+  @Test
   func testVoteButtonTextShowsVoteWhenNotVoted() {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
       voteCount: 5, hasVoted: false, createdAt: Date(), updatedAt: Date())
 
-    XCTAssertEqual(model.voteButtonText(suggestion), "Vote")
+    #expect(model.voteButtonText(suggestion) == "Vote")
   }
 
+  @Test
   func testVoteCountText() {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
       voteCount: 42, hasVoted: false, createdAt: Date(), updatedAt: Date())
 
-    XCTAssertEqual(model.voteCountText(suggestion), "42")
+    #expect(model.voteCountText(suggestion) == "42")
   }
 
   // MARK: - Double-Tap Guard Tests
 
+  @Test
   func testVoteTappedIgnoredWhileVoteInProgress() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let voteCount = LockIsolated(0)
@@ -422,9 +453,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertEqual(voteCount.value, 0)
+    #expect(voteCount.value == 0)
   }
 
+  @Test
   func testSuggestTappedIgnoredWhileSubmitInProgress() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let createCount = LockIsolated(0)
@@ -439,9 +471,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.suggestTapped()
 
-    XCTAssertEqual(createCount.value, 0)
+    #expect(createCount.value == 0)
   }
 
+  @Test
   func testVoteTappedResetsIsVotingAfterCompletion() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
@@ -451,9 +484,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertFalse(model.isVoting)
+    #expect(!model.isVoting)
   }
 
+  @Test
   func testVoteTappedResetsIsVotingAfterError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
@@ -465,9 +499,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertFalse(model.isVoting)
+    #expect(!model.isVoting)
   }
 
+  @Test
   func testSuggestTappedResetsIsSubmittingAfterCompletion() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel()
@@ -475,9 +510,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.suggestTapped()
 
-    XCTAssertFalse(model.isSubmitting)
+    #expect(!model.isSubmitting)
   }
 
+  @Test
   func testSuggestTappedResetsIsSubmittingAfterError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel(onCreate: { _, _ in
@@ -487,11 +523,12 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.suggestTapped()
 
-    XCTAssertFalse(model.isSubmitting)
+    #expect(!model.isSubmitting)
   }
 
   // MARK: - Dismiss Tests
 
+  @Test
   func testDismissTappedCallsOnDismiss() {
     let model = makeModel()
     var dismissed = false
@@ -499,9 +536,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     model.dismissTapped()
 
-    XCTAssertTrue(dismissed)
+    #expect(dismissed)
   }
 
+  @Test
   func testDismissTappedDoesNothingWithoutCallback() {
     let model = makeModel()
     model.onDismiss = nil


### PR DESCRIPTION
## Summary

Converts 10 XCTest files under `PlayolaRadio/Views/Pages` to swift-testing,
following the same playbook used in PR #278 for the Core suites.

- Test classes become `struct` test suites
- `XCTAssert*` → `#expect` / `Issue.record`
- snake_case test names → camelCase
- `LikedSongsPageTests` `setUp()` (which only zeroed `@Shared` state) is removed; per-test `@Shared` declarations now own the reset
- `MainContainerTests.testRatingPromptNotEnjoyingTracksAnalyticsAndShowsFeedback` swaps `XCTestExpectation` / `fulfillment` for swift-testing's `confirmation` API plus a `Task.yield()` loop to drain the spawned analytics Task

## Test plan

- [x] All 10 converted suites pass via `xcodebuild test -only-testing:…` (302 tests across 11 suites incl. `StationListNotificationPromptTests`).
- [x] swift-format lint passes.
- [ ] CI green on merge.

## Files

1. `HomePageTests.swift`
2. `LibraryPageTests.swift`
3. `LikedSongsPageTests.swift`
4. `StationListPageTests.swift`
5. `StationSuggestionPageTests.swift`
6. `ChooseStationPageTests.swift`
7. `ChooseStationToBroadcastPageTests.swift`
8. `SongSearchPageTests.swift`
9. `PlayerPageTests.swift`
10. `MainContainerTests.swift`

🤖 Generated with [Claude Code](https://claude.com/claude-code)