### PR TITLE
Convert auth/profile/recording page tests to swift-testing

### DIFF
--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
@@ -5,41 +5,39 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class AskQuestionPageTests: XCTestCase {
-  override func setUp() {
-    super.setUp()
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
-    coordinator.path = []
-  }
-
+struct AskQuestionPageTests {
   // MARK: - Init
 
+  @Test
   func testInitStoresStation() {
     let station = Station.mockWith(id: "station-123", curatorName: "Test Curator")
 
     let model = AskQuestionPageModel(station: station)
 
-    XCTAssertEqual(model.station.id, "station-123")
-    XCTAssertEqual(model.station.curatorName, "Test Curator")
+    #expect(model.station.id == "station-123")
+    #expect(model.station.curatorName == "Test Curator")
   }
 
+  @Test
   func testCuratorNameReturnsCuratorName() {
     let station = Station.mockWith(curatorName: "Bri Bagwell")
 
     let model = AskQuestionPageModel(station: station)
 
-    XCTAssertEqual(model.curatorName, "Bri Bagwell")
+    #expect(model.curatorName == "Bri Bagwell")
   }
 
   // MARK: - Recording
 
+  @Test
   func testRecordTappedRequestsPermissionBeforeRecording() async {
     let requestPermissionCalled = LockIsolated(false)
     let startRecordingCalled = LockIsolated(false)
@@ -50,22 +48,23 @@ final class AskQuestionPageTests: XCTestCase {
         return true
       }
       $0.audioRecorder.startRecording = {
-        XCTAssertTrue(
+        #expect(
           requestPermissionCalled.value, "Permission should be requested before recording starts")
         startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = AskQuestionPageModel(station: .mock)
-      XCTAssertEqual(model.recordingPhase, .idle)
+      #expect(model.recordingPhase == .idle)
 
       await model.recordTapped()
 
-      XCTAssertTrue(requestPermissionCalled.value)
-      XCTAssertTrue(startRecordingCalled.value)
-      XCTAssertEqual(model.recordingPhase, .recording)
+      #expect(requestPermissionCalled.value)
+      #expect(startRecordingCalled.value)
+      #expect(model.recordingPhase == .recording)
     }
   }
 
+  @Test
   func testRecordTappedShowsAlertWhenPermissionDenied() async {
     let startRecordingCalled = LockIsolated(false)
 
@@ -79,13 +78,14 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.recordTapped()
 
-      XCTAssertFalse(startRecordingCalled.value)
-      XCTAssertEqual(model.recordingPhase, .idle)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Microphone Access Required")
+      #expect(!startRecordingCalled.value)
+      #expect(model.recordingPhase == .idle)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Microphone Access Required")
     }
   }
 
+  @Test
   func testStopTappedTransitionsToReview() async {
     let expectedURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
 
@@ -100,14 +100,15 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.stopTapped()
 
-      XCTAssertEqual(model.recordingPhase, .review)
-      XCTAssertEqual(model.recordingURL, expectedURL)
-      XCTAssertEqual(model.recordingDuration, 5.0)
+      #expect(model.recordingPhase == .review)
+      #expect(model.recordingURL == expectedURL)
+      #expect(model.recordingDuration == 5.0)
     }
   }
 
   // MARK: - Re-record
 
+  @Test
   func testReRecordTappedResetsToIdleState() async {
     let model = AskQuestionPageModel(station: .mock)
     model.recordingPhase = .review
@@ -118,50 +119,56 @@ final class AskQuestionPageTests: XCTestCase {
 
     await model.reRecordTapped()
 
-    XCTAssertEqual(model.recordingPhase, .idle)
-    XCTAssertNil(model.recordingURL)
-    XCTAssertEqual(model.recordingDuration, 0)
-    XCTAssertEqual(model.playbackPosition, 0)
-    XCTAssertFalse(model.isPlaying)
+    #expect(model.recordingPhase == .idle)
+    #expect(model.recordingURL == nil)
+    #expect(model.recordingDuration == 0)
+    #expect(model.playbackPosition == 0)
+    #expect(!model.isPlaying)
   }
 
   // MARK: - Cancel
 
+  @Test
   func testCancelTappedShowsConfirmationWhenInReview() async {
     let model = AskQuestionPageModel(station: .mock)
     model.recordingPhase = .review
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
 
     await model.cancelTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Discard Recording?")
   }
 
+  @Test
   func testCancelTappedPopsNavigationWhenIdle() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
     let model = AskQuestionPageModel(station: .mock)
     coordinator.path = [.askQuestionPage(model)]
     model.recordingPhase = .idle
 
     await model.cancelTapped()
 
-    XCTAssertTrue(coordinator.path.isEmpty)
+    #expect(coordinator.path.isEmpty)
   }
 
+  @Test
   func testConfirmCancelPopsNavigation() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
     let model = AskQuestionPageModel(station: .mock)
     coordinator.path = [.askQuestionPage(model)]
 
     await model.confirmCancel()
 
-    XCTAssertTrue(coordinator.path.isEmpty)
+    #expect(coordinator.path.isEmpty)
   }
 
   // MARK: - Playback
 
+  @Test
   func testPlayPauseTappedPlaysWhenNotPlaying() async {
     let playCalled = LockIsolated(false)
 
@@ -175,11 +182,12 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.playPauseTapped()
 
-      XCTAssertTrue(playCalled.value)
-      XCTAssertTrue(model.isPlaying)
+      #expect(playCalled.value)
+      #expect(model.isPlaying)
     }
   }
 
+  @Test
   func testPlayPauseTappedPausesWhenPlaying() async {
     let pauseCalled = LockIsolated(false)
 
@@ -191,11 +199,12 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.playPauseTapped()
 
-      XCTAssertTrue(pauseCalled.value)
-      XCTAssertFalse(model.isPlaying)
+      #expect(pauseCalled.value)
+      #expect(!model.isPlaying)
     }
   }
 
+  @Test
   func testRewindTappedSeeksToZero() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
@@ -207,28 +216,30 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.rewindTapped()
 
-      XCTAssertEqual(seekTime.value, 0)
-      XCTAssertEqual(model.playbackPosition, 0)
+      #expect(seekTime.value == 0)
+      #expect(model.playbackPosition == 0)
     }
   }
 
   // MARK: - Display Time
 
+  @Test
   func testDisplayTimeFormatsCorrectly() {
     let model = AskQuestionPageModel(station: .mock)
 
     model.recordingDuration = 0
-    XCTAssertEqual(model.displayTime, "0:00")
+    #expect(model.displayTime == "0:00")
 
     model.recordingDuration = 65
-    XCTAssertEqual(model.displayTime, "1:05")
+    #expect(model.displayTime == "1:05")
 
     model.recordingDuration = 3661
-    XCTAssertEqual(model.displayTime, "1:01:01")
+    #expect(model.displayTime == "1:01:01")
   }
 
   // MARK: - Station Pause/Resume on Page Lifecycle
 
+  @Test
   func testViewAppearedPausesStationWhenPlaying() async {
     let playingStation = AnyStation.mock
     let stationPlayerMock = StationPlayerMock()
@@ -241,10 +252,11 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(stationPlayerMock.stopCalledCount, 1)
+      #expect(stationPlayerMock.stopCalledCount == 1)
     }
   }
 
+  @Test
   func testViewAppearedDoesNotPauseStationWhenNotPlaying() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .stopped)
@@ -256,15 +268,17 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(stationPlayerMock.stopCalledCount, 0)
+      #expect(stationPlayerMock.stopCalledCount == 0)
     }
   }
 
+  @Test
   func testConfirmCancelResumesStationIfWasPaused() async {
     let playingStation = AnyStation.mock
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .playing(playingStation))
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
@@ -277,15 +291,17 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.confirmCancel()
 
-      XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
-      XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, playingStation.id)
+      #expect(stationPlayerMock.callsToPlay.count == 1)
+      #expect(stationPlayerMock.callsToPlay.first?.id == playingStation.id)
     }
   }
 
+  @Test
   func testConfirmCancelDoesNotResumeStationIfWasNotPaused() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .stopped)
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
@@ -297,16 +313,17 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.confirmCancel()
 
-      XCTAssertEqual(stationPlayerMock.callsToPlay.count, 0)
+      #expect(stationPlayerMock.callsToPlay.count == 0)
     }
   }
 
   // MARK: - Alerts
 
