### PR TITLE
Fix: hang reading @Shared(.unreadSupportCount) on main thread

### DIFF
--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -210,24 +210,25 @@ extension PushNotificationsClient: DependencyKey {
       try? await UNUserNotificationCenter.current().setBadgeCount(count)
     },
     handleSupportNotificationBadge: { badgeFromPayload in
-      @Shared(.unreadSupportCount) var unreadSupportCount
-      @Dependency(\.pushNotifications) var pushNotifications
-
-      let newCount: Int
-      if let badge = badgeFromPayload {
-        newCount = badge
-        $unreadSupportCount.withLock { $0 = badge }
-      } else {
-        $unreadSupportCount.withLock { $0 += 1 }
-        newCount = unreadSupportCount
+      let newCount = await MainActor.run { () -> Int in
+        @Shared(.unreadSupportCount) var unreadSupportCount
+        if let badge = badgeFromPayload {
+          $unreadSupportCount.withLock { $0 = badge }
+          return badge
+        } else {
+          $unreadSupportCount.withLock { $0 += 1 }
+          return unreadSupportCount
+        }
       }
+      @Dependency(\.pushNotifications) var pushNotifications
       await pushNotifications.setBadgeCount(newCount)
     },
     clearSupportBadge: {
-      @Shared(.unreadSupportCount) var unreadSupportCount
+      await MainActor.run {
+        @Shared(.unreadSupportCount) var unreadSupportCount
+        $unreadSupportCount.withLock { $0 = 0 }
+      }
       @Dependency(\.pushNotifications) var pushNotifications
-
-      $unreadSupportCount.withLock { $0 = 0 }
       await pushNotifications.setBadgeCount(0)
     }
   )


### PR DESCRIPTION
## Summary

Fixes Sentry [APPLE-IOS-W](https://playola-radio.sentry.io/issues/APPLE-IOS-W) — fatal app hang where the OS watchdog terminated the app while the main thread was blocked >2s on swift-sharing's `_PersistentReference` lock.

The Sentry stacktrace points cleanly at `HomePageView` body re-evaluation reading `model.hasUnreadSupportMessages`:

```
HomePageView.body
  if model.hasUnreadSupportMessages {
    HomePageModel.hasUnreadSupportMessages.getter
      unreadSupportCount > 0
        @Shared.wrappedValue
          _PersistentReference.wrappedValue
            lock.withLock { value }   ← blocked
              __psynch_mutexwait
```

## Root cause

`AppDelegate.userNotificationCenter(_:willPresent:)` dispatches `pushNotifications.handleSupportNotificationBadge(...)` inside an unstructured `Task { }`, which runs on a generic executor (not main). The badge handler then writes to `@Shared(.unreadSupportCount)` from that background thread.

When a support push arrives mid-render, the main thread reading `unreadSupportCount` for the SwiftUI body can block on the same lock long enough to trip the OS watchdog (≥2s = fatal).

## Fix

Wrap the `@Shared(.unreadSupportCount)` writes inside `handleSupportNotificationBadge` and `clearSupportBadge` with `MainActor.run { … }`. With this change all writers to `unreadSupportCount` (push handler, clear handler, `MainContainerModel.fetchUnreadSupportCount`) run on the main actor — same thread as the SwiftUI reads — so there's no cross-thread lock contention.

The async `setBadgeCount` calls remain outside `MainActor.run` since they don't touch the shared lock.

## Test plan

- [x] `PushNotificationsTests` (11 tests) pass
- [x] `HomePageTests` pass
- [ ] Verify in TestFlight that subsequent builds don't repro APPLE-IOS-W