### PR TITLE
Inject Date and UUID dependencies in Core services

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		D35EFC562F1AFF76000F64A4 /* AppRatingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC542F1AFF76000F64A4 /* AppRatingClient.swift */; };
 		D35EFC572F1AFF76000F64A4 /* AppRatingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC542F1AFF76000F64A4 /* AppRatingClient.swift */; };
 		D35EFC592F1B0472000F64A4 /* AppRatingClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC582F1B0472000F64A4 /* AppRatingClientTests.swift */; };
+		D3ABC1252F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3ABC1242F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift */; };
 		D36FBCC02E37FC8100D1241C /* PrizeTierRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36FBCBF2E37FC7800D1241C /* PrizeTierRow.swift */; };
 		D37257AB2DF87C72001BC6F9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D37257AA2DF87C72001BC6F9 /* LaunchScreen.storyboard */; };
 		D37257B02DF88BB7001BC6F9 /* HomePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257AF2DF88BB2001BC6F9 /* HomePageView.swift */; };
@@ -527,6 +528,7 @@
 		D35EFC4B2F1A9911000F64A4 /* ConversationListPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListPageView.swift; sourceTree = "<group>"; };
 		D35EFC542F1AFF76000F64A4 /* AppRatingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingClient.swift; sourceTree = "<group>"; };
 		D35EFC582F1B0472000F64A4 /* AppRatingClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingClientTests.swift; sourceTree = "<group>"; };
+		D3ABC1242F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClientTests.swift; sourceTree = "<group>"; };
 		D36FBCBF2E37FC7800D1241C /* PrizeTierRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrizeTierRow.swift; sourceTree = "<group>"; };
 		D37257AA2DF87C72001BC6F9 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D37257AF2DF88BB2001BC6F9 /* HomePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageView.swift; sourceTree = "<group>"; };
@@ -1224,6 +1226,7 @@
 			children = (
 				D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */,
 				D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */,
+				D3ABC1242F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -2034,6 +2037,7 @@
 				D39728762F60E2A7008591E3 /* StationSuggestionPageTests.swift in Sources */,
 				D30257812E639FF200F4228B /* LikesManagerTests.swift in Sources */,
 				D35EFC592F1B0472000F64A4 /* AppRatingClientTests.swift in Sources */,
+				D3ABC1252F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift in Sources */,
 				D35EFC092F159014000F64A4 /* EpisodeRowTests.swift in Sources */,
 				D3776A332F2695BE00200ADF /* ListenerQuestionDetailPageTests.swift in Sources */,
 				D30257842E63A37400F4228B /* LikeOperationTests.swift in Sources */,