+  @Test
   func testQuestionSentSuccessAlertIncludesCuratorName() {
     let alert = PlayolaAlert.questionSentSuccess(curatorName: "Bri Bagwell") {}
 
-    XCTAssertTrue(
+    #expect(
       alert.message?.contains("Bri Bagwell") ?? false,
       "Alert message should contain the curator name"
     )

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -8,14 +8,15 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class BroadcastPageTests: XCTestCase {
+struct BroadcastPageTests {
   // MARK: - Test Helpers
 
   private let testStationId = "test-station-id"
@@ -54,27 +55,29 @@ final class BroadcastPageTests: XCTestCase {
 
   // MARK: - Schedule Loading Tests
 
-  func testViewAppeared_LoadsScheduleSuccessfully() async {
+  @Test
+  func testViewAppearedLoadsScheduleSuccessfully() async {
     let mockSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { requestedStationId, extended in
-        XCTAssertEqual(requestedStationId, self.testStationId)
-        XCTAssertTrue(extended)
+        #expect(requestedStationId == self.testStationId)
+        #expect(extended)
         return mockSpins
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNotNil(model.schedule)
-      XCTAssertNil(model.presentedAlert)
-      XCTAssertFalse(model.isLoading)
+      #expect(model.schedule != nil)
+      #expect(model.presentedAlert == nil)
+      #expect(!model.isLoading)
     }
   }
 
-  func testViewAppeared_ShowsErrorAlertOnFailure() async {
+  @Test
+  func testViewAppearedShowsErrorAlertOnFailure() async {
     await withDependencies {
       $0.api.fetchSchedule = { _, _ in
         throw TestError.networkError
@@ -83,17 +86,17 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNil(model.schedule)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Error")
-      XCTAssertFalse(model.isLoading)
+      #expect(model.schedule == nil)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Error")
+      #expect(!model.isLoading)
     }
   }
 
-  func testNowPlaying_ReturnsCurrentSpin() async {
+  @Test
+  func testNowPlayingReturnsCurrentSpin() async {
     let stationId = "test-station-id"
     let fixedNow = Date(timeIntervalSince1970: 1_000_000)
-    // Create audioBlock with 180 second (3 min) duration so spin is still playing
     let longAudioBlock = AudioBlock.mockWith(endOfMessageMS: 180_000)
     let mockSpins = [
       Spin.mockWith(
@@ -115,11 +118,12 @@ final class BroadcastPageTests: XCTestCase {
     } operation: {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
-      XCTAssertEqual(model.nowPlaying?.id, "spin-1")
+      #expect(model.nowPlaying?.id == "spin-1")
     }
   }
 
-  func testUpcomingSpins_ExcludesNowPlaying() async {
+  @Test
+  func testUpcomingSpinsExcludesNowPlaying() async {
     let stationId = "test-station-id"
     let fixedNow = Date(timeIntervalSince1970: 1_000_000)
     let mockSpins = [
@@ -148,18 +152,17 @@ final class BroadcastPageTests: XCTestCase {
       await model.viewAppeared()
 
       let upcomingIds = model.upcomingSpins.map { $0.id }
-      XCTAssertFalse(upcomingIds.contains("spin-1"))
-      XCTAssertTrue(upcomingIds.contains("spin-2"))
-      XCTAssertTrue(upcomingIds.contains("spin-3"))
+      #expect(!upcomingIds.contains("spin-1"))
+      #expect(upcomingIds.contains("spin-2"))
+      #expect(upcomingIds.contains("spin-3"))
     }
   }
 
-  func testTick_UpdatesCurrentNowPlayingIdWhenSpinChanges() async {
+  @Test
+  func testTickUpdatesCurrentNowPlayingIdWhenSpinChanges() async {
     let stationId = "test-station-id"
     let initialTime = Date(timeIntervalSince1970: 1_000_000)
 
-    // spin-1: started 60s ago, 90s duration (ends in 30s)
-    // spin-2: starts in 30s
     let spin1AudioBlock = AudioBlock.mockWith(endOfMessageMS: 90000)
     let spin2AudioBlock = AudioBlock.mockWith(endOfMessageMS: 180_000)
     let mockSpins = [
@@ -184,12 +187,10 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      // Initially spin-1 is playing
-      XCTAssertEqual(model.currentNowPlayingId, "spin-1")
-      XCTAssertEqual(model.upcomingSpins.first?.id, "spin-2")
+      #expect(model.currentNowPlayingId == "spin-1")
+      #expect(model.upcomingSpins.first?.id == "spin-2")
     }
 
-    // Advance time past spin-1's end
     let laterTime = initialTime.addingTimeInterval(35)
 
     await withDependencies {
@@ -199,18 +200,17 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      // Call tick - should detect spin change and update currentNowPlayingId
       model.tick()
 
-      XCTAssertEqual(model.currentNowPlayingId, "spin-2")
+      #expect(model.currentNowPlayingId == "spin-2")
     }
   }
 
-  func testTick_DoesNotChangeIdWhenNowPlayingUnchanged() async {
+  @Test
+  func testTickDoesNotChangeIdWhenNowPlayingUnchanged() async {
     let stationId = "test-station-id"
     let initialTime = Date(timeIntervalSince1970: 1_000_000)
 
-    // spin-1: started 10s ago, 180s duration (plenty of time left)
     let spin1AudioBlock = AudioBlock.mockWith(endOfMessageMS: 180_000)
     let mockSpins = [
       Spin.mockWith(
@@ -228,18 +228,18 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.currentNowPlayingId, "spin-1")
+      #expect(model.currentNowPlayingId == "spin-1")
 
-      // Tick should not change the ID since spin hasn't changed
       model.tick()
 
-      XCTAssertEqual(model.currentNowPlayingId, "spin-1")
+      #expect(model.currentNowPlayingId == "spin-1")
     }
   }
 
   // MARK: - Station Name Tests
 
-  func testNavigationTitle_UsesStationNameWhenProvided() async {
+  @Test
+  func testNavigationTitleUsesStationNameWhenProvided() async {
     let stationId = "test-station-id"
     let stationName = "My Awesome Station"
 
@@ -250,11 +250,12 @@ final class BroadcastPageTests: XCTestCase {
     } operation: {
       let model = BroadcastPageModel(stationId: stationId, stationName: stationName)
 
-      XCTAssertEqual(model.navigationTitle, stationName)
+      #expect(model.navigationTitle == stationName)
     }
   }
 
-  func testNavigationTitle_FetchesStationNameOnLoad() async {
+  @Test
+  func testNavigationTitleFetchesStationNameOnLoad() async {
     let stationId = "test-station-id"
     let fetchedStationName = "Fetched Station Name"
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -263,20 +264,21 @@ final class BroadcastPageTests: XCTestCase {
       $0.date.now = Date()
       $0.api.fetchSchedule = { _, _ in [] }
       $0.api.fetchStation = { _, requestedId in
-        XCTAssertEqual(requestedId, stationId)
+        #expect(requestedId == stationId)
         return Station.mockWith(name: fetchedStationName)
       }
     } operation: {
       let model = BroadcastPageModel(stationId: stationId)
-      XCTAssertEqual(model.navigationTitle, "My Station")  // Default before load
+      #expect(model.navigationTitle == "My Station")
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.navigationTitle, fetchedStationName)
+      #expect(model.navigationTitle == fetchedStationName)
     }
   }
 
-  func testNavigationTitle_FallsBackToDefaultWhenFetchFails() async {
+  @Test
+  func testNavigationTitleFallsBackToDefaultWhenFetchFails() async {
     let stationId = "test-station-id"
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -288,13 +290,14 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.navigationTitle, "My Station")
+      #expect(model.navigationTitle == "My Station")
     }
   }
 
   // MARK: - Grouped Spin Tests
 
-  func testMoveSpins_MovesUngroupedSpinNormally() async {
+  @Test
+  func testMoveSpinsMovesUngroupedSpinNormally() async {
     let mockSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     let reorderedSpins = makeSpins(ids: ["spin-2", "spin-1", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -307,15 +310,15 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      // Move spin-1 to position 2 (after spin-2)
       await model.moveSpins(from: IndexSet(integer: 0), to: 2)
 
       let ids = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(ids, ["spin-2", "spin-1", "spin-3"])
+      #expect(ids == ["spin-2", "spin-1", "spin-3"])
     }
   }
 
-  func testMoveSpins_MovesEntireGroupTogether() async {
+  @Test
+  func testMoveSpinsMovesEntireGroupTogether() async {
     let groupId = "group-1"
     let mockSpins =
       makeSpins(ids: ["spin-1", "spin-2"], groupId: groupId)
@@ -334,16 +337,15 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      // Move spin-1 (part of group) to position 3 (after spin-3)
-      // Should move both spin-1 and spin-2 together
       await model.moveSpins(from: IndexSet(integer: 0), to: 3)
 
       let ids = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(ids, ["spin-3", "spin-1", "spin-2", "spin-4"])
+      #expect(ids == ["spin-3", "spin-1", "spin-2", "spin-4"])
     }
   }
 
-  func testMoveSpins_PreservesRelativeOrderWithinGroup() async {
+  @Test
+  func testMoveSpinsPreservesRelativeOrderWithinGroup() async {
     let stationId = "test-station-id"
     let fixedNow = Date(timeIntervalSince1970: 1_000_000)
     let groupId = "group-1"
@@ -383,71 +385,73 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      // Move spin-2 (middle of group) to the end
-      // Should move entire group (spin-1, spin-2, spin-3) and preserve their order
       await model.moveSpins(from: IndexSet(integer: 2), to: 5)
 
       let ids = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(ids, ["spin-A", "spin-B", "spin-1", "spin-2", "spin-3"])
+      #expect(ids == ["spin-A", "spin-B", "spin-1", "spin-2", "spin-3"])
     }
   }
 
   // MARK: - Coming Soon Alert Tests
 
-  func testOnAddVoiceTrackTapped_PresentsRecordPageSheet() {
+  @Test
+  func testOnAddVoiceTrackTappedPresentsRecordPageSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     let model = BroadcastPageModel(stationId: "test-station")
 
-    XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
 
     model.onAddVoiceTrackTapped()
 
-    XCTAssertNotNil(model.recordPageModel)
+    #expect(model.recordPageModel != nil)
     if case .recordPage = mainContainerNavigationCoordinator.presentedSheet {
       // Success - presented record page sheet
     } else {
-      XCTFail("Expected recordPage sheet presentation")
+      Issue.record("Expected recordPage sheet presentation")
     }
   }
 
+  @Test
   func testOnAddSongTappedPresentsSongSearchPageSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     let model = BroadcastPageModel(stationId: "test-station")
 
-    XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
-    XCTAssertNil(model.songSearchPageModel)
+    #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
+    #expect(model.songSearchPageModel == nil)
 
     await model.onAddSongTapped()
 
-    XCTAssertNotNil(model.songSearchPageModel)
+    #expect(model.songSearchPageModel != nil)
     if case .songSearchPage = mainContainerNavigationCoordinator.presentedSheet {
     } else {
-      XCTFail("Expected songSearchPage sheet presentation")
+      Issue.record("Expected songSearchPage sheet presentation")
     }
   }
 
+  @Test
   func testOnAddSongTappedUsesAllSearchMode() async {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     let model = BroadcastPageModel(stationId: "test-station")
 
     await model.onAddSongTapped()
 
-    XCTAssertEqual(model.songSearchPageModel?.searchMode, .all)
+    #expect(model.songSearchPageModel?.searchMode == .all)
   }
 
+  @Test
   func testOnAddSongTappedSongSelectedCallbackAddsSongToStaging() async {
     await withMainSerialExecutor {
       @Shared(.mainContainerNavigationCoordinator)
-      var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+      var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
       let model = BroadcastPageModel(stationId: "test-station")
-      XCTAssertTrue(model.stagingItems.isEmpty)
+      #expect(model.stagingItems.isEmpty)
 
       await model.onAddSongTapped()
 
@@ -456,27 +460,29 @@ final class BroadcastPageTests: XCTestCase {
       model.songSearchPageModel?.onSongSelected?(testSong)
       await Task.yield()
 
-      XCTAssertEqual(model.stagingItems.count, 1)
-      XCTAssertEqual(model.stagingItems.first?.stagingId, "test-song-123")
-      XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
+      #expect(model.stagingItems.count == 1)
+      #expect(model.stagingItems.first?.stagingId == "test-song-123")
+      #expect(model.stagingItems.first?.titleText == "Test Song")
     }
   }
 
+  @Test
   func testOnAddSongTappedSongSelectedCallbackDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     let model = BroadcastPageModel(stationId: "test-station")
     await model.onAddSongTapped()
 
-    XCTAssertNotNil(mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerNavigationCoordinator.presentedSheet != nil)
 
     let testSong = AudioBlock.mockWith(id: "test-song-123")
     model.songSearchPageModel?.onSongSelected?(testSong)
 
-    XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
   }
 
+  @Test
   func testAddSongToStagingDoesNotAddDuplicates() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let testSong = AudioBlock.mockWith(id: "test-song-123")
@@ -484,9 +490,10 @@ final class BroadcastPageTests: XCTestCase {
     await model.addSongToStaging(testSong)
     await model.addSongToStaging(testSong)
 
-    XCTAssertEqual(model.stagingItems.count, 1)
+    #expect(model.stagingItems.count == 1)
   }
 
+  @Test
   func testAddSongToStagingAddsMultipleDifferentSongs() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let song1 = AudioBlock.mockWith(id: "song-1", title: "First Song")
@@ -495,11 +502,12 @@ final class BroadcastPageTests: XCTestCase {
     await model.addSongToStaging(song1)
     await model.addSongToStaging(song2)
 
-    XCTAssertEqual(model.stagingItems.count, 2)
-    XCTAssertEqual(model.stagingItems[0].stagingId, "song-1")
-    XCTAssertEqual(model.stagingItems[1].stagingId, "song-2")
+    #expect(model.stagingItems.count == 2)
+    #expect(model.stagingItems[0].stagingId == "song-1")
+    #expect(model.stagingItems[1].stagingId == "song-2")
   }
 
+  @Test
   func testRecordingAcceptedAddsToStagingArea() async {
     let calendar = Calendar.current
     let components = DateComponents(year: 2023, month: 12, day: 13, hour: 11, minute: 0)
@@ -515,23 +523,24 @@ final class BroadcastPageTests: XCTestCase {
       }
     } operation: {
       let model = BroadcastPageModel(stationId: "test-station")
-      XCTAssertTrue(model.stagingItems.isEmpty)
+      #expect(model.stagingItems.isEmpty)
 
       model.onAddVoiceTrackTapped()
       let recordingURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
       await model.recordPageModel?.onRecordingAccepted?(recordingURL)
 
-      XCTAssertEqual(model.stagingItems.count, 1)
+      #expect(model.stagingItems.count == 1)
       let voicetrack = model.stagingItems.first as? LocalVoicetrack
-      XCTAssertEqual(voicetrack?.originalURL, recordingURL)
-      XCTAssertEqual(voicetrack?.title, "Voice Track 11:00am")
-      XCTAssertEqual(voicetrack?.status, .completed)
+      #expect(voicetrack?.originalURL == recordingURL)
+      #expect(voicetrack?.title == "Voice Track 11:00am")
+      #expect(voicetrack?.status == .completed)
     }
   }
 
   // MARK: - Grouped Spin Tests
 
-  func testMoveSpins_MovesGroupToBeginning() async {
+  @Test
+  func testMoveSpinsMovesGroupToBeginning() async {
     let stationId = "test-station-id"
     let fixedNow = Date(timeIntervalSince1970: 1_000_000)
     let groupId = "group-1"
@@ -565,11 +574,10 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      // Move spin-1 (part of group) to position 0
       await model.moveSpins(from: IndexSet(integer: 2), to: 0)
 
       let ids = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(ids, ["spin-1", "spin-2", "spin-A", "spin-B"])
+      #expect(ids == ["spin-1", "spin-2", "spin-A", "spin-B"])
     }
   }
 
@@ -589,6 +597,7 @@ private enum TestError: Error, LocalizedError {
 // MARK: - canDeleteSpin Tests
 
 extension BroadcastPageTests {
+  @Test
   func testCanDeleteSpinReturnsTrueForSpinMoreThanTwoMinutesAway() async {
     let spinMoreThanTwoMinutesAway = makeSpins(ids: ["spin-1"], startOffset: 121).first!
 
@@ -599,10 +608,11 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertTrue(model.canDeleteSpin(spinMoreThanTwoMinutesAway))
+      #expect(model.canDeleteSpin(spinMoreThanTwoMinutesAway))
     }
   }
 
+  @Test
   func testCanDeleteSpinReturnsFalseForSpinExactlyTwoMinutesAway() async {
     let spinExactlyTwoMinutesAway = makeSpins(ids: ["spin-1"], startOffset: 120).first!
 
@@ -613,10 +623,11 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertFalse(model.canDeleteSpin(spinExactlyTwoMinutesAway))
+      #expect(!model.canDeleteSpin(spinExactlyTwoMinutesAway))
     }
   }
 
+  @Test
   func testCanDeleteSpinReturnsFalseForSpinLessThanTwoMinutesAway() async {
     let spinLessThanTwoMinutesAway = makeSpins(ids: ["spin-1"]).first!
 
@@ -627,7 +638,7 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertFalse(model.canDeleteSpin(spinLessThanTwoMinutesAway))
+      #expect(!model.canDeleteSpin(spinLessThanTwoMinutesAway))
     }
   }
 }
@@ -635,6 +646,7 @@ extension BroadcastPageTests {
 // MARK: - Move Spin Tests
 
 extension BroadcastPageTests {
+  @Test
   func testMoveSpinSuccessUpdatesScheduleWithReturnedSpins() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     let updatedSpins = makeSpins(ids: ["spin-2", "spin-1", "spin-3"])
@@ -644,25 +656,25 @@ extension BroadcastPageTests {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in initialSpins }
       $0.api.moveSpin = { _, spinId, placeAfterSpinId in
-        XCTAssertEqual(spinId, "spin-1")
-        XCTAssertEqual(placeAfterSpinId, "spin-2")
+        #expect(spinId == "spin-1")
+        #expect(placeAfterSpinId == "spin-2")
         return updatedSpins
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-1", "spin-2", "spin-3"])
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-1", "spin-2", "spin-3"])
 
-      // Move spin-1 to after spin-2
       await model.moveSpins(from: IndexSet(integer: 0), to: 2)
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-2", "spin-1", "spin-3"])
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-2", "spin-1", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.presentedAlert == nil)
     }
   }
 
+  @Test
   func testMoveSpinToBeginningCallsAPIWithNilPlaceAfterSpinId() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     let updatedSpins = makeSpins(ids: ["spin-3", "spin-1", "spin-2"])
@@ -672,21 +684,21 @@ extension BroadcastPageTests {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in initialSpins }
       $0.api.moveSpin = { _, spinId, placeAfterSpinId in
-        XCTAssertEqual(spinId, "spin-3")
-        XCTAssertNil(placeAfterSpinId)
+        #expect(spinId == "spin-3")
+        #expect(placeAfterSpinId == nil)
         return updatedSpins
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      // Move spin-3 to beginning
       await model.moveSpins(from: IndexSet(integer: 2), to: 0)
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-3", "spin-1", "spin-2"])
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-3", "spin-1", "spin-2"])
     }
   }
 
+  @Test
   func testMoveSpinMarksAllSpinsAsReschedulingDuringCall() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -707,7 +719,7 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
 
       let moveTask = Task {
         await model.moveSpins(from: IndexSet(integer: 0), to: 2)
@@ -717,8 +729,7 @@ extension BroadcastPageTests {
         await Task.yield()
       }
 
-      // During the call, all spins should be marked as rescheduling
-      XCTAssertEqual(model.spinIdsBeingRescheduled, ["spin-1", "spin-2", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled == ["spin-1", "spin-2", "spin-3"])
 
       moveContinuation.withValue { continuation in
         continuation?.resume()
@@ -727,11 +738,11 @@ extension BroadcastPageTests {
 
       await moveTask.value
 
-      // After the call completes, the set should be cleared
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
     }
   }
 
+  @Test
   func testMoveSpinErrorRestoresOriginalSchedule() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -747,16 +758,17 @@ extension BroadcastPageTests {
       await model.viewAppeared()
 
       let originalIds = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(originalIds, ["spin-1", "spin-2", "spin-3"])
+      #expect(originalIds == ["spin-1", "spin-2", "spin-3"])
 
       await model.moveSpins(from: IndexSet(integer: 0), to: 2)
 
       let restoredIds = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(restoredIds, ["spin-1", "spin-2", "spin-3"])
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(restoredIds == ["spin-1", "spin-2", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
     }
   }
 
+  @Test
   func testMoveSpinErrorShowsErrorAlert() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -771,12 +783,12 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.moveSpins(from: IndexSet(integer: 0), to: 2)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Error")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Error")
     }
   }
 }
@@ -784,6 +796,7 @@ extension BroadcastPageTests {
 // MARK: - Delete Spin Tests
 
 extension BroadcastPageTests {
+  @Test
   func testDeleteSpinSuccessUpdatesScheduleWithReturnedSpins() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     let updatedSpins = makeSpins(ids: ["spin-1", "spin-3"])
@@ -793,24 +806,25 @@ extension BroadcastPageTests {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in initialSpins }
       $0.api.deleteSpin = { _, spinId in
-        XCTAssertEqual(spinId, "spin-2")
+        #expect(spinId == "spin-2")
         return updatedSpins
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-1", "spin-2", "spin-3"])
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-1", "spin-2", "spin-3"])
 
       let spinToDelete = initialSpins[1]
       await model.deleteSpin(spinToDelete)
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-1", "spin-3"])
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-1", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.presentedAlert == nil)
     }
   }
 
+  @Test
   func testDeleteSpinMarksSpinsAfterDeletedAsReschedulingDuringCall() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -831,7 +845,7 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
 
       let deleteTask = Task {
         await model.deleteSpin(initialSpins[1])
@@ -841,8 +855,7 @@ extension BroadcastPageTests {
         await Task.yield()
       }
 
-      // During the call, spin-3 should have been marked as rescheduling (it comes after spin-2)
-      XCTAssertEqual(model.spinIdsBeingRescheduled, ["spin-3"])
+      #expect(model.spinIdsBeingRescheduled == ["spin-3"])
 
       deleteContinuation.withValue { continuation in
         continuation?.resume()
@@ -851,11 +864,11 @@ extension BroadcastPageTests {
 
       await deleteTask.value
 
-      // After the call completes, the set should be cleared
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
     }
   }
 
+  @Test
   func testDeleteSpinErrorRestoresOriginalSchedule() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -871,16 +884,17 @@ extension BroadcastPageTests {
       await model.viewAppeared()
 
       let originalIds = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(originalIds, ["spin-1", "spin-2", "spin-3"])
+      #expect(originalIds == ["spin-1", "spin-2", "spin-3"])
 
       await model.deleteSpin(initialSpins[1])
 
       let restoredIds = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(restoredIds, ["spin-1", "spin-2", "spin-3"])
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(restoredIds == ["spin-1", "spin-2", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
     }
   }
 
+  @Test
   func testDeleteSpinErrorShowsErrorAlert() async {
     let initialSpins = makeSpins(ids: ["spin-1"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -895,12 +909,12 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.deleteSpin(initialSpins[0])
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Error")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Error")
     }
   }
 }
@@ -908,6 +922,7 @@ extension BroadcastPageTests {
 // MARK: - Insert Voicetrack Tests
 
 extension BroadcastPageTests {
+  @Test
   func testInsertVoicetrackCallsAPIWithCorrectParameters() async {
     let voicetrackAudioBlockId = "voicetrack-audio-block-id"
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
@@ -933,14 +948,14 @@ extension BroadcastPageTests {
         makeStagingVoicetrack(id: voicetrackId, audioBlockId: voicetrackAudioBlockId)
       ]
 
-      // Drop voicetrack before spin-2 (should insert after spin-1)
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-2")
 
-      XCTAssertEqual(capturedAudioBlockId.value, voicetrackAudioBlockId)
-      XCTAssertEqual(capturedPlaceAfterSpinId.value, "spin-1")
+      #expect(capturedAudioBlockId.value == voicetrackAudioBlockId)
+      #expect(capturedPlaceAfterSpinId.value == "spin-1")
     }
   }
 
+  @Test
   func testInsertStagingItemRemovesFromStagingOnSuccess() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -956,14 +971,15 @@ extension BroadcastPageTests {
       let voicetrackId = UUID()
       model.stagingItems = [makeStagingVoicetrack(id: voicetrackId)]
 
-      XCTAssertEqual(model.stagingItems.count, 1)
+      #expect(model.stagingItems.count == 1)
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-2")
 
-      XCTAssertEqual(model.stagingItems.count, 0)
+      #expect(model.stagingItems.count == 0)
     }
   }
 
+  @Test
   func testInsertStagingItemUpdatesScheduleWithResponse() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"], interval: 120)
     let updatedSpins = makeSpins(ids: ["spin-1", "new-spin", "spin-2"])
@@ -982,10 +998,11 @@ extension BroadcastPageTests {
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-2")
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-1", "new-spin", "spin-2"])
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-1", "new-spin", "spin-2"])
     }
   }
 
+  @Test
   func testInsertStagingItemAtTopUsesNowPlayingAsPlaceAfter() async {
     let nowPlayingAudioBlock = AudioBlock.mockWith(endOfMessageMS: 180_000)
     let nowPlayingSpin = Spin.mockWith(
@@ -1011,19 +1028,20 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.nowPlaying?.id, "now-playing")
-      XCTAssertEqual(model.upcomingSpins.first?.id, "spin-1")
+      #expect(model.nowPlaying?.id == "now-playing")
+      #expect(model.upcomingSpins.first?.id == "spin-1")
 
       let voicetrackId = UUID()
       model.stagingItems = [makeStagingVoicetrack(id: voicetrackId)]
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-1")
 
-      XCTAssertEqual(capturedPlaceAfterSpinId.value, "now-playing")
-      XCTAssertNil(model.presentedAlert)
+      #expect(capturedPlaceAfterSpinId.value == "now-playing")
+      #expect(model.presentedAlert == nil)
     }
   }
 
+  @Test
   func testInsertStagingItemAtTopWithNoNowPlayingShowsError() async {
     let upcomingSpins = makeSpins(ids: ["spin-1", "spin-2"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -1041,16 +1059,16 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNil(model.nowPlaying)
+      #expect(model.nowPlaying == nil)
 
       let voicetrackId = UUID()
       model.stagingItems = [makeStagingVoicetrack(id: voicetrackId)]
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-1")
 
-      XCTAssertFalse(apiWasCalled.value)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Cannot Place Here")
+      #expect(!apiWasCalled.value)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Cannot Place Here")
     }
   }
 }
@@ -1058,16 +1076,18 @@ extension BroadcastPageTests {
 // MARK: - Notify Listeners Tests
 
 extension BroadcastPageTests {
+  @Test
   func testOnNotifyListenersTappedShowsSheet() {
     let model = BroadcastPageModel(stationId: testStationId)
 
-    XCTAssertFalse(model.showNotifyListenersSheet)
+    #expect(!model.showNotifyListenersSheet)
 
     model.onNotifyListenersTapped()
 
-    XCTAssertTrue(model.showNotifyListenersSheet)
+    #expect(model.showNotifyListenersSheet)
   }
 
+  @Test
   func testCancelNotifyListenersDismissesSheet() {
     let model = BroadcastPageModel(stationId: testStationId)
     model.showNotifyListenersSheet = true
@@ -1075,10 +1095,11 @@ extension BroadcastPageTests {
 
     model.cancelNotifyListeners()
 
-    XCTAssertFalse(model.showNotifyListenersSheet)
-    XCTAssertEqual(model.notifyMessage, "")
+    #expect(!model.showNotifyListenersSheet)
+    #expect(model.notifyMessage == "")
   }
 
+  @Test
   func testSendNotificationCallsAPIWithMessage() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let capturedStationId = LockIsolated<String?>(nil)
@@ -1096,11 +1117,12 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertEqual(capturedStationId.value, testStationId)
-      XCTAssertEqual(capturedMessage.value, "I'm going live from the van!")
+      #expect(capturedStationId.value == testStationId)
+      #expect(capturedMessage.value == "I'm going live from the van!")
     }
   }
 
+  @Test
   func testSendNotificationDismissesSheetAndClearsMessage() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -1114,11 +1136,12 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertFalse(model.showNotifyListenersSheet)
-      XCTAssertEqual(model.notifyMessage, "")
+      #expect(!model.showNotifyListenersSheet)
+      #expect(model.notifyMessage == "")
     }
   }
 
+  @Test
   func testSendNotificationUpdatesLastSentTime() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
@@ -1132,10 +1155,11 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertEqual(lastSent[testStationId], fixedNow)
+      #expect(lastSent[testStationId] == fixedNow)
     }
   }
 
+  @Test
   func testCanSendNotificationReturnsTrueWhenNeverSent() {
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
 
@@ -1144,10 +1168,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertTrue(model.canSendNotification)
+      #expect(model.canSendNotification)
     }
   }
 
+  @Test
   func testCanSendNotificationReturnsFalseWithin12Hours() {
     let elevenHoursAgo = fixedNow.addingTimeInterval(-11 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [testStationId: elevenHoursAgo]
@@ -1157,10 +1182,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertFalse(model.canSendNotification)
+      #expect(!model.canSendNotification)
     }
   }
 
+  @Test
   func testCanSendNotificationReturnsTrueAfter12Hours() {
     let thirteenHoursAgo = fixedNow.addingTimeInterval(-13 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [
@@ -1172,10 +1198,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertTrue(model.canSendNotification)
+      #expect(model.canSendNotification)
     }
   }
 
+  @Test
   func testTimeUntilNextNotificationReturnsNilWhenCanSend() {
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
 
@@ -1184,10 +1211,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertNil(model.timeUntilNextNotification)
+      #expect(model.timeUntilNextNotification == nil)
     }
   }
 
+  @Test
   func testTimeUntilNextNotificationReturnsRemainingTime() {
     let elevenHoursAgo = fixedNow.addingTimeInterval(-11 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [testStationId: elevenHoursAgo]
@@ -1197,12 +1225,12 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      // Should be approximately 1 hour (3600 seconds) remaining
-      XCTAssertNotNil(model.timeUntilNextNotification)
-      XCTAssertEqual(model.timeUntilNextNotification!, 3600, accuracy: 1)
+      #expect(model.timeUntilNextNotification != nil)
+      #expect(abs(model.timeUntilNextNotification! - 3600) < 1)
     }
   }
 
+  @Test
   func testSendNotificationShowsErrorAlertOnFailure() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -1215,15 +1243,16 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       model.notifyMessage = "Test"
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.sendNotification()
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Error")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Error")
     }
   }
 
+  @Test
   func testSendNotificationDoesNotUpdateLastSentOnFailure() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
@@ -1239,10 +1268,11 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertNil(lastSent[testStationId])
+      #expect(lastSent[testStationId] == nil)
     }
   }
 
+  @Test
   func testSendNotificationDoesNothingWhenMessageIsEmpty() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let apiWasCalled = LockIsolated(false)
@@ -1259,11 +1289,12 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertFalse(apiWasCalled.value)
-      XCTAssertTrue(model.showNotifyListenersSheet)
+      #expect(!apiWasCalled.value)
+      #expect(model.showNotifyListenersSheet)
     }
   }
 
