### PR TITLE
Tighten lifecycle on long-lived Combine subscriptions

### DIFF
--- a/PlayolaRadio/Core/Likes/LikesManager.swift
+++ b/PlayolaRadio/Core/Likes/LikesManager.swift
@@ -39,6 +39,11 @@ final class LikesManager: ObservableObject {
     setupAuthObserver()
   }
 
+  // The auth subscription is intentionally tied to this instance's lifetime.
+  // LikesManager is registered as a DependencyKey with a `liveValue` singleton,
+  // so in production the subscription lives for the duration of the process.
+  // The `[weak self]` capture prevents retain cycles in tests where fresh
+  // instances are constructed and discarded between cases.
   private func setupAuthObserver() {
     authCancellable = $auth.publisher
       .sink { [weak self] newAuth in

--- a/PlayolaRadio/Core/ListeningTracker/ListeningTracker.swift
+++ b/PlayolaRadio/Core/ListeningTracker/ListeningTracker.swift
@@ -13,6 +13,12 @@ import SwiftUI
 final class ListeningTracker {
   let rewardsProfile: RewardsProfile
   var localListeningSessions: [LocalListeningSession]
+
+  // The sink closure captures `self` weakly so the cancellable owned by this
+  // tracker is the only thing keeping the subscription alive. When the tracker
+  // is deallocated, `cancellables` releases the cancellable and the subscription
+  // is torn down — without this, the strong self/closure/cancellables cycle
+  // would keep replaced trackers alive forever.
   private var cancellables = Set<AnyCancellable>()
 
   var isListening: Bool {
@@ -28,19 +34,22 @@ final class ListeningTracker {
     self.rewardsProfile = rewardsProfile
     self.localListeningSessions = localListeningSessions
 
-    $nowPlaying.publisher.sink { nowPlaying in
+    $nowPlaying.publisher
+      .sink { [weak self] in self?.handleNowPlayingChange($0) }
+      .store(in: &cancellables)
+  }
 
-      if self.isCurrentlyPlaying(nowPlaying?.playbackStatus) && !self.isListening {
-        print("Starting a new session!")
-        self.localListeningSessions.append(LocalListeningSession(startTime: .now))
-      } else if !self.isCurrentlyPlaying(nowPlaying?.playbackStatus) && self.isListening {
-        if !self.localListeningSessions.isEmpty {
-          print("Ending the current session")
-          let lastIndex = self.localListeningSessions.count - 1
-          self.localListeningSessions[lastIndex].endTime = .now
-        }
+  private func handleNowPlayingChange(_ nowPlaying: NowPlaying?) {
+    if isCurrentlyPlaying(nowPlaying?.playbackStatus) && !isListening {
+      print("Starting a new session!")
+      localListeningSessions.append(LocalListeningSession(startTime: .now))
+    } else if !isCurrentlyPlaying(nowPlaying?.playbackStatus) && isListening {
+      if !localListeningSessions.isEmpty {
+        print("Ending the current session")
+        let lastIndex = localListeningSessions.count - 1
+        localListeningSessions[lastIndex].endTime = .now
       }
-    }.store(in: &cancellables)
+    }
   }
 
   private func isCurrentlyPlaying(_ status: StationPlayer.PlaybackStatus?) -> Bool {

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
@@ -53,8 +53,9 @@ class ListeningTimeTileModel: ViewModel {
 
   func viewAppeared() {
     refreshTask?.cancel()
-    refreshTask = Task {
+    refreshTask = Task { [weak self] in
       while !Task.isCancelled {
+        guard let self else { return }
         if let ms = listeningTracker?.totalListenTimeMS {
           totalListeningTime = ms
         } else {


### PR DESCRIPTION
## Summary

Continues the Point-Free-style cleanup series (after PRs #277 and #282), this time focused on long-lived Combine subscriptions in shared services. The headline bug here is that `ListeningTracker.swift` had a retain cycle that kept every replaced tracker — and its `nowPlaying` subscription — alive forever. Every call to `MainContainerModel.loadListeningTracker()` layered another live observer on top of the last.

## What changed

- **`ListeningTracker`**: the sink closure captured `self` strongly, so the closure → `cancellables` → `self` cycle prevented the tracker from ever deallocating. Capture `self` weakly so the stored `cancellables` becomes the sole keepalive; when the tracker is replaced or otherwise released, the cancellable releases and the subscription tears down. Extracted the body to `handleNowPlayingChange(_:)` so the closure is trivial and added a comment explaining the lifecycle contract.
- **`ListeningTimeTileModel`**: the refresh `Task` captured `self` strongly. If the model is deallocated before `viewDisappeared()` fires, the task would keep running. Now captures `self` weakly and exits the loop when `self` is `nil`.
- **`LikesManager`**: the auth subscription already used `[weak self]`, and the manager is registered as a `DependencyKey` `liveValue` so in production the subscription is meant to live for the duration of the process. No code change — added a comment explaining that the lifetime is intentional and that the `[weak self]` capture is there for test isolation.

## Deliberately skipped (for the next PR)

These were called out in the brief and left for the upcoming audio-playback `@DependencyClient` PR, which is the natural place to rework them:

- `UrlStreamListeningSessionReporter` — `$state.sink` into a `disposeBag` without lifecycle
- `StationPlayer` — three `disposeBag` sinks, same situation

Those classes will fold into the audio-playback DI rewrite (`URLStreamPlayer`, `StationPlayer`, `NowPlayingUpdater`, `UrlStreamListeningSessionReporter`, plus a few stray unstructured `Task {}` blocks).

## Why not convert `ListeningTracker` to `for await … in publisher.values`?

Considered it (it was the brief's suggested option for a per-feature service), but the actual bug is the retain cycle, and `[weak self]` fixes it without changing semantics. The existing `ListeningTracker` tests rely on synchronous `withLock` → sink-fires-immediately behavior, and `Task.yield()` after a `withLock` doesn't reliably drain the Combine→`AsyncSequence` bridge in time for the assertions. The `[weak self]` fix is local, behavior-preserving, and doesn't require touching 18 tests. If/when the audio-playback DI PR moves the tracker into a different ownership model, an `AsyncStream`-based observation can land then.

## Test plan

- [x] `xcodebuild … build-for-testing` reports `** TEST BUILD SUCCEEDED **`
- [x] `ListeningTrackerTests` (18 tests) pass
- [x] `ListeningTimeTileModelTests` (11 tests) pass
- [x] `LikesManagerTests` pass
- [x] `HomePageTests`, `RewardsPageModelTests`, `MainContainerTests` (consumers of `ListeningTracker`) pass — 122 tests across the affected suites all green
- [x] `make format` / `make lint` clean