### PR TITLE
Inject audio playback services as Dependencies

### DIFF
--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -50,7 +50,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
   private func playStation(_ station: AnyStation?) {
     guard let station else { return }
 
-    stationPlayer.play(station: station)
+    Task { @MainActor in
+      await stationPlayer.play(station: station)
+    }
     showNowPlayingTemplate()
   }
 
@@ -335,7 +337,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     )
     listItem.handler = { _, completion in
       if station.active {
-        self.stationPlayer.play(station: station)
+        Task { @MainActor in
+          await self.stationPlayer.play(station: station)
+        }
       }
       completion()
     }

--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -36,10 +36,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
   var observers = Set<AnyCancellable>()
 
   @Dependency(\.analytics) var analytics
+  @Dependency(\.stationPlayer) var stationPlayer
 
   private var isTransitioningToNowPlaying = false
-
-  var stationPlayer: StationPlayer { StationPlayer.shared }
 
   override init() {
     super.init()
@@ -177,7 +176,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
   }
 
   private func setupNowPlayingTemplate() {
-    _ = NowPlayingUpdater.shared
+    @Dependency(\.nowPlayingUpdater) var nowPlayingUpdater
+    _ = nowPlayingUpdater
   }
 
   private func observePlaybackErrors() {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -66,6 +66,7 @@ class NowPlayingUpdater {
   @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.analytics) var analytics
+  @ObservationIgnored @Dependency(\.date.now) var now
 
   private var disposeBag = Set<AnyCancellable>()
   private var inactivityTask: Task<Void, Never>?
@@ -300,11 +301,18 @@ class NowPlayingUpdater {
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
   }
 
+  // The Combine subscriptions below capture `self` weakly so the cancellable
+  // owned by this updater is the only thing keeping each subscription alive.
+  // When the updater is deallocated, `disposeBag` releases the cancellables
+  // and the subscriptions are torn down — without `[weak self]` the strong
+  // self/closure/disposeBag cycle would keep replaced updaters alive forever.
   init(stationPlayer: StationPlayer? = nil) {
     self.stationPlayer = stationPlayer ?? .shared
-    self.stationPlayer.$state.sink { state in
-      self.updateNowPlaying(with: state)
-    }.store(in: &disposeBag)
+    self.stationPlayer.$state
+      .sink { [weak self] state in
+        self?.updateNowPlaying(with: state)
+      }
+      .store(in: &disposeBag)
     setupRemoteControlCenter()
     setupSharedStateObservation()
   }
@@ -559,7 +567,7 @@ extension NowPlayingUpdater {
     // Start session when transitioning to playing
     case (_, .playing(let station)):
       if sessionStartTime == nil {
-        sessionStartTime = Date()
+        sessionStartTime = now
         await analytics.track(
           .listeningSessionStarted(
             station: StationInfo(from: station)
@@ -571,7 +579,7 @@ extension NowPlayingUpdater {
     case (.playing(let station), .stopped),
       (.playing(let station), .error):
       if let startTime = sessionStartTime {
-        let duration = Date().timeIntervalSince(startTime)
+        let duration = now.timeIntervalSince(startTime)
         await analytics.track(
           .listeningSessionEnded(
             station: StationInfo(from: station),
@@ -599,7 +607,7 @@ extension NowPlayingUpdater {
 
   private func trackStationSwitch(from fromStation: AnyStation, to toStation: AnyStation) async {
     guard let startTime = sessionStartTime else { return }
-    let duration = Date().timeIntervalSince(startTime)
+    let duration = now.timeIntervalSince(startTime)
 
     // End current session
     await analytics.track(
@@ -626,6 +634,6 @@ extension NowPlayingUpdater {
       )
     )
 
-    sessionStartTime = Date()
+    sessionStartTime = now
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -642,6 +642,7 @@ extension NowPlayingUpdater {
 
 extension NowPlayingUpdater: @preconcurrency DependencyKey {
   static let liveValue = NowPlayingUpdater()
+  static var testValue: NowPlayingUpdater { NowPlayingUpdater() }
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -307,7 +307,8 @@ class NowPlayingUpdater {
   // and the subscriptions are torn down — without `[weak self]` the strong
   // self/closure/disposeBag cycle would keep replaced updaters alive forever.
   init(stationPlayer: StationPlayer? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
+    @Dependency(\.stationPlayer) var injectedStationPlayer
+    self.stationPlayer = stationPlayer ?? injectedStationPlayer
     self.stationPlayer.$state
       .sink { [weak self] state in
         self?.updateNowPlaying(with: state)
@@ -320,15 +321,15 @@ class NowPlayingUpdater {
   // MARK: - Shared State Management
 
   private func setupSharedStateObservation() {
-    // Observe PlayolaStationPlayer state changes
+    @Dependency(\.urlStreamPlayer) var urlStreamPlayer
+
     PlayolaStationPlayer.shared.$state
       .sink { [weak self] playolaState in
         self?.processPlayolaStationPlayerState(playolaState)
       }
       .store(in: &disposeBag)
 
-    // Observe URLStreamPlayer state changes
-    URLStreamPlayer.shared.$state
+    urlStreamPlayer.$state
       .sink { [weak self] urlStreamState in
         self?.processUrlStreamStateChanged(urlStreamState)
       }
@@ -465,7 +466,7 @@ class NowPlayingUpdater {
     commandCenter.nextTrackCommand.isEnabled = true
     commandCenter.nextTrackCommand.addTarget { [weak self] _ in
       Task { @MainActor in
-        self?.stationPlayer.seekNext()
+        await self?.stationPlayer.seekNext()
       }
       return .success
     }
@@ -473,7 +474,7 @@ class NowPlayingUpdater {
     commandCenter.previousTrackCommand.isEnabled = true
     commandCenter.previousTrackCommand.addTarget { [weak self] _ in
       Task { @MainActor in
-        self?.stationPlayer.seekPrevious()
+        await self?.stationPlayer.seekPrevious()
       }
       return .success
     }
@@ -487,14 +488,15 @@ class NowPlayingUpdater {
 
     // Play command - restart last played station when stopped
     commandCenter.playCommand.isEnabled = true
-    commandCenter.playCommand.addTarget { _ in
-      if let lastStation = self.lastPlayedStation,
+    commandCenter.playCommand.addTarget { [weak self] _ in
+      guard let self,
+        let lastStation = self.lastPlayedStation,
         self.stationPlayer.currentStation == nil
-      {
-        self.stationPlayer.play(station: lastStation)
-        return .success
+      else { return .commandFailed }
+      Task { @MainActor in
+        await self.stationPlayer.play(station: lastStation)
       }
-      return .commandFailed
+      return .success
     }
   }
 
@@ -635,5 +637,18 @@ extension NowPlayingUpdater {
     )
 
     sessionStartTime = now
+  }
+}
+
+// MARK: - Dependency
+
+extension NowPlayingUpdater: @preconcurrency DependencyKey {
+  static var liveValue: NowPlayingUpdater { .shared }
+}
+
+extension DependencyValues {
+  var nowPlayingUpdater: NowPlayingUpdater {
+    get { self[NowPlayingUpdater.self] }
+    set { self[NowPlayingUpdater.self] = newValue }
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -61,8 +61,6 @@ struct NowPlaying: Equatable, Codable {
 class NowPlayingUpdater {
   var stationPlayer: StationPlayer
 
-  static var shared = NowPlayingUpdater()
-
   @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.analytics) var analytics
@@ -643,7 +641,7 @@ extension NowPlayingUpdater {
 // MARK: - Dependency
 
 extension NowPlayingUpdater: @preconcurrency DependencyKey {
-  static var liveValue: NowPlayingUpdater { .shared }
+  static let liveValue = NowPlayingUpdater()
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -27,6 +27,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -58,6 +59,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -111,6 +113,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -151,6 +154,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -187,6 +191,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -237,6 +242,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -270,6 +276,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -300,6 +307,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -55,8 +55,6 @@ class StationPlayer: ObservableObject {
     }
   }
 
-  static let shared = StationPlayer()
-
   // MARK: Dependencies
 
   var urlStreamPlayer: URLStreamPlayer
@@ -268,7 +266,7 @@ protocol AudioBlockProvider {
 // MARK: - Dependency
 
 extension StationPlayer: @preconcurrency DependencyKey {
-  static var liveValue: StationPlayer { .shared }
+  static let liveValue = StationPlayer()
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -267,6 +267,7 @@ protocol AudioBlockProvider {
 
 extension StationPlayer: @preconcurrency DependencyKey {
   static let liveValue = StationPlayer()
+  static var testValue: StationPlayer { StationPlayer() }
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 1/18/25.
 //
 import Combine
+import Dependencies
 import FRadioPlayer
 import Foundation
 import IdentifiedCollections
@@ -61,24 +62,36 @@ class StationPlayer: ObservableObject {
   var urlStreamPlayer: URLStreamPlayer
   var playolaStationPlayer: PlayolaStationPlayer
 
+  // The Combine subscriptions below capture `self` weakly so the cancellable
+  // owned by this StationPlayer is the only thing keeping each subscription
+  // alive. Without `[weak self]` the disposeBag/closure/self cycle would keep
+  // replaced players alive past instance lifetime — which matters once
+  // StationPlayer is a dependency-injected service.
   init(
     urlStreamPlayer: URLStreamPlayer? = nil,
     playolaStationPlayer: PlayolaStationPlayer? = nil
   ) {
-    self.urlStreamPlayer = urlStreamPlayer ?? .shared
+    @Dependency(\.urlStreamPlayer) var injectedUrlStreamPlayer
+    self.urlStreamPlayer = urlStreamPlayer ?? injectedUrlStreamPlayer
     self.playolaStationPlayer = playolaStationPlayer ?? .shared
 
-    self.urlStreamPlayer.$state.sink(receiveValue: { state in
-      self.processUrlStreamStateChanged(state)
-    }).store(in: &disposeBag)
+    self.urlStreamPlayer.$state
+      .sink { [weak self] state in
+        self?.processUrlStreamStateChanged(state)
+      }
+      .store(in: &disposeBag)
 
-    self.urlStreamPlayer.$albumArtworkURL.sink(receiveValue: { url in
-      self.processAlbumArtworkURLChanged(url)
-    }).store(in: &disposeBag)
+    self.urlStreamPlayer.$albumArtworkURL
+      .sink { [weak self] url in
+        self?.processAlbumArtworkURLChanged(url)
+      }
+      .store(in: &disposeBag)
 
-    self.playolaStationPlayer.$state.sink(receiveValue: { state in
-      self.processPlayolaStationPlayerState(state)
-    }).store(in: &disposeBag)
+    self.playolaStationPlayer.$state
+      .sink { [weak self] state in
+        self?.processPlayolaStationPlayerState(state)
+      }
+      .store(in: &disposeBag)
 
     self.playolaStationPlayer.configure(
       authProvider: self.authProvider, baseURL: Config.shared.baseUrl)
@@ -88,7 +101,7 @@ class StationPlayer: ObservableObject {
 
   /// Starts playing the specified station
   /// - Parameter station: The station to play
-  public func play(station: AnyStation) {
+  public func play(station: AnyStation) async {
     guard currentStation != station else { return }
     stop()
     state = State(playbackStatus: .startingNewStation(station))
@@ -99,7 +112,7 @@ class StationPlayer: ObservableObject {
       urlStreamPlayer.set(station: urlStation)
     case .playola(let playolaStation):
       urlStreamPlayer.reset()
-      Task { try? await playolaStationPlayer.play(stationId: playolaStation.id) }
+      try? await playolaStationPlayer.play(stationId: playolaStation.id)
     }
   }
 
@@ -111,7 +124,7 @@ class StationPlayer: ObservableObject {
   }
 
   /// Seeks to the next station in the artist list, wrapping around if at the end
-  public func seekNext() {
+  public func seekNext() async {
     let stations = seekableStations()
     guard !stations.isEmpty else { return }
 
@@ -121,16 +134,16 @@ class StationPlayer: ObservableObject {
     guard let current = currentStation,
       let currentIndex = stations.firstIndex(where: { $0.id == current.id })
     else {
-      play(station: stations[0])
+      await play(station: stations[0])
       return
     }
 
     let nextIndex = (currentIndex + 1) % stations.count
-    play(station: stations[nextIndex])
+    await play(station: stations[nextIndex])
   }
 
   /// Seeks to the previous station in the artist list, wrapping around if at the beginning
-  public func seekPrevious() {
+  public func seekPrevious() async {
     let stations = seekableStations()
     guard !stations.isEmpty else { return }
 
@@ -140,12 +153,12 @@ class StationPlayer: ObservableObject {
     guard let current = currentStation,
       let currentIndex = stations.firstIndex(where: { $0.id == current.id })
     else {
-      play(station: stations[0])
+      await play(station: stations[0])
       return
     }
 
     let previousIndex = (currentIndex - 1 + stations.count) % stations.count
-    play(station: stations[previousIndex])
+    await play(station: stations[previousIndex])
   }
 
   func seekableStations() -> [AnyStation] {
@@ -250,4 +263,17 @@ class StationPlayer: ObservableObject {
 // MARK: - AudioBlockProvider Protocol
 protocol AudioBlockProvider {
   var audioBlock: AudioBlock? { get }
+}
+
+// MARK: - Dependency
+
+extension StationPlayer: @preconcurrency DependencyKey {
+  static var liveValue: StationPlayer { .shared }
+}
+
+extension DependencyValues {
+  var stationPlayer: StationPlayer {
+    get { self[StationPlayer.self] }
+    set { self[StationPlayer.self] = newValue }
+  }
 }

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -19,54 +19,54 @@ struct StationPlayerTests {
   // MARK: - seekNext Tests
 
   @Test
-  func testSeekNextPlaysNextStation() {
+  func testSeekNextPlaysNextStation() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[0])
+    await stationPlayer.play(station: stations[0])
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == stations[1].id)
   }
 
   @Test
-  func testSeekNextWrapsAroundFromLastToFirst() {
+  func testSeekNextWrapsAroundFromLastToFirst() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[2])
+    await stationPlayer.play(station: stations[2])
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
   @Test
-  func testSeekNextWithNoCurrentStationPlaysFirst() {
+  func testSeekNextWithNoCurrentStationPlaysFirst() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
   @Test
-  func testSeekNextWithEmptyStationListDoesNothing() {
+  func testSeekNextWithEmptyStationListDoesNothing() async {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation == nil)
   }
@@ -74,42 +74,42 @@ struct StationPlayerTests {
   // MARK: - seekPrevious Tests
 
   @Test
-  func testSeekPreviousPlaysPreviousStation() {
+  func testSeekPreviousPlaysPreviousStation() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[1])
+    await stationPlayer.play(station: stations[1])
 
-    stationPlayer.seekPrevious()
+    await stationPlayer.seekPrevious()
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
   @Test
-  func testSeekPreviousWrapsAroundFromFirstToLast() {
+  func testSeekPreviousWrapsAroundFromFirstToLast() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[0])
+    await stationPlayer.play(station: stations[0])
 
-    stationPlayer.seekPrevious()
+    await stationPlayer.seekPrevious()
 
     #expect(stationPlayer.currentStation?.id == stations[2].id)
   }
 
   @Test
-  func testSeekPreviousWithNoCurrentStationPlaysFirst() {
+  func testSeekPreviousWithNoCurrentStationPlaysFirst() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
 
-    stationPlayer.seekPrevious()
+    await stationPlayer.seekPrevious()
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
@@ -117,7 +117,7 @@ struct StationPlayerTests {
   // MARK: - Station Filtering Tests
 
   @Test
-  func testSeekOnlyUsesArtistListStations() {
+  func testSeekOnlyUsesArtistListStations() async {
     @Shared(.stationLists) var stationLists = makeArtistAndFmLists()
     @Shared(.showSecretStations) var showSecretStations = false
 
@@ -125,50 +125,50 @@ struct StationPlayerTests {
     let artistList = stationLists.first { $0.id == StationList.KnownIDs.artistList.rawValue }!
     let artistStations = artistList.stations
 
-    stationPlayer.play(station: artistStations[0])
-    stationPlayer.seekNext()
+    await stationPlayer.play(station: artistStations[0])
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == artistStations[1].id)
   }
 
   @Test
-  func testSeekSkipsInactiveStations() {
+  func testSeekSkipsInactiveStations() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithInactiveStation()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let allStations = stationLists.first!.stations
 
-    stationPlayer.play(station: allStations[0])
-    stationPlayer.seekNext()
+    await stationPlayer.play(station: allStations[0])
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
 
   @Test
-  func testSeekSkipsComingSoonStationsWhenSecretsDisabled() {
+  func testSeekSkipsComingSoonStationsWhenSecretsDisabled() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithComingSoonStation()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let allStations = stationLists.first!.stations
 
-    stationPlayer.play(station: allStations[0])
-    stationPlayer.seekNext()
+    await stationPlayer.play(station: allStations[0])
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
 
   @Test
-  func testSeekIncludesComingSoonStationsWhenSecretsEnabled() {
+  func testSeekIncludesComingSoonStationsWhenSecretsEnabled() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithComingSoonStation()
     @Shared(.showSecretStations) var showSecretStations = true
 
     let stationPlayer = StationPlayer()
     let allStations = stationLists.first!.stations
 
-    stationPlayer.play(station: allStations[0])
-    stationPlayer.seekNext()
+    await stationPlayer.play(station: allStations[0])
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == allStations[1].id)
   }
@@ -236,41 +236,41 @@ struct StationPlayerTests {
   }
 
   @Test
-  func testIsSeekingIsFalseAfterSeekNextCompletes() {
+  func testIsSeekingIsFalseAfterSeekNextCompletes() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[0])
+    await stationPlayer.play(station: stations[0])
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
 
   @Test
-  func testIsSeekingIsFalseAfterSeekPreviousCompletes() {
+  func testIsSeekingIsFalseAfterSeekPreviousCompletes() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[1])
+    await stationPlayer.play(station: stations[1])
 
-    stationPlayer.seekPrevious()
+    await stationPlayer.seekPrevious()
 
     #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
 
   @Test
-  func testIsSeekingIsFalseWhenSeekHasNoStations() {
+  func testIsSeekingIsFalseWhenSeekHasNoStations() async {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(!stationPlayer.isSeeking, "isSeeking should remain false when no stations")
   }

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -186,6 +186,7 @@ extension URLStreamPlayer {
 
 extension URLStreamPlayer: @preconcurrency DependencyKey {
   public static let liveValue = URLStreamPlayer()
+  public static var testValue: URLStreamPlayer { URLStreamPlayer() }
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Dependencies
 import FRadioPlayer
 import Foundation
 import MediaPlayer
@@ -180,5 +181,18 @@ extension URLStreamPlayer {
         groups: []
       ))
     return stationPlayer
+  }
+}
+
+// MARK: - Dependency
+
+extension URLStreamPlayer: @preconcurrency DependencyKey {
+  public static var liveValue: URLStreamPlayer { .shared }
+}
+
+extension DependencyValues {
+  var urlStreamPlayer: URLStreamPlayer {
+    get { self[URLStreamPlayer.self] }
+    set { self[URLStreamPlayer.self] = newValue }
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -39,8 +39,6 @@ public class URLStreamPlayer: ObservableObject {
 
   @Published var albumArtworkURL: URL?
 
-  static let shared = URLStreamPlayer()
-
   @Published private(set) var currentStation: UrlStation?
 
   var searchedStations: [UrlStation] = []
@@ -187,7 +185,7 @@ extension URLStreamPlayer {
 // MARK: - Dependency
 
 extension URLStreamPlayer: @preconcurrency DependencyKey {
-  public static var liveValue: URLStreamPlayer { .shared }
+  public static let liveValue = URLStreamPlayer()
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
+++ b/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
@@ -21,23 +21,36 @@ public class UrlStreamListeningSessionReporter {
   var currentListeningSessionID: String?
   var lastSendStreamUrl: String?
 
+  // The $state sink captures `self` weakly so the cancellable owned by this
+  // reporter is the only thing keeping the subscription alive. Without
+  // `[weak self]` the disposeBag/closure/self cycle plus the strong capture
+  // of urlStreamPlayer would keep the URLStreamPlayer alive past instance
+  // lifetime — which matters once URLStreamPlayer is a dependency-injected
+  // service rather than a process-scoped singleton.
   init(urlStreamPlayer: URLStreamPlayer) {
     self.urlStreamPlayer = urlStreamPlayer
 
-    urlStreamPlayer.$state.sink { _ in
-      if let stationUrl = urlStreamPlayer.currentStation?.streamUrl {
-        if stationUrl != self.lastSendStreamUrl {
-          self.lastSendStreamUrl = stationUrl
-          self.reportOrExtendListeningSession(stationUrl)
-          self.startPeriodicNotifications()
+    urlStreamPlayer.$state
+      .sink { [weak self] _ in
+        guard let self else { return }
+        if let stationUrl = self.urlStreamPlayer?.currentStation?.streamUrl {
+          if stationUrl != self.lastSendStreamUrl {
+            self.lastSendStreamUrl = stationUrl
+            self.reportOrExtendListeningSession(stationUrl)
+            self.startPeriodicNotifications()
+          }
+        } else {
+          guard self.lastSendStreamUrl != nil else { return }
+          self.lastSendStreamUrl = nil
+          self.endListeningSession()
+          self.stopPeriodicNotifications()
         }
-      } else {
-        guard self.lastSendStreamUrl != nil else { return }
-        self.lastSendStreamUrl = nil
-        self.endListeningSession()
-        self.stopPeriodicNotifications()
       }
-    }.store(in: &disposeBag)
+      .store(in: &disposeBag)
+  }
+
+  deinit {
+    timer?.invalidate()
   }
 
   public func endListeningSession() {

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -199,7 +199,7 @@ extension PushNotificationsClient: DependencyKey {
       }
 
       await MainActor.run {
-        StationPlayer.shared.play(station: station)
+        Task { await StationPlayer.shared.play(station: station) }
       }
     },
     setBadgeCount: { count in

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -170,19 +170,24 @@ extension PushNotificationsClient: DependencyKey {
       let navCoordinatorShared = $navCoordinator
 
       if NotificationPayload.notificationType(from: userInfo) == "support_message" {
-        await MainActor.run {
+        // Decide on the main actor whether the support tap should refresh the
+        // already-visible support page or push a new one, then await the push
+        // outside the sync MainActor.run closure so we don't have to spawn an
+        // unstructured Task to bridge the async navigateToSupport call.
+        let needsNavigation = await MainActor.run { () -> Bool in
           let coordinator = navCoordinatorShared.wrappedValue
           let isSupportPageVisible = coordinator.path.contains { pathItem in
             if case .supportPage = pathItem { return true }
             return false
           }
-
           if isSupportPageVisible {
             NotificationCenter.default.post(name: .refreshSupportMessages, object: nil)
-          } else {
-            let supportModel = SupportPageModel()
-            Task { await coordinator.navigateToSupport(supportModel) }
+            return false
           }
+          return true
+        }
+        if needsNavigation {
+          await navCoordinatorShared.wrappedValue.navigateToSupport(SupportPageModel())
         }
         return
       }

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -198,9 +198,8 @@ extension PushNotificationsClient: DependencyKey {
         return
       }
 
-      await MainActor.run {
-        Task { await StationPlayer.shared.play(station: station) }
-      }
+      @Dependency(\.stationPlayer) var stationPlayer
+      await stationPlayer.play(station: station)
     },
     setBadgeCount: { count in
       try? await UNUserNotificationCenter.current().setBadgeCount(count)

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -152,7 +152,8 @@ struct PlayolaRadioApp: App {
     // Register SVG coder for SDWebImage
     SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
 
-    NowPlayingUpdater.shared.setupRemoteControlCenter()
+    @Dependency(\.nowPlayingUpdater) var nowPlayingUpdater
+    nowPlayingUpdater.setupRemoteControlCenter()
 
     // Initialize analytics
     Task {

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
@@ -242,7 +242,7 @@ class AskQuestionPageModel: ViewModel {
     if let url = recordingURL {
       await audioRecorder.deleteRecording(url)
     }
-    resumeStationIfNeeded()
+    await resumeStationIfNeeded()
     mainContainerNavigationCoordinator.pop()
   }
 
@@ -291,8 +291,10 @@ class AskQuestionPageModel: ViewModel {
       // Step 8: Show success and dismiss
       uploadPhase = .completed
       presentedAlert = .questionSentSuccess(curatorName: station.curatorName) { [weak self] in
-        self?.resumeStationIfNeeded()
-        self?.mainContainerNavigationCoordinator.popToRoot()
+        Task { @MainActor in
+          await self?.resumeStationIfNeeded()
+          self?.mainContainerNavigationCoordinator.popToRoot()
+        }
       }
 
     } catch {
@@ -326,9 +328,9 @@ class AskQuestionPageModel: ViewModel {
     }
   }
 
-  private func resumeStationIfNeeded() {
+  private func resumeStationIfNeeded() async {
     if let station = stationToResume {
-      stationPlayer.play(station: station)
+      await stationPlayer.play(station: station)
       stationToResume = nil
     }
   }

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
@@ -51,10 +51,13 @@ class AskQuestionPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.date.now) var now
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
+
+  // MARK: - Shared State
+
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
-  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
   // MARK: - Computed Properties
 

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
@@ -54,7 +54,7 @@ class AskQuestionPageModel: ViewModel {
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
   // MARK: - Computed Properties
 
@@ -101,9 +101,8 @@ class AskQuestionPageModel: ViewModel {
 
   // MARK: - Init
 
-  init(station: Station, stationPlayer: StationPlayer? = nil) {
+  init(station: Station) {
     self.station = station
-    self.stationPlayer = stationPlayer ?? .shared
     super.init()
   }
 

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
@@ -247,8 +247,9 @@ struct AskQuestionPageTests {
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = AskQuestionPageModel(station: .mock, stationPlayer: stationPlayerMock)
+      let model = AskQuestionPageModel(station: .mock)
 
       await model.viewAppeared()
 
@@ -263,8 +264,9 @@ struct AskQuestionPageTests {
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = AskQuestionPageModel(station: .mock, stationPlayer: stationPlayerMock)
+      let model = AskQuestionPageModel(station: .mock)
 
       await model.viewAppeared()
 
@@ -282,8 +284,9 @@ struct AskQuestionPageTests {
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = AskQuestionPageModel(station: .mock, stationPlayer: stationPlayerMock)
+      let model = AskQuestionPageModel(station: .mock)
       coordinator.path = [.askQuestionPage(model)]
 
       await model.viewAppeared()
@@ -305,8 +308,9 @@ struct AskQuestionPageTests {
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = AskQuestionPageModel(station: .mock, stationPlayer: stationPlayerMock)
+      let model = AskQuestionPageModel(station: .mock)
       coordinator.path = [.askQuestionPage(model)]
 
       await model.viewAppeared()

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -14,13 +14,21 @@ import SwiftUI
 @MainActor
 @Observable
 class ContactPageModel: ViewModel {
+  // MARK: - Dependencies
+
+  @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
+
+  // MARK: - Shared State
+
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.stationLists) var stationLists
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
-  @ObservationIgnored @Dependency(\.api) var api
-  @ObservationIgnored @Dependency(\.analytics) var analytics
+
+  // MARK: - Properties
+
   var editProfilePageModel: EditProfilePageModel = EditProfilePageModel()
   var likedSongsPageModel: LikedSongsPageModel = LikedSongsPageModel()
   var notificationsSettingsPageModel: NotificationsSettingsPageModel =

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -14,7 +14,7 @@ import SwiftUI
 @MainActor
 @Observable
 class ContactPageModel: ViewModel {
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.stationLists) var stationLists
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
@@ -66,12 +66,6 @@ class ContactPageModel: ViewModel {
 
   func switchToListeningMode() {
     mainContainerNavigationCoordinator.switchToListeningMode()
-  }
-
-  init(
-    stationPlayer: StationPlayer? = nil
-  ) {
-    self.stationPlayer = stationPlayer ?? .shared
   }
 
   func onViewAppeared() async {

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -42,8 +42,9 @@ struct ContactPageTests {
       }
       $0.analytics = .noop
       $0.analytics.reset = { resetCallCount.withValue { $0 += 1 } }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      await ContactPageModel(stationPlayer: stationPlayerMock).onLogOutTapped()
+      await ContactPageModel().onLogOutTapped()
     }
 
     #expect(stationPlayerMock.stopCalledCount == 1)
@@ -485,8 +486,9 @@ struct ContactPageTests {
     await withDependencies {
       $0.api.unregisterDevice = { _, _ in }
       $0.analytics = .noop
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = ContactPageModel(stationPlayer: stationPlayerMock)
+      let model = ContactPageModel()
       await model.onLogOutTapped()
     }
 
@@ -508,7 +510,7 @@ struct ContactPageTests {
       }
       $0.analytics = .noop
     } operation: {
-      let model = ContactPageModel(stationPlayer: StationPlayerMock())
+      let model = ContactPageModel()
       await model.onLogOutTapped()
     }
 
@@ -527,7 +529,7 @@ struct ContactPageTests {
       $0.api.unregisterDevice = { _, _ in throw UnregisterError() }
       $0.analytics = .noop
     } operation: {
-      let model = ContactPageModel(stationPlayer: StationPlayerMock())
+      let model = ContactPageModel()
       await model.onLogOutTapped()
     }
 

--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -24,12 +24,17 @@ struct ContentView: View {
   @State private var hasTrackedAppOpen = false
   @State private var requiresUpdate = false
 
+  @Dependency(\.stationPlayer) private var stationPlayer
+  @Dependency(\.nowPlayingUpdater) private var nowPlayingUpdater
+
   var mainContainerModel = MainContainerModel()
 
   init() {
-    // Ensure StationPlayer and NowPlayingUpdater are initialized early
-    _ = StationPlayer.shared
-    _ = NowPlayingUpdater.shared
+    // Resolve audio playback dependencies eagerly so the live singletons are
+    // wired (state sinks, FRadioPlayer observers, remote-control center) by
+    // the time the first view appears.
+    _ = stationPlayer
+    _ = nowPlayingUpdater
   }
 
   private let appStoreURL = URL(

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -19,7 +19,7 @@ class HomePageModel: ViewModel {
   @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored @Dependency(\.date.now) var now
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
   // MARK: - Shared State
 
@@ -33,12 +33,6 @@ class HomePageModel: ViewModel {
   var mainContainerNavigationCoordinator
   @ObservationIgnored @Shared(.unreadSupportCount) var unreadSupportCount
   @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
-
-  // MARK: - Initialization
-
-  init(stationPlayer: StationPlayer? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
-  }
 
   // MARK: - Properties
 

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -170,7 +170,7 @@ class HomePageModel: ViewModel {
         station: StationInfo(from: station),
         entryPoint: "home_recommendations"
       ))
-    stationPlayer.play(station: station)
+    await stationPlayer.play(station: station)
   }
 
   // MARK: - View Helpers

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -302,8 +302,9 @@ struct HomePageTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      HomePageModel(stationPlayer: stationPlayerMock)
+      HomePageModel()
     }
 
     await homePageModel.stationTapped(station)

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -22,7 +22,7 @@ class MainContainerModel: ViewModel {
   @ObservationIgnored @Dependency(\.toast) var toast
   @ObservationIgnored @Dependency(\.pushNotifications) var pushNotifications
   @ObservationIgnored @Dependency(\.appRating) var appRating
-  @ObservationIgnored var stationPlayer: StationPlayer!
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
   @ObservationIgnored @Shared(.stationLists) var stationLists
   @ObservationIgnored @Shared(.stationListsLoaded) var stationListsLoaded: Bool = false
   @ObservationIgnored @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
@@ -66,11 +66,6 @@ class MainContainerModel: ViewModel {
 
   var shouldShowSmallPlayer: Bool = false
   private var hasCheckedRatingPromptThisSession = false
-
-  init(stationPlayer: StationPlayer? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
-    super.init()
-  }
 
   // MARK: - Mode-Aware Properties
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -196,8 +196,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -212,8 +213,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -227,8 +229,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -243,8 +246,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -259,8 +263,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -272,7 +277,11 @@ struct MainContainerTests {
   @Test
   func testSmallPlayerActionsOnSmallPlayerTapped() {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
-    let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
+    let mainContainerModel = withDependencies {
+      $0.stationPlayer = stationPlayerMock
+    } operation: {
+      MainContainerModel()
+    }
 
     mainContainerModel.onSmallPlayerTapped()
 
@@ -289,7 +298,11 @@ struct MainContainerTests {
   @Test
   func testProcessNewStationStatePresentsPlayerSheetWhenStartingNewStation() {
     let stationPlayerMock = StationPlayerMock()
-    let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
+    let mainContainerModel = withDependencies {
+      $0.stationPlayer = stationPlayerMock
+    } operation: {
+      MainContainerModel()
+    }
 
     let newState = StationPlayer.State(playbackStatus: .startingNewStation(.mock))
     mainContainerModel.processNewStationState(newState)
@@ -308,7 +321,11 @@ struct MainContainerTests {
     var coordinator = MainContainerNavigationCoordinator()
 
     let stationPlayerMock = StationPlayerMock()
-    let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
+    let mainContainerModel = withDependencies {
+      $0.stationPlayer = stationPlayerMock
+    } operation: {
+      MainContainerModel()
+    }
 
     let playingState = StationPlayer.State(playbackStatus: .playing(.mock))
     mainContainerModel.processNewStationState(playingState)
@@ -332,7 +349,11 @@ struct MainContainerTests {
   @Test
   func testDismissButtonPlayerPageOnDismissClearsPresentedSheet() {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
-    let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
+    let mainContainerModel = withDependencies {
+      $0.stationPlayer = stationPlayerMock
+    } operation: {
+      MainContainerModel()
+    }
 
     mainContainerModel.onSmallPlayerTapped()
 
@@ -720,8 +741,9 @@ struct MainContainerTests {
         shouldShowCalled.setValue(true)
         return false
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     $activeTab.withLock { $0 = .stationsList }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -183,10 +183,9 @@ class PlayerPageModel: ViewModel {
     return likesManager.isLiked(audioBlock.id) ? .filled : .empty
   }
 
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
-  init(stationPlayer: StationPlayer? = nil, onDismiss: (() -> Void)? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
+  init(onDismiss: (() -> Void)? = nil) {
     self.onDismiss = onDismiss
   }
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -23,7 +23,11 @@ struct PlayerPageTests {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -40,7 +44,11 @@ struct PlayerPageTests {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station, 0.42))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -58,7 +66,11 @@ struct PlayerPageTests {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       artistPlaying: "Rachel Loy", titlePlaying: "Selfie", station: station)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Selfie - Rachel Loy")
     #expect(model.stationArtUrl == station.imageUrl)
@@ -72,7 +84,11 @@ struct PlayerPageTests {
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       artistPlaying: "Rachel Loy", titlePlaying: "Selfie", spin: spin, station: station)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Selfie - Rachel Loy")
     #expect(model.stationArtUrl == station.imageUrl)
@@ -89,7 +105,11 @@ struct PlayerPageTests {
     ]
     let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.relatedText?.title == "Why I chose this song")
     #expect(model.relatedText?.body == transcription)
@@ -105,7 +125,11 @@ struct PlayerPageTests {
     ]
     let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.relatedText != nil)
     #expect(model.relatedText == relatedTexts[0] || model.relatedText == relatedTexts[1])
@@ -115,7 +139,11 @@ struct PlayerPageTests {
   @Test
   func testViewAppearedPopulatesCorrectlyWhenStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "")
     #expect(model.albumArtUrl == nil)
@@ -125,7 +153,11 @@ struct PlayerPageTests {
   @Test
   func testViewAppearedPopulatesCorrectlyWhenError() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .error)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Error Playing Station")
     #expect(model.primaryNavBarTitle == "")
@@ -139,7 +171,11 @@ struct PlayerPageTests {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -159,7 +195,11 @@ struct PlayerPageTests {
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       spin: spin, station: station, status: .startingNewStation(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -181,7 +221,11 @@ struct PlayerPageTests {
     ]
     let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     let firstResult = model.relatedText
     #expect(firstResult != nil)
@@ -195,7 +239,11 @@ struct PlayerPageTests {
   func testPlayPauseButtonTappedStopsWhenPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()
     let spy = StationPlayerMock()
-    let model = PlayerPageModel(stationPlayer: spy)
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel()
+    }
 
     model.playPauseButtonTapped()
 
@@ -208,7 +256,11 @@ struct PlayerPageTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()
     let spy = StationPlayerMock()
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.playPauseButtonTapped()
 
@@ -224,7 +276,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -237,7 +293,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .error)
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -251,7 +311,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .playing(station))
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -265,7 +329,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .loading(station))
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -279,7 +347,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .startingNewStation(station))
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -292,7 +364,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .background)
 
@@ -305,7 +381,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .inactive)
 
@@ -317,7 +397,11 @@ struct PlayerPageTests {
   @Test
   func testHeartStateHiddenWhenNotPlayingPlayolaSong() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()  // No spin
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.heartState == .hidden)
     #expect(model.heartState.imageName == "")
@@ -333,7 +417,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .empty)
       #expect(model.heartState.imageName == "heart")
@@ -352,7 +440,11 @@ struct PlayerPageTests {
       likesManager.like(audioBlock)
       $0.likesManager = likesManager
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .filled)
       #expect(model.heartState.imageName == "heart.fill")
@@ -369,7 +461,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
       model.heartButtonTapped()
       #expect(model.likesManager.allLikedAudioBlocks.count == 0)
     }
@@ -386,7 +482,11 @@ struct PlayerPageTests {
       $0.uuid = .incrementing
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .empty)
       model.heartButtonTapped()
@@ -408,7 +508,11 @@ struct PlayerPageTests {
       likesManager.like(audioBlock)
       $0.likesManager = likesManager
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .filled)
       model.heartButtonTapped()
@@ -430,7 +534,11 @@ struct PlayerPageTests {
       $0.uuid = .incrementing
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
       model.heartButtonTapped()
 
       #expect(model.likesManager.pendingOperations.count == 1)
@@ -450,7 +558,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .hidden)
       #expect(model.heartState.imageName == "")
@@ -467,7 +579,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .empty)
       #expect(model.heartState.imageName == "heart")
@@ -484,7 +600,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
       model.heartButtonTapped()
 
       #expect(model.likesManager.allLikedAudioBlocks.count == 0)
@@ -499,7 +619,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockPlayola(name: "Test Radio Show", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "Test Curator")
     #expect(model.secondaryNavBarTitle == "Test Radio Show")
@@ -510,7 +634,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockPlayola(name: "Another Radio Show", curatorName: "Another Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "Another Curator")
     #expect(model.secondaryNavBarTitle == "Another Radio Show")
@@ -521,7 +649,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockUrl(name: "Test FM", location: "Test City, TX")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "Test FM")
     #expect(model.secondaryNavBarTitle == "Test City, TX")
@@ -532,7 +664,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockUrl(name: "Another FM", location: "Another City, CA")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "Another FM")
     #expect(model.secondaryNavBarTitle == "Another City, CA")
@@ -543,7 +679,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockUrl(name: "No Location FM", location: "")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "No Location FM")
     #expect(model.secondaryNavBarTitle == "")
@@ -553,7 +693,11 @@ struct PlayerPageTests {
   func testNavBarTitlesWhenPlaying() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -566,7 +710,11 @@ struct PlayerPageTests {
   @Test
   func testNavBarTitlesEmptyWhenStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "")
     #expect(model.secondaryNavBarTitle == "")
@@ -579,7 +727,11 @@ struct PlayerPageTests {
     let commercialBlock = AudioBlock.mockWith(type: "commercial")
     let spin = Spin.mockWith(audioBlock: commercialBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Playola Pays")
   }
@@ -589,7 +741,11 @@ struct PlayerPageTests {
     let songBlock = AudioBlock.mockWith(title: "Test Song", artist: "Test Artist", type: "song")
     let spin = Spin.mockWith(audioBlock: songBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Test Song - Test Artist")
   }
@@ -608,7 +764,11 @@ struct PlayerPageTests {
 
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
 
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Airing Song - Airing Artist")
   }
@@ -623,7 +783,11 @@ struct PlayerPageTests {
 
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
 
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "My Cool Episode")
   }
@@ -636,7 +800,11 @@ struct PlayerPageTests {
 
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin, station: station)
 
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Test Station Name")
   }
@@ -646,21 +814,33 @@ struct PlayerPageTests {
   @Test
   func testCanAskQuestionTrueForPlayolaStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockPlayola())
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(model.canAskQuestion)
   }
 
   @Test
   func testCanAskQuestionFalseForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(!model.canAskQuestion)
   }
 
   @Test
   func testCanAskQuestionFalseWhenNoStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(!model.canAskQuestion)
   }
 
@@ -668,7 +848,11 @@ struct PlayerPageTests {
   func testCurrentPlayolaStationReturnsStationForPlayolaStation() {
     let station = AnyStation.mockPlayola(id: "test-id", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(model.currentPlayolaStation?.id == "test-id")
     #expect(model.currentPlayolaStation?.curatorName == "Test Curator")
   }
@@ -676,7 +860,11 @@ struct PlayerPageTests {
   @Test
   func testCurrentPlayolaStationReturnsNilForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(model.currentPlayolaStation == nil)
   }
 
@@ -688,8 +876,11 @@ struct PlayerPageTests {
       MainContainerNavigationCoordinator()
 
     var dismissCalled = false
-    let model = PlayerPageModel(
-      stationPlayer: StationPlayerMock(), onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.askQuestionButtonTapped()
 
@@ -709,7 +900,11 @@ struct PlayerPageTests {
     @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
       MainContainerNavigationCoordinator()
 
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     model.askQuestionButtonTapped()
 
     #expect(navCoordinator.path.isEmpty)

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -20,7 +20,7 @@ class StationListModel: ViewModel {
 
   @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.pushNotifications) var pushNotifications
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
   // MARK: - Shared State
 
@@ -32,12 +32,6 @@ class StationListModel: ViewModel {
   var hasAskedForNotificationPermission: Bool
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
-
-  // MARK: - Initialization
-
-  init(stationPlayer: StationPlayer? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
-  }
 
   // MARK: - Properties
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -166,7 +166,7 @@ class StationListModel: ViewModel {
         entryPoint: "station_list"
       ))
 
-    stationPlayer.play(station: station)
+    await stationPlayer.play(station: station)
   }
 
   // MARK: - View Helpers

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -174,8 +174,9 @@ struct StationListPageTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      StationListModel(stationPlayer: stationPlayerMock)
+      StationListModel()
     }
 
     let now = Date()
@@ -212,8 +213,9 @@ struct StationListPageTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      StationListModel(stationPlayer: stationPlayerMock)
+      StationListModel()
     }
 
     let now = Date()
@@ -263,8 +265,9 @@ struct StationListPageTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      StationListModel(stationPlayer: stationPlayerMock)
+      StationListModel()
     }
 
     let now = Date()
@@ -879,11 +882,10 @@ private func makeStationListModel(
   stationPlayer: StationPlayerMock
 ) -> StationListModel {
   withDependencies {
-    $0.analytics.track = { event in
-      analyticsSink.withValue { $0.append(event) }
-    }
+    $0.analytics.track = { event in analyticsSink.withValue { $0.append(event) } }
+    $0.stationPlayer = stationPlayer
   } operation: {
-    StationListModel(stationPlayer: stationPlayer)
+    StationListModel()
   }
 }
 

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct SmallPlayer: View {
   @Shared(.nowPlaying) var nowPlaying: NowPlaying?
   @Dependency(\.likesManager) var likesManager
+  @Dependency(\.stationPlayer) var stationPlayer
 
   // Computed properties from nowPlaying data
   var mainTitle: String {
@@ -98,7 +99,7 @@ struct SmallPlayer: View {
         }
 
         Button(
-          action: { StationPlayer.shared.stop() },
+          action: { stationPlayer.stop() },
           label: {
             Image(systemName: "stop.fill")
               .foregroundColor(.black)

--- a/PlayolaRadioTests/Mocks/StationPlayerMock.swift
+++ b/PlayolaRadioTests/Mocks/StationPlayerMock.swift
@@ -18,7 +18,7 @@ class StationPlayerMock: StationPlayer {
     super.init(urlStreamPlayer: URLStreamPlayerMock())
   }
 
-  override public func play(station: AnyStation) {
+  override public func play(station: AnyStation) async {
     callsToPlay.append(station)
   }
 


### PR DESCRIPTION
## Summary

Final cleanup PR in the Point-Free-style series. Converts the audio playback services (`URLStreamPlayer`, `StationPlayer`, `NowPlayingUpdater`) from `.shared` singletons to dependency-injected services, threads `await` through the now-async `play` API, and folds in the stray unstructured `Task{}` blocks left over from prior PRs.

Five focused commits — review per-commit is the easiest path:

1. **NowPlayingUpdater** — inject `@Dependency(\.date.now)`, replace 4 raw `Date()` reads, capture self weakly in the long-lived `$state` sink.
2. **UrlStreamListeningSessionReporter** — `[weak self]` in the sink, deinit invalidates the periodic-notification timer.
3. **Audio services as DependencyKey** — register `URLStreamPlayer`, `StationPlayer`, `NowPlayingUpdater`. Capture self weakly in StationPlayer's three sinks. Make `play` / `seekNext` / `seekPrevious` async so the playola play call is awaited directly instead of fire-and-forget. Threads `await` through every in-tree call site.
4. **Migrate consumers and delete singletons** — 6 page models drop `stationPlayer ?? .shared` init param → `@Dependency(\.stationPlayer)`. App-level sites (ContentView, PlayolaRadioApp, CarPlaySceneDelegate, SmallPlayer, PushNotifications) drop `.shared` access. ~64 test invocations switch from `Model(stationPlayer: mock)` to `withDependencies { $0.stationPlayer = mock } operation: { Model() }`. `URLStreamPlayer.shared` / `StationPlayer.shared` / `NowPlayingUpdater.shared` deleted.
5. **PushNotifications support tap** — restructure to await `navigateToSupport` directly instead of spawning a fire-and-forget `Task{}` inside a sync `MainActor.run`.

## What's NOT included

- **`PlayolaStationPlayer` (the SPM library type) does not get its own `DependencyKey`.** Our swift-format profile forbids `@retroactive` conformances and we don't own the type, so `StationPlayer.init` and `NowPlayingUpdater.setupSharedStateObservation` access `PlayolaStationPlayer.shared` directly. There are no tests overriding playola playback today, so this is a no-op for current coverage; if we ever need to mock it, the cleanest next step is a thin `PlayolaStationPlayerClient` wrapper in this repo.
- **`StationPlayer` is not `final`.** `StationPlayerMock` still subclasses it and overrides `play` / `stop` to spy on calls. Tests inject the mock via `withDependencies`. Making `StationPlayer` final would require either a protocol-based test double or replacing the spy with closure-based behavior — out of scope here.
- **The duplicated state-processing logic between `StationPlayer` and `NowPlayingUpdater`** (both subscribe to `URLStreamPlayer.$state` and `PlayolaStationPlayer.$state` and run very similar switch statements) is unchanged. Worth a follow-up; not a lifecycle/DI concern.

This is the last PR in the audit's series. After this lands, the only outstanding item is the optional reusable-component-model spot-check (PR G).

## Test plan
- [ ] `xcodebuild -project PlayolaRadio.xcodeproj -scheme PlayolaRadio -destination 'platform=iOS Simulator,id=B21D9417-B868-48E8-BC55-0386260836BA' build-for-testing` → `** TEST BUILD SUCCEEDED **`
- [ ] All audio-playback unit tests pass in Xcode (StationPlayerTests, NowPlayingUpdaterTests, the 6 page-model tests).
- [ ] Smoke test in the simulator: tap a station from Home → starts playing; tap stop on small player → stops; CarPlay still routes; lock-screen now-playing still updates.