+  @Test
   func testSendNotificationDoesNothingWhenMessageIsWhitespaceOnly() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let apiWasCalled = LockIsolated(false)
@@ -1280,11 +1311,12 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertFalse(apiWasCalled.value)
-      XCTAssertTrue(model.showNotifyListenersSheet)
+      #expect(!apiWasCalled.value)
+      #expect(model.showNotifyListenersSheet)
     }
   }
 
+  @Test
   func testNotificationRestTimeRemainingStringReturnsNilWhenCanSend() {
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
 
@@ -1293,10 +1325,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertNil(model.notificationRestTimeRemainingString)
+      #expect(model.notificationRestTimeRemainingString == nil)
     }
   }
 
+  @Test
   func testNotificationRestTimeRemainingStringShowsHoursAndMinutes() {
     let elevenHoursAgo = fixedNow.addingTimeInterval(-11 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [testStationId: elevenHoursAgo]
@@ -1306,10 +1339,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertEqual(model.notificationRestTimeRemainingString, "1h 0m")
+      #expect(model.notificationRestTimeRemainingString == "1h 0m")
     }
   }
 
+  @Test
   func testNotificationRestTimeRemainingStringShowsOnlyMinutesWhenUnderOneHour() {
     let elevenAndAHalfHoursAgo = fixedNow.addingTimeInterval(-11.5 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [
@@ -1321,10 +1355,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertEqual(model.notificationRestTimeRemainingString, "30m")
+      #expect(model.notificationRestTimeRemainingString == "30m")
     }
   }
 
+  @Test
   func testIsSendingNotificationTracksLoadingState() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let requestStarted = LockIsolated(false)
@@ -1342,7 +1377,7 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       model.notifyMessage = "Test"
 
-      XCTAssertFalse(model.isSendingNotification)
+      #expect(!model.isSendingNotification)
 
       let sendTask = Task {
         await model.sendNotification()
@@ -1352,7 +1387,7 @@ extension BroadcastPageTests {
         await Task.yield()
       }
 
-      XCTAssertTrue(model.isSendingNotification)
+      #expect(model.isSendingNotification)
 
       requestContinuation.withValue { continuation in
         continuation?.resume()
@@ -1361,7 +1396,7 @@ extension BroadcastPageTests {
 
       await sendTask.value
 
-      XCTAssertFalse(model.isSendingNotification)
+      #expect(!model.isSendingNotification)
     }
   }
 }
@@ -1369,6 +1404,7 @@ extension BroadcastPageTests {
 // MARK: - Voicetrack Upload Tests
 
 extension BroadcastPageTests {
+  @Test
   func testVoicetrackStatusUpdatesAsUploadProgresses() async {
     let stationId = "test-station-id"
     let fixedDate = Date(timeIntervalSince1970: 1_702_486_800)
@@ -1401,18 +1437,19 @@ extension BroadcastPageTests {
       await model.recordPageModel?.onRecordingAccepted?(recordingURL)
 
       let statuses = capturedStatuses.value
-      XCTAssertEqual(statuses.count, 6)
-      XCTAssertEqual(statuses[0], .converting)
-      XCTAssertEqual(statuses[1], .uploading(progress: 0.0))
-      XCTAssertEqual(statuses[2], .uploading(progress: 0.5))
-      XCTAssertEqual(statuses[3], .uploading(progress: 1.0))
-      XCTAssertEqual(statuses[4], .finalizing)
-      XCTAssertEqual(statuses[5], .completed)
+      #expect(statuses.count == 6)
+      #expect(statuses[0] == .converting)
+      #expect(statuses[1] == .uploading(progress: 0.0))
+      #expect(statuses[2] == .uploading(progress: 0.5))
+      #expect(statuses[3] == .uploading(progress: 1.0))
+      #expect(statuses[4] == .finalizing)
+      #expect(statuses[5] == .completed)
       let voicetrack = model.stagingItems.first as? LocalVoicetrack
-      XCTAssertEqual(voicetrack?.status, .completed)
+      #expect(voicetrack?.status == .completed)
     }
   }
 
+  @Test
   func testVoicetrackUploadSuccessStoresAudioBlockId() async {
     let stationId = "test-station-id"
     let fixedDate = Date(timeIntervalSince1970: 1_702_486_800)
@@ -1435,13 +1472,14 @@ extension BroadcastPageTests {
       let recordingURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
       await model.recordPageModel?.onRecordingAccepted?(recordingURL)
 
-      XCTAssertEqual(model.stagingItems.count, 1)
+      #expect(model.stagingItems.count == 1)
       let voicetrack = model.stagingItems.first as? LocalVoicetrack
-      XCTAssertEqual(voicetrack?.audioBlockId, expectedAudioBlockId)
-      XCTAssertEqual(voicetrack?.status, .completed)
+      #expect(voicetrack?.audioBlockId == expectedAudioBlockId)
+      #expect(voicetrack?.status == .completed)
     }
   }
 
+  @Test
   func testVoicetrackUploadErrorShowsAlertWithServerErrorMessage() async {
     let stationId = "test-station-id"
     let fixedDate = Date(timeIntervalSince1970: 1_702_486_800)
@@ -1457,20 +1495,21 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: stationId)
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       model.onAddVoiceTrackTapped()
       let recordingURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
       await model.recordPageModel?.onRecordingAccepted?(recordingURL)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Upload Failed")
-      XCTAssertEqual(model.presentedAlert?.message, serverErrorMessage)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Upload Failed")
+      #expect(model.presentedAlert?.message == serverErrorMessage)
     }
   }
 
   // MARK: - Analytics Tests
 
+  @Test
   func testViewAppearedTracksViewedBroadcastScreen() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let loggedInUser = LoggedInUser(
@@ -1500,10 +1539,11 @@ extension BroadcastPageTests {
         }
         return false
       }
-      XCTAssertTrue(hasViewedEvent)
+      #expect(hasViewedEvent)
     }
   }
 
+  @Test
   func testSendNotificationTracksNotificationSent() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let loggedInUser = LoggedInUser(
@@ -1537,10 +1577,11 @@ extension BroadcastPageTests {
         }
         return false
       }
-      XCTAssertTrue(hasNotificationEvent)
+      #expect(hasNotificationEvent)
     }
   }
 
+  @Test
   func testHandleAcceptedRecordingTracksVoicetrackRecorded() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let loggedInUser = LoggedInUser(
@@ -1575,10 +1616,11 @@ extension BroadcastPageTests {
         }
         return false
       }
-      XCTAssertTrue(hasRecordedEvent)
+      #expect(hasRecordedEvent)
     }
   }
 
+  @Test
   func testVoicetrackUploadCompletedTracksVoicetrackUploaded() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let loggedInUser = LoggedInUser(
@@ -1614,14 +1656,14 @@ extension BroadcastPageTests {
         }
         return false
       }
-      XCTAssertTrue(hasUploadedEvent)
+      #expect(hasUploadedEvent)
     }
   }
 