--- a/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
@@ -69,106 +69,110 @@ extension DependencyValues {
 // MARK: - Live Implementation
 
 extension AnalyticsClient: DependencyKey {
-  static let liveValue = Self(
-    track: { event in
-      await MainActor.run {
-        @Shared(.auth) var auth: Auth
-        var properties = event.properties
+  static var liveValue: Self {
+    @Dependency(\.date.now) var now
 
-        // Automatically add userId to all events when available
-        if let userId = auth.currentUser?.id {
-          properties["user_id"] = userId
-        }
+    return Self(
+      track: { event in
+        await MainActor.run {
+          @Shared(.auth) var auth: Auth
+          var properties = event.properties
 
-        Mixpanel.mainInstance().track(
-          event: event.name,
-          properties: properties
-        )
-      }
-    },
-    identify: { userId in
-      await MainActor.run {
-        Mixpanel.mainInstance().identify(distinctId: userId)
-      }
-    },
-    reset: {
-      await MainActor.run {
-        Mixpanel.mainInstance().reset()
-      }
-    },
-    setUserProperties: { properties in
-      await MainActor.run {
-        let mixpanelProps: [String: any MixpanelType] = properties
-        Mixpanel.mainInstance().people.set(properties: mixpanelProps)
-      }
-    },
-    startListeningSession: { station in
-      await MainActor.run {
-        let properties: [String: any MixpanelType] = [
-          "station_id": station.id,
-          "station_name": station.name,
-          "station_type": station.type.rawValue,
-        ]
-        Mixpanel.mainInstance().track(
-          event: "Listening Session Started",
-          properties: properties
-        )
-        Mixpanel.mainInstance().time(event: "Listening Session Ended")
-      }
-    },
-    endListeningSession: { station, duration in
-      await MainActor.run {
-        let properties: [String: any MixpanelType] = [
-          "station_id": station.id,
-          "station_name": station.name,
-          "station_type": station.type.rawValue,
-          "session_length_sec": Int(duration),
-        ]
-        Mixpanel.mainInstance().track(
-          event: "Listening Session Ended",
-          properties: properties
-        )
-      }
-    },
-    pauseListeningSession: {
-      await MainActor.run {
-        // Store current timestamp for calculating pause duration
-        UserDefaults.standard.set(
-          Date().timeIntervalSince1970, forKey: "analytics_session_paused_at")
-      }
-    },
-    resumeListeningSession: {
-      await MainActor.run {
-        // Calculate pause duration and track if needed
-        if let pausedAt = UserDefaults.standard.object(forKey: "analytics_session_paused_at")
-          as? TimeInterval
-        {
-          let pauseDuration = Date().timeIntervalSince1970 - pausedAt
-          let properties: [String: any MixpanelType] = [
-            "pause_duration_sec": Int(pauseDuration)
-          ]
+          // Automatically add userId to all events when available
+          if let userId = auth.currentUser?.id {
+            properties["user_id"] = userId
+          }
+
           Mixpanel.mainInstance().track(
-            event: "Listening Session Resumed",
+            event: event.name,
             properties: properties
           )
-          UserDefaults.standard.removeObject(forKey: "analytics_session_paused_at")
+        }
+      },
+      identify: { userId in
+        await MainActor.run {
+          Mixpanel.mainInstance().identify(distinctId: userId)
+        }
+      },
+      reset: {
+        await MainActor.run {
+          Mixpanel.mainInstance().reset()
+        }
+      },
+      setUserProperties: { properties in
+        await MainActor.run {
+          let mixpanelProps: [String: any MixpanelType] = properties
+          Mixpanel.mainInstance().people.set(properties: mixpanelProps)
+        }
+      },
+      startListeningSession: { station in
+        await MainActor.run {
+          let properties: [String: any MixpanelType] = [
+            "station_id": station.id,
+            "station_name": station.name,
+            "station_type": station.type.rawValue,
+          ]
+          Mixpanel.mainInstance().track(
+            event: "Listening Session Started",
+            properties: properties
+          )
+          Mixpanel.mainInstance().time(event: "Listening Session Ended")
+        }
+      },
+      endListeningSession: { station, duration in
+        await MainActor.run {
+          let properties: [String: any MixpanelType] = [
+            "station_id": station.id,
+            "station_name": station.name,
+            "station_type": station.type.rawValue,
+            "session_length_sec": Int(duration),
+          ]
+          Mixpanel.mainInstance().track(
+            event: "Listening Session Ended",
+            properties: properties
+          )
+        }
+      },
+      pauseListeningSession: {
+        await MainActor.run {
+          // Store current timestamp for calculating pause duration
+          UserDefaults.standard.set(
+            now.timeIntervalSince1970, forKey: "analytics_session_paused_at")
+        }
+      },
+      resumeListeningSession: {
+        await MainActor.run {
+          // Calculate pause duration and track if needed
+          if let pausedAt = UserDefaults.standard.object(forKey: "analytics_session_paused_at")
+            as? TimeInterval
+          {
+            let pauseDuration = now.timeIntervalSince1970 - pausedAt
+            let properties: [String: any MixpanelType] = [
+              "pause_duration_sec": Int(pauseDuration)
+            ]
+            Mixpanel.mainInstance().track(
+              event: "Listening Session Resumed",
+              properties: properties
+            )
+            UserDefaults.standard.removeObject(forKey: "analytics_session_paused_at")
+          }
+        }
+      },
+      initialize: {
+        await MainActor.run {
+          Mixpanel.initialize(
+            token: Config.shared.mixpanelToken,
+            trackAutomaticEvents: false
+          )
+        }
+      },
+      flush: {
+        await MainActor.run {
+          Mixpanel.mainInstance().flush()
         }
       }
-    },
-    initialize: {
-      await MainActor.run {
-        Mixpanel.initialize(
-          token: Config.shared.mixpanelToken,
-          trackAutomaticEvents: false
-        )
-      }
-    },
-    flush: {
-      await MainActor.run {
-        Mixpanel.mainInstance().flush()
-      }
-    }
-  )
+    )
+  }
 }
 
 // MARK: - Test Implementation

--- a/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
@@ -70,9 +70,7 @@ extension DependencyValues {
 
 extension AnalyticsClient: DependencyKey {
   static var liveValue: Self {
-    @Dependency(\.date.now) var now
-
-    return Self(
+    Self(
       track: { event in
         await MainActor.run {
           @Shared(.auth) var auth: Auth
@@ -134,19 +132,21 @@ extension AnalyticsClient: DependencyKey {
         }
       },
       pauseListeningSession: {
+        @Dependency(\.date) var date
         await MainActor.run {
           // Store current timestamp for calculating pause duration
           UserDefaults.standard.set(
-            now.timeIntervalSince1970, forKey: "analytics_session_paused_at")
+            date.now.timeIntervalSince1970, forKey: "analytics_session_paused_at")
         }
       },
       resumeListeningSession: {
+        @Dependency(\.date) var date
         await MainActor.run {
           // Calculate pause duration and track if needed
           if let pausedAt = UserDefaults.standard.object(forKey: "analytics_session_paused_at")
             as? TimeInterval
           {
-            let pauseDuration = now.timeIntervalSince1970 - pausedAt
+            let pauseDuration = date.now.timeIntervalSince1970 - pausedAt
             let properties: [String: any MixpanelType] = [
               "pause_duration_sec": Int(pauseDuration)
             ]

--- a/PlayolaRadio/Core/Analytics/AnalyticsClientTests.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsClientTests.swift
@@ -1,0 +1,62 @@
+//
+//  AnalyticsClientTests.swift
+//  PlayolaRadio
+//
+
+import Dependencies
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct AnalyticsClientTests {
+  private static let pauseKey = "analytics_session_paused_at"
+
+  @Test
+  func testPauseListeningSessionStoresInjectedDateTimestamp() async {
+    UserDefaults.standard.removeObject(forKey: Self.pauseKey)
+    defer { UserDefaults.standard.removeObject(forKey: Self.pauseKey) }
+
+    let pausedAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+    await withDependencies {
+      $0.date = .constant(pausedAt)
+    } operation: {
+      let client = AnalyticsClient.liveValue
+      await client.pauseListeningSession()
+    }
+
+    let stored = UserDefaults.standard.object(forKey: Self.pauseKey) as? TimeInterval
+    #expect(stored == pausedAt.timeIntervalSince1970)
+  }
+
+  @Test
+  func testPauseAndResumeUseCallTimeDates() async {
+    UserDefaults.standard.removeObject(forKey: Self.pauseKey)
+    defer { UserDefaults.standard.removeObject(forKey: Self.pauseKey) }
+
+    let pausedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let resumedAt = pausedAt.addingTimeInterval(60)
+
+    await withDependencies {
+      $0.date = .constant(pausedAt)
+    } operation: {
+      let client = AnalyticsClient.liveValue
+      await client.pauseListeningSession()
+    }
+
+    let storedAfterPause = UserDefaults.standard.object(forKey: Self.pauseKey) as? TimeInterval
+    #expect(storedAfterPause == pausedAt.timeIntervalSince1970)
+
+    await withDependencies {
+      $0.date = .constant(resumedAt)
+    } operation: {
+      let client = AnalyticsClient.liveValue
+      await client.resumeListeningSession()
+    }
+
+    // resume should clear the stored timestamp after computing the duration
+    #expect(UserDefaults.standard.object(forKey: Self.pauseKey) == nil)
+  }
+}

--- a/PlayolaRadio/Core/AppRating/AppRatingClient.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClient.swift
@@ -33,68 +33,72 @@ extension AppRatingClient: DependencyKey {
   private static let oneHourMS = 60 * 60 * 1000
   private static let sevenDaysInterval: TimeInterval = 7 * 24 * 60 * 60
 
-  static let liveValue = Self(
-    shouldShowRatingPrompt: { totalListenTimeMS in
-      @Shared(.appInstallDate) var appInstallDate
-      @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
-      @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
+  static var liveValue: Self {
+    @Dependency(\.date.now) var now
 
-      let currentVersion = Bundle.main.releaseVersionNumber ?? "unknown"
+    return Self(
+      shouldShowRatingPrompt: { totalListenTimeMS in
+        @Shared(.appInstallDate) var appInstallDate
+        @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
+        @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
 
-      // Already shown for this version
-      if lastRatingPromptVersion == currentVersion {
-        return false
-      }
+        let currentVersion = Bundle.main.releaseVersionNumber ?? "unknown"
 
-      // Not enough listening time (need 1 hour)
-      guard totalListenTimeMS >= oneHourMS else {
-        return false
-      }
-
-      // App not installed long enough (need 7 days)
-      guard let installDate = appInstallDate else {
-        return false
-      }
-      let daysSinceInstall = Date().timeIntervalSince(installDate)
-      guard daysSinceInstall >= sevenDaysInterval else {
-        return false
-      }
-
-      // If previously dismissed, check if 7 days have passed
-      if let dismissDate = lastRatingPromptDismissDate {
-        let daysSinceDismiss = Date().timeIntervalSince(dismissDate)
-        guard daysSinceDismiss >= sevenDaysInterval else {
+        // Already shown for this version
+        if lastRatingPromptVersion == currentVersion {
           return false
         }
-      }
 
-      return true
-    },
-    recordInstallDateIfNeeded: {
-      @Shared(.appInstallDate) var appInstallDate
-      if appInstallDate == nil {
-        $appInstallDate.withLock { $0 = Date() }
-      }
-    },
-    markRatingPromptShown: {
-      @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
-      @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
-      let currentVersion = Bundle.main.releaseVersionNumber ?? "unknown"
-      $lastRatingPromptVersion.withLock { $0 = currentVersion }
-      $lastRatingPromptDismissDate.withLock { $0 = nil }
-    },
-    markRatingPromptDismissed: {
-      @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
-      $lastRatingPromptDismissDate.withLock { $0 = Date() }
-    },
-    requestAppStoreReview: {
-      await MainActor.run {
-        if let scene = UIApplication.shared.connectedScenes
-          .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-        {
-          AppStore.requestReview(in: scene)
+        // Not enough listening time (need 1 hour)
+        guard totalListenTimeMS >= oneHourMS else {
+          return false
+        }
+
+        // App not installed long enough (need 7 days)
+        guard let installDate = appInstallDate else {
+          return false
+        }
+        let daysSinceInstall = now.timeIntervalSince(installDate)
+        guard daysSinceInstall >= sevenDaysInterval else {
+          return false
+        }
+
+        // If previously dismissed, check if 7 days have passed
+        if let dismissDate = lastRatingPromptDismissDate {
+          let daysSinceDismiss = now.timeIntervalSince(dismissDate)
+          guard daysSinceDismiss >= sevenDaysInterval else {
+            return false
+          }
+        }
+
+        return true
+      },
+      recordInstallDateIfNeeded: {
+        @Shared(.appInstallDate) var appInstallDate
+        if appInstallDate == nil {
+          $appInstallDate.withLock { $0 = now }
+        }
+      },
+      markRatingPromptShown: {
+        @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
+        @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
+        let currentVersion = Bundle.main.releaseVersionNumber ?? "unknown"
+        $lastRatingPromptVersion.withLock { $0 = currentVersion }
+        $lastRatingPromptDismissDate.withLock { $0 = nil }
+      },
+      markRatingPromptDismissed: {
+        @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
+        $lastRatingPromptDismissDate.withLock { $0 = now }
+      },
+      requestAppStoreReview: {
+        await MainActor.run {
+          if let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+          {
+            AppStore.requestReview(in: scene)
+          }
         }
       }
-    }
-  )
+    )
+  }
 }

--- a/PlayolaRadio/Core/AppRating/AppRatingClient.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClient.swift
@@ -34,10 +34,9 @@ extension AppRatingClient: DependencyKey {
   private static let sevenDaysInterval: TimeInterval = 7 * 24 * 60 * 60
 
   static var liveValue: Self {
-    @Dependency(\.date.now) var now
-
-    return Self(
+    Self(
       shouldShowRatingPrompt: { totalListenTimeMS in
+        @Dependency(\.date) var date
         @Shared(.appInstallDate) var appInstallDate
         @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
         @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
@@ -58,14 +57,14 @@ extension AppRatingClient: DependencyKey {
         guard let installDate = appInstallDate else {
           return false
         }
-        let daysSinceInstall = now.timeIntervalSince(installDate)
+        let daysSinceInstall = date.now.timeIntervalSince(installDate)
         guard daysSinceInstall >= sevenDaysInterval else {
           return false
         }
 
         // If previously dismissed, check if 7 days have passed
         if let dismissDate = lastRatingPromptDismissDate {
-          let daysSinceDismiss = now.timeIntervalSince(dismissDate)
+          let daysSinceDismiss = date.now.timeIntervalSince(dismissDate)
           guard daysSinceDismiss >= sevenDaysInterval else {
             return false
           }
@@ -74,9 +73,10 @@ extension AppRatingClient: DependencyKey {
         return true
       },
       recordInstallDateIfNeeded: {
+        @Dependency(\.date) var date
         @Shared(.appInstallDate) var appInstallDate
         if appInstallDate == nil {
-          $appInstallDate.withLock { $0 = now }
+          $appInstallDate.withLock { $0 = date.now }
         }
       },
       markRatingPromptShown: {
@@ -87,8 +87,9 @@ extension AppRatingClient: DependencyKey {
         $lastRatingPromptDismissDate.withLock { $0 = nil }
       },
       markRatingPromptDismissed: {
+        @Dependency(\.date) var date
         @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
-        $lastRatingPromptDismissDate.withLock { $0 = now }
+        $lastRatingPromptDismissDate.withLock { $0 = date.now }
       },
       requestAppStoreReview: {
         await MainActor.run {

--- a/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
@@ -25,10 +25,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let thirtyMinutesMS = 30 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(thirtyMinutesMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(thirtyMinutesMS))
+    }
   }
 
   @Test
@@ -39,10 +43,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -51,10 +59,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -66,10 +78,14 @@ struct AppRatingClientTests {
       Bundle.main.releaseVersionNumber
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -81,10 +97,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? =
       Calendar.current.date(byAdding: .day, value: -3, to: Date())
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -95,10 +115,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -110,10 +134,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? =
       Calendar.current.date(byAdding: .day, value: -10, to: Date())
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   // MARK: - recordInstallDateIfNeeded Tests
@@ -124,17 +152,21 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
 
-    #expect(appInstallDate == nil)
+      #expect(appInstallDate == nil)
 
-    client.recordInstallDateIfNeeded()
-    let firstDate = appInstallDate
-    #expect(firstDate != nil)
+      client.recordInstallDateIfNeeded()
+      let firstDate = appInstallDate
+      #expect(firstDate != nil)
 
-    // Wait a tiny bit and try again
-    client.recordInstallDateIfNeeded()
-    #expect(appInstallDate == firstDate)
+      // Wait a tiny bit and try again
+      client.recordInstallDateIfNeeded()
+      #expect(appInstallDate == firstDate)
+    }
   }
 
   // MARK: - markRatingPromptShown Tests
@@ -160,13 +192,17 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
 
-    #expect(lastRatingPromptDismissDate == nil)
+      #expect(lastRatingPromptDismissDate == nil)
 
-    client.markRatingPromptDismissed()
+      client.markRatingPromptDismissed()
 
-    #expect(lastRatingPromptDismissDate != nil)
+      #expect(lastRatingPromptDismissDate != nil)
+    }
   }
 }
 

--- a/PlayolaRadio/Core/AudioRecording/AudioConverterClient.swift
+++ b/PlayolaRadio/Core/AudioRecording/AudioConverterClient.swift
@@ -17,7 +17,9 @@ public struct AudioConverterClient: Sendable {
 
 extension AudioConverterClient: DependencyKey {
   public static var liveValue: AudioConverterClient {
-    AudioConverterClient(
+    @Dependency(\.uuid) var uuid
+
+    return AudioConverterClient(
       convertToM4A: { inputURL in
         let asset = AVURLAsset(url: inputURL)
 
@@ -31,7 +33,7 @@ extension AudioConverterClient: DependencyKey {
         }
 
         let outputURL = FileManager.default.temporaryDirectory
-          .appendingPathComponent("voicetrack_\(UUID().uuidString).m4a")
+          .appendingPathComponent("voicetrack_\(uuid().uuidString).m4a")
 
         do {
           try await exportSession.export(to: outputURL, as: .m4a)

--- a/PlayolaRadio/Core/AudioRecording/AudioRecorderClient.swift
+++ b/PlayolaRadio/Core/AudioRecording/AudioRecorderClient.swift
@@ -66,12 +66,18 @@ public final class RecordingSession: Sendable {
 
 extension AudioRecorderClient: DependencyKey {
   public static var liveValue: AudioRecorderClient {
+    @Dependency(\.uuid) var uuid
     let recorder = LiveAudioRecorder()
+
+    @Sendable func makeRecordingURL() -> URL {
+      FileManager.default.temporaryDirectory
+        .appendingPathComponent("voicetrack_\(uuid().uuidString).wav")
+    }
 
     return AudioRecorderClient(
       requestPermission: { await recorder.requestPermission() },
       prepareForRecording: { try await recorder.prepareForRecording() },
-      startRecording: { try await recorder.startRecording() },
+      startRecording: { try await recorder.startRecording(at: makeRecordingURL()) },
       stopRecording: { try await recorder.stopRecording() },
       currentTime: { await recorder.currentTime() },
       deleteRecording: { url in await recorder.deleteRecording(url) },
@@ -82,7 +88,7 @@ extension AudioRecorderClient: DependencyKey {
           throw AudioRecorderError.permissionDenied
         }
 
-        try await recorder.startRecording()
+        try await recorder.startRecording(at: makeRecordingURL())
 
         let updateTask = Task {
           while !Task.isCancelled {
@@ -194,13 +200,10 @@ private actor LiveAudioRecorder {
     isPrepared = true
   }
 
-  func startRecording() throws {
+  func startRecording(at url: URL) throws {
     // Always prepare audio session before recording - the session may have been
     // reconfigured by other audio components (e.g., StationPlayer) since last prepare
     try prepareForRecording()
-
-    let url = FileManager.default.temporaryDirectory
-      .appendingPathComponent("voicetrack_\(UUID().uuidString).wav")
 
     let recorder = try AVAudioRecorder(url: url, settings: recordingSettings)
     recorder.isMeteringEnabled = true

--- a/PlayolaRadio/Core/Likes/LikeOperation.swift
+++ b/PlayolaRadio/Core/Likes/LikeOperation.swift
@@ -71,8 +71,8 @@ struct LikeOperation: Codable, Equatable, Identifiable {
   }
 
   /// Whether this operation has expired (older than 7 days)
-  var isExpired: Bool {
-    Date().timeIntervalSince(timestamp) > 7 * 24 * 60 * 60
+  func isExpired(now: Date) -> Bool {
+    now.timeIntervalSince(timestamp) > 7 * 24 * 60 * 60
   }
 }
 

--- a/PlayolaRadio/Core/Likes/LikeOperationTests.swift
+++ b/PlayolaRadio/Core/Likes/LikeOperationTests.swift
@@ -89,20 +89,21 @@ struct LikeOperationTests {
 
   @Test
   func testIsExpired() {
+    let now = Date()
     let recentOperation = LikeOperation(
       audioBlock: testAudioBlock,
       type: .like,
-      timestamp: Date()
+      timestamp: now
     )
 
     let oldOperation = LikeOperation(
       audioBlock: testAudioBlock,
       type: .like,
-      timestamp: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60)
+      timestamp: now.addingTimeInterval(-8 * 24 * 60 * 60)
     )
 
-    #expect(!recentOperation.isExpired)
-    #expect(oldOperation.isExpired)
+    #expect(!recentOperation.isExpired(now: now))
+    #expect(oldOperation.isExpired(now: now))
   }
 
   // MARK: - Equatable Tests

--- a/PlayolaRadio/Core/Likes/LikesManager.swift
+++ b/PlayolaRadio/Core/Likes/LikesManager.swift
@@ -26,6 +26,8 @@ final class LikesManager: ObservableObject {
 
   @Dependency(\.api) private var api
   @Dependency(\.toast) private var toast
+  @Dependency(\.date.now) private var now
+  @Dependency(\.uuid) private var uuid
   @Shared(.auth) private var auth
   @Shared(.mainContainerNavigationCoordinator) private var navigationCoordinator
   @Shared(.activeTab) private var activeTab
@@ -126,8 +128,10 @@ final class LikesManager: ObservableObject {
     }
 
     let operation = LikeOperation(
+      id: uuid(),
       audioBlock: audioBlock,
       type: .like,
+      timestamp: now,
       spinId: spinId
     )
     $pendingOperations.withLock {
@@ -164,8 +168,10 @@ final class LikesManager: ObservableObject {
     }
 
     let operation = LikeOperation(
+      id: uuid(),
       audioBlock: audioBlock,
-      type: .unlike
+      type: .unlike,
+      timestamp: now
     )
     $pendingOperations.withLock {
       $0.append(operation)
@@ -178,8 +184,9 @@ final class LikesManager: ObservableObject {
 
   /// Clears expired operations from the pending queue
   func cleanupExpiredOperations() {
+    let currentDate = now
     $pendingOperations.withLock {
-      $0.removeAll { $0.isExpired }
+      $0.removeAll { $0.isExpired(now: currentDate) }
     }
   }
 

--- a/PlayolaRadio/Core/Likes/LikesManagerTests.swift
+++ b/PlayolaRadio/Core/Likes/LikesManagerTests.swift
@@ -23,10 +23,16 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      return manager
+    }
 
     #expect(manager.isLiked(audioBlock.id))
     #expect(manager.getLikedAudioBlock(audioBlock.id) == audioBlock)
@@ -39,10 +45,16 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      return manager
+    }
 
     #expect(manager.pendingOperations.count == 1)
     #expect(manager.pendingOperations.first?.audioBlock == audioBlock)
@@ -54,11 +66,17 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
     let beforeLike = Date()
 
-    manager.like(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      return manager
+    }
 
     let timestamp = manager.getLikedTimestamp(audioBlock.id)
     #expect(timestamp != nil)
@@ -71,11 +89,17 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
-    manager.like(audioBlock)  // Try to like again
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      manager.like(audioBlock)  // Try to like again
+      return manager
+    }
 
     #expect(manager.allLikedAudioBlocks.count == 1)
     #expect(manager.pendingOperations.count == 1)
@@ -88,13 +112,19 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
-    #expect(manager.isLiked(audioBlock.id))
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      #expect(manager.isLiked(audioBlock.id))
 
-    manager.unlike(audioBlock)
+      manager.unlike(audioBlock)
+      return manager
+    }
 
     #expect(!manager.isLiked(audioBlock.id))
     #expect(manager.getLikedAudioBlock(audioBlock.id) == nil)
@@ -106,12 +136,17 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
-
-    manager.unlike(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      manager.unlike(audioBlock)
+      return manager
+    }
 
     #expect(manager.pendingOperations.count == 2)
     #expect(manager.pendingOperations.last?.audioBlock == audioBlock)
@@ -123,10 +158,16 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.unlike(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.unlike(audioBlock)
+      return manager
+    }
 
     #expect(manager.pendingOperations.count == 0)
   }
@@ -138,10 +179,16 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.toggleLike(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.toggleLike(audioBlock)
+      return manager
+    }
 
     #expect(manager.isLiked(audioBlock.id))
   }
@@ -151,13 +198,19 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
-    #expect(manager.isLiked(audioBlock.id))
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      #expect(manager.isLiked(audioBlock.id))
 
-    manager.toggleLike(audioBlock)
+      manager.toggleLike(audioBlock)
+      return manager
+    }
 
     #expect(!manager.isLiked(audioBlock.id))
   }
@@ -169,14 +222,20 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock1 = AudioBlock.mock
     let audioBlock2 = AudioBlock.mockWith(id: "different-id")
     let audioBlock3 = AudioBlock.mockWith(id: "another-id")
 
-    manager.like(audioBlock1)
-    manager.like(audioBlock2)
-    manager.like(audioBlock3)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock1)
+      manager.like(audioBlock2)
+      manager.like(audioBlock3)
+      return manager
+    }
 
     #expect(manager.allLikedAudioBlocks.count == 3)
     #expect(manager.isLiked(audioBlock1.id))
@@ -191,10 +250,13 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    let recentOp = LikeOperation(audioBlock: audioBlock, type: .like)
+    let recentOp = LikeOperation(
+      audioBlock: audioBlock,
+      type: .like,
+      timestamp: Date()
+    )
 
     let expiredOp = LikeOperation(
       audioBlock: audioBlock,
@@ -202,11 +264,17 @@ struct LikesManagerTests {
       timestamp: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60)
     )
 
-    manager.$pendingOperations.withLock {
-      $0 = [recentOp, expiredOp]
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.$pendingOperations.withLock {
+        $0 = [recentOp, expiredOp]
+      }
+      manager.cleanupExpiredOperations()
+      return manager
     }
-
-    manager.cleanupExpiredOperations()
 
     #expect(manager.pendingOperations.count == 1)
     #expect(manager.pendingOperations.first == recentOp)
@@ -221,10 +289,15 @@ struct LikesManagerTests {
 
     let audioBlock = AudioBlock.mock
 
-    let manager1 = LikesManager()
-    manager1.like(audioBlock)
+    let manager2 = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager1 = LikesManager()
+      manager1.like(audioBlock)
 
-    let manager2 = LikesManager()
+      return LikesManager()
+    }
 
     #expect(manager2.isLiked(audioBlock.id))
     #expect(manager2.allLikedAudioBlocks.count == 1)

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -596,18 +596,18 @@ struct MainContainerTests {
       )
     )
 
-    let mainContainerModel = withDependencies {
+    withDependencies {
+      $0.date = .constant(Date())
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
       $0.appRating = .liveValue
     } operation: {
-      MainContainerModel()
+      let mainContainerModel = MainContainerModel()
+      mainContainerModel.checkAndShowRatingPromptIfNeeded()
+
+      #expect(mainContainerModel.presentedAlert != nil)
+      #expect(mainContainerModel.presentedAlert?.title == "Are you enjoying Playola Radio?")
     }
-
-    mainContainerModel.checkAndShowRatingPromptIfNeeded()
-
-    #expect(mainContainerModel.presentedAlert != nil)
-    #expect(mainContainerModel.presentedAlert?.title == "Are you enjoying Playola Radio?")
   }
 
   @Test
@@ -623,17 +623,17 @@ struct MainContainerTests {
       )
     )
 
-    let mainContainerModel = withDependencies {
+    withDependencies {
+      $0.date = .constant(Date())
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
       $0.appRating = .liveValue
     } operation: {
-      MainContainerModel()
+      let mainContainerModel = MainContainerModel()
+      mainContainerModel.checkAndShowRatingPromptIfNeeded()
+
+      #expect(mainContainerModel.presentedAlert == nil)
     }
-
-    mainContainerModel.checkAndShowRatingPromptIfNeeded()
-
-    #expect(mainContainerModel.presentedAlert == nil)
   }
 
   @Test

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -382,6 +382,8 @@ struct PlayerPageTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
 
     withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
       $0.likesManager = LikesManager()
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
@@ -424,6 +426,8 @@ struct PlayerPageTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
 
     withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
       $0.likesManager = LikesManager()
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())


### PR DESCRIPTION
## Summary

Follow-up to #277 applying the same `@Dependency` patterns to the rest of the Core services.

- `LikesManager` reads `@Dependency(\.date.now)` / `@Dependency(\.uuid)` when constructing `LikeOperation` and when checking expiration; `LikeOperation.isExpired` becomes a function taking `now: Date`.
- `AnalyticsClient.pauseListeningSession` / `resumeListeningSession` use the injected clock for the `analytics_session_paused_at` timestamp.
- `AppRatingClient` reads `\.date.now` for install/dismissal comparisons and the `recordInstallDateIfNeeded` / `markRatingPromptDismissed` writes.
- `AudioRecorderClient` and `AudioConverterClient` use `@Dependency(\.uuid)` for temp file naming inside the live-value closures (their static stored `liveValue`s become computed `var`s so the dep can be declared at the top of the closure).

## Test plan

- [ ] Run the full test suite in Xcode (verified locally via `xcodebuild ... test-without-building` — all suites pass).
- [ ] Spot-check that liking/unliking still works end-to-end and that the rating prompt still appears at the right time.
- [ ] Verify a recording flow still produces a temp `.wav` and converts to `.m4a` (UUID-based filenames).