+  @Test
   func testOnAddSongTappedTracksSongSearchTapped() async {
     await withMainSerialExecutor {
       let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-      let searchTappedExpectation = XCTestExpectation(description: "songSearchTapped tracked")
       let loggedInUser = LoggedInUser(
         id: "user-123",
         firstName: "Test",
@@ -1630,40 +1672,47 @@ extension BroadcastPageTests {
       )
       @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-      await withDependencies {
-        $0.date.now = fixedNow
-        $0.analytics.track = { event in
-          capturedEvents.withValue { $0.append(event) }
-          if case .broadcastSongSearchTapped = event {
-            searchTappedExpectation.fulfill()
+      await confirmation("songSearchTapped tracked") { confirm in
+        await withDependencies {
+          $0.date.now = fixedNow
+          $0.analytics.track = { event in
+            capturedEvents.withValue { $0.append(event) }
+            if case .broadcastSongSearchTapped = event {
+              confirm()
+            }
+          }
+        } operation: {
+          let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
+          await model.onAddSongTapped()
+
+          while !capturedEvents.value.contains(where: {
+            if case .broadcastSongSearchTapped = $0 { return true }
+            return false
+          }) {
+            await Task.yield()
           }
         }
-      } operation: {
-        let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
-        await model.onAddSongTapped()
-
-        await fulfillment(of: [searchTappedExpectation], timeout: 1.0)
-
-        let events = capturedEvents.value
-        let hasSearchEvent = events.contains { event in
-          if case .broadcastSongSearchTapped(
-            let stationId, let stationName, let userName
-          ) = event {
-            return stationId == testStationId
-              && stationName == "Test Station"
-              && userName == "Test User"
-          }
-          return false
-        }
-        XCTAssertTrue(hasSearchEvent)
       }
+
+      let events = capturedEvents.value
+      let hasSearchEvent = events.contains { event in
+        if case .broadcastSongSearchTapped(
+          let stationId, let stationName, let userName
+        ) = event {
+          return stationId == testStationId
+            && stationName == "Test Station"
+            && userName == "Test User"
+        }
+        return false
+      }
+      #expect(hasSearchEvent)
     }
   }
 
+  @Test
   func testAddSongToStagingTracksSongAdded() async {
     await withMainSerialExecutor {
       let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-      let songAddedExpectation = XCTestExpectation(description: "songAdded tracked")
       let loggedInUser = LoggedInUser(
         id: "user-123",
         firstName: "Test",
@@ -1672,45 +1721,53 @@ extension BroadcastPageTests {
       )
       @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-      await withDependencies {
-        $0.date.now = fixedNow
-        $0.analytics.track = { event in
-          capturedEvents.withValue { $0.append(event) }
-          if case .broadcastSongAdded = event {
-            songAddedExpectation.fulfill()
+      await confirmation("songAdded tracked") { confirm in
+        await withDependencies {
+          $0.date.now = fixedNow
+          $0.analytics.track = { event in
+            capturedEvents.withValue { $0.append(event) }
+            if case .broadcastSongAdded = event {
+              confirm()
+            }
+          }
+        } operation: {
+          let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
+          let audioBlock = AudioBlock.mockWith(
+            id: "song-123",
+            title: "Test Song",
+            artist: "Test Artist"
+          )
+          await model.addSongToStaging(audioBlock)
+
+          while !capturedEvents.value.contains(where: {
+            if case .broadcastSongAdded = $0 { return true }
+            return false
+          }) {
+            await Task.yield()
           }
         }
-      } operation: {
-        let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
-        let audioBlock = AudioBlock.mockWith(
-          id: "song-123",
-          title: "Test Song",
-          artist: "Test Artist"
-        )
-        await model.addSongToStaging(audioBlock)
-
-        await fulfillment(of: [songAddedExpectation], timeout: 1.0)
-
-        let events = capturedEvents.value
-        let hasSongAddedEvent = events.contains { event in
-          if case .broadcastSongAdded(
-            let stationId, let stationName, let userName, let songTitle, let artistName
-          ) = event {
-            return stationId == testStationId
-              && stationName == "Test Station"
-              && userName == "Test User"
-              && songTitle == "Test Song"
-              && artistName == "Test Artist"
-          }
-          return false
-        }
-        XCTAssertTrue(hasSongAddedEvent)
       }
+
+      let events = capturedEvents.value
+      let hasSongAddedEvent = events.contains { event in
+        if case .broadcastSongAdded(
+          let stationId, let stationName, let userName, let songTitle, let artistName
+        ) = event {
+          return stationId == testStationId
+            && stationName == "Test Station"
+            && userName == "Test User"
+            && songTitle == "Test Song"
+            && artistName == "Test Artist"
+        }
+        return false
+      }
+      #expect(hasSongAddedEvent)
     }
   }
 
   // MARK: - Schedule Update Notification Tests
 
+  @Test
   func testRefreshScheduleFromRemoteUpdatesSchedule() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     let updatedSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
@@ -1725,15 +1782,16 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.schedule?.current().count, 2)
+      #expect(model.schedule?.current().count == 2)
 
       useUpdatedSpins.setValue(true)
       await model.refreshScheduleFromRemote()
 
-      XCTAssertEqual(model.schedule?.current().count, 3)
+      #expect(model.schedule?.current().count == 3)
     }
   }
 
+  @Test
   func testRefreshScheduleFromRemoteClearsReorderedSpinIds() async {
     let spins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
 
@@ -1746,10 +1804,11 @@ extension BroadcastPageTests {
 
       await model.refreshScheduleFromRemote()
 
-      XCTAssertNotNil(model.schedule)
+      #expect(model.schedule != nil)
     }
   }
 
+  @Test
   func testRefreshScheduleFromRemoteSilentlyFailsOnError() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     let shouldThrow = LockIsolated(false)
@@ -1767,11 +1826,12 @@ extension BroadcastPageTests {
       shouldThrow.setValue(true)
       await model.refreshScheduleFromRemote()
 
-      XCTAssertNotNil(model.schedule)
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.schedule != nil)
+      #expect(model.presentedAlert == nil)
     }
   }
 
+  @Test
   func testScheduleUpdateNotificationTriggersRefresh() async {
     let uniqueStationId = "notification-trigger-test-station"
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
@@ -1793,7 +1853,7 @@ extension BroadcastPageTests {
         let model = BroadcastPageModel(stationId: uniqueStationId)
         await model.viewAppeared()
 
-        XCTAssertEqual(fetchCount.value, 1)
+        #expect(fetchCount.value == 1)
 
         NotificationCenter.default.post(
           name: .scheduleUpdated,
@@ -1801,18 +1861,17 @@ extension BroadcastPageTests {
           userInfo: ["stationId": uniqueStationId, "editorName": "Jane Smith"]
         )
 
-        // The notification handler spawns a Task that calls refreshScheduleFromRemote.
-        // Suspension points: Task start + fetchSchedule + toast.show
         await Task.yield()
         await Task.yield()
         await Task.yield()
         await Task.yield()
 
-        XCTAssertEqual(fetchCount.value, 2)
+        #expect(fetchCount.value == 2)
       }
     }
   }
 
+  @Test
   func testRefreshScheduleFromRemoteShowsToastWithEditorName() async {
     let spins = makeSpins(ids: ["spin-1", "spin-2"])
     let shownToast = LockIsolated<PlayolaToast?>(nil)
@@ -1827,11 +1886,12 @@ extension BroadcastPageTests {
 
       await model.refreshScheduleFromRemote(editorName: "Jane Smith")
 
-      XCTAssertNotNil(shownToast.value)
-      XCTAssertEqual(shownToast.value?.message, "Edited by Jane Smith")
+      #expect(shownToast.value != nil)
+      #expect(shownToast.value?.message == "Edited by Jane Smith")
     }
   }
 
+  @Test
   func testRefreshScheduleFromRemoteNoToastWithoutEditorName() async {
     let spins = makeSpins(ids: ["spin-1", "spin-2"])
     let shownToast = LockIsolated<PlayolaToast?>(nil)
@@ -1846,10 +1906,11 @@ extension BroadcastPageTests {
 
       await model.refreshScheduleFromRemote()
 
-      XCTAssertNil(shownToast.value)
+      #expect(shownToast.value == nil)
     }
   }
 
+  @Test
   func testScheduleUpdateNotificationIgnoredForDifferentStation() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     let fetchCount = LockIsolated(0)
@@ -1874,7 +1935,7 @@ extension BroadcastPageTests {
 
       await Task.yield()
 
-      XCTAssertEqual(fetchCount.value, initialFetchCount)
+      #expect(fetchCount.value == initialFetchCount)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageTests.swift
@@ -3,53 +3,61 @@
 //  PlayolaRadio
 //
 
+import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class BroadcastersListenerQuestionPageTests: XCTestCase {
+struct BroadcastersListenerQuestionPageTests {
   private let testStationId = "test-station-id"
   private let testJwt = "test-jwt-token"
 
   // MARK: - Initialization Tests
 
+  @Test
   func testInitSetsStationId() {
     let model = makeModel()
 
-    XCTAssertEqual(model.stationId, testStationId)
+    #expect(model.stationId == testStationId)
   }
 
+  @Test
   func testInitialStateIsNotLoading() {
     let model = makeModel()
 
-    XCTAssertFalse(model.isLoading)
+    #expect(!model.isLoading)
   }
 
+  @Test
   func testInitialStateHasNoExpandedQuestions() {
     let model = makeModel()
 
-    XCTAssertTrue(model.expandedQuestionIds.isEmpty)
+    #expect(model.expandedQuestionIds.isEmpty)
   }
 
+  @Test
   func testInitialStateHasNoPlayingQuestion() {
     let model = makeModel()
 
-    XCTAssertNil(model.playingQuestionId)
+    #expect(model.playingQuestionId == nil)
   }
 
+  @Test
   func testInitialStateHasEmptyQuestions() {
     let model = makeModel()
 
-    XCTAssertTrue(model.questions.isEmpty)
+    #expect(model.questions.isEmpty)
   }
 
   // MARK: - Fetch Tests
 
+  @Test
   func testViewAppearedCallsAPIWithStationId() async {
     let calledStationId = LockIsolated<String?>(nil)
 
@@ -66,9 +74,10 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertEqual(calledStationId.value, testStationId)
+    #expect(calledStationId.value == testStationId)
   }
 
+  @Test
   func testViewAppearedPopulatesQuestionsArray() async {
     let mockQuestions: [ListenerQuestion] = [
       .mockWith(id: "q1"),
@@ -85,11 +94,12 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertEqual(model.questions.count, 2)
-    XCTAssertEqual(model.questions[0].id, "q1")
-    XCTAssertEqual(model.questions[1].id, "q2")
+    #expect(model.questions.count == 2)
+    #expect(model.questions[0].id == "q1")
+    #expect(model.questions[1].id == "q2")
   }
 
+  @Test
   func testViewAppearedSetsIsLoadingDuringFetch() async {
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
@@ -101,13 +111,14 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
       BroadcastersListenerQuestionPageModel(stationId: testStationId)
     }
 
-    XCTAssertFalse(model.isLoading)
+    #expect(!model.isLoading)
 
     await model.viewAppeared()
 
-    XCTAssertFalse(model.isLoading)
+    #expect(!model.isLoading)
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
@@ -121,10 +132,11 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Error Loading Questions")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Error Loading Questions")
   }
 
+  @Test
   func testViewAppearedDoesNothingWithoutJwt() async {
     let apiCalled = LockIsolated(false)
 
@@ -141,9 +153,10 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertFalse(apiCalled.value)
+    #expect(!apiCalled.value)
   }
 
+  @Test
   func testViewAppearedCallsFetchQuestions() async {
     let fetchCalled = LockIsolated(false)
 
@@ -160,9 +173,10 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertTrue(fetchCalled.value)
+    #expect(fetchCalled.value)
   }
 
+  @Test
   func testRefreshPulledDownCallsFetchQuestions() async {
     let fetchCalled = LockIsolated(false)
 
@@ -179,38 +193,42 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.refreshPulledDown()
 
-    XCTAssertTrue(fetchCalled.value)
+    #expect(fetchCalled.value)
   }
 
   // MARK: - Expand/Collapse Tests
 
+  @Test
   func testIsExpandedReturnsFalseForCollapsedQuestion() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
-    XCTAssertFalse(model.isExpanded(questionId))
+    #expect(!model.isExpanded(questionId))
   }
 
+  @Test
   func testToggleExpandedExpandsCollapsedQuestion() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
     model.showMoreButtonTapped(questionId)
 
-    XCTAssertTrue(model.isExpanded(questionId))
+    #expect(model.isExpanded(questionId))
   }
 
+  @Test
   func testToggleExpandedCollapsesExpandedQuestion() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
     model.showMoreButtonTapped(questionId)
-    XCTAssertTrue(model.isExpanded(questionId))
+    #expect(model.isExpanded(questionId))
 
     model.showMoreButtonTapped(questionId)
-    XCTAssertFalse(model.isExpanded(questionId))
+    #expect(!model.isExpanded(questionId))
   }
 
+  @Test
   func testMultipleQuestionsCanBeExpandedSimultaneously() {
     let model = makeModelWithQuestions()
     let firstQuestionId = model.questions[0].id
@@ -219,28 +237,31 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
     model.showMoreButtonTapped(firstQuestionId)
     model.showMoreButtonTapped(secondQuestionId)
 
-    XCTAssertTrue(model.isExpanded(firstQuestionId))
-    XCTAssertTrue(model.isExpanded(secondQuestionId))
+    #expect(model.isExpanded(firstQuestionId))
+    #expect(model.isExpanded(secondQuestionId))
   }
 
   // MARK: - Playback Tests
 
+  @Test
   func testIsPlayingReturnsFalseWhenNotPlaying() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
-    XCTAssertFalse(model.isPlaying(questionId))
+    #expect(!model.isPlaying(questionId))
   }
 
+  @Test
   func testIsPlayingReturnsTrueForPlayingQuestion() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
     model.playingQuestionId = questionId
 
-    XCTAssertTrue(model.isPlaying(questionId))
+    #expect(model.isPlaying(questionId))
   }
 
+  @Test
   func testIsPlayingReturnsFalseForDifferentQuestion() {
     let model = makeModelWithQuestions()
     let firstQuestionId = model.questions[0].id
@@ -248,9 +269,10 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     model.playingQuestionId = firstQuestionId
 
-    XCTAssertFalse(model.isPlaying(secondQuestionId))
+    #expect(!model.isPlaying(secondQuestionId))
   }
 
+  @Test
   func testOnPlayTappedStartsPlaybackWhenNotPlaying() async {
     let loadFileCalled = LockIsolated(false)
     let playCalled = LockIsolated(false)
@@ -271,11 +293,12 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(question)
 
-    XCTAssertTrue(loadFileCalled.value)
-    XCTAssertTrue(playCalled.value)
-    XCTAssertEqual(model.playingQuestionId, question.id)
+    #expect(loadFileCalled.value)
+    #expect(playCalled.value)
+    #expect(model.playingQuestionId == question.id)
   }
 
+  @Test
   func testOnPlayTappedStopsPlaybackWhenAlreadyPlaying() async {
     let stopCalled = LockIsolated(false)
 
@@ -292,10 +315,11 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(question)
 
-    XCTAssertTrue(stopCalled.value)
-    XCTAssertNil(model.playingQuestionId)
+    #expect(stopCalled.value)
+    #expect(model.playingQuestionId == nil)
   }
 
+  @Test
   func testOnPlayTappedStopsPreviousBeforeStartingNew() async {
     let stopCallCount = LockIsolated(0)
     let loadFileCalled = LockIsolated(false)
@@ -318,11 +342,12 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(secondQuestion)
 
-    XCTAssertEqual(stopCallCount.value, 1)
-    XCTAssertTrue(loadFileCalled.value)
-    XCTAssertEqual(model.playingQuestionId, secondQuestion.id)
+    #expect(stopCallCount.value == 1)
+    #expect(loadFileCalled.value)
+    #expect(model.playingQuestionId == secondQuestion.id)
   }
 
+  @Test
   func testPlayButtonTappedOnSameQuestionStopsPlayback() async {
     let stopCalled = LockIsolated(false)
 
@@ -341,12 +366,13 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(question)
 
-    XCTAssertTrue(stopCalled.value)
-    XCTAssertNil(model.playingQuestionId)
+    #expect(stopCalled.value)
+    #expect(model.playingQuestionId == nil)
   }
 
   // MARK: - Error Handling Tests
 
+  @Test
   func testOnPlayTappedShowsAlertOnError() async {
     let model = withDependencies {
       $0.audioPlayer.loadFile = { _ in
@@ -359,14 +385,15 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     let question = model.questions.first!
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
 
     await model.playButtonTapped(question)
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Playback Error")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Playback Error")
   }
 
+  @Test
   func testOnPlayTappedDoesNothingWhenNoAudioBlock() async {
     let audioPlayerCalled = LockIsolated(false)
 
@@ -389,74 +416,84 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(questionWithoutAudio)
 
-    XCTAssertFalse(audioPlayerCalled.value)
+    #expect(!audioPlayerCalled.value)
   }
 
   // MARK: - Filter Tests
 
+  @Test
   func testDefaultFilterIsPending() {
     let model = makeModel()
 
-    XCTAssertEqual(model.selectedFilter, .pending)
+    #expect(model.selectedFilter == .pending)
   }
 
+  @Test
   func testFilterOptionsContainsAllExpectedValues() {
     let model = makeModel()
 
-    XCTAssertEqual(model.filterOptions, [.pending, .answered, .all])
+    #expect(model.filterOptions == [.pending, .answered, .all])
   }
 
+  @Test
   func testFilteredQuestionsReturnsOnlyPendingByDefault() {
     let model = makeModelWithMixedStatusQuestions()
 
     let filtered = model.filteredQuestions
 
-    XCTAssertEqual(filtered.count, 2)
-    XCTAssertTrue(filtered.allSatisfy { $0.status == .pending })
+    #expect(filtered.count == 2)
+    #expect(filtered.allSatisfy { $0.status == .pending })
   }
 
+  @Test
   func testFilteredQuestionsReturnsOnlyAnsweredWhenFilterIsAnswered() {
     let model = makeModelWithMixedStatusQuestions()
 
     model.selectedFilter = .answered
 
     let filtered = model.filteredQuestions
-    XCTAssertEqual(filtered.count, 1)
-    XCTAssertTrue(filtered.allSatisfy { $0.status == .answered })
+    #expect(filtered.count == 1)
+    #expect(filtered.allSatisfy { $0.status == .answered })
   }
 
+  @Test
   func testFilteredQuestionsReturnsAllExceptDeclinedWhenFilterIsAll() {
     let model = makeModelWithMixedStatusQuestions()
 
     model.selectedFilter = .all
 
     let filtered = model.filteredQuestions
-    XCTAssertEqual(filtered.count, 3)
-    XCTAssertTrue(filtered.allSatisfy { $0.status != .declined })
+    #expect(filtered.count == 3)
+    #expect(filtered.allSatisfy { $0.status != .declined })
   }
 
+  @Test
   func testFilterSelectedUpdatesSelectedFilter() {
     let model = makeModel()
 
     model.filterSelected(.answered)
 
-    XCTAssertEqual(model.selectedFilter, .answered)
+    #expect(model.selectedFilter == .answered)
   }
 
+  @Test
   func testFilterDisplayTextForPending() {
-    XCTAssertEqual(ListenerQuestionFilter.pending.displayText, "Pending")
+    #expect(ListenerQuestionFilter.pending.displayText == "Pending")
   }
 
+  @Test
   func testFilterDisplayTextForAnswered() {
-    XCTAssertEqual(ListenerQuestionFilter.answered.displayText, "Answered")
+    #expect(ListenerQuestionFilter.answered.displayText == "Answered")
   }
 
+  @Test
   func testFilterDisplayTextForAll() {
-    XCTAssertEqual(ListenerQuestionFilter.all.displayText, "All")
+    #expect(ListenerQuestionFilter.all.displayText == "All")
   }
 
   // MARK: - Decline Question Tests
 
+  @Test
   func testDeclineQuestionCallsAPI() async {
     let declineCalled = LockIsolated(false)
     let capturedStationId = LockIsolated<String?>(nil)
@@ -482,11 +519,12 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.declineQuestionSwiped(model.questions[0])
 
-    XCTAssertTrue(declineCalled.value)
-    XCTAssertEqual(capturedStationId.value, testStationId)
-    XCTAssertEqual(capturedQuestionId.value, "q1")
+    #expect(declineCalled.value)
+    #expect(capturedStationId.value == testStationId)
+    #expect(capturedQuestionId.value == "q1")
   }
 
+  @Test
   func testDeclineQuestionUpdatesLocalState() async {
     let declinedQuestion = ListenerQuestion.mockWith(
       id: "q1",
@@ -509,30 +547,34 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.declineQuestionSwiped(model.questions[0])
 
-    XCTAssertEqual(model.questions[id: "q1"]?.status, .declined)
+    #expect(model.questions[id: "q1"]?.status == .declined)
   }
 
+  @Test
   func testCanDeclineReturnsTrueForPendingQuestion() {
     let model = makeModel()
     let pendingQuestion = ListenerQuestion.mockWith(status: .pending)
 
-    XCTAssertTrue(model.canDecline(pendingQuestion))
+    #expect(model.canDecline(pendingQuestion))
   }
 
+  @Test
   func testCanDeclineReturnsFalseForAnsweredQuestion() {
     let model = makeModel()
     let answeredQuestion = ListenerQuestion.mockWith(status: .answered)
 
-    XCTAssertFalse(model.canDecline(answeredQuestion))
+    #expect(!model.canDecline(answeredQuestion))
   }
 
+  @Test
   func testCanDeclineReturnsFalseForDeclinedQuestion() {
     let model = makeModel()
     let declinedQuestion = ListenerQuestion.mockWith(status: .declined)
 
-    XCTAssertFalse(model.canDecline(declinedQuestion))
+    #expect(!model.canDecline(declinedQuestion))
   }
 
+  @Test
   func testDeclineQuestionShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
@@ -551,7 +593,7 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.declineQuestionSwiped(model.questions[0])
 
-    XCTAssertNotNil(model.presentedAlert)
+    #expect(model.presentedAlert != nil)
   }
 
   // MARK: - Test Helpers

--- a/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageTests.swift
+++ b/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageTests.swift
@@ -6,14 +6,16 @@
 //
 
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class EditProfilePageTests: XCTestCase {
-  func testInit_WithLoggedInUser_SetsInitialValues() async {
+struct EditProfilePageTests {
+  @Test
+  func testInitWithLoggedInUserSetsInitialValues() async {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -26,46 +28,43 @@ final class EditProfilePageTests: XCTestCase {
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    XCTAssertEqual(model.firstName, "John")
-    XCTAssertEqual(model.lastName, "Doe")
-    XCTAssertEqual(model.email, "john@example.com")
+    #expect(model.firstName == "John")
+    #expect(model.lastName == "Doe")
+    #expect(model.email == "john@example.com")
   }
 
-  func testInit_WithNoLoggedInUser_SetsEmptyValues() {
+  @Test
+  func testInitWithNoLoggedInUserSetsEmptyValues() {
     @Shared(.auth) var auth = Auth()
 
-    // When: Creating the model
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    // Then: Model should be initialized with empty values
-    XCTAssertEqual(model.firstName, "")
-    XCTAssertEqual(model.lastName, "")
-    XCTAssertEqual(model.email, "")
+    #expect(model.firstName == "")
+    #expect(model.lastName == "")
+    #expect(model.email == "")
   }
 
-  func testInit_WithPartialUserData_SetsAvailableValues() {
-    // Given: A logged in user with only some profile data
+  @Test
+  func testInitWithPartialUserDataSetsAvailableValues() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "Jane",
-      lastName: nil,  // No last name
+      lastName: nil,
       email: "jane@example.com"
     )
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-    // When: Creating the model
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    // Then: Model should be initialized with available data
-    XCTAssertEqual(model.firstName, "Jane")
-    XCTAssertEqual(model.lastName, "")
-    XCTAssertEqual(model.email, "jane@example.com")
+    #expect(model.firstName == "Jane")
+    #expect(model.lastName == "")
+    #expect(model.email == "jane@example.com")
   }
 
-  func testSaveButtonEnabled_NoChanges_ReturnsFalse() {
-    // Given: A logged in user
+  @Test
+  func testSaveButtonEnabledNoChangesReturnsFalse() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -74,16 +73,14 @@ final class EditProfilePageTests: XCTestCase {
     )
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-    // When: Creating the model with no changes
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    // Then: Save button should be disabled
-    XCTAssertFalse(model.isSaveButtonEnabled)
+    #expect(!model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_FirstNameChanged_ReturnsTrue() {
-    // Given: A logged in user
+  @Test
+  func testSaveButtonEnabledFirstNameChangedReturnsTrue() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -92,16 +89,15 @@ final class EditProfilePageTests: XCTestCase {
     )
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-    // When: Creating the model and changing firstName
     let model = EditProfilePageModel()
     model.viewAppeared()
     model.firstName = "Jane"
 
-    // Then: Save button should be enabled
-    XCTAssertTrue(model.isSaveButtonEnabled)
+    #expect(model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_LastNameChanged_ReturnsTrue() {
+  @Test
+  func testSaveButtonEnabledLastNameChangedReturnsTrue() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -114,10 +110,11 @@ final class EditProfilePageTests: XCTestCase {
     model.viewAppeared()
     model.lastName = "Smith"
 
-    XCTAssertTrue(model.isSaveButtonEnabled)
+    #expect(model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_LastNameNilToEmpty_ReturnsFalse() {
+  @Test
+  func testSaveButtonEnabledLastNameNilToEmptyReturnsFalse() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -129,10 +126,11 @@ final class EditProfilePageTests: XCTestCase {
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    XCTAssertFalse(model.isSaveButtonEnabled)
+    #expect(!model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_LastNameEmptyToValue_ReturnsTrue() {
+  @Test
+  func testSaveButtonEnabledLastNameEmptyToValueReturnsTrue() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -145,10 +143,11 @@ final class EditProfilePageTests: XCTestCase {
     model.viewAppeared()
     model.lastName = "Doe"
 
-    XCTAssertTrue(model.isSaveButtonEnabled)
+    #expect(model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_RevertChanges_ReturnsFalse() {
+  @Test
+  func testSaveButtonEnabledRevertChangesReturnsFalse() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -160,14 +159,15 @@ final class EditProfilePageTests: XCTestCase {
     let model = EditProfilePageModel()
     model.viewAppeared()
     model.firstName = "Jane"
-    XCTAssertTrue(model.isSaveButtonEnabled)  // Should be enabled after change
+    #expect(model.isSaveButtonEnabled)
 
-    model.firstName = "John"  // Revert back
+    model.firstName = "John"
 
-    XCTAssertFalse(model.isSaveButtonEnabled)
+    #expect(!model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonTapped_UpdateUserIsSuccessful() async {
+  @Test
+  func testSaveButtonTappedUpdateUserIsSuccessful() async {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -187,9 +187,9 @@ final class EditProfilePageTests: XCTestCase {
 
     let model = withDependencies {
       $0.api.updateUser = { jwtToken, firstName, lastName, _ in
-        XCTAssertEqual(jwtToken, expectedJwt)
-        XCTAssertEqual(firstName, "Joe")
-        XCTAssertEqual(lastName, "Jones")
+        #expect(jwtToken == expectedJwt)
+        #expect(firstName == "Joe")
+        #expect(lastName == "Jones")
         return expectedAuth
       }
       $0.continuousClock = ImmediateClock()
@@ -203,14 +203,15 @@ final class EditProfilePageTests: XCTestCase {
 
     await model.saveButtonTapped()
 
-    XCTAssertEqual(auth.currentUser?.firstName, "Jane")
-    XCTAssertEqual(auth.currentUser?.lastName, "Smith")
-    XCTAssertEqual(auth.jwt, "new-jwt-token")
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert, PlayolaAlert.updateProfileSuccessfullAlert)
+    #expect(auth.currentUser?.firstName == "Jane")
+    #expect(auth.currentUser?.lastName == "Smith")
+    #expect(auth.jwt == "new-jwt-token")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert == PlayolaAlert.updateProfileSuccessfullAlert)
   }
 
-  func testSaveButtonTapped_UpdateUserFails() async {
+  @Test
+  func testSaveButtonTappedUpdateUserFails() async {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -234,17 +235,16 @@ final class EditProfilePageTests: XCTestCase {
 
     await model.saveButtonTapped()
 
-    // Auth should remain unchanged on error
-    XCTAssertEqual(auth.currentUser?.firstName, "John")
-    XCTAssertEqual(auth.currentUser?.lastName, "Doe")
-    XCTAssertEqual(auth.jwt, loggedInUser.jwt)
+    #expect(auth.currentUser?.firstName == "John")
+    #expect(auth.currentUser?.lastName == "Doe")
+    #expect(auth.jwt == loggedInUser.jwt)
 
-    // Error alert should be presented
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert, PlayolaAlert.updateProfileErrorAlert)
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert == PlayolaAlert.updateProfileErrorAlert)
   }
 
-  func testSaveButtonTapped_NavigationPopsAfterSuccess() async {
+  @Test
+  func testSaveButtonTappedNavigationPopsAfterSuccess() async {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -252,9 +252,9 @@ final class EditProfilePageTests: XCTestCase {
       email: "john@example.com"
     )
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
-    @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator
+    @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
+      MainContainerNavigationCoordinator()
 
-    // Clear navigation and add a test path
     navigationCoordinator.popToRoot()
 
     let updatedUser = LoggedInUser(
@@ -274,9 +274,8 @@ final class EditProfilePageTests: XCTestCase {
       EditProfilePageModel()
     }
 
-    // Add the model to the navigation stack
     navigationCoordinator.push(.editProfilePage(model))
-    XCTAssertEqual(navigationCoordinator.path.count, 1)
+    #expect(navigationCoordinator.path.count == 1)
 
     model.viewAppeared()
     model.firstName = "Jane"
@@ -284,10 +283,8 @@ final class EditProfilePageTests: XCTestCase {
 
     await model.saveButtonTapped()
 
-    // Verify navigation was popped
-    XCTAssertEqual(navigationCoordinator.path.count, 0)
+    #expect(navigationCoordinator.path.count == 0)
 
-    // Clean up
     navigationCoordinator.popToRoot()
   }
 }

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageTests.swift
@@ -7,15 +7,17 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class NotificationsSettingsPageTests: XCTestCase {
+struct NotificationsSettingsPageTests {
+  @Test
   func testViewAppearedLoadsSubscriptions() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -30,12 +32,13 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.stationItems.count, 2)
-      XCTAssertTrue(model.isSubscribed(stationId: "station-1"))
-      XCTAssertFalse(model.isSubscribed(stationId: "station-2"))
+      #expect(model.stationItems.count == 2)
+      #expect(model.isSubscribed(stationId: "station-1"))
+      #expect(!model.isSubscribed(stationId: "station-2"))
     }
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -49,10 +52,11 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
+  @Test
   func testStationItemsShowsAllStations() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -66,18 +70,19 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertEqual(model.stationItems.count, 2)
+      #expect(model.stationItems.count == 2)
 
       let station1Item = model.stationItems.first { $0.station.id == "station-1" }
       let station2Item = model.stationItems.first { $0.station.id == "station-2" }
 
-      XCTAssertNotNil(station1Item)
-      XCTAssertNotNil(station2Item)
-      XCTAssertTrue(station1Item?.isSubscribed ?? false)
-      XCTAssertFalse(station2Item?.isSubscribed ?? true)
+      #expect(station1Item != nil)
+      #expect(station2Item != nil)
+      #expect(station1Item?.isSubscribed ?? false)
+      #expect(!(station2Item?.isSubscribed ?? true))
     }
   }
 
+  @Test
   func testStationItemStatusTextForNotSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -89,11 +94,12 @@ final class NotificationsSettingsPageTests: XCTestCase {
       await model.viewAppeared()
 
       let item = model.stationItems.first
-      XCTAssertEqual(item?.statusText, "Not subscribed")
-      XCTAssertFalse(item?.isSubscribed ?? true)
+      #expect(item?.statusText == "Not subscribed")
+      #expect(!(item?.isSubscribed ?? true))
     }
   }
 
+  @Test
   func testAllNotificationsEnabledWhenAllSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -108,10 +114,11 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertTrue(model.allNotificationsEnabled)
+      #expect(model.allNotificationsEnabled)
     }
   }
 
+  @Test
   func testAllNotificationsDisabledWhenSomeUnsubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -126,11 +133,12 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertFalse(model.allNotificationsEnabled)
-      XCTAssertTrue(model.someNotificationsEnabled)
+      #expect(!model.allNotificationsEnabled)
+      #expect(model.someNotificationsEnabled)
     }
   }
 
+  @Test
   func testToggleSubscriptionCallsUnsubscribeWhenSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -145,7 +153,7 @@ final class NotificationsSettingsPageTests: XCTestCase {
       $0.api.unsubscribeFromStationNotifications = { _, stationId in
         unsubscribeCalled.setValue(true)
         unsubscribedStationId.setValue(stationId)
-        return self.mockSubscription(stationId: stationId, isSubscribed: false)
+        return Self.mockSubscription(stationId: stationId, isSubscribed: false)
       }
     } operation: {
       let model = NotificationsSettingsPageModel()
@@ -153,11 +161,12 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.toggleSubscription(for: "station-1")
 
-      XCTAssertTrue(unsubscribeCalled.value)
-      XCTAssertEqual(unsubscribedStationId.value, "station-1")
+      #expect(unsubscribeCalled.value)
+      #expect(unsubscribedStationId.value == "station-1")
     }
   }
 
+  @Test
   func testToggleSubscriptionCallsSubscribeWhenNotSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -169,7 +178,7 @@ final class NotificationsSettingsPageTests: XCTestCase {
       $0.api.subscribeToStationNotifications = { _, stationId in
         subscribeCalled.setValue(true)
         subscribedStationId.setValue(stationId)
-        return self.mockSubscription(stationId: stationId, isSubscribed: true)
+        return Self.mockSubscription(stationId: stationId, isSubscribed: true)
       }
     } operation: {
       let model = NotificationsSettingsPageModel()
@@ -177,11 +186,12 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.toggleSubscription(for: "station-1")
 
-      XCTAssertTrue(subscribeCalled.value)
-      XCTAssertEqual(subscribedStationId.value, "station-1")
+      #expect(subscribeCalled.value)
+      #expect(subscribedStationId.value == "station-1")
     }
   }
 
+  @Test
   func testToggleSubscriptionShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -201,10 +211,11 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.toggleSubscription(for: "station-1")
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
+  @Test
   func testInactiveStationsAreFilteredOut() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationListsWithInactiveStation()
@@ -215,13 +226,14 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertEqual(model.stationItems.count, 2)
-      XCTAssertNotNil(model.stationItems.first { $0.station.id == "station-1" })
-      XCTAssertNotNil(model.stationItems.first { $0.station.id == "station-2" })
-      XCTAssertNil(model.stationItems.first { $0.station.id == "inactive-station" })
+      #expect(model.stationItems.count == 2)
+      #expect(model.stationItems.first { $0.station.id == "station-1" } != nil)
+      #expect(model.stationItems.first { $0.station.id == "station-2" } != nil)
+      #expect(model.stationItems.first { $0.station.id == "inactive-station" } == nil)
     }
   }
 
+  @Test
   func testStationsAreSortedByCuratorName() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationListsUnsorted()
@@ -232,10 +244,10 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertEqual(model.stationItems.count, 3)
-      XCTAssertEqual(model.stationItems[0].station.curatorName, "Alice")
-      XCTAssertEqual(model.stationItems[1].station.curatorName, "Bob")
-      XCTAssertEqual(model.stationItems[2].station.curatorName, "Charlie")
+      #expect(model.stationItems.count == 3)
+      #expect(model.stationItems[0].station.curatorName == "Alice")
+      #expect(model.stationItems[1].station.curatorName == "Bob")
+      #expect(model.stationItems[2].station.curatorName == "Charlie")
     }
   }
 
@@ -351,7 +363,7 @@ final class NotificationsSettingsPageTests: XCTestCase {
     ])
   }
 
-  nonisolated private func mockSubscription(stationId: String, isSubscribed: Bool)
+  nonisolated static func mockSubscription(stationId: String, isSubscribed: Bool)
     -> PushNotificationSubscription
   {
     PushNotificationSubscription(

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
@@ -5,19 +5,14 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class RecordIntroPageTests: XCTestCase {
-  override func setUp() {
-    super.setUp()
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
-    coordinator.presentedSheet = nil
-  }
-
+struct RecordIntroPageTests {
   private func makeModel() -> RecordIntroPageModel {
     RecordIntroPageModel(
       songTitle: "Test", songArtist: "Artist", songImageUrl: nil,
@@ -26,6 +21,7 @@ final class RecordIntroPageTests: XCTestCase {
 
   // MARK: - Initial Properties
 
+  @Test
   func testInitialProperties() {
     let model = RecordIntroPageModel(
       songTitle: "Bohemian Rhapsody",
@@ -35,17 +31,18 @@ final class RecordIntroPageTests: XCTestCase {
       audioBlockId: "block-1"
     )
 
-    XCTAssertEqual(model.songTitle, "Bohemian Rhapsody")
-    XCTAssertEqual(model.songArtist, "Queen")
-    XCTAssertEqual(model.songImageUrl, URL(string: "https://example.com/image.jpg"))
-    XCTAssertEqual(model.navigationTitle, "Record Intro")
-    XCTAssertEqual(model.instructionItems.count, 2)
-    XCTAssertEqual(model.recordingPhase, .idle)
-    XCTAssertNil(model.uploadStatus)
+    #expect(model.songTitle == "Bohemian Rhapsody")
+    #expect(model.songArtist == "Queen")
+    #expect(model.songImageUrl == URL(string: "https://example.com/image.jpg"))
+    #expect(model.navigationTitle == "Record Intro")
+    #expect(model.instructionItems.count == 2)
+    #expect(model.recordingPhase == .idle)
+    #expect(model.uploadStatus == nil)
   }
 
   // MARK: - Lifecycle
 
+  @Test
   func testViewAppearedPreparesForRecording() async {
     let prepareCalled = LockIsolated(false)
 
@@ -58,47 +55,52 @@ final class RecordIntroPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertTrue(prepareCalled.value)
+      #expect(prepareCalled.value)
     }
   }
 
   // MARK: - Done Button
 
+  @Test
   func testShouldShowDoneButtonTrueOnlyInIdlePhase() {
     let model = makeModel()
 
     model.recordingPhase = .idle
-    XCTAssertTrue(model.shouldShowDoneButton)
+    #expect(model.shouldShowDoneButton)
 
     model.recordingPhase = .recording
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
 
     model.recordingPhase = .review
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
   }
 
+  @Test
   func testShouldShowDoneButtonFalseWhenUploading() {
     let model = makeModel()
     model.recordingPhase = .idle
     model.uploadStatus = .converting
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
   }
 
+  @Test
   func testOnDoneTappedDismissesSheet() {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let model = makeModel()
     coordinator.presentedSheet = .recordIntroPage(model)
 
-    XCTAssertNotNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet != nil)
 
     model.onDoneTapped()
 
-    XCTAssertNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet == nil)
   }
 
   // MARK: - Recording
 
+  @Test
   func testOnRecordTappedRequestsPermissionBeforeRecording() async {
     let requestPermissionCalled = LockIsolated(false)
     let startRecordingCalled = LockIsolated(false)
@@ -109,22 +111,23 @@ final class RecordIntroPageTests: XCTestCase {
         return true
       }
       $0.audioRecorder.startRecording = {
-        XCTAssertTrue(
+        #expect(
           requestPermissionCalled.value, "Permission should be requested before recording starts")
         startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = makeModel()
-      XCTAssertEqual(model.recordingPhase, .idle)
+      #expect(model.recordingPhase == .idle)
 
       await model.onRecordTapped()
 
-      XCTAssertTrue(requestPermissionCalled.value)
-      XCTAssertTrue(startRecordingCalled.value)
-      XCTAssertEqual(model.recordingPhase, .recording)
+      #expect(requestPermissionCalled.value)
+      #expect(startRecordingCalled.value)
+      #expect(model.recordingPhase == .recording)
     }
   }
 
+  @Test
   func testOnRecordTappedDoesNotRecordWhenPermissionDenied() async {
     let startRecordingCalled = LockIsolated(false)
 
@@ -138,16 +141,17 @@ final class RecordIntroPageTests: XCTestCase {
 
       await model.onRecordTapped()
 
-      XCTAssertFalse(
-        startRecordingCalled.value, "Recording should not start when permission is denied")
-      XCTAssertEqual(model.recordingPhase, .idle)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Microphone Access Required")
+      #expect(
+        !startRecordingCalled.value, "Recording should not start when permission is denied")
+      #expect(model.recordingPhase == .idle)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Microphone Access Required")
     }
   }
 
   // MARK: - Stop Recording
 
+  @Test
   func testOnStopTappedStopsRecordingAndChangesPhase() async {
     let expectedURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
 
@@ -162,14 +166,15 @@ final class RecordIntroPageTests: XCTestCase {
 
       await model.onStopTapped()
 
-      XCTAssertEqual(model.recordingPhase, .review)
-      XCTAssertEqual(model.recordingURL, expectedURL)
-      XCTAssertEqual(model.recordingDuration, 5.0)
+      #expect(model.recordingPhase == .review)
+      #expect(model.recordingURL == expectedURL)
+      #expect(model.recordingDuration == 5.0)
     }
   }
 
   // MARK: - Re-record
 
+  @Test
   func testOnReRecordTappedResetsToIdleState() async {
     let model = makeModel()
     model.recordingPhase = .review
@@ -180,40 +185,44 @@ final class RecordIntroPageTests: XCTestCase {
 
     await model.onReRecordTapped()
 
-    XCTAssertEqual(model.recordingPhase, .idle)
-    XCTAssertNil(model.recordingURL)
-    XCTAssertEqual(model.recordingDuration, 0)
-    XCTAssertEqual(model.playbackPosition, 0)
-    XCTAssertFalse(model.isPlaying)
+    #expect(model.recordingPhase == .idle)
+    #expect(model.recordingURL == nil)
+    #expect(model.recordingDuration == 0)
+    #expect(model.playbackPosition == 0)
+    #expect(!model.isPlaying)
   }
 
   // MARK: - Discard
 
+  @Test
   func testOnDiscardTappedShowsConfirmationAlert() {
     let model = makeModel()
     model.recordingPhase = .review
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
 
     model.onDiscardTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Discard Recording?")
   }
 
+  @Test
   func testConfirmDiscardDismissesSheet() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let model = makeModel()
     coordinator.presentedSheet = .recordIntroPage(model)
 
     await model.confirmDiscard()
 
-    XCTAssertNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet == nil)
   }
 
   // MARK: - Accept Recording (Upload)
 
+  @Test
   func testOnAcceptRecordingTappedStartsUpload() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let uploadCalled = LockIsolated(false)
@@ -233,56 +242,59 @@ final class RecordIntroPageTests: XCTestCase {
 
         await model.onAcceptRecordingTapped()
 
-        XCTAssertNotNil(model.uploadStatus)
-        XCTAssertTrue(uploadCalled.value)
+        #expect(model.uploadStatus != nil)
+        #expect(uploadCalled.value)
       }
     }
   }
 
+  @Test
   func testOnAcceptRecordingTappedDoesNothingWithoutURL() async {
     let model = makeModel()
     model.recordingURL = nil
 
     await model.onAcceptRecordingTapped()
 
-    XCTAssertNil(model.uploadStatus)
+    #expect(model.uploadStatus == nil)
   }
 
+  @Test
   func testUploadStatusTransitionsReflectedInProperties() {
     let model = makeModel()
 
-    XCTAssertFalse(model.isUploading)
-    XCTAssertFalse(model.shouldShowUploadStatus)
-    XCTAssertFalse(model.shouldShowRetryButton)
-    XCTAssertNil(model.uploadProgress)
+    #expect(!model.isUploading)
+    #expect(!model.shouldShowUploadStatus)
+    #expect(!model.shouldShowRetryButton)
+    #expect(model.uploadProgress == nil)
 
     model.uploadStatus = .converting
-    XCTAssertTrue(model.isUploading)
-    XCTAssertTrue(model.shouldShowUploadStatus)
-    XCTAssertEqual(model.uploadStatusLabel, "Converting...")
-    XCTAssertNil(model.uploadProgress)
+    #expect(model.isUploading)
+    #expect(model.shouldShowUploadStatus)
+    #expect(model.uploadStatusLabel == "Converting...")
+    #expect(model.uploadProgress == nil)
 
     model.uploadStatus = .uploading(progress: 0.5)
-    XCTAssertTrue(model.isUploading)
-    XCTAssertEqual(model.uploadStatusLabel, "Uploading...")
-    XCTAssertEqual(model.uploadProgress, 0.5)
+    #expect(model.isUploading)
+    #expect(model.uploadStatusLabel == "Uploading...")
+    #expect(model.uploadProgress == 0.5)
 
     model.uploadStatus = .registering
-    XCTAssertTrue(model.isUploading)
-    XCTAssertEqual(model.uploadStatusLabel, "Registering...")
-    XCTAssertNil(model.uploadProgress)
+    #expect(model.isUploading)
+    #expect(model.uploadStatusLabel == "Registering...")
+    #expect(model.uploadProgress == nil)
 
     model.uploadStatus = .completed
-    XCTAssertFalse(model.isUploading)
-    XCTAssertTrue(model.shouldShowUploadStatus)
-    XCTAssertEqual(model.uploadStatusLabel, "Upload Complete!")
+    #expect(!model.isUploading)
+    #expect(model.shouldShowUploadStatus)
+    #expect(model.uploadStatusLabel == "Upload Complete!")
 
     model.uploadStatus = .failed("Network error")
-    XCTAssertFalse(model.isUploading)
-    XCTAssertTrue(model.shouldShowRetryButton)
-    XCTAssertEqual(model.uploadStatusLabel, "Upload Failed")
+    #expect(!model.isUploading)
+    #expect(model.shouldShowRetryButton)
+    #expect(model.uploadStatusLabel == "Upload Failed")
   }
 
+  @Test
   func testOnRetryTappedRestartsUpload() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let uploadCallCount = LockIsolated(0)
@@ -302,11 +314,12 @@ final class RecordIntroPageTests: XCTestCase {
 
         await model.onRetryTapped()
 
-        XCTAssertEqual(uploadCallCount.value, 1)
+        #expect(uploadCallCount.value == 1)
       }
     }
   }
 
+  @Test
   func testUploadSuccessCallsOnUploadCompleted() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let completedCalled = LockIsolated(false)
@@ -327,8 +340,8 @@ final class RecordIntroPageTests: XCTestCase {
 
         await model.onAcceptRecordingTapped()
 
-        XCTAssertTrue(completedCalled.value)
-        XCTAssertEqual(model.uploadStatus, .completed)
+        #expect(completedCalled.value)
+        #expect(model.uploadStatus == .completed)
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
@@ -7,22 +7,18 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class RecordPageTests: XCTestCase {
-  override func setUp() {
-    super.setUp()
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
-    coordinator.presentedSheet = nil
-  }
-
+struct RecordPageTests {
   // MARK: - Lifecycle
 
-  func testViewAppeared_PreparesForRecording() async {
+  @Test
+  func testViewAppearedPreparesForRecording() async {
     let prepareCalled = LockIsolated(false)
 
     await withDependencies {
@@ -34,40 +30,44 @@ final class RecordPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertTrue(prepareCalled.value)
+      #expect(prepareCalled.value)
     }
   }
 
   // MARK: - Done Button
 
-  func testShouldShowDoneButton_TrueOnlyInIdlePhase() {
+  @Test
+  func testShouldShowDoneButtonTrueOnlyInIdlePhase() {
     let model = RecordPageModel()
 
     model.recordingPhase = .idle
-    XCTAssertTrue(model.shouldShowDoneButton)
+    #expect(model.shouldShowDoneButton)
 
     model.recordingPhase = .recording
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
 
     model.recordingPhase = .review
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
   }
 
-  func testOnDoneTapped_DismissesSheet() {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+  @Test
+  func testOnDoneTappedDismissesSheet() {
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let model = RecordPageModel()
     coordinator.presentedSheet = .recordPage(model)
 
-    XCTAssertNotNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet != nil)
 
     model.onDoneTapped()
 
-    XCTAssertNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet == nil)
   }
 
   // MARK: - Recording
 
+  @Test
   func testOnRecordTappedRequestsPermissionBeforeRecording() async {
     let requestPermissionCalled = LockIsolated(false)
     let startRecordingCalled = LockIsolated(false)
@@ -78,22 +78,23 @@ final class RecordPageTests: XCTestCase {
         return true
       }
       $0.audioRecorder.startRecording = {
-        XCTAssertTrue(
+        #expect(
           requestPermissionCalled.value, "Permission should be requested before recording starts")
         startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = RecordPageModel()
-      XCTAssertEqual(model.recordingPhase, .idle)
+      #expect(model.recordingPhase == .idle)
 
       await model.onRecordTapped()
 
-      XCTAssertTrue(requestPermissionCalled.value)
-      XCTAssertTrue(startRecordingCalled.value)
-      XCTAssertEqual(model.recordingPhase, .recording)
+      #expect(requestPermissionCalled.value)
+      #expect(startRecordingCalled.value)
+      #expect(model.recordingPhase == .recording)
     }
   }
 
+  @Test
   func testOnRecordTappedDoesNotRecordWhenPermissionDenied() async {
     let startRecordingCalled = LockIsolated(false)
 
@@ -107,15 +108,16 @@ final class RecordPageTests: XCTestCase {
 
       await model.onRecordTapped()
 
-      XCTAssertFalse(
-        startRecordingCalled.value, "Recording should not start when permission is denied")
-      XCTAssertEqual(model.recordingPhase, .idle)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Microphone Access Required")
+      #expect(
+        !startRecordingCalled.value, "Recording should not start when permission is denied")
+      #expect(model.recordingPhase == .idle)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Microphone Access Required")
     }
   }
 
-  func testOnRecordTapped_ShowsAlertOnError() async {
+  @Test
+  func testOnRecordTappedShowsAlertOnError() async {
     await withDependencies {
       $0.audioRecorder.requestPermission = { true }
       $0.audioRecorder.startRecording = {
@@ -126,13 +128,14 @@ final class RecordPageTests: XCTestCase {
 
       await model.onRecordTapped()
 
-      XCTAssertEqual(model.recordingPhase, .idle)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Recording Error")
+      #expect(model.recordingPhase == .idle)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Recording Error")
     }
   }
 
-  func testOnStopTapped_StopsRecordingAndChangesPhase() async {
+  @Test
+  func testOnStopTappedStopsRecordingAndChangesPhase() async {
     let expectedURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
 
     await withDependencies {
@@ -146,13 +149,14 @@ final class RecordPageTests: XCTestCase {
 
       await model.onStopTapped()
 
-      XCTAssertEqual(model.recordingPhase, .review)
-      XCTAssertEqual(model.recordingURL, expectedURL)
-      XCTAssertEqual(model.recordingDuration, 5.0)
+      #expect(model.recordingPhase == .review)
+      #expect(model.recordingURL == expectedURL)
+      #expect(model.recordingDuration == 5.0)
     }
   }
 
-  func testOnStopTapped_ShowsAlertOnError() async {
+  @Test
+  func testOnStopTappedShowsAlertOnError() async {
     await withDependencies {
       $0.audioRecorder.currentTime = { 0 }
       $0.audioRecorder.stopRecording = {
@@ -164,13 +168,14 @@ final class RecordPageTests: XCTestCase {
 
       await model.onStopTapped()
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Recording Error")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Recording Error")
     }
   }
 
   // MARK: - Re-record
 
+  @Test
   func testOnReRecordTappedResetsToIdleState() async {
     let model = RecordPageModel()
     model.recordingPhase = .review
@@ -181,42 +186,47 @@ final class RecordPageTests: XCTestCase {
 
     await model.onReRecordTapped()
 
-    XCTAssertEqual(model.recordingPhase, .idle)
-    XCTAssertNil(model.recordingURL)
-    XCTAssertEqual(model.recordingDuration, 0)
-    XCTAssertEqual(model.playbackPosition, 0)
-    XCTAssertFalse(model.isPlaying)
+    #expect(model.recordingPhase == .idle)
+    #expect(model.recordingURL == nil)
+    #expect(model.recordingDuration == 0)
+    #expect(model.playbackPosition == 0)
+    #expect(!model.isPlaying)
   }
 
   // MARK: - Discard
 
-  func testOnDiscardTapped_ShowsConfirmationAlert() {
+  @Test
+  func testOnDiscardTappedShowsConfirmationAlert() {
     let model = RecordPageModel()
     model.recordingPhase = .review
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
 
     model.onDiscardTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Discard Recording?")
   }
 
+  @Test
   func testConfirmDiscardDismissesSheet() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let model = RecordPageModel()
     coordinator.presentedSheet = .recordPage(model)
 
     await model.confirmDiscard()
 
-    XCTAssertNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet == nil)
   }
 
   // MARK: - Accept Recording
 
+  @Test
   func testOnAcceptRecordingTappedCallsCallbackAndDismisses() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let expectedURL = URL(fileURLWithPath: "/tmp/test.wav")
     let receivedURL = LockIsolated<URL?>(nil)
@@ -230,12 +240,14 @@ final class RecordPageTests: XCTestCase {
 
     await model.onAcceptRecordingTapped()
 
-    XCTAssertNil(coordinator.presentedSheet)
-    XCTAssertEqual(receivedURL.value, expectedURL)
+    #expect(coordinator.presentedSheet == nil)
+    #expect(receivedURL.value == expectedURL)
   }
 
+  @Test
   func testOnAcceptRecordingTappedDoesNothingWithoutURL() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let callbackCalled = LockIsolated(false)
 
@@ -248,12 +260,13 @@ final class RecordPageTests: XCTestCase {
 
     await model.onAcceptRecordingTapped()
 
-    XCTAssertFalse(callbackCalled.value)
-    XCTAssertNotNil(coordinator.presentedSheet)
+    #expect(!callbackCalled.value)
+    #expect(coordinator.presentedSheet != nil)
   }
 
   // MARK: - Playback
 
+  @Test
   func testOnPlayPauseTappedPlaysWhenNotPlaying() async {
     let playCalled = LockIsolated(false)
 
@@ -267,11 +280,12 @@ final class RecordPageTests: XCTestCase {
 
       await model.onPlayPauseTapped()
 
-      XCTAssertTrue(playCalled.value)
-      XCTAssertTrue(model.isPlaying)
+      #expect(playCalled.value)
+      #expect(model.isPlaying)
     }
   }
 
+  @Test
   func testOnPlayPauseTappedPausesWhenPlaying() async {
     let pauseCalled = LockIsolated(false)
 
@@ -283,11 +297,12 @@ final class RecordPageTests: XCTestCase {
 
       await model.onPlayPauseTapped()
 
-      XCTAssertTrue(pauseCalled.value)
-      XCTAssertFalse(model.isPlaying)
+      #expect(pauseCalled.value)
+      #expect(!model.isPlaying)
     }
   }
 
+  @Test
   func testOnRewindTappedSeeksToZero() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
@@ -299,11 +314,12 @@ final class RecordPageTests: XCTestCase {
 
       await model.onRewindTapped()
 
-      XCTAssertEqual(seekTime.value, 0)
-      XCTAssertEqual(model.playbackPosition, 0)
+      #expect(seekTime.value == 0)
+      #expect(model.playbackPosition == 0)
     }
   }
 
+  @Test
   func testSeekToUpdatesPlaybackPosition() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
@@ -315,8 +331,8 @@ final class RecordPageTests: XCTestCase {
 
       await model.seekTo(30.0)
 
-      XCTAssertEqual(seekTime.value, 30.0)
-      XCTAssertEqual(model.playbackPosition, 30.0)
+      #expect(seekTime.value == 30.0)
+      #expect(model.playbackPosition == 30.0)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/RewardsPage/RedeemPrizeSheetTests.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RedeemPrizeSheetTests.swift
@@ -3,16 +3,18 @@
 //  PlayolaRadio
 //
 
+import ConcurrencyExtras
 import Dependencies
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class RedeemPrizeSheetModelTests: XCTestCase {
+struct RedeemPrizeSheetModelTests {
 
+  @Test
   func testInitPreFillsVerifiedEmail() {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
@@ -21,10 +23,11 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
-    XCTAssertEqual(model.emailAddress, "test@example.com")
-    XCTAssertTrue(model.hasVerifiedEmail)
+    #expect(model.emailAddress == "test@example.com")
+    #expect(model.hasVerifiedEmail)
   }
 
+  @Test
   func testInitUsesUnverifiedEmailWhenNoVerifiedEmail() {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
@@ -32,33 +35,36 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
-    XCTAssertEqual(model.emailAddress, "apple@privaterelay.com")
-    XCTAssertFalse(model.hasVerifiedEmail)
+    #expect(model.emailAddress == "apple@privaterelay.com")
+    #expect(!model.hasVerifiedEmail)
   }
 
+  @Test
   func testInitLeavesEmailEmptyWhenNoAuth() {
     @Shared(.auth) var auth = Auth()
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
-    XCTAssertEqual(model.emailAddress, "")
+    #expect(model.emailAddress == "")
   }
 
+  @Test
   func testCanSubmitRequiresOptionAndEmail() {
     @Shared(.auth) var auth = Auth()
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
-    XCTAssertFalse(model.canSubmit)
+    #expect(!model.canSubmit)
 
     let option = model.redeemOptions[0]
     model.optionTapped(option)
-    XCTAssertFalse(model.canSubmit)
+    #expect(!model.canSubmit)
 
     model.emailAddress = "test@example.com"
-    XCTAssertTrue(model.canSubmit)
+    #expect(model.canSubmit)
   }
 
+  @Test
   func testOptionTappedSelectsOption() {
     @Shared(.auth) var auth = Auth()
 
@@ -67,26 +73,29 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     model.optionTapped(option)
 
-    XCTAssertEqual(model.selectedOption, option)
-    XCTAssertTrue(model.isSelected(option))
+    #expect(model.selectedOption == option)
+    #expect(model.isSelected(option))
   }
 
+  @Test
   func testRedeemOptionsIncludesRegularPrizes() {
     @Shared(.auth) var auth = Auth()
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
     let options = model.redeemOptions
-    XCTAssertFalse(options.isEmpty)
-    XCTAssertTrue(options.allSatisfy { $0.stationId == nil })
+    #expect(!options.isEmpty)
+    #expect(options.allSatisfy { $0.stationId == nil })
   }
 
+  @Test
   func testSubmitWithVerifiedEmailSkipsUpdateUser() async {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
         id: "user-1", firstName: "Test", email: "test@example.com",
         verifiedEmail: "test@example.com"))
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
+      MainContainerNavigationCoordinator()
 
     let mockUserPrize = UserPrize(id: "up-1", userId: "user-1", prizeId: "p-1")
     let updateUserCalled = LockIsolated(false)
@@ -112,16 +121,18 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     await model.submitButtonTapped()
 
-    XCTAssertFalse(updateUserCalled.value)
-    XCTAssertTrue(successCalled.value)
-    XCTAssertFalse(model.isSubmitting)
+    #expect(!updateUserCalled.value)
+    #expect(successCalled.value)
+    #expect(!model.isSubmitting)
   }
 
+  @Test
   func testSubmitWithoutVerifiedEmailCallsUpdateUser() async {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
         id: "user-1", firstName: "Test", email: "apple@privaterelay.com"))
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
+      MainContainerNavigationCoordinator()
 
     let mockUserPrize = UserPrize(id: "up-1", userId: "user-1", prizeId: "p-1")
     let capturedVerifiedEmail = LockIsolated<String?>(nil)
@@ -151,11 +162,12 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     await model.submitButtonTapped()
 
-    XCTAssertEqual(capturedVerifiedEmail.value, "real@email.com")
-    XCTAssertTrue(successCalled.value)
-    XCTAssertFalse(model.isSubmitting)
+    #expect(capturedVerifiedEmail.value == "real@email.com")
+    #expect(successCalled.value)
+    #expect(!model.isSubmitting)
   }
 
+  @Test
   func testSubmitShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
@@ -174,7 +186,7 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     await model.submitButtonTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertFalse(model.isSubmitting)
+    #expect(model.presentedAlert != nil)
+    #expect(!model.isSubmitting)
   }
 }

--- a/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageTests.swift
@@ -6,17 +6,18 @@
 //
 
 import Combine
+import ConcurrencyExtras
 import Dependencies
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 // swiftlint:disable redundant_optional_initialization
 
 @MainActor
-final class RewardsPageModelTests: XCTestCase {
+struct RewardsPageModelTests {
   func createMockListeningTracker(totalTimeMS: Int) -> ListeningTracker {
     let rewardsProfile = RewardsProfile(
       totalTimeListenedMS: totalTimeMS,
@@ -28,7 +29,8 @@ final class RewardsPageModelTests: XCTestCase {
 
   // MARK: - Prize Tiers Loading Tests
 
-  func testOnViewAppeared_LoadsPrizeTiers() async {
+  @Test
+  func testOnViewAppearedLoadsPrizeTiers() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(totalTimeMS: 0)
     let mockPrizeTiers = PrizeTier.mocks
 
@@ -40,20 +42,20 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertEqual(model.prizeTiers.count, 3)  // Based on our mock data
+    #expect(model.prizeTiers.count == 3)
 
-    // Verify we have the expected tiers
     let tierNames = model.prizeTiers.map { $0.name }
-    XCTAssertTrue(tierNames.contains("Koozie"))
-    XCTAssertTrue(tierNames.contains("T-Shirt"))
-    XCTAssertTrue(tierNames.contains("Show Tix"))
+    #expect(tierNames.contains("Koozie"))
+    #expect(tierNames.contains("T-Shirt"))
+    #expect(tierNames.contains("Show Tix"))
   }
 
   // MARK: - Analytics Tests
 
-  func testOnViewAppeared_TracksRewardsScreenAnalytics() async {
+  @Test
+  func testOnViewAppearedTracksRewardsScreenAnalytics() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 54_000_000)  // 15 hours
+      totalTimeMS: 54_000_000)
     let mockPrizeTiers = PrizeTier.mocks
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
@@ -68,20 +70,21 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .viewedRewardsScreen(let currentHours) = events.first {
-      XCTAssertEqual(currentHours, 15.0, accuracy: 0.1)
+      #expect(abs(currentHours - 15.0) < 0.1)
     } else {
-      XCTFail("Expected viewedRewardsScreen event, got: \(String(describing: events.first))")
+      Issue.record("Expected viewedRewardsScreen event, got: \(String(describing: events.first))")
     }
   }
 
-  func testRedeemPrize_TracksRedeemAnalytics() async {
+  @Test
+  func testRedeemPrizeTracksRedeemAnalytics() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 108_000_000)  // 30 hours
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      totalTimeMS: 108_000_000)
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
+      MainContainerNavigationCoordinator()
     let mockPrizeTiers = PrizeTier.mocks
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
@@ -94,22 +97,23 @@ final class RewardsPageModelTests: XCTestCase {
       RewardsPageModel()
     }
 
-    await model.redeemPrizeTapped(for: mockPrizeTiers[0])  // Redeem Koozie
+    await model.redeemPrizeTapped(for: mockPrizeTiers[0])
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .tappedRedeemRewards(let currentHours) = events.first {
-      XCTAssertEqual(currentHours, 30.0, accuracy: 0.1)
+      #expect(abs(currentHours - 30.0) < 0.1)
     } else {
-      XCTFail("Expected tappedRedeemRewards event, got: \(String(describing: events.first))")
+      Issue.record("Expected tappedRedeemRewards event, got: \(String(describing: events.first))")
     }
   }
 
-  func testRedeemPrizeTapped_PresentsRedeemSheet() async {
+  @Test
+  func testRedeemPrizeTappedPresentsRedeemSheet() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
       totalTimeMS: 108_000_000)
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
+      MainContainerNavigationCoordinator()
     let mockPrizeTiers = PrizeTier.mocks
 
     let model = withDependencies {
@@ -121,14 +125,15 @@ final class RewardsPageModelTests: XCTestCase {
     await model.redeemPrizeTapped(for: mockPrizeTiers[0])
 
     if case .redeemPrize(let sheetModel) = navCoordinator.presentedSheet {
-      XCTAssertEqual(sheetModel.prizeTier.id, mockPrizeTiers[0].id)
+      #expect(sheetModel.prizeTier.id == mockPrizeTiers[0].id)
     } else {
-      XCTFail(
+      Issue.record(
         "Expected redeemPrize sheet, got \(String(describing: navCoordinator.presentedSheet))")
     }
   }
 
-  func testLoadUserPrizes_PopulatesRedeemedTierIds() async {
+  @Test
+  func testLoadUserPrizesPopulatesRedeemedTierIds() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(totalTimeMS: 0)
     @Shared(.auth) var auth = Auth(jwt: "test-token")
     let mockPrizeTiers = PrizeTier.mocks
@@ -147,14 +152,15 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertTrue(model.redeemedPrizeTierIds.contains(mockPrizeTiers[0].id))
+    #expect(model.redeemedPrizeTierIds.contains(mockPrizeTiers[0].id))
   }
 
   // MARK: - Redemption Status Tests
 
-  func testRedemptionStatus_Redeemed() async {
+  @Test
+  func testRedemptionStatusRedeemed() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 50 * 60 * 60 * 1000)  // 50 hours
+      totalTimeMS: 50 * 60 * 60 * 1000)
     let mockPrizeTiers = PrizeTier.mocks
 
     let model = withDependencies {
@@ -165,7 +171,6 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // Simulate the user has redeemed the first tier (Koozie - 10 hours)
     let koozieId = mockPrizeTiers[0].id
     model.redeemedPrizeTierIds.insert(koozieId)
 
@@ -174,13 +179,14 @@ final class RewardsPageModelTests: XCTestCase {
     if case .redeemed = status {
       // Test passes
     } else {
-      XCTFail("Expected redeemed status, got \(status)")
+      Issue.record("Expected redeemed status, got \(status)")
     }
   }
 
-  func testRedemptionStatus_Redeemable() async {
+  @Test
+  func testRedemptionStatusRedeemable() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 35 * 60 * 60 * 1000)  // 35 hours
+      totalTimeMS: 35 * 60 * 60 * 1000)
     let mockPrizeTiers = PrizeTier.mocks
 
     let model = withDependencies {
@@ -191,20 +197,20 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // User has 35 hours, T-Shirt requires 30 hours - should be redeemable
-    let tshirtTier = mockPrizeTiers[1]  // T-Shirt tier
+    let tshirtTier = mockPrizeTiers[1]
     let status = model.redemptionStatus(for: tshirtTier)
 
     if case .redeemable = status {
       // Test passes
     } else {
-      XCTFail("Expected redeemable status, got \(status)")
+      Issue.record("Expected redeemable status, got \(status)")
     }
   }
 
-  func testRedemptionStatus_MoreTimeRequired() async {
+  @Test
+  func testRedemptionStatusMoreTimeRequired() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 25 * 60 * 60 * 1000)  // 25 hours
+      totalTimeMS: 25 * 60 * 60 * 1000)
     let mockPrizeTiers = PrizeTier.mocks
 
     let model = withDependencies {
@@ -215,18 +221,18 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // User has 25 hours, Show Tix requires 70 hours - should need 45 more hours
-    let showTixTier = mockPrizeTiers[2]  // Show Tix tier (70 hours required)
+    let showTixTier = mockPrizeTiers[2]
     let status = model.redemptionStatus(for: showTixTier)
 
     if case .moreTimeRequired(let hoursToGo) = status {
-      XCTAssertEqual(hoursToGo, 45, "Expected 45 hours to go, got \(hoursToGo)")
+      #expect(hoursToGo == 45, "Expected 45 hours to go, got \(hoursToGo)")
     } else {
-      XCTFail("Expected moreTimeRequired status, got \(status)")
+      Issue.record("Expected moreTimeRequired status, got \(status)")
     }
   }
 
-  func testRedemptionStatus_ZeroListeningTime() async {
+  @Test
+  func testRedemptionStatusZeroListeningTime() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(totalTimeMS: 0)
     let mockPrizeTiers = PrizeTier.mocks
 
@@ -238,18 +244,18 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // User has 0 hours, Koozie requires 10 hours - should need 10 more hours
-    let koozieIdTier = mockPrizeTiers[0]  // Koozie tier (10 hours required)
+    let koozieIdTier = mockPrizeTiers[0]
     let status = model.redemptionStatus(for: koozieIdTier)
 
     if case .moreTimeRequired(let hoursToGo) = status {
-      XCTAssertEqual(hoursToGo, 10, "Expected 10 hours to go, got \(hoursToGo)")
+      #expect(hoursToGo == 10, "Expected 10 hours to go, got \(hoursToGo)")
     } else {
-      XCTFail("Expected moreTimeRequired status, got \(status)")
+      Issue.record("Expected moreTimeRequired status, got \(status)")
     }
   }
 
-  func testRedemptionStatus_NilListeningTracker() async {
+  @Test
+  func testRedemptionStatusNilListeningTracker() async {
     @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let mockPrizeTiers = PrizeTier.mocks
 
@@ -261,17 +267,15 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // With nil listening tracker, should default to 0 hours and need full requirement
-    let koozieIdTier = mockPrizeTiers[0]  // Koozie tier (10 hours required)
+    let koozieIdTier = mockPrizeTiers[0]
     let status = model.redemptionStatus(for: koozieIdTier)
 
     if case .moreTimeRequired(let hoursToGo) = status {
-      XCTAssertEqual(hoursToGo, 10, "Expected 10 hours to go with nil tracker, got \(hoursToGo)")
+      #expect(hoursToGo == 10, "Expected 10 hours to go with nil tracker, got \(hoursToGo)")
     } else {
-      XCTFail("Expected moreTimeRequired status with nil tracker, got \(status)")
+      Issue.record("Expected moreTimeRequired status with nil tracker, got \(status)")
     }
   }
-
 }
 
 // swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -29,27 +29,28 @@ struct SignInPageTests {
   func testSignInWithAppleTracksSignInStartedEvent() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
-    await confirmation("Apple sign-in started event tracked") { confirm in
-      let model = withDependencies {
-        $0.analytics.track = { event in
-          capturedEvents.withValue { $0.append(event) }
-          if case .signInStarted(let method) = event, method == .apple {
-            confirm()
+    await withMainSerialExecutor {
+      await confirmation("Apple sign-in started event tracked") { confirm in
+        let model = withDependencies {
+          $0.analytics.track = { event in
+            capturedEvents.withValue { $0.append(event) }
+            if case .signInStarted(let method) = event, method == .apple {
+              confirm()
+            }
           }
+        } operation: {
+          SignInPageModel()
         }
-      } operation: {
-        SignInPageModel()
-      }
 
-      let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
-      model.signInWithAppleButtonTapped(request: request)
+        let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
+        model.signInWithAppleButtonTapped(request: request)
 
-      // Yield to let the spawned Task run the analytics callback.
-      while !capturedEvents.value.contains(where: {
-        if case .signInStarted(let method) = $0 { return method == .apple }
-        return false
-      }) {
-        await Task.yield()
+        while !capturedEvents.value.contains(where: {
+          if case .signInStarted(let method) = $0 { return method == .apple }
+          return false
+        }) {
+          await Task.yield()
+        }
       }
     }
 

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -7,40 +7,51 @@
 
 import Alamofire
 import AuthenticationServices
+import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SignInPageTests: XCTestCase {
-  func testSignInWithApple_CorrectlyAddsScopeToTheAppleSignInRequest() async {
+struct SignInPageTests {
+  @Test
+  func testSignInWithAppleCorrectlyAddsScopeToTheAppleSignInRequest() async {
     let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
     let model = SignInPageModel()
     model.signInWithAppleButtonTapped(request: request)
-    XCTAssertEqual(request.requestedScopes, [.email, .fullName])
+    #expect(request.requestedScopes == [.email, .fullName])
   }
 
-  func testSignInWithApple_TracksSignInStartedEvent() async {
+  @Test
+  func testSignInWithAppleTracksSignInStartedEvent() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-    let expectation = XCTestExpectation(description: "Analytics event tracked")
 
-    let model = withDependencies {
-      $0.analytics.track = { event in
-        capturedEvents.withValue { $0.append(event) }
-        if case .signInStarted(let method) = event, method == .apple {
-          expectation.fulfill()
+    await confirmation("Apple sign-in started event tracked") { confirm in
+      let model = withDependencies {
+        $0.analytics.track = { event in
+          capturedEvents.withValue { $0.append(event) }
+          if case .signInStarted(let method) = event, method == .apple {
+            confirm()
+          }
         }
+      } operation: {
+        SignInPageModel()
       }
-    } operation: {
-      SignInPageModel()
+
+      let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
+      model.signInWithAppleButtonTapped(request: request)
+
+      // Yield to let the spawned Task run the analytics callback.
+      while !capturedEvents.value.contains(where: {
+        if case .signInStarted(let method) = $0 { return method == .apple }
+        return false
+      }) {
+        await Task.yield()
+      }
     }
-
-    let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
-    model.signInWithAppleButtonTapped(request: request)
-
-    await fulfillment(of: [expectation], timeout: 1.0)
 
     let hasSignInStartedEvent = capturedEvents.value.contains { event in
       if case .signInStarted(let method) = event {
@@ -49,10 +60,11 @@ final class SignInPageTests: XCTestCase {
       return false
     }
 
-    XCTAssertTrue(hasSignInStartedEvent, "Should track signInStarted event for Apple")
+    #expect(hasSignInStartedEvent, "Should track signInStarted event for Apple")
   }
 
-  func testSignInWithGoogle_TracksSignInStartedEvent() async {
+  @Test
+  func testSignInWithGoogleTracksSignInStartedEvent() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
     let model = withDependencies {
@@ -75,11 +87,12 @@ final class SignInPageTests: XCTestCase {
       return false
     }
 
-    XCTAssertTrue(hasSignInStartedEvent, "Should track signInStarted event for Google")
+    #expect(hasSignInStartedEvent, "Should track signInStarted event for Google")
   }
 
   // MARK: - signInWithAppleCompleted() Error Reporting Tests
 
+  @Test
   func testSignInWithAppleCompletedReportsErrorOnAuthorizationFailure() async {
     let reportedErrors = LockIsolated<[(Error, [String: String])]>([])
 
@@ -94,11 +107,12 @@ final class SignInPageTests: XCTestCase {
     let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
     await model.signInWithAppleCompleted(result: .failure(genericError))
 
-    XCTAssertEqual(reportedErrors.value.count, 1, "Should call reportError exactly once")
+    #expect(reportedErrors.value.count == 1, "Should call reportError exactly once")
     let tags = reportedErrors.value.first?.1 ?? [:]
-    XCTAssertEqual(tags["auth_method"], "apple")
+    #expect(tags["auth_method"] == "apple")
   }
 
+  @Test
   func testSignInWithAppleCompletedDoesNotReportErrorOnUserCancel() async {
     let reportedErrors = LockIsolated<[(Error, [String: String])]>([])
 
@@ -113,13 +127,14 @@ final class SignInPageTests: XCTestCase {
     let cancelError = ASAuthorizationError(.canceled)
     await model.signInWithAppleCompleted(result: .failure(cancelError))
 
-    XCTAssertTrue(
+    #expect(
       reportedErrors.value.isEmpty,
       "Should not report ASAuthorizationError.canceled (user cancellations are not bugs)")
   }
 
   // MARK: - presentedAlert Tests
 
+  @Test
   func testSignInWithAppleCompletedPresentsAlertOnAuthorizationFailure() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -130,9 +145,10 @@ final class SignInPageTests: XCTestCase {
     let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
     await model.signInWithAppleCompleted(result: .failure(genericError))
 
-    XCTAssertEqual(model.presentedAlert, .signInError)
+    #expect(model.presentedAlert == .signInError)
   }
 
+  @Test
   func testSignInWithAppleCompletedDoesNotPresentAlertOnUserCancel() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -143,9 +159,10 @@ final class SignInPageTests: XCTestCase {
     let cancelError = ASAuthorizationError(.canceled)
     await model.signInWithAppleCompleted(result: .failure(cancelError))
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testSignInWithGooglePresentsAlertWhenNoKeyWindow() async {
     let model = withDependencies {
       $0.errorReporting.reportMessage = { _, _ in }
@@ -157,11 +174,12 @@ final class SignInPageTests: XCTestCase {
 
     await model.signInWithGoogleButtonTapped()
 
-    XCTAssertEqual(model.presentedAlert, .signInError)
+    #expect(model.presentedAlert == .signInError)
   }
 
   // MARK: - handleSignInAPIFailure Routing Tests
 
+  @Test
   func testHandleSignInAPIFailureShowsNetworkAlertOnAppleSSLError() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -175,10 +193,11 @@ final class SignInPageTests: XCTestCase {
 
     await model.handleSignInAPIFailure(afError, authMethod: .apple, step: "api_call")
 
-    XCTAssertEqual(model.presentedAlert, .signInNetworkError)
-    XCTAssertNotEqual(model.presentedAlert, .signInError)
+    #expect(model.presentedAlert == .signInNetworkError)
+    #expect(model.presentedAlert != .signInError)
   }
 
+  @Test
   func testHandleSignInAPIFailureShowsGenericAlertOnAppleUnknownError() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -191,10 +210,11 @@ final class SignInPageTests: XCTestCase {
 
     await model.handleSignInAPIFailure(genericError, authMethod: .apple, step: "api_call")
 
-    XCTAssertEqual(model.presentedAlert, .signInError)
-    XCTAssertEqual(model.presentedAlert?.title, "Sign-In Failed")
+    #expect(model.presentedAlert == .signInError)
+    #expect(model.presentedAlert?.title == "Sign-In Failed")
   }
 
+  @Test
   func testHandleSignInAPIFailureShowsNetworkAlertOnGoogleSSLError() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -208,9 +228,10 @@ final class SignInPageTests: XCTestCase {
 
     await model.handleSignInAPIFailure(afError, authMethod: .google, step: "google_sign_in_flow")
 
-    XCTAssertEqual(model.presentedAlert, .signInNetworkError)
+    #expect(model.presentedAlert == .signInNetworkError)
   }
 
+  @Test
   func testHandleSignInAPIFailureShowsGenericAlertOnGoogleUnknownError() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -224,12 +245,13 @@ final class SignInPageTests: XCTestCase {
     await model.handleSignInAPIFailure(
       genericError, authMethod: .google, step: "google_sign_in_flow")
 
-    XCTAssertEqual(model.presentedAlert, .signInError)
-    XCTAssertEqual(model.presentedAlert?.title, "Sign-In Failed")
+    #expect(model.presentedAlert == .signInError)
+    #expect(model.presentedAlert?.title == "Sign-In Failed")
   }
 
   // MARK: - Sign-in Error Reporting Context Tests
 
+  @Test
   func testSignInErrorReportIncludesNSErrorDomainAndCode() {
     let error = NSError(domain: "com.google.GIDSignIn", code: -4)
 
@@ -238,56 +260,63 @@ final class SignInPageTests: XCTestCase {
       authMethod: .google,
       step: "google_sign_in_flow")
 
-    XCTAssertEqual(report.tags["auth_method"], "google")
-    XCTAssertEqual(report.tags["sign_in_step"], "google_sign_in_flow")
-    XCTAssertEqual(report.tags["error_domain"], "com.google.GIDSignIn")
-    XCTAssertEqual(report.tags["error_code"], "-4")
-    XCTAssertEqual(report.contextKey, "sign_in")
+    #expect(report.tags["auth_method"] == "google")
+    #expect(report.tags["sign_in_step"] == "google_sign_in_flow")
+    #expect(report.tags["error_domain"] == "com.google.GIDSignIn")
+    #expect(report.tags["error_code"] == "-4")
+    #expect(report.contextKey == "sign_in")
   }
 
   // MARK: - SignInNetworkErrorClassifier Tests
 
+  @Test
   func testClassifierMatchesSecureConnectionFailed() {
     let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
-    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(error))
-    XCTAssertTrue(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
+    #expect(SignInNetworkErrorClassifier.isNetworkError(error))
+    #expect(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
   }
 
+  @Test
   func testClassifierMatchesNotConnectedToInternet() {
     let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
-    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(error))
-    XCTAssertFalse(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
+    #expect(SignInNetworkErrorClassifier.isNetworkError(error))
+    #expect(!SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
   }
 
+  @Test
   func testClassifierMatchesTimedOutCannotConnectAndConnectionLost() {
     for code in [
       NSURLErrorTimedOut, NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost,
     ] {
       let error = NSError(domain: NSURLErrorDomain, code: code)
-      XCTAssertTrue(
+      #expect(
         SignInNetworkErrorClassifier.isNetworkError(error),
         "Expected code \(code) to classify as network error")
     }
   }
 
+  @Test
   func testClassifierRejectsUnrelatedDomain() {
     let error = NSError(domain: "com.example.other", code: NSURLErrorSecureConnectionFailed)
-    XCTAssertFalse(SignInNetworkErrorClassifier.isNetworkError(error))
-    XCTAssertFalse(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
+    #expect(!SignInNetworkErrorClassifier.isNetworkError(error))
+    #expect(!SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
   }
 
+  @Test
   func testClassifierRejectsNSURLDomainWithUnrelatedCode() {
     let error = NSError(domain: NSURLErrorDomain, code: -9999)
-    XCTAssertFalse(SignInNetworkErrorClassifier.isNetworkError(error))
+    #expect(!SignInNetworkErrorClassifier.isNetworkError(error))
   }
 
+  @Test
   func testClassifierUnwrapsAFErrorSessionTaskFailed() {
     let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
     let afError = AFError.sessionTaskFailed(error: underlying)
-    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(afError))
-    XCTAssertTrue(SignInNetworkErrorClassifier.isSecureConnectionFailed(afError))
+    #expect(SignInNetworkErrorClassifier.isNetworkError(afError))
+    #expect(SignInNetworkErrorClassifier.isSecureConnectionFailed(afError))
   }
 
+  @Test
   func testClassifierUnwrapsSignInAPIErrorWrappingAFError() {
     let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
     let afError = AFError.sessionTaskFailed(error: underlying)
@@ -297,10 +326,11 @@ final class SignInPageTests: XCTestCase {
       statusCode: nil,
       responseBody: nil,
       underlyingError: afError)
-    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(signInError))
-    XCTAssertTrue(SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
+    #expect(SignInNetworkErrorClassifier.isNetworkError(signInError))
+    #expect(SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
   }
 
+  @Test
   func testClassifierRejectsSignInAPIErrorWrappingNonNetworkError() {
     let signInError = SignInAPIError(
       authMethod: .google,
@@ -308,10 +338,11 @@ final class SignInPageTests: XCTestCase {
       statusCode: 500,
       responseBody: nil,
       underlyingError: NSError(domain: "decode", code: 7))
-    XCTAssertFalse(SignInNetworkErrorClassifier.isNetworkError(signInError))
-    XCTAssertFalse(SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
+    #expect(!SignInNetworkErrorClassifier.isNetworkError(signInError))
+    #expect(!SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
   }
 
+  @Test
   func testSignInErrorReportIncludesHTTPContextAndRedactsTokens() {
     let responseBody = #"{"playolaToken":"secret-jwt","message":"unexpected shape"}"#
     let error = SignInAPIError(
@@ -323,17 +354,17 @@ final class SignInPageTests: XCTestCase {
 
     let report = SignInErrorReport(error: error, authMethod: .apple, step: "api_call")
 
-    XCTAssertEqual(report.tags["auth_method"], "apple")
-    XCTAssertEqual(report.tags["sign_in_step"], "api_call")
-    XCTAssertEqual(report.tags["http_status_code"], "200")
-    XCTAssertEqual(report.context["endpoint_path"], "/v1/auth/apple/mobile/signup")
-    XCTAssertEqual(
-      report.context["response_body_bytes"], "\(responseBody.lengthOfBytes(using: .utf8))")
-    XCTAssertEqual(report.context["response_body_top_level_keys"], "message,playolaToken")
-    XCTAssertTrue(
+    #expect(report.tags["auth_method"] == "apple")
+    #expect(report.tags["sign_in_step"] == "api_call")
+    #expect(report.tags["http_status_code"] == "200")
+    #expect(report.context["endpoint_path"] == "/v1/auth/apple/mobile/signup")
+    #expect(
+      report.context["response_body_bytes"] == "\(responseBody.lengthOfBytes(using: .utf8))")
+    #expect(report.context["response_body_top_level_keys"] == "message,playolaToken")
+    #expect(
       report.context["response_body"]?.contains(#""playolaToken":"[REDACTED]""#) ?? false)
-    XCTAssertTrue(
+    #expect(
       report.context["response_body"]?.contains(#""message":"unexpected shape""#) ?? false)
-    XCTAssertFalse(report.context["response_body"]?.contains("secret-jwt") ?? true)
+    #expect(!(report.context["response_body"]?.contains("secret-jwt") ?? true))
   }
 }


### PR DESCRIPTION
## Summary

Converts 10 page-level test suites from XCTest to swift-testing, following the same patterns established in #278. No test logic, mocks, or values were changed — only the framework wiring.

Files converted:
- SignInPageTests, EditProfilePageTests, NotificationsSettingsPageTests
- RecordIntroPageTests, RecordPageTests
- RewardsPageTests (RewardsPageModelTests), RedeemPrizeSheetTests (RedeemPrizeSheetModelTests)
- AskQuestionPageTests
- BroadcastPageTests, BroadcastersListenerQuestionPageTests

`XCTestExpectation` callsites that waited on Task-spawned analytics callbacks were ported to `confirmation { ... }`. Underscored test names were normalized to project camelCase convention. Class-level `setUp()` shared-state resets were moved into per-test `@Shared` declarations.

## Test plan

- [x] All 227 tests in 10 suites pass via `xcodebuild test`