### PR TITLE
Release 6.2.0: Swift Testing Conversion - Hang Fix

### DIFF
--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -38,13 +38,13 @@
     },
     {
       "id": "shared-state-in-tests",
-      "rule": "In tests, declare `@Shared` locally inside each test method with an initial value: `@Shared(.key) var key = initialValue`. Do NOT use class-level `@Shared` properties or `$shared.withLock` patterns anywhere in tests.",
+      "rule": "In tests, declare `@Shared` locally inside each test method with an initial value: `@Shared(.key) var key = initialValue`. Do NOT use class-level `@Shared` properties. `$shared.withLock` is permitted only when verifying production code that subscribes to `@Shared` and reacts to changes (use it to drive the change mid-test). For state setup or resets, use the per-test `= initialValue` pattern.",
       "scope": ["PlayolaRadio/**/*Tests.swift"],
       "severity": "high"
     },
     {
       "id": "test-class-main-actor",
-      "rule": "All test classes must be annotated with `@MainActor`: `@MainActor final class SomeTests: XCTestCase`.",
+      "rule": "Test types that touch MainActor-isolated code must be annotated with `@MainActor`. For XCTest: `@MainActor final class SomeTests: XCTestCase`. For swift-testing: `@MainActor struct SomeTests` (or `@MainActor @Suite struct ...`).",
       "scope": ["PlayolaRadio/**/*Tests.swift"],
       "severity": "medium"
     },

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2085,7 +2085,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 85;
+				CURRENT_PROJECT_VERSION = 86;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2105,7 +2105,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.2.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2129,7 +2129,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 85;
+				CURRENT_PROJECT_VERSION = 86;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2149,7 +2149,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.2.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2173,7 +2173,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 85;
+				CURRENT_PROJECT_VERSION = 86;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2193,7 +2193,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.2.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2338,7 +2338,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 85;
+				CURRENT_PROJECT_VERSION = 86;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2360,7 +2360,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.2.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2384,7 +2384,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 85;
+				CURRENT_PROJECT_VERSION = 86;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2406,7 +2406,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.2.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2425,7 +2425,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 85;
+				CURRENT_PROJECT_VERSION = 86;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2444,7 +2444,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 85;
+				CURRENT_PROJECT_VERSION = 86;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2532,7 +2532,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 85;
+				CURRENT_PROJECT_VERSION = 86;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2554,7 +2554,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.1.0;
+				MARKETING_VERSION = 6.2.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2573,7 +2573,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 85;
+				CURRENT_PROJECT_VERSION = 86;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2078,7 +2078,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2122,7 +2122,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2166,7 +2166,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2331,7 +2331,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2377,7 +2377,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2418,7 +2418,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2437,7 +2437,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2525,7 +2525,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2566,7 +2566,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 84;
+				CURRENT_PROJECT_VERSION = 85;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -400,6 +400,7 @@
 		D3FEC80B2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */; };
 		D3FEC80C2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */; };
 		D3FEC80D2EDF689F00A33AE8 /* ChooseStationToBroadcastPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */; };
+		D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = D3FF74D42FA7CA760052D500 /* CustomDump */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
 /* End PBXBuildFile section */
 
@@ -686,6 +687,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				D334827B2F9B1A83002CAC52 /* Sentry in Frameworks */,
+				D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1602,6 +1604,7 @@
 				D3916A652ECD229B00CAAD50 /* XCRemoteSwiftPackageReference "swift-identified-collections" */,
 				D3916A6A2ECD231200CAAD50 /* XCRemoteSwiftPackageReference "swift-sharing" */,
 				9E0939D453C04700B9C51BBD /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
+				D3FF74D32FA7CA760052D500 /* XCRemoteSwiftPackageReference "swift-custom-dump" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = D3536A022BFA4F49006942D6 /* Products */;
@@ -2786,6 +2789,14 @@
 				minimumVersion = 0.14.0;
 			};
 		};
+		D3FF74D32FA7CA760052D500 /* XCRemoteSwiftPackageReference "swift-custom-dump" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/pointfreeco/swift-custom-dump";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.5.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -2931,6 +2942,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = D3CE19012D3C825C0091B888 /* XCRemoteSwiftPackageReference "PlayolaPlayer" */;
 			productName = PlayolaPlayer;
+		};
+		D3FF74D42FA7CA760052D500 /* CustomDump */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = D3FF74D32FA7CA760052D500 /* XCRemoteSwiftPackageReference "swift-custom-dump" */;
+			productName = CustomDump;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -240,6 +240,7 @@
 		D35EFC562F1AFF76000F64A4 /* AppRatingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC542F1AFF76000F64A4 /* AppRatingClient.swift */; };
 		D35EFC572F1AFF76000F64A4 /* AppRatingClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC542F1AFF76000F64A4 /* AppRatingClient.swift */; };
 		D35EFC592F1B0472000F64A4 /* AppRatingClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC582F1B0472000F64A4 /* AppRatingClientTests.swift */; };
+		D3ABC1252F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3ABC1242F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift */; };
 		D36FBCC02E37FC8100D1241C /* PrizeTierRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36FBCBF2E37FC7800D1241C /* PrizeTierRow.swift */; };
 		D37257AB2DF87C72001BC6F9 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D37257AA2DF87C72001BC6F9 /* LaunchScreen.storyboard */; };
 		D37257B02DF88BB7001BC6F9 /* HomePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257AF2DF88BB2001BC6F9 /* HomePageView.swift */; };
@@ -527,6 +528,7 @@
 		D35EFC4B2F1A9911000F64A4 /* ConversationListPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConversationListPageView.swift; sourceTree = "<group>"; };
 		D35EFC542F1AFF76000F64A4 /* AppRatingClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingClient.swift; sourceTree = "<group>"; };
 		D35EFC582F1B0472000F64A4 /* AppRatingClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppRatingClientTests.swift; sourceTree = "<group>"; };
+		D3ABC1242F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClientTests.swift; sourceTree = "<group>"; };
 		D36FBCBF2E37FC7800D1241C /* PrizeTierRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrizeTierRow.swift; sourceTree = "<group>"; };
 		D37257AA2DF87C72001BC6F9 /* LaunchScreen.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = LaunchScreen.storyboard; sourceTree = "<group>"; };
 		D37257AF2DF88BB2001BC6F9 /* HomePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageView.swift; sourceTree = "<group>"; };
@@ -1224,6 +1226,7 @@
 			children = (
 				D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */,
 				D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */,
+				D3ABC1242F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -2034,6 +2037,7 @@
 				D39728762F60E2A7008591E3 /* StationSuggestionPageTests.swift in Sources */,
 				D30257812E639FF200F4228B /* LikesManagerTests.swift in Sources */,
 				D35EFC592F1B0472000F64A4 /* AppRatingClientTests.swift in Sources */,
+				D3ABC1252F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift in Sources */,
 				D35EFC092F159014000F64A4 /* EpisodeRowTests.swift in Sources */,
 				D3776A332F2695BE00200ADF /* ListenerQuestionDetailPageTests.swift in Sources */,
 				D30257842E63A37400F4228B /* LikeOperationTests.swift in Sources */,

--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -50,7 +50,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
   private func playStation(_ station: AnyStation?) {
     guard let station else { return }
 
-    stationPlayer.play(station: station)
+    Task { @MainActor in
+      await stationPlayer.play(station: station)
+    }
     showNowPlayingTemplate()
   }
 
@@ -335,7 +337,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
     )
     listItem.handler = { _, completion in
       if station.active {
-        self.stationPlayer.play(station: station)
+        Task { @MainActor in
+          await self.stationPlayer.play(station: station)
+        }
       }
       completion()
     }

--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -36,10 +36,9 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
   var observers = Set<AnyCancellable>()
 
   @Dependency(\.analytics) var analytics
+  @Dependency(\.stationPlayer) var stationPlayer
 
   private var isTransitioningToNowPlaying = false
-
-  var stationPlayer: StationPlayer { StationPlayer.shared }
 
   override init() {
     super.init()
@@ -177,7 +176,8 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
   }
 
   private func setupNowPlayingTemplate() {
-    _ = NowPlayingUpdater.shared
+    @Dependency(\.nowPlayingUpdater) var nowPlayingUpdater
+    _ = nowPlayingUpdater
   }
 
   private func observePlaybackErrors() {

--- a/PlayolaRadio/Core/API/APIClientTests.swift
+++ b/PlayolaRadio/Core/API/APIClientTests.swift
@@ -5,27 +5,29 @@
 //  Created by Brian D Keane on 12/31/25.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class APIClientTests: XCTestCase {
+struct APIClientTests {
 
   // MARK: - URL Encoding Tests
 
+  @Test
   func testS3KeyWithSlashIsProperlyEncodedForURLPath() {
     let s3Key = "station123/mock-uuid.m4a"
 
     // Using urlQueryAllowed does NOT encode "/" - this is the bug
     let badEncoding = s3Key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)
-    XCTAssertEqual(badEncoding, "station123/mock-uuid.m4a", "urlQueryAllowed doesn't encode slash")
+    #expect(badEncoding == "station123/mock-uuid.m4a", "urlQueryAllowed doesn't encode slash")
 
     // The correct encoding should encode "/" as %2F
     var allowedCharacters = CharacterSet.urlPathAllowed
     allowedCharacters.remove("/")
     let goodEncoding = s3Key.addingPercentEncoding(withAllowedCharacters: allowedCharacters)
-    XCTAssertEqual(goodEncoding, "station123%2Fmock-uuid.m4a", "Slash should be encoded as %2F")
+    #expect(goodEncoding == "station123%2Fmock-uuid.m4a", "Slash should be encoded as %2F")
     func testVoicetrackStatusURLEncodesS3KeyWithSlashes() {
       let baseUrl = "https://api.example.com"
       let stationId = "station-123"
@@ -35,9 +37,8 @@ final class APIClientTests: XCTestCase {
         s3Key.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? s3Key
       let url = "\(baseUrl)/v1/stations/\(stationId)/voicetrack-status/\(encodedS3Key)"
 
-      XCTAssertEqual(
-        url,
-        "https://api.example.com/v1/stations/station-123/voicetrack-status/"
+      #expect(
+        url == "https://api.example.com/v1/stations/station-123/voicetrack-status/"
           + "voicetracks%2Fstation123%2Fabc%2Ddef%2D123%2Em4a"
       )
     }
@@ -48,7 +49,7 @@ final class APIClientTests: XCTestCase {
       let encodedWithQueryAllowed =
         s3Key.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? s3Key
 
-      XCTAssertTrue(
+      #expect(
         encodedWithQueryAllowed.contains("/"),
         "urlQueryAllowed does NOT encode slashes - this causes 404 errors when used in URL paths"
       )
@@ -60,11 +61,11 @@ final class APIClientTests: XCTestCase {
       let encodedWithAlphanumerics =
         s3Key.addingPercentEncoding(withAllowedCharacters: .alphanumerics) ?? s3Key
 
-      XCTAssertFalse(
-        encodedWithAlphanumerics.contains("/"),
+      #expect(
+        !encodedWithAlphanumerics.contains("/"),
         "alphanumerics should encode slashes"
       )
-      XCTAssertTrue(
+      #expect(
         encodedWithAlphanumerics.contains("%2F"),
         "Slashes should be encoded as %2F"
       )

--- a/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
@@ -69,106 +69,110 @@ extension DependencyValues {
 // MARK: - Live Implementation
 
 extension AnalyticsClient: DependencyKey {
-  static let liveValue = Self(
-    track: { event in
-      await MainActor.run {
-        @Shared(.auth) var auth: Auth
-        var properties = event.properties
+  static var liveValue: Self {
+    @Dependency(\.date.now) var now
 
-        // Automatically add userId to all events when available
-        if let userId = auth.currentUser?.id {
-          properties["user_id"] = userId
-        }
+    return Self(
+      track: { event in
+        await MainActor.run {
+          @Shared(.auth) var auth: Auth
+          var properties = event.properties
 
-        Mixpanel.mainInstance().track(
-          event: event.name,
-          properties: properties
-        )
-      }
-    },
-    identify: { userId in
-      await MainActor.run {
-        Mixpanel.mainInstance().identify(distinctId: userId)
-      }
-    },
-    reset: {
-      await MainActor.run {
-        Mixpanel.mainInstance().reset()
-      }
-    },
-    setUserProperties: { properties in
-      await MainActor.run {
-        let mixpanelProps: [String: any MixpanelType] = properties
-        Mixpanel.mainInstance().people.set(properties: mixpanelProps)
-      }
-    },
-    startListeningSession: { station in
-      await MainActor.run {
-        let properties: [String: any MixpanelType] = [
-          "station_id": station.id,
-          "station_name": station.name,
-          "station_type": station.type.rawValue,
-        ]
-        Mixpanel.mainInstance().track(
-          event: "Listening Session Started",
-          properties: properties
-        )
-        Mixpanel.mainInstance().time(event: "Listening Session Ended")
-      }
-    },
-    endListeningSession: { station, duration in
-      await MainActor.run {
-        let properties: [String: any MixpanelType] = [
-          "station_id": station.id,
-          "station_name": station.name,
-          "station_type": station.type.rawValue,
-          "session_length_sec": Int(duration),
-        ]
-        Mixpanel.mainInstance().track(
-          event: "Listening Session Ended",
-          properties: properties
-        )
-      }
-    },
-    pauseListeningSession: {
-      await MainActor.run {
-        // Store current timestamp for calculating pause duration
-        UserDefaults.standard.set(
-          Date().timeIntervalSince1970, forKey: "analytics_session_paused_at")
-      }
-    },
-    resumeListeningSession: {
-      await MainActor.run {
-        // Calculate pause duration and track if needed
-        if let pausedAt = UserDefaults.standard.object(forKey: "analytics_session_paused_at")
-          as? TimeInterval
-        {
-          let pauseDuration = Date().timeIntervalSince1970 - pausedAt
-          let properties: [String: any MixpanelType] = [
-            "pause_duration_sec": Int(pauseDuration)
-          ]
+          // Automatically add userId to all events when available
+          if let userId = auth.currentUser?.id {
+            properties["user_id"] = userId
+          }
+
           Mixpanel.mainInstance().track(
-            event: "Listening Session Resumed",
+            event: event.name,
             properties: properties
           )
-          UserDefaults.standard.removeObject(forKey: "analytics_session_paused_at")
+        }
+      },
+      identify: { userId in
+        await MainActor.run {
+          Mixpanel.mainInstance().identify(distinctId: userId)
+        }
+      },
+      reset: {
+        await MainActor.run {
+          Mixpanel.mainInstance().reset()
+        }
+      },
+      setUserProperties: { properties in
+        await MainActor.run {
+          let mixpanelProps: [String: any MixpanelType] = properties
+          Mixpanel.mainInstance().people.set(properties: mixpanelProps)
+        }
+      },
+      startListeningSession: { station in
+        await MainActor.run {
+          let properties: [String: any MixpanelType] = [
+            "station_id": station.id,
+            "station_name": station.name,
+            "station_type": station.type.rawValue,
+          ]
+          Mixpanel.mainInstance().track(
+            event: "Listening Session Started",
+            properties: properties
+          )
+          Mixpanel.mainInstance().time(event: "Listening Session Ended")
+        }
+      },
+      endListeningSession: { station, duration in
+        await MainActor.run {
+          let properties: [String: any MixpanelType] = [
+            "station_id": station.id,
+            "station_name": station.name,
+            "station_type": station.type.rawValue,
+            "session_length_sec": Int(duration),
+          ]
+          Mixpanel.mainInstance().track(
+            event: "Listening Session Ended",
+            properties: properties
+          )
+        }
+      },
+      pauseListeningSession: {
+        await MainActor.run {
+          // Store current timestamp for calculating pause duration
+          UserDefaults.standard.set(
+            now.timeIntervalSince1970, forKey: "analytics_session_paused_at")
+        }
+      },
+      resumeListeningSession: {
+        await MainActor.run {
+          // Calculate pause duration and track if needed
+          if let pausedAt = UserDefaults.standard.object(forKey: "analytics_session_paused_at")
+            as? TimeInterval
+          {
+            let pauseDuration = now.timeIntervalSince1970 - pausedAt
+            let properties: [String: any MixpanelType] = [
+              "pause_duration_sec": Int(pauseDuration)
+            ]
+            Mixpanel.mainInstance().track(
+              event: "Listening Session Resumed",
+              properties: properties
+            )
+            UserDefaults.standard.removeObject(forKey: "analytics_session_paused_at")
+          }
+        }
+      },
+      initialize: {
+        await MainActor.run {
+          Mixpanel.initialize(
+            token: Config.shared.mixpanelToken,
+            trackAutomaticEvents: false
+          )
+        }
+      },
+      flush: {
+        await MainActor.run {
+          Mixpanel.mainInstance().flush()
         }
       }
-    },
-    initialize: {
-      await MainActor.run {
-        Mixpanel.initialize(
-          token: Config.shared.mixpanelToken,
-          trackAutomaticEvents: false
-        )
-      }
-    },
-    flush: {
-      await MainActor.run {
-        Mixpanel.mainInstance().flush()
-      }
-    }
-  )
+    )
+  }
 }
 
 // MARK: - Test Implementation

--- a/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
@@ -70,9 +70,7 @@ extension DependencyValues {
 
 extension AnalyticsClient: DependencyKey {
   static var liveValue: Self {
-    @Dependency(\.date.now) var now
-
-    return Self(
+    Self(
       track: { event in
         await MainActor.run {
           @Shared(.auth) var auth: Auth
@@ -134,19 +132,21 @@ extension AnalyticsClient: DependencyKey {
         }
       },
       pauseListeningSession: {
+        @Dependency(\.date) var date
         await MainActor.run {
           // Store current timestamp for calculating pause duration
           UserDefaults.standard.set(
-            now.timeIntervalSince1970, forKey: "analytics_session_paused_at")
+            date.now.timeIntervalSince1970, forKey: "analytics_session_paused_at")
         }
       },
       resumeListeningSession: {
+        @Dependency(\.date) var date
         await MainActor.run {
           // Calculate pause duration and track if needed
           if let pausedAt = UserDefaults.standard.object(forKey: "analytics_session_paused_at")
             as? TimeInterval
           {
-            let pauseDuration = now.timeIntervalSince1970 - pausedAt
+            let pauseDuration = date.now.timeIntervalSince1970 - pausedAt
             let properties: [String: any MixpanelType] = [
               "pause_duration_sec": Int(pauseDuration)
             ]

--- a/PlayolaRadio/Core/Analytics/AnalyticsClientTests.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsClientTests.swift
@@ -1,0 +1,62 @@
+//
+//  AnalyticsClientTests.swift
+//  PlayolaRadio
+//
+
+import Dependencies
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct AnalyticsClientTests {
+  private static let pauseKey = "analytics_session_paused_at"
+
+  @Test
+  func testPauseListeningSessionStoresInjectedDateTimestamp() async {
+    UserDefaults.standard.removeObject(forKey: Self.pauseKey)
+    defer { UserDefaults.standard.removeObject(forKey: Self.pauseKey) }
+
+    let pausedAt = Date(timeIntervalSince1970: 1_700_000_000)
+
+    await withDependencies {
+      $0.date = .constant(pausedAt)
+    } operation: {
+      let client = AnalyticsClient.liveValue
+      await client.pauseListeningSession()
+    }
+
+    let stored = UserDefaults.standard.object(forKey: Self.pauseKey) as? TimeInterval
+    #expect(stored == pausedAt.timeIntervalSince1970)
+  }
+
+  @Test
+  func testPauseAndResumeUseCallTimeDates() async {
+    UserDefaults.standard.removeObject(forKey: Self.pauseKey)
+    defer { UserDefaults.standard.removeObject(forKey: Self.pauseKey) }
+
+    let pausedAt = Date(timeIntervalSince1970: 1_700_000_000)
+    let resumedAt = pausedAt.addingTimeInterval(60)
+
+    await withDependencies {
+      $0.date = .constant(pausedAt)
+    } operation: {
+      let client = AnalyticsClient.liveValue
+      await client.pauseListeningSession()
+    }
+
+    let storedAfterPause = UserDefaults.standard.object(forKey: Self.pauseKey) as? TimeInterval
+    #expect(storedAfterPause == pausedAt.timeIntervalSince1970)
+
+    await withDependencies {
+      $0.date = .constant(resumedAt)
+    } operation: {
+      let client = AnalyticsClient.liveValue
+      await client.resumeListeningSession()
+    }
+
+    // resume should clear the stored timestamp after computing the duration
+    #expect(UserDefaults.standard.object(forKey: Self.pauseKey) == nil)
+  }
+}

--- a/PlayolaRadio/Core/AppRating/AppRatingClient.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClient.swift
@@ -33,68 +33,72 @@ extension AppRatingClient: DependencyKey {
   private static let oneHourMS = 60 * 60 * 1000
   private static let sevenDaysInterval: TimeInterval = 7 * 24 * 60 * 60
 
-  static let liveValue = Self(
-    shouldShowRatingPrompt: { totalListenTimeMS in
-      @Shared(.appInstallDate) var appInstallDate
-      @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
-      @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
+  static var liveValue: Self {
+    @Dependency(\.date.now) var now
 
-      let currentVersion = Bundle.main.releaseVersionNumber ?? "unknown"
+    return Self(
+      shouldShowRatingPrompt: { totalListenTimeMS in
+        @Shared(.appInstallDate) var appInstallDate
+        @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
+        @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
 
-      // Already shown for this version
-      if lastRatingPromptVersion == currentVersion {
-        return false
-      }
+        let currentVersion = Bundle.main.releaseVersionNumber ?? "unknown"
 
-      // Not enough listening time (need 1 hour)
-      guard totalListenTimeMS >= oneHourMS else {
-        return false
-      }
-
-      // App not installed long enough (need 7 days)
-      guard let installDate = appInstallDate else {
-        return false
-      }
-      let daysSinceInstall = Date().timeIntervalSince(installDate)
-      guard daysSinceInstall >= sevenDaysInterval else {
-        return false
-      }
-
-      // If previously dismissed, check if 7 days have passed
-      if let dismissDate = lastRatingPromptDismissDate {
-        let daysSinceDismiss = Date().timeIntervalSince(dismissDate)
-        guard daysSinceDismiss >= sevenDaysInterval else {
+        // Already shown for this version
+        if lastRatingPromptVersion == currentVersion {
           return false
         }
-      }
 
-      return true
-    },
-    recordInstallDateIfNeeded: {
-      @Shared(.appInstallDate) var appInstallDate
-      if appInstallDate == nil {
-        $appInstallDate.withLock { $0 = Date() }
-      }
-    },
-    markRatingPromptShown: {
-      @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
-      @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
-      let currentVersion = Bundle.main.releaseVersionNumber ?? "unknown"
-      $lastRatingPromptVersion.withLock { $0 = currentVersion }
-      $lastRatingPromptDismissDate.withLock { $0 = nil }
-    },
-    markRatingPromptDismissed: {
-      @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
-      $lastRatingPromptDismissDate.withLock { $0 = Date() }
-    },
-    requestAppStoreReview: {
-      await MainActor.run {
-        if let scene = UIApplication.shared.connectedScenes
-          .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
-        {
-          AppStore.requestReview(in: scene)
+        // Not enough listening time (need 1 hour)
+        guard totalListenTimeMS >= oneHourMS else {
+          return false
+        }
+
+        // App not installed long enough (need 7 days)
+        guard let installDate = appInstallDate else {
+          return false
+        }
+        let daysSinceInstall = now.timeIntervalSince(installDate)
+        guard daysSinceInstall >= sevenDaysInterval else {
+          return false
+        }
+
+        // If previously dismissed, check if 7 days have passed
+        if let dismissDate = lastRatingPromptDismissDate {
+          let daysSinceDismiss = now.timeIntervalSince(dismissDate)
+          guard daysSinceDismiss >= sevenDaysInterval else {
+            return false
+          }
+        }
+
+        return true
+      },
+      recordInstallDateIfNeeded: {
+        @Shared(.appInstallDate) var appInstallDate
+        if appInstallDate == nil {
+          $appInstallDate.withLock { $0 = now }
+        }
+      },
+      markRatingPromptShown: {
+        @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
+        @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
+        let currentVersion = Bundle.main.releaseVersionNumber ?? "unknown"
+        $lastRatingPromptVersion.withLock { $0 = currentVersion }
+        $lastRatingPromptDismissDate.withLock { $0 = nil }
+      },
+      markRatingPromptDismissed: {
+        @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
+        $lastRatingPromptDismissDate.withLock { $0 = now }
+      },
+      requestAppStoreReview: {
+        await MainActor.run {
+          if let scene = UIApplication.shared.connectedScenes
+            .first(where: { $0.activationState == .foregroundActive }) as? UIWindowScene
+          {
+            AppStore.requestReview(in: scene)
+          }
         }
       }
-    }
-  )
+    )
+  }
 }

--- a/PlayolaRadio/Core/AppRating/AppRatingClient.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClient.swift
@@ -34,10 +34,9 @@ extension AppRatingClient: DependencyKey {
   private static let sevenDaysInterval: TimeInterval = 7 * 24 * 60 * 60
 
   static var liveValue: Self {
-    @Dependency(\.date.now) var now
-
-    return Self(
+    Self(
       shouldShowRatingPrompt: { totalListenTimeMS in
+        @Dependency(\.date) var date
         @Shared(.appInstallDate) var appInstallDate
         @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion
         @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
@@ -58,14 +57,14 @@ extension AppRatingClient: DependencyKey {
         guard let installDate = appInstallDate else {
           return false
         }
-        let daysSinceInstall = now.timeIntervalSince(installDate)
+        let daysSinceInstall = date.now.timeIntervalSince(installDate)
         guard daysSinceInstall >= sevenDaysInterval else {
           return false
         }
 
         // If previously dismissed, check if 7 days have passed
         if let dismissDate = lastRatingPromptDismissDate {
-          let daysSinceDismiss = now.timeIntervalSince(dismissDate)
+          let daysSinceDismiss = date.now.timeIntervalSince(dismissDate)
           guard daysSinceDismiss >= sevenDaysInterval else {
             return false
           }
@@ -74,9 +73,10 @@ extension AppRatingClient: DependencyKey {
         return true
       },
       recordInstallDateIfNeeded: {
+        @Dependency(\.date) var date
         @Shared(.appInstallDate) var appInstallDate
         if appInstallDate == nil {
-          $appInstallDate.withLock { $0 = now }
+          $appInstallDate.withLock { $0 = date.now }
         }
       },
       markRatingPromptShown: {
@@ -87,8 +87,9 @@ extension AppRatingClient: DependencyKey {
         $lastRatingPromptDismissDate.withLock { $0 = nil }
       },
       markRatingPromptDismissed: {
+        @Dependency(\.date) var date
         @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate
-        $lastRatingPromptDismissDate.withLock { $0 = now }
+        $lastRatingPromptDismissDate.withLock { $0 = date.now }
       },
       requestAppStoreReview: {
         await MainActor.run {

--- a/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
@@ -10,6 +10,8 @@ import Testing
 
 @testable import PlayolaRadio
 
+// swiftlint:disable redundant_optional_initialization
+
 @MainActor
 struct AppRatingClientTests {
 
@@ -167,3 +169,5 @@ struct AppRatingClientTests {
     #expect(lastRatingPromptDismissDate != nil)
   }
 }
+
+// swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
@@ -25,10 +25,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let thirtyMinutesMS = 30 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(thirtyMinutesMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(thirtyMinutesMS))
+    }
   }
 
   @Test
@@ -39,10 +43,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -51,10 +59,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -66,10 +78,14 @@ struct AppRatingClientTests {
       Bundle.main.releaseVersionNumber
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -81,10 +97,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? =
       Calendar.current.date(byAdding: .day, value: -3, to: Date())
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(!client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -95,10 +115,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   @Test
@@ -110,10 +134,14 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? =
       Calendar.current.date(byAdding: .day, value: -10, to: Date())
 
-    let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    #expect(client.shouldShowRatingPrompt(twoHoursMS))
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
+      #expect(client.shouldShowRatingPrompt(twoHoursMS))
+    }
   }
 
   // MARK: - recordInstallDateIfNeeded Tests
@@ -124,17 +152,21 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
 
-    #expect(appInstallDate == nil)
+      #expect(appInstallDate == nil)
 
-    client.recordInstallDateIfNeeded()
-    let firstDate = appInstallDate
-    #expect(firstDate != nil)
+      client.recordInstallDateIfNeeded()
+      let firstDate = appInstallDate
+      #expect(firstDate != nil)
 
-    // Wait a tiny bit and try again
-    client.recordInstallDateIfNeeded()
-    #expect(appInstallDate == firstDate)
+      // Wait a tiny bit and try again
+      client.recordInstallDateIfNeeded()
+      #expect(appInstallDate == firstDate)
+    }
   }
 
   // MARK: - markRatingPromptShown Tests
@@ -160,13 +192,17 @@ struct AppRatingClientTests {
     @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
     @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
-    let client = AppRatingClient.liveValue
+    withDependencies {
+      $0.date = .constant(Date())
+    } operation: {
+      let client = AppRatingClient.liveValue
 
-    #expect(lastRatingPromptDismissDate == nil)
+      #expect(lastRatingPromptDismissDate == nil)
 
-    client.markRatingPromptDismissed()
+      client.markRatingPromptDismissed()
 
-    #expect(lastRatingPromptDismissDate != nil)
+      #expect(lastRatingPromptDismissDate != nil)
+    }
   }
 }
 

--- a/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
@@ -6,152 +6,164 @@
 import Dependencies
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class AppRatingClientTests: XCTestCase {
-
-  override func setUp() {
-    super.setUp()
-    // Reset shared state before each test
-    @Shared(.appInstallDate) var appInstallDate: Date?
-    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String?
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date?
-
-    $appInstallDate.withLock { $0 = nil }
-    $lastRatingPromptVersion.withLock { $0 = nil }
-    $lastRatingPromptDismissDate.withLock { $0 = nil }
-  }
+struct AppRatingClientTests {
 
   // MARK: - shouldShowRatingPrompt Tests
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenListenTimeTooShort() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
     )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let thirtyMinutesMS = 30 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(thirtyMinutesMS))
+    #expect(!client.shouldShowRatingPrompt(thirtyMinutesMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenInstallTooRecent() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -3, to: Date()
     )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenNoInstallDate() {
-    @Shared(.appInstallDate) var appInstallDate: Date?
+    @Shared(.appInstallDate) var appInstallDate: Date? = nil
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenAlreadyShownThisVersion() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
     )
-    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion =
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? =
       Bundle.main.releaseVersionNumber
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsFalseWhenDismissedRecently() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
     )
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate = Calendar.current.date(
-      byAdding: .day, value: -3, to: Date()
-    )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? =
+      Calendar.current.date(byAdding: .day, value: -3, to: Date())
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertFalse(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(!client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsTrueWhenAllConditionsMet() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
     )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertTrue(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(client.shouldShowRatingPrompt(twoHoursMS))
   }
 
+  @Test
   func testShouldShowRatingPromptReturnsTrueWhenDismissedOver7DaysAgo() {
-    @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
+    @Shared(.appInstallDate) var appInstallDate: Date? = Calendar.current.date(
       byAdding: .day, value: -20, to: Date()
     )
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate = Calendar.current.date(
-      byAdding: .day, value: -10, to: Date()
-    )
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? =
+      Calendar.current.date(byAdding: .day, value: -10, to: Date())
 
     let client = AppRatingClient.liveValue
     let twoHoursMS = 2 * 60 * 60 * 1000
 
-    XCTAssertTrue(client.shouldShowRatingPrompt(twoHoursMS))
+    #expect(client.shouldShowRatingPrompt(twoHoursMS))
   }
 
   // MARK: - recordInstallDateIfNeeded Tests
 
+  @Test
   func testRecordInstallDateOnlyRecordsOnce() {
-    @Shared(.appInstallDate) var appInstallDate: Date?
+    @Shared(.appInstallDate) var appInstallDate: Date? = nil
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
 
-    XCTAssertNil(appInstallDate)
+    #expect(appInstallDate == nil)
 
     client.recordInstallDateIfNeeded()
     let firstDate = appInstallDate
-    XCTAssertNotNil(firstDate)
+    #expect(firstDate != nil)
 
     // Wait a tiny bit and try again
     client.recordInstallDateIfNeeded()
-    XCTAssertEqual(appInstallDate, firstDate)
+    #expect(appInstallDate == firstDate)
   }
 
   // MARK: - markRatingPromptShown Tests
 
+  @Test
   func testMarkRatingPromptShownSetsVersionAndClearsDismissDate() {
-    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String?
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate = Date()
+    @Shared(.appInstallDate) var appInstallDate: Date? = nil
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = Date()
 
     let client = AppRatingClient.liveValue
     client.markRatingPromptShown()
 
-    XCTAssertEqual(lastRatingPromptVersion, Bundle.main.releaseVersionNumber)
-    XCTAssertNil(lastRatingPromptDismissDate)
+    #expect(lastRatingPromptVersion == Bundle.main.releaseVersionNumber)
+    #expect(lastRatingPromptDismissDate == nil)
   }
 
   // MARK: - markRatingPromptDismissed Tests
 
+  @Test
   func testMarkRatingPromptDismissedSetsDate() {
-    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date?
+    @Shared(.appInstallDate) var appInstallDate: Date? = nil
+    @Shared(.lastRatingPromptVersion) var lastRatingPromptVersion: String? = nil
+    @Shared(.lastRatingPromptDismissDate) var lastRatingPromptDismissDate: Date? = nil
 
     let client = AppRatingClient.liveValue
 
-    XCTAssertNil(lastRatingPromptDismissDate)
+    #expect(lastRatingPromptDismissDate == nil)
 
     client.markRatingPromptDismissed()
 
-    XCTAssertNotNil(lastRatingPromptDismissDate)
+    #expect(lastRatingPromptDismissDate != nil)
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -66,6 +66,7 @@ class NowPlayingUpdater {
   @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.analytics) var analytics
+  @ObservationIgnored @Dependency(\.date.now) var now
 
   private var disposeBag = Set<AnyCancellable>()
   private var inactivityTask: Task<Void, Never>?
@@ -300,11 +301,18 @@ class NowPlayingUpdater {
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
   }
 
+  // The Combine subscriptions below capture `self` weakly so the cancellable
+  // owned by this updater is the only thing keeping each subscription alive.
+  // When the updater is deallocated, `disposeBag` releases the cancellables
+  // and the subscriptions are torn down — without `[weak self]` the strong
+  // self/closure/disposeBag cycle would keep replaced updaters alive forever.
   init(stationPlayer: StationPlayer? = nil) {
     self.stationPlayer = stationPlayer ?? .shared
-    self.stationPlayer.$state.sink { state in
-      self.updateNowPlaying(with: state)
-    }.store(in: &disposeBag)
+    self.stationPlayer.$state
+      .sink { [weak self] state in
+        self?.updateNowPlaying(with: state)
+      }
+      .store(in: &disposeBag)
     setupRemoteControlCenter()
     setupSharedStateObservation()
   }
@@ -559,7 +567,7 @@ extension NowPlayingUpdater {
     // Start session when transitioning to playing
     case (_, .playing(let station)):
       if sessionStartTime == nil {
-        sessionStartTime = Date()
+        sessionStartTime = now
         await analytics.track(
           .listeningSessionStarted(
             station: StationInfo(from: station)
@@ -571,7 +579,7 @@ extension NowPlayingUpdater {
     case (.playing(let station), .stopped),
       (.playing(let station), .error):
       if let startTime = sessionStartTime {
-        let duration = Date().timeIntervalSince(startTime)
+        let duration = now.timeIntervalSince(startTime)
         await analytics.track(
           .listeningSessionEnded(
             station: StationInfo(from: station),
@@ -599,7 +607,7 @@ extension NowPlayingUpdater {
 
   private func trackStationSwitch(from fromStation: AnyStation, to toStation: AnyStation) async {
     guard let startTime = sessionStartTime else { return }
-    let duration = Date().timeIntervalSince(startTime)
+    let duration = now.timeIntervalSince(startTime)
 
     // End current session
     await analytics.track(
@@ -626,6 +634,6 @@ extension NowPlayingUpdater {
       )
     )
 
-    sessionStartTime = Date()
+    sessionStartTime = now
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -642,6 +642,7 @@ extension NowPlayingUpdater {
 
 extension NowPlayingUpdater: @preconcurrency DependencyKey {
   static let liveValue = NowPlayingUpdater()
+  static var testValue: NowPlayingUpdater { NowPlayingUpdater() }
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -321,7 +321,7 @@ class NowPlayingUpdater {
   private func setupSharedStateObservation() {
     @Dependency(\.urlStreamPlayer) var urlStreamPlayer
 
-    PlayolaStationPlayer.shared.$state
+    stationPlayer.playolaStationPlayer.$state
       .sink { [weak self] playolaState in
         self?.processPlayolaStationPlayerState(playolaState)
       }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -307,7 +307,8 @@ class NowPlayingUpdater {
   // and the subscriptions are torn down — without `[weak self]` the strong
   // self/closure/disposeBag cycle would keep replaced updaters alive forever.
   init(stationPlayer: StationPlayer? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
+    @Dependency(\.stationPlayer) var injectedStationPlayer
+    self.stationPlayer = stationPlayer ?? injectedStationPlayer
     self.stationPlayer.$state
       .sink { [weak self] state in
         self?.updateNowPlaying(with: state)
@@ -320,15 +321,15 @@ class NowPlayingUpdater {
   // MARK: - Shared State Management
 
   private func setupSharedStateObservation() {
-    // Observe PlayolaStationPlayer state changes
+    @Dependency(\.urlStreamPlayer) var urlStreamPlayer
+
     PlayolaStationPlayer.shared.$state
       .sink { [weak self] playolaState in
         self?.processPlayolaStationPlayerState(playolaState)
       }
       .store(in: &disposeBag)
 
-    // Observe URLStreamPlayer state changes
-    URLStreamPlayer.shared.$state
+    urlStreamPlayer.$state
       .sink { [weak self] urlStreamState in
         self?.processUrlStreamStateChanged(urlStreamState)
       }
@@ -465,7 +466,7 @@ class NowPlayingUpdater {
     commandCenter.nextTrackCommand.isEnabled = true
     commandCenter.nextTrackCommand.addTarget { [weak self] _ in
       Task { @MainActor in
-        self?.stationPlayer.seekNext()
+        await self?.stationPlayer.seekNext()
       }
       return .success
     }
@@ -473,7 +474,7 @@ class NowPlayingUpdater {
     commandCenter.previousTrackCommand.isEnabled = true
     commandCenter.previousTrackCommand.addTarget { [weak self] _ in
       Task { @MainActor in
-        self?.stationPlayer.seekPrevious()
+        await self?.stationPlayer.seekPrevious()
       }
       return .success
     }
@@ -487,14 +488,15 @@ class NowPlayingUpdater {
 
     // Play command - restart last played station when stopped
     commandCenter.playCommand.isEnabled = true
-    commandCenter.playCommand.addTarget { _ in
-      if let lastStation = self.lastPlayedStation,
+    commandCenter.playCommand.addTarget { [weak self] _ in
+      guard let self,
+        let lastStation = self.lastPlayedStation,
         self.stationPlayer.currentStation == nil
-      {
-        self.stationPlayer.play(station: lastStation)
-        return .success
+      else { return .commandFailed }
+      Task { @MainActor in
+        await self.stationPlayer.play(station: lastStation)
       }
-      return .commandFailed
+      return .success
     }
   }
 
@@ -635,5 +637,18 @@ extension NowPlayingUpdater {
     )
 
     sessionStartTime = now
+  }
+}
+
+// MARK: - Dependency
+
+extension NowPlayingUpdater: @preconcurrency DependencyKey {
+  static var liveValue: NowPlayingUpdater { .shared }
+}
+
+extension DependencyValues {
+  var nowPlayingUpdater: NowPlayingUpdater {
+    get { self[NowPlayingUpdater.self] }
+    set { self[NowPlayingUpdater.self] = newValue }
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -61,8 +61,6 @@ struct NowPlaying: Equatable, Codable {
 class NowPlayingUpdater {
   var stationPlayer: StationPlayer
 
-  static var shared = NowPlayingUpdater()
-
   @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.analytics) var analytics
@@ -643,7 +641,7 @@ extension NowPlayingUpdater {
 // MARK: - Dependency
 
 extension NowPlayingUpdater: @preconcurrency DependencyKey {
-  static var liveValue: NowPlayingUpdater { .shared }
+  static let liveValue = NowPlayingUpdater()
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -27,6 +27,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -58,6 +59,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -111,6 +113,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -151,6 +154,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -187,6 +191,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -237,6 +242,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -270,6 +276,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }
@@ -300,6 +307,7 @@ struct NowPlayingUpdaterTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.date = .constant(Date())
     } operation: {
       NowPlayingUpdater()
     }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -6,18 +6,20 @@
 //
 
 import Dependencies
+import Foundation
 import MediaPlayer
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class NowPlayingUpdaterTests: XCTestCase {
+struct NowPlayingUpdaterTests {
 
   // MARK: - Analytics Tests
 
-  func testTrackListeningSession_StartsSessionWhenTransitioningToPlaying() async {
+  @Test
+  func testTrackListeningSessionStartsSessionWhenTransitioningToPlaying() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -37,16 +39,18 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify session started event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .listeningSessionStarted(let stationInfo) = events.first {
-      XCTAssertEqual(stationInfo.id, station.id)
-      XCTAssertEqual(stationInfo.name, station.name)
+      #expect(stationInfo.id == station.id)
+      #expect(stationInfo.name == station.name)
     } else {
-      XCTFail("Expected listeningSessionStarted event, got: \(String(describing: events.first))")
+      Issue.record(
+        "Expected listeningSessionStarted event, got: \(String(describing: events.first))")
     }
   }
 
-  func testTrackListeningSession_EndsSessionWhenStoppingFromPlaying() async {
+  @Test
+  func testTrackListeningSessionEndsSessionWhenStoppingFromPlaying() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -75,17 +79,18 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify session ended event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .listeningSessionEnded(let stationInfo, let sessionLengthSec) = events.first {
-      XCTAssertEqual(stationInfo.id, station.id)
-      XCTAssertEqual(stationInfo.name, station.name)
-      XCTAssertGreaterThanOrEqual(sessionLengthSec, 0)
+      #expect(stationInfo.id == station.id)
+      #expect(stationInfo.name == station.name)
+      #expect(sessionLengthSec >= 0)
     } else {
-      XCTFail("Expected listeningSessionEnded event, got: \(String(describing: events.first))")
+      Issue.record("Expected listeningSessionEnded event, got: \(String(describing: events.first))")
     }
   }
 
-  func testTrackListeningSession_InitiatesSessionBeforeSwitch() async {
+  @Test
+  func testTrackListeningSessionInitiatesSessionBeforeSwitch() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station1 = AnyStation.mock
     let station2 = AnyStation.url(
@@ -118,9 +123,9 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify session was started
     let initialEvents = capturedEvents.value
-    XCTAssertEqual(initialEvents.count, 1, "Expected 1 event after starting session")
+    #expect(initialEvents.count == 1, "Expected 1 event after starting session")
     guard case .listeningSessionStarted = initialEvents.first else {
-      XCTFail("Expected listeningSessionStarted event after starting session")
+      Issue.record("Expected listeningSessionStarted event after starting session")
       return
     }
 
@@ -133,10 +138,11 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify switch generated events
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 3, "Station switch must generate exactly 3 events")
+    #expect(events.count == 3, "Station switch must generate exactly 3 events")
   }
 
-  func testTrackListeningSession_TracksStationSwitchEvents() async {
+  @Test
+  func testTrackListeningSessionTracksStationSwitchEvents() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station1 = AnyStation.mock
     let station2 = makeTestStation2()
@@ -164,7 +170,7 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify the three expected events
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 3, "Expected exactly 3 events when switching stations")
+    #expect(events.count == 3, "Expected exactly 3 events when switching stations")
     guard events.count == 3 else { return }
 
     verifySessionEndedEvent(events[0], expectedStationId: station1.id, eventIndex: 0)
@@ -173,7 +179,8 @@ final class NowPlayingUpdaterTests: XCTestCase {
     verifySessionStartedEvent(events[2], expectedStationId: station2.id, eventIndex: 2)
   }
 
-  func testTrackListeningSession_TracksPlaybackError() async {
+  @Test
+  func testTrackListeningSessionTracksPlaybackError() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
     let updater = withDependencies {
@@ -205,23 +212,24 @@ final class NowPlayingUpdaterTests: XCTestCase {
     // Verify events were tracked
     let events = capturedEvents.value
     guard events.count > 0 else {
-      XCTFail("Expected at least 1 event, got 0")
+      Issue.record("Expected at least 1 event, got 0")
       return
     }
 
     // When transitioning from playing to error, only session ended is tracked
     // The error case in the switch statement is only for non-playing to error transitions
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
 
     // Should be session ended
     if case .listeningSessionEnded = events[0] {
       // Expected
     } else {
-      XCTFail("Expected listeningSessionEnded event, got: \(events[0])")
+      Issue.record("Expected listeningSessionEnded event, got: \(events[0])")
     }
   }
 
-  func testTrackListeningSession_DoesNotStartMultipleSessions() async {
+  @Test
+  func testTrackListeningSessionDoesNotStartMultipleSessions() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -250,10 +258,11 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify no new session was started
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 0)
+    #expect(events.count == 0)
   }
 
-  func testTrackListeningSession_HandlesLoadingToPlayingTransition() async {
+  @Test
+  func testTrackListeningSessionHandlesLoadingToPlayingTransition() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -273,15 +282,17 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify session started
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .listeningSessionStarted(let stationInfo) = events.first {
-      XCTAssertEqual(stationInfo.id, station.id)
+      #expect(stationInfo.id == station.id)
     } else {
-      XCTFail("Expected listeningSessionStarted event, got: \(String(describing: events.first))")
+      Issue.record(
+        "Expected listeningSessionStarted event, got: \(String(describing: events.first))")
     }
   }
 
-  func testTrackListeningSession_DoesNotTrackSameStationSwitch() async {
+  @Test
+  func testTrackListeningSessionDoesNotTrackSameStationSwitch() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let station = AnyStation.mock
 
@@ -310,12 +321,13 @@ final class NowPlayingUpdaterTests: XCTestCase {
 
     // Verify no events were tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 0)
+    #expect(events.count == 0)
   }
 
   // MARK: - Now Playing Title/Artist Tests
 
-  func testPopulatePlayingInfo_CommercialShowsPlayolaPaysAndStationName() {
+  @Test
+  func testPopulatePlayingInfoCommercialShowsPlayolaPaysAndStationName() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -335,11 +347,12 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "Playola Pays")
-    XCTAssertEqual(artist, "Test Station Name")
+    #expect(title == "Playola Pays")
+    #expect(artist == "Test Station Name")
   }
 
-  func testPopulatePlayingInfo_SongShowsTitleAndArtist() {
+  @Test
+  func testPopulatePlayingInfoSongShowsTitleAndArtist() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -359,11 +372,12 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "My Song Title")
-    XCTAssertEqual(artist, "My Song Artist")
+    #expect(title == "My Song Title")
+    #expect(artist == "My Song Artist")
   }
 
-  func testPopulatePlayingInfo_SongWithAiringShowsTitleAndArtist() {
+  @Test
+  func testPopulatePlayingInfoSongWithAiringShowsTitleAndArtist() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -386,11 +400,12 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "My Song Title")
-    XCTAssertEqual(artist, "My Song Artist")
+    #expect(title == "My Song Title")
+    #expect(artist == "My Song Artist")
   }
 
-  func testPopulatePlayingInfo_NonSongWithAiringShowsEpisodeTitleAndStationName() {
+  @Test
+  func testPopulatePlayingInfoNonSongWithAiringShowsEpisodeTitleAndStationName() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -413,11 +428,12 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "Episode Title")
-    XCTAssertEqual(artist, "Test Station Name")
+    #expect(title == "Episode Title")
+    #expect(artist == "Test Station Name")
   }
 
-  func testPopulatePlayingInfo_NonSongWithoutAiringShowsStationNameAndEmptyArtist() {
+  @Test
+  func testPopulatePlayingInfoNonSongWithoutAiringShowsStationNameAndEmptyArtist() {
     let station = AnyStation.playola(
       Station.mockWith(
         name: "Test Station Name"
@@ -437,8 +453,8 @@ final class NowPlayingUpdaterTests: XCTestCase {
       station: station
     )
 
-    XCTAssertEqual(title, "Test Station Name")
-    XCTAssertEqual(artist, "")
+    #expect(title == "Test Station Name")
+    #expect(artist == "")
   }
 
   // MARK: - Helper Methods
@@ -463,10 +479,10 @@ final class NowPlayingUpdaterTests: XCTestCase {
     _ event: AnalyticsEvent, expectedStationId: String, eventIndex: Int
   ) {
     guard case .listeningSessionEnded(let stationInfo, _) = event else {
-      XCTFail("Expected listeningSessionEnded event at index \(eventIndex), got: \(event)")
+      Issue.record("Expected listeningSessionEnded event at index \(eventIndex), got: \(event)")
       return
     }
-    XCTAssertEqual(stationInfo.id, expectedStationId)
+    #expect(stationInfo.id == expectedStationId)
   }
 
   private func verifySwitchedStationEvent(
@@ -477,22 +493,22 @@ final class NowPlayingUpdaterTests: XCTestCase {
   ) {
     guard case .switchedStation(let from, let to, let timeBeforeSwitchSec, let reason) = event
     else {
-      XCTFail("Expected switchedStation event at index \(eventIndex), got: \(event)")
+      Issue.record("Expected switchedStation event at index \(eventIndex), got: \(event)")
       return
     }
-    XCTAssertEqual(from.id, fromStationId)
-    XCTAssertEqual(to.id, toStationId)
-    XCTAssertGreaterThanOrEqual(timeBeforeSwitchSec, 0)
-    XCTAssertEqual(reason, .userInitiated)
+    #expect(from.id == fromStationId)
+    #expect(to.id == toStationId)
+    #expect(timeBeforeSwitchSec >= 0)
+    #expect(reason == .userInitiated)
   }
 
   private func verifySessionStartedEvent(
     _ event: AnalyticsEvent, expectedStationId: String, eventIndex: Int
   ) {
     guard case .listeningSessionStarted(let stationInfo) = event else {
-      XCTFail("Expected listeningSessionStarted event at index \(eventIndex), got: \(event)")
+      Issue.record("Expected listeningSessionStarted event at index \(eventIndex), got: \(event)")
       return
     }
-    XCTAssertEqual(stationInfo.id, expectedStationId)
+    #expect(stationInfo.id == expectedStationId)
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -55,8 +55,6 @@ class StationPlayer: ObservableObject {
     }
   }
 
-  static let shared = StationPlayer()
-
   // MARK: Dependencies
 
   var urlStreamPlayer: URLStreamPlayer
@@ -268,7 +266,7 @@ protocol AudioBlockProvider {
 // MARK: - Dependency
 
 extension StationPlayer: @preconcurrency DependencyKey {
-  static var liveValue: StationPlayer { .shared }
+  static let liveValue = StationPlayer()
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -267,6 +267,7 @@ protocol AudioBlockProvider {
 
 extension StationPlayer: @preconcurrency DependencyKey {
   static let liveValue = StationPlayer()
+  static var testValue: StationPlayer { StationPlayer() }
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 1/18/25.
 //
 import Combine
+import Dependencies
 import FRadioPlayer
 import Foundation
 import IdentifiedCollections
@@ -61,24 +62,36 @@ class StationPlayer: ObservableObject {
   var urlStreamPlayer: URLStreamPlayer
   var playolaStationPlayer: PlayolaStationPlayer
 
+  // The Combine subscriptions below capture `self` weakly so the cancellable
+  // owned by this StationPlayer is the only thing keeping each subscription
+  // alive. Without `[weak self]` the disposeBag/closure/self cycle would keep
+  // replaced players alive past instance lifetime — which matters once
+  // StationPlayer is a dependency-injected service.
   init(
     urlStreamPlayer: URLStreamPlayer? = nil,
     playolaStationPlayer: PlayolaStationPlayer? = nil
   ) {
-    self.urlStreamPlayer = urlStreamPlayer ?? .shared
+    @Dependency(\.urlStreamPlayer) var injectedUrlStreamPlayer
+    self.urlStreamPlayer = urlStreamPlayer ?? injectedUrlStreamPlayer
     self.playolaStationPlayer = playolaStationPlayer ?? .shared
 
-    self.urlStreamPlayer.$state.sink(receiveValue: { state in
-      self.processUrlStreamStateChanged(state)
-    }).store(in: &disposeBag)
+    self.urlStreamPlayer.$state
+      .sink { [weak self] state in
+        self?.processUrlStreamStateChanged(state)
+      }
+      .store(in: &disposeBag)
 
-    self.urlStreamPlayer.$albumArtworkURL.sink(receiveValue: { url in
-      self.processAlbumArtworkURLChanged(url)
-    }).store(in: &disposeBag)
+    self.urlStreamPlayer.$albumArtworkURL
+      .sink { [weak self] url in
+        self?.processAlbumArtworkURLChanged(url)
+      }
+      .store(in: &disposeBag)
 
-    self.playolaStationPlayer.$state.sink(receiveValue: { state in
-      self.processPlayolaStationPlayerState(state)
-    }).store(in: &disposeBag)
+    self.playolaStationPlayer.$state
+      .sink { [weak self] state in
+        self?.processPlayolaStationPlayerState(state)
+      }
+      .store(in: &disposeBag)
 
     self.playolaStationPlayer.configure(
       authProvider: self.authProvider, baseURL: Config.shared.baseUrl)
@@ -88,7 +101,7 @@ class StationPlayer: ObservableObject {
 
   /// Starts playing the specified station
   /// - Parameter station: The station to play
-  public func play(station: AnyStation) {
+  public func play(station: AnyStation) async {
     guard currentStation != station else { return }
     stop()
     state = State(playbackStatus: .startingNewStation(station))
@@ -99,7 +112,7 @@ class StationPlayer: ObservableObject {
       urlStreamPlayer.set(station: urlStation)
     case .playola(let playolaStation):
       urlStreamPlayer.reset()
-      Task { try? await playolaStationPlayer.play(stationId: playolaStation.id) }
+      try? await playolaStationPlayer.play(stationId: playolaStation.id)
     }
   }
 
@@ -111,7 +124,7 @@ class StationPlayer: ObservableObject {
   }
 
   /// Seeks to the next station in the artist list, wrapping around if at the end
-  public func seekNext() {
+  public func seekNext() async {
     let stations = seekableStations()
     guard !stations.isEmpty else { return }
 
@@ -121,16 +134,16 @@ class StationPlayer: ObservableObject {
     guard let current = currentStation,
       let currentIndex = stations.firstIndex(where: { $0.id == current.id })
     else {
-      play(station: stations[0])
+      await play(station: stations[0])
       return
     }
 
     let nextIndex = (currentIndex + 1) % stations.count
-    play(station: stations[nextIndex])
+    await play(station: stations[nextIndex])
   }
 
   /// Seeks to the previous station in the artist list, wrapping around if at the beginning
-  public func seekPrevious() {
+  public func seekPrevious() async {
     let stations = seekableStations()
     guard !stations.isEmpty else { return }
 
@@ -140,12 +153,12 @@ class StationPlayer: ObservableObject {
     guard let current = currentStation,
       let currentIndex = stations.firstIndex(where: { $0.id == current.id })
     else {
-      play(station: stations[0])
+      await play(station: stations[0])
       return
     }
 
     let previousIndex = (currentIndex - 1 + stations.count) % stations.count
-    play(station: stations[previousIndex])
+    await play(station: stations[previousIndex])
   }
 
   func seekableStations() -> [AnyStation] {
@@ -250,4 +263,17 @@ class StationPlayer: ObservableObject {
 // MARK: - AudioBlockProvider Protocol
 protocol AudioBlockProvider {
   var audioBlock: AudioBlock? { get }
+}
+
+// MARK: - Dependency
+
+extension StationPlayer: @preconcurrency DependencyKey {
+  static var liveValue: StationPlayer { .shared }
+}
+
+extension DependencyValues {
+  var stationPlayer: StationPlayer {
+    get { self[StationPlayer.self] }
+    set { self[StationPlayer.self] = newValue }
+  }
 }

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -19,54 +19,54 @@ struct StationPlayerTests {
   // MARK: - seekNext Tests
 
   @Test
-  func testSeekNextPlaysNextStation() {
+  func testSeekNextPlaysNextStation() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[0])
+    await stationPlayer.play(station: stations[0])
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == stations[1].id)
   }
 
   @Test
-  func testSeekNextWrapsAroundFromLastToFirst() {
+  func testSeekNextWrapsAroundFromLastToFirst() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[2])
+    await stationPlayer.play(station: stations[2])
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
   @Test
-  func testSeekNextWithNoCurrentStationPlaysFirst() {
+  func testSeekNextWithNoCurrentStationPlaysFirst() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
   @Test
-  func testSeekNextWithEmptyStationListDoesNothing() {
+  func testSeekNextWithEmptyStationListDoesNothing() async {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation == nil)
   }
@@ -74,42 +74,42 @@ struct StationPlayerTests {
   // MARK: - seekPrevious Tests
 
   @Test
-  func testSeekPreviousPlaysPreviousStation() {
+  func testSeekPreviousPlaysPreviousStation() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[1])
+    await stationPlayer.play(station: stations[1])
 
-    stationPlayer.seekPrevious()
+    await stationPlayer.seekPrevious()
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
   @Test
-  func testSeekPreviousWrapsAroundFromFirstToLast() {
+  func testSeekPreviousWrapsAroundFromFirstToLast() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[0])
+    await stationPlayer.play(station: stations[0])
 
-    stationPlayer.seekPrevious()
+    await stationPlayer.seekPrevious()
 
     #expect(stationPlayer.currentStation?.id == stations[2].id)
   }
 
   @Test
-  func testSeekPreviousWithNoCurrentStationPlaysFirst() {
+  func testSeekPreviousWithNoCurrentStationPlaysFirst() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
 
-    stationPlayer.seekPrevious()
+    await stationPlayer.seekPrevious()
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
@@ -117,7 +117,7 @@ struct StationPlayerTests {
   // MARK: - Station Filtering Tests
 
   @Test
-  func testSeekOnlyUsesArtistListStations() {
+  func testSeekOnlyUsesArtistListStations() async {
     @Shared(.stationLists) var stationLists = makeArtistAndFmLists()
     @Shared(.showSecretStations) var showSecretStations = false
 
@@ -125,50 +125,50 @@ struct StationPlayerTests {
     let artistList = stationLists.first { $0.id == StationList.KnownIDs.artistList.rawValue }!
     let artistStations = artistList.stations
 
-    stationPlayer.play(station: artistStations[0])
-    stationPlayer.seekNext()
+    await stationPlayer.play(station: artistStations[0])
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == artistStations[1].id)
   }
 
   @Test
-  func testSeekSkipsInactiveStations() {
+  func testSeekSkipsInactiveStations() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithInactiveStation()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let allStations = stationLists.first!.stations
 
-    stationPlayer.play(station: allStations[0])
-    stationPlayer.seekNext()
+    await stationPlayer.play(station: allStations[0])
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
 
   @Test
-  func testSeekSkipsComingSoonStationsWhenSecretsDisabled() {
+  func testSeekSkipsComingSoonStationsWhenSecretsDisabled() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithComingSoonStation()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let allStations = stationLists.first!.stations
 
-    stationPlayer.play(station: allStations[0])
-    stationPlayer.seekNext()
+    await stationPlayer.play(station: allStations[0])
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
 
   @Test
-  func testSeekIncludesComingSoonStationsWhenSecretsEnabled() {
+  func testSeekIncludesComingSoonStationsWhenSecretsEnabled() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithComingSoonStation()
     @Shared(.showSecretStations) var showSecretStations = true
 
     let stationPlayer = StationPlayer()
     let allStations = stationLists.first!.stations
 
-    stationPlayer.play(station: allStations[0])
-    stationPlayer.seekNext()
+    await stationPlayer.play(station: allStations[0])
+    await stationPlayer.seekNext()
 
     #expect(stationPlayer.currentStation?.id == allStations[1].id)
   }
@@ -236,41 +236,41 @@ struct StationPlayerTests {
   }
 
   @Test
-  func testIsSeekingIsFalseAfterSeekNextCompletes() {
+  func testIsSeekingIsFalseAfterSeekNextCompletes() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[0])
+    await stationPlayer.play(station: stations[0])
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
 
   @Test
-  func testIsSeekingIsFalseAfterSeekPreviousCompletes() {
+  func testIsSeekingIsFalseAfterSeekPreviousCompletes() async {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    stationPlayer.play(station: stations[1])
+    await stationPlayer.play(station: stations[1])
 
-    stationPlayer.seekPrevious()
+    await stationPlayer.seekPrevious()
 
     #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
 
   @Test
-  func testIsSeekingIsFalseWhenSeekHasNoStations() {
+  func testIsSeekingIsFalseWhenSeekHasNoStations() async {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
 
     let stationPlayer = StationPlayer()
 
-    stationPlayer.seekNext()
+    await stationPlayer.seekNext()
 
     #expect(!stationPlayer.isSeeking, "isSeeking should remain false when no stations")
   }

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -5,18 +5,20 @@
 //  Created by Claude on 1/8/26.
 //
 
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class StationPlayerTests: XCTestCase {
+struct StationPlayerTests {
 
   // MARK: - seekNext Tests
 
+  @Test
   func testSeekNextPlaysNextStation() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -27,9 +29,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[1].id)
+    #expect(stationPlayer.currentStation?.id == stations[1].id)
   }
 
+  @Test
   func testSeekNextWrapsAroundFromLastToFirst() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -40,9 +43,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[0].id)
+    #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
+  @Test
   func testSeekNextWithNoCurrentStationPlaysFirst() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -52,9 +56,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[0].id)
+    #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
+  @Test
   func testSeekNextWithEmptyStationListDoesNothing() {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
@@ -63,11 +68,12 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertNil(stationPlayer.currentStation)
+    #expect(stationPlayer.currentStation == nil)
   }
 
   // MARK: - seekPrevious Tests
 
+  @Test
   func testSeekPreviousPlaysPreviousStation() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -78,9 +84,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekPrevious()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[0].id)
+    #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
+  @Test
   func testSeekPreviousWrapsAroundFromFirstToLast() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -91,9 +98,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekPrevious()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[2].id)
+    #expect(stationPlayer.currentStation?.id == stations[2].id)
   }
 
+  @Test
   func testSeekPreviousWithNoCurrentStationPlaysFirst() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -103,11 +111,12 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekPrevious()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, stations[0].id)
+    #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
 
   // MARK: - Station Filtering Tests
 
+  @Test
   func testSeekOnlyUsesArtistListStations() {
     @Shared(.stationLists) var stationLists = makeArtistAndFmLists()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -119,9 +128,10 @@ final class StationPlayerTests: XCTestCase {
     stationPlayer.play(station: artistStations[0])
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, artistStations[1].id)
+    #expect(stationPlayer.currentStation?.id == artistStations[1].id)
   }
 
+  @Test
   func testSeekSkipsInactiveStations() {
     @Shared(.stationLists) var stationLists = makeArtistListWithInactiveStation()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -132,9 +142,10 @@ final class StationPlayerTests: XCTestCase {
     stationPlayer.play(station: allStations[0])
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, allStations[2].id)
+    #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
 
+  @Test
   func testSeekSkipsComingSoonStationsWhenSecretsDisabled() {
     @Shared(.stationLists) var stationLists = makeArtistListWithComingSoonStation()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -145,9 +156,10 @@ final class StationPlayerTests: XCTestCase {
     stationPlayer.play(station: allStations[0])
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, allStations[2].id)
+    #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
 
+  @Test
   func testSeekIncludesComingSoonStationsWhenSecretsEnabled() {
     @Shared(.stationLists) var stationLists = makeArtistListWithComingSoonStation()
     @Shared(.showSecretStations) var showSecretStations = true
@@ -158,11 +170,12 @@ final class StationPlayerTests: XCTestCase {
     stationPlayer.play(station: allStations[0])
     stationPlayer.seekNext()
 
-    XCTAssertEqual(stationPlayer.currentStation?.id, allStations[1].id)
+    #expect(stationPlayer.currentStation?.id == allStations[1].id)
   }
 
   // MARK: - seekableStations Tests
 
+  @Test
   func testSeekableStationsReturnsStationsFromArtistList() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -170,12 +183,13 @@ final class StationPlayerTests: XCTestCase {
     let stationPlayer = StationPlayer()
     let seekable = stationPlayer.seekableStations()
 
-    XCTAssertEqual(seekable.count, 3)
-    XCTAssertEqual(seekable[0].id, "station1")
-    XCTAssertEqual(seekable[1].id, "station2")
-    XCTAssertEqual(seekable[2].id, "station3")
+    #expect(seekable.count == 3)
+    #expect(seekable[0].id == "station1")
+    #expect(seekable[1].id == "station2")
+    #expect(seekable[2].id == "station3")
   }
 
+  @Test
   func testSeekableStationsReturnsEmptyWhenNoArtistList() {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
@@ -183,9 +197,10 @@ final class StationPlayerTests: XCTestCase {
     let stationPlayer = StationPlayer()
     let seekable = stationPlayer.seekableStations()
 
-    XCTAssertTrue(seekable.isEmpty)
+    #expect(seekable.isEmpty)
   }
 
+  @Test
   func testSeekableStationsFiltersInactiveStations() {
     @Shared(.stationLists) var stationLists = makeArtistListWithInactiveStation()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -193,11 +208,12 @@ final class StationPlayerTests: XCTestCase {
     let stationPlayer = StationPlayer()
     let seekable = stationPlayer.seekableStations()
 
-    XCTAssertEqual(seekable.count, 2)
-    XCTAssertEqual(seekable[0].id, "station1")
-    XCTAssertEqual(seekable[1].id, "station3")
+    #expect(seekable.count == 2)
+    #expect(seekable[0].id == "station1")
+    #expect(seekable[1].id == "station3")
   }
 
+  @Test
   func testSeekableStationsAccessesSharedState() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -205,19 +221,21 @@ final class StationPlayerTests: XCTestCase {
     let stationPlayer = StationPlayer()
 
     // Verify stationPlayer can see the shared state
-    XCTAssertEqual(stationPlayer.stationLists.count, 1, "StationPlayer should see 1 station list")
-    XCTAssertEqual(
-      stationPlayer.stationLists.first?.slug, "artist-list",
+    #expect(stationPlayer.stationLists.count == 1, "StationPlayer should see 1 station list")
+    #expect(
+      stationPlayer.stationLists.first?.slug == "artist-list",
       "StationPlayer should see artist-list slug")
   }
 
   // MARK: - isSeeking Flag Tests
 
+  @Test
   func testIsSeekingIsFalseByDefault() {
     let stationPlayer = StationPlayer()
-    XCTAssertFalse(stationPlayer.isSeeking)
+    #expect(!stationPlayer.isSeeking)
   }
 
+  @Test
   func testIsSeekingIsFalseAfterSeekNextCompletes() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -228,9 +246,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertFalse(stationPlayer.isSeeking, "isSeeking should be false after seek completes")
+    #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
 
+  @Test
   func testIsSeekingIsFalseAfterSeekPreviousCompletes() {
     @Shared(.stationLists) var stationLists = makeArtistListWithThreeStations()
     @Shared(.showSecretStations) var showSecretStations = false
@@ -241,9 +260,10 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekPrevious()
 
-    XCTAssertFalse(stationPlayer.isSeeking, "isSeeking should be false after seek completes")
+    #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
 
+  @Test
   func testIsSeekingIsFalseWhenSeekHasNoStations() {
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.showSecretStations) var showSecretStations = false
@@ -252,7 +272,7 @@ final class StationPlayerTests: XCTestCase {
 
     stationPlayer.seekNext()
 
-    XCTAssertFalse(stationPlayer.isSeeking, "isSeeking should remain false when no stations")
+    #expect(!stationPlayer.isSeeking, "isSeeking should remain false when no stations")
   }
 
   // MARK: - Helper Methods

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -186,6 +186,7 @@ extension URLStreamPlayer {
 
 extension URLStreamPlayer: @preconcurrency DependencyKey {
   public static let liveValue = URLStreamPlayer()
+  public static var testValue: URLStreamPlayer { URLStreamPlayer() }
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -6,6 +6,7 @@
 //
 
 import Combine
+import Dependencies
 import FRadioPlayer
 import Foundation
 import MediaPlayer
@@ -180,5 +181,18 @@ extension URLStreamPlayer {
         groups: []
       ))
     return stationPlayer
+  }
+}
+
+// MARK: - Dependency
+
+extension URLStreamPlayer: @preconcurrency DependencyKey {
+  public static var liveValue: URLStreamPlayer { .shared }
+}
+
+extension DependencyValues {
+  var urlStreamPlayer: URLStreamPlayer {
+    get { self[URLStreamPlayer.self] }
+    set { self[URLStreamPlayer.self] = newValue }
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -39,8 +39,6 @@ public class URLStreamPlayer: ObservableObject {
 
   @Published var albumArtworkURL: URL?
 
-  static let shared = URLStreamPlayer()
-
   @Published private(set) var currentStation: UrlStation?
 
   var searchedStations: [UrlStation] = []
@@ -187,7 +185,7 @@ extension URLStreamPlayer {
 // MARK: - Dependency
 
 extension URLStreamPlayer: @preconcurrency DependencyKey {
-  public static var liveValue: URLStreamPlayer { .shared }
+  public static let liveValue = URLStreamPlayer()
 }
 
 extension DependencyValues {

--- a/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
+++ b/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
@@ -21,23 +21,36 @@ public class UrlStreamListeningSessionReporter {
   var currentListeningSessionID: String?
   var lastSendStreamUrl: String?
 
+  // The $state sink captures `self` weakly so the cancellable owned by this
+  // reporter is the only thing keeping the subscription alive. Without
+  // `[weak self]` the disposeBag/closure/self cycle plus the strong capture
+  // of urlStreamPlayer would keep the URLStreamPlayer alive past instance
+  // lifetime — which matters once URLStreamPlayer is a dependency-injected
+  // service rather than a process-scoped singleton.
   init(urlStreamPlayer: URLStreamPlayer) {
     self.urlStreamPlayer = urlStreamPlayer
 
-    urlStreamPlayer.$state.sink { _ in
-      if let stationUrl = urlStreamPlayer.currentStation?.streamUrl {
-        if stationUrl != self.lastSendStreamUrl {
-          self.lastSendStreamUrl = stationUrl
-          self.reportOrExtendListeningSession(stationUrl)
-          self.startPeriodicNotifications()
+    urlStreamPlayer.$state
+      .sink { [weak self] _ in
+        guard let self else { return }
+        if let stationUrl = self.urlStreamPlayer?.currentStation?.streamUrl {
+          if stationUrl != self.lastSendStreamUrl {
+            self.lastSendStreamUrl = stationUrl
+            self.reportOrExtendListeningSession(stationUrl)
+            self.startPeriodicNotifications()
+          }
+        } else {
+          guard self.lastSendStreamUrl != nil else { return }
+          self.lastSendStreamUrl = nil
+          self.endListeningSession()
+          self.stopPeriodicNotifications()
         }
-      } else {
-        guard self.lastSendStreamUrl != nil else { return }
-        self.lastSendStreamUrl = nil
-        self.endListeningSession()
-        self.stopPeriodicNotifications()
       }
-    }.store(in: &disposeBag)
+      .store(in: &disposeBag)
+  }
+
+  deinit {
+    timer?.invalidate()
   }
 
   public func endListeningSession() {

--- a/PlayolaRadio/Core/AudioRecording/AudioConverterClient.swift
+++ b/PlayolaRadio/Core/AudioRecording/AudioConverterClient.swift
@@ -17,7 +17,9 @@ public struct AudioConverterClient: Sendable {
 
 extension AudioConverterClient: DependencyKey {
   public static var liveValue: AudioConverterClient {
-    AudioConverterClient(
+    @Dependency(\.uuid) var uuid
+
+    return AudioConverterClient(
       convertToM4A: { inputURL in
         let asset = AVURLAsset(url: inputURL)
 
@@ -31,7 +33,7 @@ extension AudioConverterClient: DependencyKey {
         }
 
         let outputURL = FileManager.default.temporaryDirectory
-          .appendingPathComponent("voicetrack_\(UUID().uuidString).m4a")
+          .appendingPathComponent("voicetrack_\(uuid().uuidString).m4a")
 
         do {
           try await exportSession.export(to: outputURL, as: .m4a)

--- a/PlayolaRadio/Core/AudioRecording/AudioRecorderClient.swift
+++ b/PlayolaRadio/Core/AudioRecording/AudioRecorderClient.swift
@@ -66,12 +66,18 @@ public final class RecordingSession: Sendable {
 
 extension AudioRecorderClient: DependencyKey {
   public static var liveValue: AudioRecorderClient {
+    @Dependency(\.uuid) var uuid
     let recorder = LiveAudioRecorder()
+
+    @Sendable func makeRecordingURL() -> URL {
+      FileManager.default.temporaryDirectory
+        .appendingPathComponent("voicetrack_\(uuid().uuidString).wav")
+    }
 
     return AudioRecorderClient(
       requestPermission: { await recorder.requestPermission() },
       prepareForRecording: { try await recorder.prepareForRecording() },
-      startRecording: { try await recorder.startRecording() },
+      startRecording: { try await recorder.startRecording(at: makeRecordingURL()) },
       stopRecording: { try await recorder.stopRecording() },
       currentTime: { await recorder.currentTime() },
       deleteRecording: { url in await recorder.deleteRecording(url) },
@@ -82,7 +88,7 @@ extension AudioRecorderClient: DependencyKey {
           throw AudioRecorderError.permissionDenied
         }
 
-        try await recorder.startRecording()
+        try await recorder.startRecording(at: makeRecordingURL())
 
         let updateTask = Task {
           while !Task.isCancelled {
@@ -194,13 +200,10 @@ private actor LiveAudioRecorder {
     isPrepared = true
   }
 
-  func startRecording() throws {
+  func startRecording(at url: URL) throws {
     // Always prepare audio session before recording - the session may have been
     // reconfigured by other audio components (e.g., StationPlayer) since last prepare
     try prepareForRecording()
-
-    let url = FileManager.default.temporaryDirectory
-      .appendingPathComponent("voicetrack_\(UUID().uuidString).wav")
 
     let recorder = try AVAudioRecorder(url: url, settings: recordingSettings)
     recorder.isMeteringEnabled = true

--- a/PlayolaRadio/Core/AudioRecording/IntroUploadServiceTests.swift
+++ b/PlayolaRadio/Core/AudioRecording/IntroUploadServiceTests.swift
@@ -5,16 +5,18 @@
 
 import ConcurrencyExtras
 import Dependencies
-import XCTest
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class IntroUploadServiceTests: XCTestCase {
+struct IntroUploadServiceTests {
 
   private let testStationId = "test-station-id"
   private let testSongTitle = "Bohemian Rhapsody"
 
+  @Test
   func testUploadIntroTransitionsThroughAllStatuses() async throws {
     let statusChanges = LockIsolated<[IntroUploadStatus]>([])
     let testURL = FileManager.default.temporaryDirectory.appendingPathComponent("test.wav")
@@ -44,16 +46,17 @@ final class IntroUploadServiceTests: XCTestCase {
     }
 
     let recordedStatuses = statusChanges.value
-    XCTAssertTrue(recordedStatuses.contains(.converting))
-    XCTAssertTrue(
+    #expect(recordedStatuses.contains(.converting))
+    #expect(
       recordedStatuses.contains(where: {
         if case .uploading = $0 { return true }
         return false
       }))
-    XCTAssertTrue(recordedStatuses.contains(.registering))
-    XCTAssertTrue(recordedStatuses.contains(.completed))
+    #expect(recordedStatuses.contains(.registering))
+    #expect(recordedStatuses.contains(.completed))
   }
 
+  @Test
   func testUploadIntroPassesCorrectStationIdAndFilename() async throws {
     let capturedStationId = LockIsolated<String?>(nil)
     let capturedFilename = LockIsolated<String?>(nil)
@@ -83,10 +86,11 @@ final class IntroUploadServiceTests: XCTestCase {
       "test-audio-block-id"
     ) { _ in }
 
-    XCTAssertEqual(capturedStationId.value, testStationId)
-    XCTAssertEqual(capturedFilename.value, "Bohemian Rhapsody.m4a")
+    #expect(capturedStationId.value == testStationId)
+    #expect(capturedFilename.value == "Bohemian Rhapsody.m4a")
   }
 
+  @Test
   func testUploadIntroPassesCorrectDataToCreateSourceTape() async throws {
     let capturedS3Key = LockIsolated<String?>(nil)
     let capturedName = LockIsolated<String?>(nil)
@@ -121,9 +125,9 @@ final class IntroUploadServiceTests: XCTestCase {
       "test-audio-block-id"
     ) { _ in }
 
-    XCTAssertEqual(capturedS3Key.value, "station/uuid-intro.m4a")
-    XCTAssertEqual(capturedName.value, "Bohemian Rhapsody")
-    XCTAssertEqual(capturedDurationMS.value, 15000)
-    XCTAssertEqual(capturedAudioBlockId.value, "test-audio-block-id")
+    #expect(capturedS3Key.value == "station/uuid-intro.m4a")
+    #expect(capturedName.value == "Bohemian Rhapsody")
+    #expect(capturedDurationMS.value == 15000)
+    #expect(capturedAudioBlockId.value == "test-audio-block-id")
   }
 }

--- a/PlayolaRadio/Core/AudioRecording/VoicetrackUploadServiceTests.swift
+++ b/PlayolaRadio/Core/AudioRecording/VoicetrackUploadServiceTests.swift
@@ -7,12 +7,13 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
-final class VoicetrackUploadServiceTests: XCTestCase {
+struct VoicetrackUploadServiceTests {
 
   // MARK: - Test Data
 
@@ -30,7 +31,8 @@ final class VoicetrackUploadServiceTests: XCTestCase {
 
   // MARK: - Normalization Polling Tests
 
-  func testProcessVoicetrack_handlesS3KeyWithSlash() async throws {
+  @Test
+  func testProcessVoicetrackHandlesS3KeyWithSlash() async throws {
     let capturedS3Key = LockIsolated<String?>(nil)
     let voicetrack = createTestVoicetrack()
     let s3KeyWithSlash = "station123/mock-uuid.m4a"
@@ -60,11 +62,12 @@ final class VoicetrackUploadServiceTests: XCTestCase {
       testJwtToken
     ) { _ in }
 
-    XCTAssertEqual(
-      capturedS3Key.value, s3KeyWithSlash, "s3Key with slash should be passed through correctly")
+    #expect(
+      capturedS3Key.value == s3KeyWithSlash, "s3Key with slash should be passed through correctly")
   }
 
-  func testProcessVoicetrack_transitionsThroughNormalizingStatus() async throws {
+  @Test
+  func testProcessVoicetrackTransitionsThroughNormalizingStatus() async throws {
     let statusChanges = LockIsolated<[LocalVoicetrackStatus]>([])
     let voicetrack = createTestVoicetrack()
 
@@ -96,7 +99,7 @@ final class VoicetrackUploadServiceTests: XCTestCase {
 
     let recordedStatuses = statusChanges.value
     // Verify that .normalizing status was reached
-    XCTAssertTrue(
+    #expect(
       recordedStatuses.contains(.normalizing),
       "Expected .normalizing status, got: \(recordedStatuses)"
     )
@@ -108,17 +111,18 @@ final class VoicetrackUploadServiceTests: XCTestCase {
     }),
       let normalizingIndex = recordedStatuses.firstIndex(of: .normalizing)
     {
-      XCTAssertLessThan(uploadingIndex, normalizingIndex)
+      #expect(uploadingIndex < normalizingIndex)
     }
 
     // Verify normalizing comes before finalizing
     if let normalizingIndex = recordedStatuses.firstIndex(of: .normalizing),
       let finalizingIndex = recordedStatuses.firstIndex(of: .finalizing)
     {
-      XCTAssertLessThan(normalizingIndex, finalizingIndex)
+      #expect(normalizingIndex < finalizingIndex)
     }
   }
 
+  @Test
   func testProcessVoicetrackPassesS3KeyWithSlashesToStatusCheck() async throws {
     let voicetrack = createTestVoicetrack()
     let s3KeyWithSlashes = "voicetracks/station123/abc-def-123.m4a"
@@ -149,6 +153,6 @@ final class VoicetrackUploadServiceTests: XCTestCase {
       testJwtToken
     ) { _ in }
 
-    XCTAssertEqual(capturedS3Key.value, s3KeyWithSlashes)
+    #expect(capturedS3Key.value == s3KeyWithSlashes)
   }
 }

--- a/PlayolaRadio/Core/Auth/PlayolaTokenProvider/PlayolaTokenProviderTests.swift
+++ b/PlayolaRadio/Core/Auth/PlayolaTokenProvider/PlayolaTokenProviderTests.swift
@@ -10,15 +10,15 @@
 import ConcurrencyExtras
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class PlayolaTokenProviderTests: XCTestCase {
+struct PlayolaTokenProviderTests {
 
   // Helper function to create valid JWT tokens for testing
-  func createTestJWT(
+  private func createTestJWT(
     id: String = "test-user-123",
     firstName: String = "Test",
     lastName: String? = "User",
@@ -58,27 +58,29 @@ final class PlayolaTokenProviderTests: XCTestCase {
 
   // MARK: - getCurrentToken Tests
 
-  func testGetCurrentToken_ReturnsNilWhenUserNotLoggedIn() async {
+  @Test
+  func testGetCurrentTokenReturnsNilWhenUserNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     let tokenProvider = PlayolaTokenProvider()
 
     let token = await tokenProvider.getCurrentToken()
 
-    XCTAssertNil(token)
+    #expect(token == nil)
   }
 
-  func testGetCurrentToken_ReturnsJWTWhenUserLoggedIn() async {
+  @Test
+  func testGetCurrentTokenReturnsJWTWhenUserLoggedIn() async {
     let expectedJWT = createTestJWT()
-    @Shared(.auth) var auth
-    $auth.withLock { $0 = Auth(jwtToken: expectedJWT) }
+    @Shared(.auth) var auth = Auth(jwtToken: expectedJWT)
     let tokenProvider = PlayolaTokenProvider()
 
     let token = await tokenProvider.getCurrentToken()
 
-    XCTAssertEqual(token, expectedJWT)
+    #expect(token == expectedJWT)
   }
 
-  func testGetCurrentToken_ReturnsNilAfterUserSignsOut() async {
+  @Test
+  func testGetCurrentTokenReturnsNilAfterUserSignsOut() async {
     let initialJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: initialJWT)
     let tokenProvider = PlayolaTokenProvider()
@@ -87,39 +89,42 @@ final class PlayolaTokenProviderTests: XCTestCase {
     $auth.withLock { $0 = Auth() }
 
     let token = await tokenProvider.getCurrentToken()
-    XCTAssertNil(token)
+    #expect(token == nil)
   }
 
   // MARK: - refreshToken Tests
 
-  func testRefreshToken_ReturnsNilWhenUserNotLoggedIn() async {
+  @Test
+  func testRefreshTokenReturnsNilWhenUserNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     let tokenProvider = PlayolaTokenProvider()
 
     let token = await tokenProvider.refreshToken()
 
-    XCTAssertNil(token)
+    #expect(token == nil)
   }
 
-  func testRefreshToken_ReturnsCurrentJWTWhenUserLoggedIn() async {
+  @Test
+  func testRefreshTokenReturnsCurrentJWTWhenUserLoggedIn() async {
     let expectedJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: expectedJWT)
     let tokenProvider = PlayolaTokenProvider()
 
     let token = await tokenProvider.refreshToken()
 
-    XCTAssertEqual(token, expectedJWT)
+    #expect(token == expectedJWT)
   }
 
   // MARK: - Reactive Authentication State Changes Tests
 
-  func testReactiveAuth_ImmediatelyReflectsAuthStateChanges() async {
+  @Test
+  func testReactiveAuthImmediatelyReflectsAuthStateChanges() async {
     @Shared(.auth) var auth = Auth()
     let tokenProvider = PlayolaTokenProvider()
 
     // Initially no token
     let initialToken = await tokenProvider.getCurrentToken()
-    XCTAssertNil(initialToken)
+    #expect(initialToken == nil)
 
     // User logs in
     let jwt = createTestJWT()
@@ -127,17 +132,18 @@ final class PlayolaTokenProviderTests: XCTestCase {
 
     // Token provider immediately reflects the change
     let newToken = await tokenProvider.getCurrentToken()
-    XCTAssertEqual(newToken, jwt)
+    #expect(newToken == jwt)
 
     // User logs out
     $auth.withLock { $0 = Auth() }
 
     // Token provider immediately reflects the logout
     let loggedOutToken = await tokenProvider.getCurrentToken()
-    XCTAssertNil(loggedOutToken)
+    #expect(loggedOutToken == nil)
   }
 
-  func testReactiveAuth_MultipleAuthStateChangesTracked() async {
+  @Test
+  func testReactiveAuthMultipleAuthStateChangesTracked() async {
     @Shared(.auth) var auth = Auth()
     let tokenProvider = PlayolaTokenProvider()
 
@@ -150,13 +156,13 @@ final class PlayolaTokenProviderTests: XCTestCase {
     for expectedToken in tokens {
       $auth.withLock { $0 = Auth(jwtToken: expectedToken) }
       let actualToken = await tokenProvider.getCurrentToken()
-      XCTAssertEqual(actualToken, expectedToken)
+      #expect(actualToken == expectedToken)
     }
 
     // Final logout
     $auth.withLock { $0 = Auth() }
     let finalToken = await tokenProvider.getCurrentToken()
-    XCTAssertNil(finalToken)
+    #expect(finalToken == nil)
   }
 }
 

--- a/PlayolaRadio/Core/Formatters/RRuleFormatterTests.swift
+++ b/PlayolaRadio/Core/Formatters/RRuleFormatterTests.swift
@@ -5,177 +5,196 @@
 //  Created by Claude on 1/8/26.
 //
 
-import XCTest
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class RRuleFormatterTests: XCTestCase {
+struct RRuleFormatterTests {
   // MARK: - Single Day Tests
 
+  @Test
   func testFormatsWeeklyMondayAt4pm() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays at 4pm")
+    #expect(result == "Mondays at 4pm")
   }
 
+  @Test
   func testFormatsWeeklyTuesdayAt9am() {
     let rrule = "FREQ=WEEKLY;BYDAY=TU"
     let airtime = dateAt(hour: 9, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Tuesdays at 9am")
+    #expect(result == "Tuesdays at 9am")
   }
 
+  @Test
   func testFormatsWeeklyWednesdayAt830pm() {
     let rrule = "FREQ=WEEKLY;BYDAY=WE"
     let airtime = dateAt(hour: 20, minute: 30)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Wednesdays at 8:30pm")
+    #expect(result == "Wednesdays at 8:30pm")
   }
 
+  @Test
   func testFormatsWeeklyThursdayAtNoon() {
     let rrule = "FREQ=WEEKLY;BYDAY=TH"
     let airtime = dateAt(hour: 12, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Thursdays at 12pm")
+    #expect(result == "Thursdays at 12pm")
   }
 
+  @Test
   func testFormatsWeeklyFridayAt6pm() {
     let rrule = "FREQ=WEEKLY;BYDAY=FR"
     let airtime = dateAt(hour: 18, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Fridays at 6pm")
+    #expect(result == "Fridays at 6pm")
   }
 
+  @Test
   func testFormatsWeeklySaturdayAt10am() {
     let rrule = "FREQ=WEEKLY;BYDAY=SA"
     let airtime = dateAt(hour: 10, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Saturdays at 10am")
+    #expect(result == "Saturdays at 10am")
   }
 
+  @Test
   func testFormatsWeeklySundayAt7pm() {
     let rrule = "FREQ=WEEKLY;BYDAY=SU"
     let airtime = dateAt(hour: 19, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Sundays at 7pm")
+    #expect(result == "Sundays at 7pm")
   }
 
   // MARK: - Multiple Days Tests
 
+  @Test
   func testFormatsTwoDays() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO,WE"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays and Wednesdays at 4pm")
+    #expect(result == "Mondays and Wednesdays at 4pm")
   }
 
+  @Test
   func testFormatsThreeDays() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO,WE,FR"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays, Wednesdays, and Fridays at 4pm")
+    #expect(result == "Mondays, Wednesdays, and Fridays at 4pm")
   }
 
+  @Test
   func testFormatsWeekdays() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR"
     let airtime = dateAt(hour: 8, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Weekdays at 8am")
+    #expect(result == "Weekdays at 8am")
   }
 
+  @Test
   func testFormatsWeekends() {
     let rrule = "FREQ=WEEKLY;BYDAY=SA,SU"
     let airtime = dateAt(hour: 10, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Weekends at 10am")
+    #expect(result == "Weekends at 10am")
   }
 
+  @Test
   func testFormatsEveryDay() {
     let rrule = "FREQ=WEEKLY;BYDAY=MO,TU,WE,TH,FR,SA,SU"
     let airtime = dateAt(hour: 20, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Every day at 8pm")
+    #expect(result == "Every day at 8pm")
   }
 
   // MARK: - Daily Frequency Tests
 
+  @Test
   func testFormatsDailyFrequency() {
     let rrule = "FREQ=DAILY"
     let airtime = dateAt(hour: 14, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Every day at 2pm")
+    #expect(result == "Every day at 2pm")
   }
 
   // MARK: - Edge Cases
 
+  @Test
   func testReturnsNilForInvalidRRule() {
     let rrule = "INVALID_RRULE"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertNil(result)
+    #expect(result == nil)
   }
 
+  @Test
   func testReturnsNilForEmptyRRule() {
     let rrule = ""
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertNil(result)
+    #expect(result == nil)
   }
 
+  @Test
   func testReturnsNilForNilRRule() {
     let result = RRuleFormatter.formatToPlainEnglish(rrule: nil, airtime: Date())
 
-    XCTAssertNil(result)
+    #expect(result == nil)
   }
 
+  @Test
   func testHandlesDaysInDifferentOrder() {
     let rrule = "FREQ=WEEKLY;BYDAY=FR,MO,WE"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays, Wednesdays, and Fridays at 4pm")
+    #expect(result == "Mondays, Wednesdays, and Fridays at 4pm")
   }
 
+  @Test
   func testHandlesLowercaseDays() {
     let rrule = "FREQ=WEEKLY;BYDAY=mo,we,fr"
     let airtime = dateAt(hour: 16, minute: 0)
 
     let result = RRuleFormatter.formatToPlainEnglish(rrule: rrule, airtime: airtime)
 
-    XCTAssertEqual(result, "Mondays, Wednesdays, and Fridays at 4pm")
+    #expect(result == "Mondays, Wednesdays, and Fridays at 4pm")
   }
 
   // MARK: - Helpers

--- a/PlayolaRadio/Core/Likes/LikeOperation.swift
+++ b/PlayolaRadio/Core/Likes/LikeOperation.swift
@@ -71,8 +71,8 @@ struct LikeOperation: Codable, Equatable, Identifiable {
   }
 
   /// Whether this operation has expired (older than 7 days)
-  var isExpired: Bool {
-    Date().timeIntervalSince(timestamp) > 7 * 24 * 60 * 60
+  func isExpired(now: Date) -> Bool {
+    now.timeIntervalSince(timestamp) > 7 * 24 * 60 * 60
   }
 }
 

--- a/PlayolaRadio/Core/Likes/LikeOperationTests.swift
+++ b/PlayolaRadio/Core/Likes/LikeOperationTests.swift
@@ -89,20 +89,21 @@ struct LikeOperationTests {
 
   @Test
   func testIsExpired() {
+    let now = Date()
     let recentOperation = LikeOperation(
       audioBlock: testAudioBlock,
       type: .like,
-      timestamp: Date()
+      timestamp: now
     )
 
     let oldOperation = LikeOperation(
       audioBlock: testAudioBlock,
       type: .like,
-      timestamp: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60)
+      timestamp: now.addingTimeInterval(-8 * 24 * 60 * 60)
     )
 
-    #expect(!recentOperation.isExpired)
-    #expect(oldOperation.isExpired)
+    #expect(!recentOperation.isExpired(now: now))
+    #expect(oldOperation.isExpired(now: now))
   }
 
   // MARK: - Equatable Tests

--- a/PlayolaRadio/Core/Likes/LikeOperationTests.swift
+++ b/PlayolaRadio/Core/Likes/LikeOperationTests.swift
@@ -5,12 +5,13 @@
 //  Created by Brian D Keane on 8/30/25.
 //
 
+import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
-final class LikeOperationTests: XCTestCase {
+struct LikeOperationTests {
 
   // MARK: - Test Data
 
@@ -18,22 +19,23 @@ final class LikeOperationTests: XCTestCase {
 
   // MARK: - Initialization Tests
 
-  func testInit_DefaultValues() {
+  @Test
+  func testInitDefaultValues() {
     let operation = LikeOperation(
       audioBlock: testAudioBlock,
       type: .like
     )
 
-    XCTAssertNotNil(operation.id)
-    XCTAssertEqual(operation.audioBlock.id, testAudioBlock.id)
-    XCTAssertEqual(operation.type, .like)
-    XCTAssertEqual(operation.retryCount, 0)
-    XCTAssertTrue(abs(operation.timestamp.timeIntervalSinceNow) < 1)  // Recent timestamp
+    #expect(operation.audioBlock.id == testAudioBlock.id)
+    #expect(operation.type == .like)
+    #expect(operation.retryCount == 0)
+    #expect(abs(operation.timestamp.timeIntervalSinceNow) < 1)
   }
 
-  func testInit_CustomValues() {
+  @Test
+  func testInitCustomValues() {
     let customId = UUID()
-    let customDate = Date(timeIntervalSinceNow: -3600)  // 1 hour ago
+    let customDate = Date(timeIntervalSinceNow: -3600)
 
     let operation = LikeOperation(
       id: customId,
@@ -43,14 +45,15 @@ final class LikeOperationTests: XCTestCase {
       retryCount: 2
     )
 
-    XCTAssertEqual(operation.id, customId)
-    XCTAssertEqual(operation.type, .unlike)
-    XCTAssertEqual(operation.timestamp, customDate)
-    XCTAssertEqual(operation.retryCount, 2)
+    #expect(operation.id == customId)
+    #expect(operation.type == .unlike)
+    #expect(operation.timestamp == customDate)
+    #expect(operation.retryCount == 2)
   }
 
   // MARK: - Retry Logic Tests
 
+  @Test
   func testIncrementingRetryCount() {
     let operation = LikeOperation(
       audioBlock: testAudioBlock,
@@ -60,13 +63,14 @@ final class LikeOperationTests: XCTestCase {
 
     let incrementedOperation = operation.incrementingRetryCount()
 
-    XCTAssertEqual(incrementedOperation.id, operation.id)
-    XCTAssertEqual(incrementedOperation.audioBlock.id, operation.audioBlock.id)
-    XCTAssertEqual(incrementedOperation.type, operation.type)
-    XCTAssertEqual(incrementedOperation.timestamp, operation.timestamp)
-    XCTAssertEqual(incrementedOperation.retryCount, 2)
+    #expect(incrementedOperation.id == operation.id)
+    #expect(incrementedOperation.audioBlock.id == operation.audioBlock.id)
+    #expect(incrementedOperation.type == operation.type)
+    #expect(incrementedOperation.timestamp == operation.timestamp)
+    #expect(incrementedOperation.retryCount == 2)
   }
 
+  @Test
   func testShouldRetry() {
     let operation0 = LikeOperation(audioBlock: testAudioBlock, type: .like, retryCount: 0)
     let operation1 = LikeOperation(audioBlock: testAudioBlock, type: .like, retryCount: 1)
@@ -74,15 +78,16 @@ final class LikeOperationTests: XCTestCase {
     let operation3 = LikeOperation(audioBlock: testAudioBlock, type: .like, retryCount: 3)
     let operation4 = LikeOperation(audioBlock: testAudioBlock, type: .like, retryCount: 4)
 
-    XCTAssertTrue(operation0.shouldRetry)
-    XCTAssertTrue(operation1.shouldRetry)
-    XCTAssertTrue(operation2.shouldRetry)
-    XCTAssertFalse(operation3.shouldRetry)  // Max retries = 3
-    XCTAssertFalse(operation4.shouldRetry)
+    #expect(operation0.shouldRetry)
+    #expect(operation1.shouldRetry)
+    #expect(operation2.shouldRetry)
+    #expect(!operation3.shouldRetry)
+    #expect(!operation4.shouldRetry)
   }
 
   // MARK: - Expiration Tests
 
+  @Test
   func testIsExpired() {
     let recentOperation = LikeOperation(
       audioBlock: testAudioBlock,
@@ -93,16 +98,17 @@ final class LikeOperationTests: XCTestCase {
     let oldOperation = LikeOperation(
       audioBlock: testAudioBlock,
       type: .like,
-      timestamp: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60)  // 8 days ago
+      timestamp: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60)
     )
 
-    XCTAssertFalse(recentOperation.isExpired)
-    XCTAssertTrue(oldOperation.isExpired)
+    #expect(!recentOperation.isExpired)
+    #expect(oldOperation.isExpired)
   }
 
   // MARK: - Equatable Tests
 
-  func testEquatable_Equal() {
+  @Test
+  func testEquatableEqual() {
     let id = UUID()
     let date = Date()
 
@@ -122,26 +128,29 @@ final class LikeOperationTests: XCTestCase {
       retryCount: 1
     )
 
-    XCTAssertEqual(operation1, operation2)
+    #expect(operation1 == operation2)
   }
 
-  func testEquatable_NotEqual_DifferentId() {
+  @Test
+  func testEquatableNotEqualDifferentId() {
     let operation1 = LikeOperation(audioBlock: testAudioBlock, type: .like)
     let operation2 = LikeOperation(audioBlock: testAudioBlock, type: .like)
 
-    XCTAssertNotEqual(operation1, operation2)  // Different IDs
+    #expect(operation1 != operation2)
   }
 
-  func testEquatable_NotEqual_DifferentType() {
+  @Test
+  func testEquatableNotEqualDifferentType() {
     let id = UUID()
     let operation1 = LikeOperation(id: id, audioBlock: testAudioBlock, type: .like)
     let operation2 = LikeOperation(id: id, audioBlock: testAudioBlock, type: .unlike)
 
-    XCTAssertNotEqual(operation1, operation2)
+    #expect(operation1 != operation2)
   }
 
   // MARK: - Codable Tests
 
+  @Test
   func testCodable() throws {
     let operation = LikeOperation(
       audioBlock: testAudioBlock,
@@ -149,27 +158,28 @@ final class LikeOperationTests: XCTestCase {
       retryCount: 2
     )
 
-    // Encode
     let encoder = JSONEncoder()
     let data = try encoder.encode(operation)
 
-    // Decode
     let decoder = JSONDecoder()
     let decodedOperation = try decoder.decode(LikeOperation.self, from: data)
 
-    // Verify
-    XCTAssertEqual(decodedOperation.id, operation.id)
-    XCTAssertEqual(decodedOperation.audioBlock.id, operation.audioBlock.id)
-    XCTAssertEqual(decodedOperation.audioBlock.title, operation.audioBlock.title)
-    XCTAssertEqual(decodedOperation.type, operation.type)
-    XCTAssertEqual(decodedOperation.retryCount, operation.retryCount)
-    XCTAssertEqual(
-      decodedOperation.timestamp.timeIntervalSince1970, operation.timestamp.timeIntervalSince1970,
-      accuracy: 0.001)
+    #expect(decodedOperation.id == operation.id)
+    #expect(decodedOperation.audioBlock.id == operation.audioBlock.id)
+    #expect(decodedOperation.audioBlock.title == operation.audioBlock.title)
+    #expect(decodedOperation.type == operation.type)
+    #expect(decodedOperation.retryCount == operation.retryCount)
+    #expect(
+      abs(
+        decodedOperation.timestamp.timeIntervalSince1970
+          - operation.timestamp.timeIntervalSince1970
+      ) < 0.001
+    )
   }
 
-  func testOperationType_RawValues() {
-    XCTAssertEqual(LikeOperation.OperationType.like.rawValue, "like")
-    XCTAssertEqual(LikeOperation.OperationType.unlike.rawValue, "unlike")
+  @Test
+  func testOperationTypeRawValues() {
+    #expect(LikeOperation.OperationType.like.rawValue == "like")
+    #expect(LikeOperation.OperationType.unlike.rawValue == "unlike")
   }
 }

--- a/PlayolaRadio/Core/Likes/LikesManager.swift
+++ b/PlayolaRadio/Core/Likes/LikesManager.swift
@@ -39,6 +39,11 @@ final class LikesManager: ObservableObject {
     setupAuthObserver()
   }
 
+  // The auth subscription is intentionally tied to this instance's lifetime.
+  // LikesManager is registered as a DependencyKey with a `liveValue` singleton,
+  // so in production the subscription lives for the duration of the process.
+  // The `[weak self]` capture prevents retain cycles in tests where fresh
+  // instances are constructed and discarded between cases.
   private func setupAuthObserver() {
     authCancellable = $auth.publisher
       .sink { [weak self] newAuth in

--- a/PlayolaRadio/Core/Likes/LikesManager.swift
+++ b/PlayolaRadio/Core/Likes/LikesManager.swift
@@ -26,6 +26,8 @@ final class LikesManager: ObservableObject {
 
   @Dependency(\.api) private var api
   @Dependency(\.toast) private var toast
+  @Dependency(\.date.now) private var now
+  @Dependency(\.uuid) private var uuid
   @Shared(.auth) private var auth
   @Shared(.mainContainerNavigationCoordinator) private var navigationCoordinator
   @Shared(.activeTab) private var activeTab
@@ -126,8 +128,10 @@ final class LikesManager: ObservableObject {
     }
 
     let operation = LikeOperation(
+      id: uuid(),
       audioBlock: audioBlock,
       type: .like,
+      timestamp: now,
       spinId: spinId
     )
     $pendingOperations.withLock {
@@ -164,8 +168,10 @@ final class LikesManager: ObservableObject {
     }
 
     let operation = LikeOperation(
+      id: uuid(),
       audioBlock: audioBlock,
-      type: .unlike
+      type: .unlike,
+      timestamp: now
     )
     $pendingOperations.withLock {
       $0.append(operation)
@@ -178,8 +184,9 @@ final class LikesManager: ObservableObject {
 
   /// Clears expired operations from the pending queue
   func cleanupExpiredOperations() {
+    let currentDate = now
     $pendingOperations.withLock {
-      $0.removeAll { $0.isExpired }
+      $0.removeAll { $0.isExpired(now: currentDate) }
     }
   }
 

--- a/PlayolaRadio/Core/Likes/LikesManagerTests.swift
+++ b/PlayolaRadio/Core/Likes/LikesManagerTests.swift
@@ -23,10 +23,16 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      return manager
+    }
 
     #expect(manager.isLiked(audioBlock.id))
     #expect(manager.getLikedAudioBlock(audioBlock.id) == audioBlock)
@@ -39,10 +45,16 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      return manager
+    }
 
     #expect(manager.pendingOperations.count == 1)
     #expect(manager.pendingOperations.first?.audioBlock == audioBlock)
@@ -54,11 +66,17 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
     let beforeLike = Date()
 
-    manager.like(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      return manager
+    }
 
     let timestamp = manager.getLikedTimestamp(audioBlock.id)
     #expect(timestamp != nil)
@@ -71,11 +89,17 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
-    manager.like(audioBlock)  // Try to like again
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      manager.like(audioBlock)  // Try to like again
+      return manager
+    }
 
     #expect(manager.allLikedAudioBlocks.count == 1)
     #expect(manager.pendingOperations.count == 1)
@@ -88,13 +112,19 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
-    #expect(manager.isLiked(audioBlock.id))
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      #expect(manager.isLiked(audioBlock.id))
 
-    manager.unlike(audioBlock)
+      manager.unlike(audioBlock)
+      return manager
+    }
 
     #expect(!manager.isLiked(audioBlock.id))
     #expect(manager.getLikedAudioBlock(audioBlock.id) == nil)
@@ -106,12 +136,17 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
-
-    manager.unlike(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      manager.unlike(audioBlock)
+      return manager
+    }
 
     #expect(manager.pendingOperations.count == 2)
     #expect(manager.pendingOperations.last?.audioBlock == audioBlock)
@@ -123,10 +158,16 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.unlike(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.unlike(audioBlock)
+      return manager
+    }
 
     #expect(manager.pendingOperations.count == 0)
   }
@@ -138,10 +179,16 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.toggleLike(audioBlock)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.toggleLike(audioBlock)
+      return manager
+    }
 
     #expect(manager.isLiked(audioBlock.id))
   }
@@ -151,13 +198,19 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    manager.like(audioBlock)
-    #expect(manager.isLiked(audioBlock.id))
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock)
+      #expect(manager.isLiked(audioBlock.id))
 
-    manager.toggleLike(audioBlock)
+      manager.toggleLike(audioBlock)
+      return manager
+    }
 
     #expect(!manager.isLiked(audioBlock.id))
   }
@@ -169,14 +222,20 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock1 = AudioBlock.mock
     let audioBlock2 = AudioBlock.mockWith(id: "different-id")
     let audioBlock3 = AudioBlock.mockWith(id: "another-id")
 
-    manager.like(audioBlock1)
-    manager.like(audioBlock2)
-    manager.like(audioBlock3)
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.like(audioBlock1)
+      manager.like(audioBlock2)
+      manager.like(audioBlock3)
+      return manager
+    }
 
     #expect(manager.allLikedAudioBlocks.count == 3)
     #expect(manager.isLiked(audioBlock1.id))
@@ -191,10 +250,13 @@ struct LikesManagerTests {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
 
-    let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
-    let recentOp = LikeOperation(audioBlock: audioBlock, type: .like)
+    let recentOp = LikeOperation(
+      audioBlock: audioBlock,
+      type: .like,
+      timestamp: Date()
+    )
 
     let expiredOp = LikeOperation(
       audioBlock: audioBlock,
@@ -202,11 +264,17 @@ struct LikesManagerTests {
       timestamp: Date(timeIntervalSinceNow: -8 * 24 * 60 * 60)
     )
 
-    manager.$pendingOperations.withLock {
-      $0 = [recentOp, expiredOp]
+    let manager = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager = LikesManager()
+      manager.$pendingOperations.withLock {
+        $0 = [recentOp, expiredOp]
+      }
+      manager.cleanupExpiredOperations()
+      return manager
     }
-
-    manager.cleanupExpiredOperations()
 
     #expect(manager.pendingOperations.count == 1)
     #expect(manager.pendingOperations.first == recentOp)
@@ -221,10 +289,15 @@ struct LikesManagerTests {
 
     let audioBlock = AudioBlock.mock
 
-    let manager1 = LikesManager()
-    manager1.like(audioBlock)
+    let manager2 = withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
+    } operation: {
+      let manager1 = LikesManager()
+      manager1.like(audioBlock)
 
-    let manager2 = LikesManager()
+      return LikesManager()
+    }
 
     #expect(manager2.isLiked(audioBlock.id))
     #expect(manager2.allLikedAudioBlocks.count == 1)

--- a/PlayolaRadio/Core/Likes/LikesManagerTests.swift
+++ b/PlayolaRadio/Core/Likes/LikesManagerTests.swift
@@ -6,51 +6,54 @@
 //
 
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class LikesManagerTests: XCTestCase {
-
-  // MARK: - Setup
-
-  override func setUp() async throws {
-    try await super.setUp()
-    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
-    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
-    $userLikes.withLock { $0 = [:] }
-    $pendingOperations.withLock { $0 = [] }
-  }
+struct LikesManagerTests {
 
   // MARK: - Like Tests
 
-  func testLike_AddsToUserLikes() async {
+  @Test
+  func testLikeAddsToUserLikes() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
 
-    XCTAssertTrue(manager.isLiked(audioBlock.id))
-    XCTAssertEqual(manager.getLikedAudioBlock(audioBlock.id), audioBlock)
-    XCTAssertEqual(manager.allLikedAudioBlocks.count, 1)
-    XCTAssertEqual(manager.allLikedAudioBlocks.first, audioBlock)
+    #expect(manager.isLiked(audioBlock.id))
+    #expect(manager.getLikedAudioBlock(audioBlock.id) == audioBlock)
+    #expect(manager.allLikedAudioBlocks.count == 1)
+    #expect(manager.allLikedAudioBlocks.first == audioBlock)
   }
 
-  func testLike_CreatesPendingOperation() async {
+  @Test
+  func testLikeCreatesPendingOperation() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
 
-    XCTAssertEqual(manager.pendingOperations.count, 1)
-    XCTAssertEqual(manager.pendingOperations.first?.audioBlock, audioBlock)
-    XCTAssertEqual(manager.pendingOperations.first?.type, .like)
+    #expect(manager.pendingOperations.count == 1)
+    #expect(manager.pendingOperations.first?.audioBlock == audioBlock)
+    #expect(manager.pendingOperations.first?.type == .like)
   }
 
-  func testLike_CreatesUserSongLikeWithTimestamp() async {
+  @Test
+  func testLikeCreatesUserSongLikeWithTimestamp() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
     let beforeLike = Date()
@@ -58,39 +61,51 @@ final class LikesManagerTests: XCTestCase {
     manager.like(audioBlock)
 
     let timestamp = manager.getLikedTimestamp(audioBlock.id)
-    XCTAssertNotNil(timestamp)
-    XCTAssertTrue(timestamp! >= beforeLike)
-    XCTAssertTrue(timestamp! <= Date())
+    #expect(timestamp != nil)
+    #expect(timestamp! >= beforeLike)
+    #expect(timestamp! <= Date())
   }
 
-  func testLike_DoesNotDuplicateIfAlreadyLiked() async {
+  @Test
+  func testLikeDoesNotDuplicateIfAlreadyLiked() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
     manager.like(audioBlock)  // Try to like again
 
-    XCTAssertEqual(manager.allLikedAudioBlocks.count, 1)
-    XCTAssertEqual(manager.pendingOperations.count, 1)
+    #expect(manager.allLikedAudioBlocks.count == 1)
+    #expect(manager.pendingOperations.count == 1)
   }
 
   // MARK: - Unlike Tests
 
-  func testUnlike_RemovesFromUserLikes() async {
+  @Test
+  func testUnlikeRemovesFromUserLikes() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
-    XCTAssertTrue(manager.isLiked(audioBlock.id))
+    #expect(manager.isLiked(audioBlock.id))
 
     manager.unlike(audioBlock)
 
-    XCTAssertFalse(manager.isLiked(audioBlock.id))
-    XCTAssertNil(manager.getLikedAudioBlock(audioBlock.id))
-    XCTAssertEqual(manager.allLikedAudioBlocks.count, 0)
+    #expect(!manager.isLiked(audioBlock.id))
+    #expect(manager.getLikedAudioBlock(audioBlock.id) == nil)
+    #expect(manager.allLikedAudioBlocks.count == 0)
   }
 
-  func testUnlike_CreatesPendingOperation() async {
+  @Test
+  func testUnlikeCreatesPendingOperation() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
@@ -98,46 +113,62 @@ final class LikesManagerTests: XCTestCase {
 
     manager.unlike(audioBlock)
 
-    XCTAssertEqual(manager.pendingOperations.count, 2)
-    XCTAssertEqual(manager.pendingOperations.last?.audioBlock, audioBlock)
-    XCTAssertEqual(manager.pendingOperations.last?.type, .unlike)
+    #expect(manager.pendingOperations.count == 2)
+    #expect(manager.pendingOperations.last?.audioBlock == audioBlock)
+    #expect(manager.pendingOperations.last?.type == .unlike)
   }
 
-  func testUnlike_DoesNothingIfNotLiked() async {
+  @Test
+  func testUnlikeDoesNothingIfNotLiked() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.unlike(audioBlock)
 
-    XCTAssertEqual(manager.pendingOperations.count, 0)
+    #expect(manager.pendingOperations.count == 0)
   }
 
   // MARK: - Toggle Tests
 
-  func testToggleLike_LikesIfNotLiked() async {
+  @Test
+  func testToggleLikeLikesIfNotLiked() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.toggleLike(audioBlock)
 
-    XCTAssertTrue(manager.isLiked(audioBlock.id))
+    #expect(manager.isLiked(audioBlock.id))
   }
 
-  func testToggleLike_UnlikesIfLiked() async {
+  @Test
+  func testToggleLikeUnlikesIfLiked() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
     manager.like(audioBlock)
-    XCTAssertTrue(manager.isLiked(audioBlock.id))
+    #expect(manager.isLiked(audioBlock.id))
 
     manager.toggleLike(audioBlock)
 
-    XCTAssertFalse(manager.isLiked(audioBlock.id))
+    #expect(!manager.isLiked(audioBlock.id))
   }
 
   // MARK: - Multiple Songs Tests
 
+  @Test
   func testMultipleLikes() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock1 = AudioBlock.mock
     let audioBlock2 = AudioBlock.mockWith(id: "different-id")
@@ -147,15 +178,19 @@ final class LikesManagerTests: XCTestCase {
     manager.like(audioBlock2)
     manager.like(audioBlock3)
 
-    XCTAssertEqual(manager.allLikedAudioBlocks.count, 3)
-    XCTAssertTrue(manager.isLiked(audioBlock1.id))
-    XCTAssertTrue(manager.isLiked(audioBlock2.id))
-    XCTAssertTrue(manager.isLiked(audioBlock3.id))
+    #expect(manager.allLikedAudioBlocks.count == 3)
+    #expect(manager.isLiked(audioBlock1.id))
+    #expect(manager.isLiked(audioBlock2.id))
+    #expect(manager.isLiked(audioBlock3.id))
   }
 
   // MARK: - Cleanup Tests
 
+  @Test
   func testCleanupExpiredOperations() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let manager = LikesManager()
     let audioBlock = AudioBlock.mock
 
@@ -173,13 +208,17 @@ final class LikesManagerTests: XCTestCase {
 
     manager.cleanupExpiredOperations()
 
-    XCTAssertEqual(manager.pendingOperations.count, 1)
-    XCTAssertEqual(manager.pendingOperations.first, recentOp)
+    #expect(manager.pendingOperations.count == 1)
+    #expect(manager.pendingOperations.first == recentOp)
   }
 
   // MARK: - Persistence Tests
 
+  @Test
   func testPersistenceBetweenInstances() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let audioBlock = AudioBlock.mock
 
     let manager1 = LikesManager()
@@ -187,8 +226,8 @@ final class LikesManagerTests: XCTestCase {
 
     let manager2 = LikesManager()
 
-    XCTAssertTrue(manager2.isLiked(audioBlock.id))
-    XCTAssertEqual(manager2.allLikedAudioBlocks.count, 1)
-    XCTAssertEqual(manager2.pendingOperations.count, 1)
+    #expect(manager2.isLiked(audioBlock.id))
+    #expect(manager2.allLikedAudioBlocks.count == 1)
+    #expect(manager2.pendingOperations.count == 1)
   }
 }

--- a/PlayolaRadio/Core/ListeningTracker/ListeningTracker.swift
+++ b/PlayolaRadio/Core/ListeningTracker/ListeningTracker.swift
@@ -13,6 +13,12 @@ import SwiftUI
 final class ListeningTracker {
   let rewardsProfile: RewardsProfile
   var localListeningSessions: [LocalListeningSession]
+
+  // The sink closure captures `self` weakly so the cancellable owned by this
+  // tracker is the only thing keeping the subscription alive. When the tracker
+  // is deallocated, `cancellables` releases the cancellable and the subscription
+  // is torn down — without this, the strong self/closure/cancellables cycle
+  // would keep replaced trackers alive forever.
   private var cancellables = Set<AnyCancellable>()
 
   var isListening: Bool {
@@ -28,19 +34,22 @@ final class ListeningTracker {
     self.rewardsProfile = rewardsProfile
     self.localListeningSessions = localListeningSessions
 
-    $nowPlaying.publisher.sink { nowPlaying in
+    $nowPlaying.publisher
+      .sink { [weak self] in self?.handleNowPlayingChange($0) }
+      .store(in: &cancellables)
+  }
 
-      if self.isCurrentlyPlaying(nowPlaying?.playbackStatus) && !self.isListening {
-        print("Starting a new session!")
-        self.localListeningSessions.append(LocalListeningSession(startTime: .now))
-      } else if !self.isCurrentlyPlaying(nowPlaying?.playbackStatus) && self.isListening {
-        if !self.localListeningSessions.isEmpty {
-          print("Ending the current session")
-          let lastIndex = self.localListeningSessions.count - 1
-          self.localListeningSessions[lastIndex].endTime = .now
-        }
+  private func handleNowPlayingChange(_ nowPlaying: NowPlaying?) {
+    if isCurrentlyPlaying(nowPlaying?.playbackStatus) && !isListening {
+      print("Starting a new session!")
+      localListeningSessions.append(LocalListeningSession(startTime: .now))
+    } else if !isCurrentlyPlaying(nowPlaying?.playbackStatus) && isListening {
+      if !localListeningSessions.isEmpty {
+        print("Ending the current session")
+        let lastIndex = localListeningSessions.count - 1
+        localListeningSessions[lastIndex].endTime = .now
       }
-    }.store(in: &cancellables)
+    }
   }
 
   private func isCurrentlyPlaying(_ status: StationPlayer.PlaybackStatus?) -> Bool {

--- a/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
+++ b/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
@@ -5,31 +5,16 @@
 //  Created by Brian D Keane on 7/23/25.
 //
 
-import Combine
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 // swiftlint:disable redundant_optional_initialization
 
 @MainActor
-final class ListeningTrackerTests: XCTestCase {
-
-  private var cancellables = Set<AnyCancellable>()
-
-  override func setUp() {
-    super.setUp()
-    cancellables.removeAll()
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
-  }
-
-  override func tearDown() {
-    super.tearDown()
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
-    cancellables.removeAll()
-  }
+struct ListeningTrackerTests {
 
   func createMockRewardsProfile(totalTimeListenedMS: Int = 0) -> RewardsProfile {
     return RewardsProfile(
@@ -52,16 +37,22 @@ final class ListeningTrackerTests: XCTestCase {
 
   // MARK: - Initialization Tests
 
-  func testInit_WithEmptyLocalSessions() {
+  @Test
+  func testInitWithEmptyLocalSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile()
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 0)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertEqual(tracker.rewardsProfile.totalTimeListenedMS, 0)
+    #expect(tracker.localListeningSessions.count == 0)
+    #expect(!tracker.isListening)
+    #expect(tracker.rewardsProfile.totalTimeListenedMS == 0)
   }
 
-  func testInit_WithExistingLocalSessions() {
+  @Test
+  func testInitWithExistingLocalSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile()
     let existingSessions = [
       LocalListeningSession(
@@ -70,20 +61,26 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
   }
 
   // MARK: - isListening Tests
 
-  func testIsListening_ReturnsFalseWhenNoSessions() {
+  @Test
+  func testIsListeningReturnsFalseWhenNoSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile()
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertFalse(tracker.isListening)
+    #expect(!tracker.isListening)
   }
 
-  func testIsListening_ReturnsFalseWhenLastSessionEnded() {
+  @Test
+  func testIsListeningReturnsFalseWhenLastSessionEnded() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile()
     let existingSessions = [
       LocalListeningSession(
@@ -92,10 +89,11 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertFalse(tracker.isListening)
+    #expect(!tracker.isListening)
   }
 
-  func testIsListening_ReturnsTrueWhenLastSessionNotEnded() {
+  @Test
+  func testIsListeningReturnsTrueWhenLastSessionNotEnded() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -108,19 +106,25 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.isListening)
   }
 
   // MARK: - totalListenTimeMS Tests
 
-  func testTotalListenTimeMS_WithOnlyServerTime() {
+  @Test
+  func testTotalListenTimeMSWithOnlyServerTime() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile(totalTimeListenedMS: 5000)
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.totalListenTimeMS, 5000)
+    #expect(tracker.totalListenTimeMS == 5000)
   }
 
-  func testTotalListenTimeMS_WithOnlyLocalSessions() {
+  @Test
+  func testTotalListenTimeMSWithOnlyLocalSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile(totalTimeListenedMS: 0)
     let startTime = Date()
     let endTime = startTime.addingTimeInterval(10)  // 10 seconds = 10000ms
@@ -130,10 +134,13 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertEqual(tracker.totalListenTimeMS, 10000)
+    #expect(tracker.totalListenTimeMS == 10000)
   }
 
-  func testTotalListenTimeMS_WithBothServerAndLocalTime() {
+  @Test
+  func testTotalListenTimeMSWithBothServerAndLocalTime() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile(totalTimeListenedMS: 5000)
     let startTime = Date()
     let endTime = startTime.addingTimeInterval(10)  // 10 seconds = 10000ms
@@ -143,10 +150,13 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertEqual(tracker.totalListenTimeMS, 15000)
+    #expect(tracker.totalListenTimeMS == 15000)
   }
 
-  func testTotalListenTimeMS_WithMultipleLocalSessions() {
+  @Test
+  func testTotalListenTimeMSWithMultipleLocalSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+
     let rewardsProfile = createMockRewardsProfile(totalTimeListenedMS: 1000)
     let baseTime = Date()
     let existingSessions = [
@@ -159,32 +169,34 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(
       rewardsProfile: rewardsProfile, localListeningSessions: existingSessions)
 
-    XCTAssertEqual(tracker.totalListenTimeMS, 9000)  // 1000 + 5000 + 3000
+    #expect(tracker.totalListenTimeMS == 9000)  // 1000 + 5000 + 3000
   }
 
   // MARK: - Playback State Change Tests
 
-  func testPlaybackStateChange_StartsNewSessionWhenPlayingStarted() {
+  @Test
+  func testPlaybackStateChangeStartsNewSessionWhenPlayingStarted() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
     // Create tracker with initial stopped state
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 0)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 0)
+    #expect(!tracker.isListening)
 
     // Update the shared state synchronously
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .playing(AnyStation.mock)) }
 
     // The publisher should have already fired synchronously
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.startTime)
-    XCTAssertNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.startTime != nil)
+    #expect(tracker.localListeningSessions.last?.endTime == nil)
   }
 
-  func testPlaybackStateChange_EndsSessionWhenPlaybackStopped() {
+  @Test
+  func testPlaybackStateChangeEndsSessionWhenPlaybackStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -194,19 +206,20 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
     // Verify initial state
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate playback stopping
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .stopped) }
 
     // The publisher should have already fired synchronously
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.endTime != nil)
   }
 
-  func testPlaybackStateChange_DoesNotStartDuplicateSessionWhenAlreadyPlaying() {
+  @Test
+  func testPlaybackStateChangeDoesNotStartDuplicateSessionWhenAlreadyPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -215,18 +228,19 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate another playing state (should not create new session)
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .playing(AnyStation.mock)) }
 
     // Should still have only one session
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
   }
 
-  func testPlaybackStateChange_HandlesLoadingStateAsNonPlaying() {
+  @Test
+  func testPlaybackStateChangeHandlesLoadingStateAsNonPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -235,18 +249,19 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate loading state (should end session)
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .loading(AnyStation.mock)) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.endTime != nil)
   }
 
-  func testPlaybackStateChange_HandlesErrorStateAsNonPlaying() {
+  @Test
+  func testPlaybackStateChangeHandlesErrorStateAsNonPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -255,18 +270,19 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate error state (should end session)
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .error) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.endTime != nil)
   }
 
-  func testPlaybackStateChange_HandlesNilNowPlayingAsNonPlaying() {
+  @Test
+  func testPlaybackStateChangeHandlesNilNowPlayingAsNonPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -275,20 +291,21 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Simulate nil nowPlaying (should end session)
     $nowPlaying.withLock { $0 = nil }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
-    XCTAssertNotNil(tracker.localListeningSessions.last?.endTime)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
+    #expect(tracker.localListeningSessions.last?.endTime != nil)
   }
 
   // MARK: - Edge Cases
 
-  func testPlaybackStateChange_DoesNotEndSessionWhenNoSessionsExist() {
+  @Test
+  func testPlaybackStateChangeDoesNotEndSessionWhenNoSessionsExist() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -297,10 +314,11 @@ final class ListeningTrackerTests: XCTestCase {
 
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 0)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 0)
+    #expect(!tracker.isListening)
   }
 
+  @Test
   func testMultiplePlaybackStateChanges() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
@@ -309,31 +327,32 @@ final class ListeningTrackerTests: XCTestCase {
     // Start playing
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .playing(AnyStation.mock)) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Stop playing
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .stopped) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(!tracker.isListening)
 
     // Start playing again
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .playing(AnyStation.mock)) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 2)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 2)
+    #expect(tracker.isListening)
 
     // Stop playing again
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .stopped) }
 
-    XCTAssertEqual(tracker.localListeningSessions.count, 2)
-    XCTAssertFalse(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 2)
+    #expect(!tracker.isListening)
   }
 
   // MARK: - Real-time Session Duration Test
 
-  func testSessionDuration_CalculatesCorrectly() {
+  @Test
+  func testSessionDurationCalculatesCorrectly() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let rewardsProfile = createMockRewardsProfile()
 
@@ -343,26 +362,26 @@ final class ListeningTrackerTests: XCTestCase {
     let tracker = ListeningTracker(rewardsProfile: rewardsProfile)
 
     // Verify session started
-    XCTAssertEqual(tracker.localListeningSessions.count, 1)
-    XCTAssertTrue(tracker.isListening)
+    #expect(tracker.localListeningSessions.count == 1)
+    #expect(tracker.isListening)
 
     // Get the start time
     let startTime = tracker.localListeningSessions.first?.startTime
-    XCTAssertNotNil(startTime)
+    #expect(startTime != nil)
 
     // Stop playing
     $nowPlaying.withLock { $0 = createNowPlaying(playbackStatus: .stopped) }
 
     // Verify session ended
-    XCTAssertFalse(tracker.isListening)
+    #expect(!tracker.isListening)
     let endTime = tracker.localListeningSessions.first?.endTime
-    XCTAssertNotNil(endTime)
+    #expect(endTime != nil)
 
     // The duration should be very small since we're testing synchronously
     if let start = startTime, let end = endTime {
       let duration = end.timeIntervalSince(start)
-      XCTAssertLessThan(duration, 1.0)  // Should be less than 1 second
-      XCTAssertGreaterThanOrEqual(duration, 0)  // Should be non-negative
+      #expect(duration < 1.0)  // Should be less than 1 second
+      #expect(duration >= 0)  // Should be non-negative
     }
   }
 }

--- a/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinatorTests.swift
@@ -6,26 +6,19 @@
 //
 
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class MainContainerNavigationCoordinatorTests: XCTestCase {
-
-  // MARK: - Setup
-
-  override func setUp() async throws {
-    try await super.setUp()
-    // Clear any shared state
-    @Shared(.activeTab) var activeTab: MainContainerModel.ActiveTab = .home
-    $activeTab.withLock { $0 = .home }
-  }
+struct MainContainerNavigationCoordinatorTests {
 
   // MARK: - navigateToLikedSongs Tests
 
-  func testNavigateToLikedSongs_WithSheetAndDifferentTab() async {
+  @Test
+  func testNavigateToLikedSongsWithSheetAndDifferentTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -38,18 +31,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Should have completed both transitions and pushed liked songs page
-      XCTAssertNil(coordinator.presentedSheet)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.presentedSheet == nil)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
-  func testNavigateToLikedSongs_WithSheetButCorrectTab() async {
+  @Test
+  func testNavigateToLikedSongsWithSheetButCorrectTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -62,18 +56,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Should have dismissed sheet, kept same tab, and pushed liked songs page
-      XCTAssertNil(coordinator.presentedSheet)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.presentedSheet == nil)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
-  func testNavigateToLikedSongs_WithDifferentTabButNoSheet() async {
+  @Test
+  func testNavigateToLikedSongsWithDifferentTabButNoSheet() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -86,17 +81,18 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Should have changed tab and pushed liked songs page
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
-  func testNavigateToLikedSongs_NoSheetAndCorrectTab() async {
+  @Test
+  func testNavigateToLikedSongsNoSheetAndCorrectTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -109,19 +105,20 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Should have pushed liked songs page
-      XCTAssertEqual(coordinator.path.count, 1)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertNil(coordinator.presentedSheet)
+      #expect(coordinator.path.count == 1)
+      #expect(activeTab == .profile)
+      #expect(coordinator.presentedSheet == nil)
 
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
-  func testNavigateToLikedSongs_CreatesLikedSongsPageModel() async {
+  @Test
+  func testNavigateToLikedSongsCreatesLikedSongsPageModel() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -136,18 +133,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       await coordinator.navigateToLikedSongs()
 
       // Verify that a LikedSongsPageModel was created
-      XCTAssertEqual(coordinator.path.count, 1)
-      if case .likedSongsPage(let model) = coordinator.path.first {
-        XCTAssertNotNil(model)
+      #expect(coordinator.path.count == 1)
+      if case .likedSongsPage = coordinator.path.first {
+        // Success
       } else {
-        XCTFail("Expected likedSongsPage with model to be pushed")
+        Issue.record("Expected likedSongsPage with model to be pushed")
       }
     }
   }
 
   // MARK: - navigateToSupport Tests
 
-  func testNavigateToSupport_WithSheetAndDifferentTab() async {
+  @Test
+  func testNavigateToSupportWithSheetAndDifferentTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -160,18 +158,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertNil(coordinator.presentedSheet)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.presentedSheet == nil)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }
 
-  func testNavigateToSupport_WithSheetButCorrectTab() async {
+  @Test
+  func testNavigateToSupportWithSheetButCorrectTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -184,18 +183,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertNil(coordinator.presentedSheet)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.presentedSheet == nil)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }
 
-  func testNavigateToSupport_WithDifferentTabButNoSheet() async {
+  @Test
+  func testNavigateToSupportWithDifferentTabButNoSheet() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -208,17 +208,18 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(activeTab == .profile)
+      #expect(coordinator.path.count == 1)
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }
 
-  func testNavigateToSupport_NoSheetAndCorrectTab() async {
+  @Test
+  func testNavigateToSupportNoSheetAndCorrectTab() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -231,19 +232,20 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertEqual(coordinator.path.count, 1)
-      XCTAssertEqual(activeTab, .profile)
-      XCTAssertNil(coordinator.presentedSheet)
+      #expect(coordinator.path.count == 1)
+      #expect(activeTab == .profile)
+      #expect(coordinator.presentedSheet == nil)
 
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }
 
-  func testNavigateToSupport_UsesProvidedModel() async {
+  @Test
+  func testNavigateToSupportUsesProvidedModel() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
     } operation: {
@@ -256,38 +258,41 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.path.count == 1)
       if case .supportPage(let model) = coordinator.path.first {
-        XCTAssertTrue(model === supportModel)
+        #expect(model === supportModel)
       } else {
-        XCTFail("Expected supportPage with the provided model to be pushed")
+        Issue.record("Expected supportPage with the provided model to be pushed")
       }
     }
   }
 
   // MARK: - switchToBroadcastMode Tests
 
+  @Test
   func testSwitchToBroadcastModeSetsAppModeAndClearsPath() {
     let coordinator = MainContainerNavigationCoordinator()
     coordinator.path = [.editProfilePage(EditProfilePageModel())]
 
     coordinator.switchToBroadcastMode(stationId: "station-123")
 
-    XCTAssertEqual(coordinator.appMode, .broadcasting(stationId: "station-123"))
-    XCTAssertTrue(coordinator.path.isEmpty)
+    #expect(coordinator.appMode == .broadcasting(stationId: "station-123"))
+    #expect(coordinator.path.isEmpty)
   }
 
+  @Test
   func testSwitchToBroadcastModeFromListeningMode() {
     let coordinator = MainContainerNavigationCoordinator()
-    XCTAssertEqual(coordinator.appMode, .listening)
+    #expect(coordinator.appMode == .listening)
 
     coordinator.switchToBroadcastMode(stationId: "my-station")
 
-    XCTAssertEqual(coordinator.appMode, .broadcasting(stationId: "my-station"))
+    #expect(coordinator.appMode == .broadcasting(stationId: "my-station"))
   }
 
   // MARK: - switchToListeningMode Tests
 
+  @Test
   func testSwitchToListeningModeSetsAppModeAndClearsPath() {
     let coordinator = MainContainerNavigationCoordinator()
     coordinator.appMode = .broadcasting(stationId: "station-123")
@@ -295,21 +300,23 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
 
     coordinator.switchToListeningMode()
 
-    XCTAssertEqual(coordinator.appMode, .listening)
-    XCTAssertTrue(coordinator.path.isEmpty)
+    #expect(coordinator.appMode == .listening)
+    #expect(coordinator.path.isEmpty)
   }
 
+  @Test
   func testSwitchToListeningModeFromBroadcastMode() {
     let coordinator = MainContainerNavigationCoordinator()
     coordinator.appMode = .broadcasting(stationId: "station-123")
 
     coordinator.switchToListeningMode()
 
-    XCTAssertEqual(coordinator.appMode, .listening)
+    #expect(coordinator.appMode == .listening)
   }
 
   // MARK: - navigateToLikedSongs from Broadcast Mode Tests
 
+  @Test
   func testNavigateToLikedSongsSwitchesToListeningModeFirst() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
@@ -322,18 +329,19 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
 
       await coordinator.navigateToLikedSongs()
 
-      XCTAssertEqual(coordinator.appMode, .listening)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.appMode == .listening)
+      #expect(coordinator.path.count == 1)
       if case .likedSongsPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected likedSongsPage to be pushed")
+        Issue.record("Expected likedSongsPage to be pushed")
       }
     }
   }
 
   // MARK: - navigateToSupport from Broadcast Mode Tests
 
+  @Test
   func testNavigateToSupportSwitchesToListeningModeFirst() async {
     await withDependencies {
       $0.continuousClock = ImmediateClock()
@@ -347,12 +355,12 @@ final class MainContainerNavigationCoordinatorTests: XCTestCase {
       let supportModel = SupportPageModel()
       await coordinator.navigateToSupport(supportModel)
 
-      XCTAssertEqual(coordinator.appMode, .listening)
-      XCTAssertEqual(coordinator.path.count, 1)
+      #expect(coordinator.appMode == .listening)
+      #expect(coordinator.path.count == 1)
       if case .supportPage = coordinator.path.first {
         // Success
       } else {
-        XCTFail("Expected supportPage to be pushed")
+        Issue.record("Expected supportPage to be pushed")
       }
     }
   }

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -199,7 +199,7 @@ extension PushNotificationsClient: DependencyKey {
       }
 
       await MainActor.run {
-        StationPlayer.shared.play(station: station)
+        Task { await StationPlayer.shared.play(station: station) }
       }
     },
     setBadgeCount: { count in

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -170,19 +170,24 @@ extension PushNotificationsClient: DependencyKey {
       let navCoordinatorShared = $navCoordinator
 
       if NotificationPayload.notificationType(from: userInfo) == "support_message" {
-        await MainActor.run {
+        // Decide on the main actor whether the support tap should refresh the
+        // already-visible support page or push a new one, then await the push
+        // outside the sync MainActor.run closure so we don't have to spawn an
+        // unstructured Task to bridge the async navigateToSupport call.
+        let needsNavigation = await MainActor.run { () -> Bool in
           let coordinator = navCoordinatorShared.wrappedValue
           let isSupportPageVisible = coordinator.path.contains { pathItem in
             if case .supportPage = pathItem { return true }
             return false
           }
-
           if isSupportPageVisible {
             NotificationCenter.default.post(name: .refreshSupportMessages, object: nil)
-          } else {
-            let supportModel = SupportPageModel()
-            Task { await coordinator.navigateToSupport(supportModel) }
+            return false
           }
+          return true
+        }
+        if needsNavigation {
+          await navCoordinatorShared.wrappedValue.navigateToSupport(SupportPageModel())
         }
         return
       }

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -210,24 +210,25 @@ extension PushNotificationsClient: DependencyKey {
       try? await UNUserNotificationCenter.current().setBadgeCount(count)
     },
     handleSupportNotificationBadge: { badgeFromPayload in
-      @Shared(.unreadSupportCount) var unreadSupportCount
-      @Dependency(\.pushNotifications) var pushNotifications
-
-      let newCount: Int
-      if let badge = badgeFromPayload {
-        newCount = badge
-        $unreadSupportCount.withLock { $0 = badge }
-      } else {
-        $unreadSupportCount.withLock { $0 += 1 }
-        newCount = unreadSupportCount
+      let newCount = await MainActor.run { () -> Int in
+        @Shared(.unreadSupportCount) var unreadSupportCount
+        if let badge = badgeFromPayload {
+          $unreadSupportCount.withLock { $0 = badge }
+          return badge
+        } else {
+          $unreadSupportCount.withLock { $0 += 1 }
+          return unreadSupportCount
+        }
       }
+      @Dependency(\.pushNotifications) var pushNotifications
       await pushNotifications.setBadgeCount(newCount)
     },
     clearSupportBadge: {
-      @Shared(.unreadSupportCount) var unreadSupportCount
+      await MainActor.run {
+        @Shared(.unreadSupportCount) var unreadSupportCount
+        $unreadSupportCount.withLock { $0 = 0 }
+      }
       @Dependency(\.pushNotifications) var pushNotifications
-
-      $unreadSupportCount.withLock { $0 = 0 }
       await pushNotifications.setBadgeCount(0)
     }
   )

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -198,9 +198,8 @@ extension PushNotificationsClient: DependencyKey {
         return
       }
 
-      await MainActor.run {
-        Task { await StationPlayer.shared.play(station: station) }
-      }
+      @Dependency(\.stationPlayer) var stationPlayer
+      await stationPlayer.play(station: station)
     },
     setBadgeCount: { count in
       try? await UNUserNotificationCenter.current().setBadgeCount(count)

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -7,16 +7,18 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class PushNotificationsTests: XCTestCase {
+struct PushNotificationsTests {
 
   // MARK: - registerForRemoteNotifications
 
+  @Test
   func testRegisterForRemoteNotificationsRequestsAuthorization() async throws {
     let authorizationRequested = LockIsolated(false)
 
@@ -31,9 +33,10 @@ final class PushNotificationsTests: XCTestCase {
       _ = try await pushNotifications.requestAuthorization()
     }
 
-    XCTAssertTrue(authorizationRequested.value)
+    #expect(authorizationRequested.value)
   }
 
+  @Test
   func testRegisterForRemoteNotificationsCallsUIApplicationRegister() async throws {
     let registerCalled = LockIsolated(false)
 
@@ -46,20 +49,22 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.registerForRemoteNotifications()
     }
 
-    XCTAssertTrue(registerCalled.value)
+    #expect(registerCalled.value)
   }
 
   // MARK: - Device Token Handling
 
+  @Test
   func testDeviceTokenConvertedToHexString() {
     let tokenBytes: [UInt8] = [0xAB, 0xCD, 0xEF, 0x12, 0x34, 0x56, 0x78, 0x90]
     let tokenData = Data(tokenBytes)
 
     let hexString = tokenData.map { String(format: "%02x", $0) }.joined()
 
-    XCTAssertEqual(hexString, "abcdef1234567890")
+    #expect(hexString == "abcdef1234567890")
   }
 
+  @Test
   func testHandleDeviceTokenCallsAPIWhenLoggedIn() async throws {
     let capturedToken = LockIsolated<String?>(nil)
     let capturedPlatform = LockIsolated<String?>(nil)
@@ -78,13 +83,14 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleDeviceToken(tokenData)
     }
 
-    XCTAssertEqual(capturedToken.value, "abcdef12")
-    XCTAssertEqual(capturedPlatform.value, "ios")
-    XCTAssertEqual(capturedAppVersion.value, "1.0.0")
+    #expect(capturedToken.value == "abcdef12")
+    #expect(capturedPlatform.value == "ios")
+    #expect(capturedAppVersion.value == "1.0.0")
   }
 
   // MARK: - Notification Payload Parsing
 
+  @Test
   func testParseNotificationPayloadExtractsStationId() {
     let userInfo: [String: any Sendable] = [
       "stationId": "test-station-123"
@@ -92,19 +98,21 @@ final class PushNotificationsTests: XCTestCase {
 
     let stationId = NotificationPayload.stationId(from: userInfo)
 
-    XCTAssertEqual(stationId, "test-station-123")
+    #expect(stationId == "test-station-123")
   }
 
+  @Test
   func testParseNotificationPayloadReturnsNilWhenNoStationId() {
     let userInfo: [String: any Sendable] = [:]
 
     let stationId = NotificationPayload.stationId(from: userInfo)
 
-    XCTAssertNil(stationId)
+    #expect(stationId == nil)
   }
 
   // MARK: - Notification Response Handling
 
+  @Test
   func testHandleNotificationResponsePlaysStation() async {
     let playedStationId = LockIsolated<String?>(nil)
 
@@ -120,11 +128,12 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleNotificationTap(userInfo)
     }
 
-    XCTAssertEqual(playedStationId.value, "station-abc")
+    #expect(playedStationId.value == "station-abc")
   }
 
   // MARK: - Support Notification Badge Handling
 
+  @Test
   func testHandleSupportNotificationBadgeSetsCountFromPayload() async {
     @Shared(.unreadSupportCount) var unreadSupportCount = 0
     let capturedBadgeCount = LockIsolated<Int?>(nil)
@@ -141,10 +150,11 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleSupportNotificationBadge(badgeFromPayload: 5)
     }
 
-    XCTAssertEqual(unreadSupportCount, 5)
-    XCTAssertEqual(capturedBadgeCount.value, 5)
+    #expect(unreadSupportCount == 5)
+    #expect(capturedBadgeCount.value == 5)
   }
 
+  @Test
   func testHandleSupportNotificationBadgeIncrementsWhenNoPayload() async {
     @Shared(.unreadSupportCount) var unreadSupportCount = 2
     let capturedBadgeCount = LockIsolated<Int?>(nil)
@@ -161,10 +171,11 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.handleSupportNotificationBadge(badgeFromPayload: nil)
     }
 
-    XCTAssertEqual(unreadSupportCount, 3)
-    XCTAssertEqual(capturedBadgeCount.value, 3)
+    #expect(unreadSupportCount == 3)
+    #expect(capturedBadgeCount.value == 3)
   }
 
+  @Test
   func testClearSupportBadgeSetsCountToZero() async {
     @Shared(.unreadSupportCount) var unreadSupportCount = 5
     let capturedBadgeCount = LockIsolated<Int?>(nil)
@@ -181,12 +192,13 @@ final class PushNotificationsTests: XCTestCase {
       await pushNotifications.clearSupportBadge()
     }
 
-    XCTAssertEqual(unreadSupportCount, 0)
-    XCTAssertEqual(capturedBadgeCount.value, 0)
+    #expect(unreadSupportCount == 0)
+    #expect(capturedBadgeCount.value == 0)
   }
 
   // MARK: - Support Message Notification Tap
 
+  @Test
   func testHandleNotificationTapPostsRefreshWhenSupportMessageAndOnSupportPage() async {
     @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
       MainContainerNavigationCoordinator()
@@ -212,6 +224,6 @@ final class PushNotificationsTests: XCTestCase {
     ]
     await PushNotificationsClient.liveValue.handleNotificationTap(userInfo)
 
-    XCTAssertTrue(refreshNotificationPosted.value)
+    #expect(refreshNotificationPosted.value)
   }
 }

--- a/PlayolaRadio/Core/Toast/ToastClientTests.swift
+++ b/PlayolaRadio/Core/Toast/ToastClientTests.swift
@@ -7,16 +7,18 @@
 
 import ConcurrencyExtras
 import Dependencies
-import XCTest
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class ToastClientTests: XCTestCase {
+struct ToastClientTests {
 
   // MARK: - Basic Show/Dismiss
 
-  func testShow_SetsCurrentToast() async {
+  @Test
+  func testShowSetsCurrentToast() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -30,12 +32,13 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast)
 
       let currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Test message")
-      XCTAssertEqual(currentToast?.buttonTitle, "OK")
+      #expect(currentToast?.message == "Test message")
+      #expect(currentToast?.buttonTitle == "OK")
     }
   }
 
-  func testDismiss_ClearsCurrentToast() async {
+  @Test
+  func testDismissClearsCurrentToast() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -48,18 +51,19 @@ final class ToastClientTests: XCTestCase {
 
       await client.show(toast)
       let currentToast = await client.currentToast()
-      XCTAssertNotNil(currentToast)
+      #expect(currentToast != nil)
 
       await client.dismiss()
 
       let dismissedToast = await client.currentToast()
-      XCTAssertNil(dismissedToast)
+      #expect(dismissedToast == nil)
     }
   }
 
   // MARK: - Queue Management
 
-  func testShow_QueuesMultipleToasts() async {
+  @Test
+  func testShowQueuesMultipleToasts() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -78,16 +82,17 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast2)
 
       let currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "First toast")
+      #expect(currentToast?.message == "First toast")
 
       await client.dismiss()
 
       let nextToast = await client.currentToast()
-      XCTAssertEqual(nextToast?.message, "Second toast")
+      #expect(nextToast?.message == "Second toast")
     }
   }
 
-  func testQueue_ShowsToastsInOrder() async {
+  @Test
+  func testQueueShowsToastsInOrder() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -102,25 +107,26 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast3)
 
       var currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "First")
+      #expect(currentToast?.message == "First")
 
       await client.dismiss()
       currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Second")
+      #expect(currentToast?.message == "Second")
 
       await client.dismiss()
       currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Third")
+      #expect(currentToast?.message == "Third")
 
       await client.dismiss()
       currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
     }
   }
 
   // MARK: - Auto-dismiss
 
-  func testAutoDismiss_AfterSpecifiedDuration() async {
+  @Test
+  func testAutoDismissAfterSpecifiedDuration() async {
     let clock = TestClock()
 
     await withDependencies {
@@ -137,19 +143,20 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast)
 
       var currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Test message")
+      #expect(currentToast?.message == "Test message")
 
       await clock.advance(by: .seconds(1.0))
       currentToast = await client.currentToast()
-      XCTAssertNotNil(currentToast)
+      #expect(currentToast != nil)
 
       await clock.advance(by: .seconds(1.5))
       currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
     }
   }
 
-  func testAutoDismiss_ShowsNextToastInQueue() async {
+  @Test
+  func testAutoDismissShowsNextToastInQueue() async {
     let clock = TestClock()
 
     await withDependencies {
@@ -172,18 +179,19 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast2)
 
       var currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "First toast")
+      #expect(currentToast?.message == "First toast")
 
       await clock.advance(by: .seconds(1.5))
 
       currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Second toast")
+      #expect(currentToast?.message == "Second toast")
     }
   }
 
   // MARK: - Manual Dismiss
 
-  func testManualDismiss_CancelsAutoDismissTimer() async {
+  @Test
+  func testManualDismissCancelsAutoDismissTimer() async {
     let clock = TestClock()
 
     await withDependencies {
@@ -200,21 +208,22 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast)
 
       var currentToast = await client.currentToast()
-      XCTAssertNotNil(currentToast)
+      #expect(currentToast != nil)
 
       await client.dismiss()
 
       currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
 
       // Ensure timer was cancelled - toast shouldn't resurrect
       await clock.advance(by: .seconds(5.0))
       currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
     }
   }
 
-  func testManualDismiss_ShowsNextToastInQueue() async {
+  @Test
+  func testManualDismissShowsNextToastInQueue() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -234,18 +243,19 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast2)
 
       var currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "First toast")
+      #expect(currentToast?.message == "First toast")
 
       await client.dismiss()
 
       currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Second toast")
+      #expect(currentToast?.message == "Second toast")
     }
   }
 
   // MARK: - Concurrent Access
 
-  func testConcurrentShow_SafelyQueuesAllToasts() async {
+  @Test
+  func testConcurrentShowSafelyQueuesAllToasts() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -264,28 +274,27 @@ final class ToastClientTests: XCTestCase {
       await show3
 
       let currentToast = await client.currentToast()
-      XCTAssertNotNil(currentToast)
-      XCTAssertTrue(
-        ["Toast 1", "Toast 2", "Toast 3"].contains(currentToast?.message)
-      )
+      #expect(currentToast != nil)
+      #expect(["Toast 1", "Toast 2", "Toast 3"].contains(currentToast?.message))
 
       await client.dismiss()
       let secondToast = await client.currentToast()
-      XCTAssertNotNil(secondToast)
+      #expect(secondToast != nil)
 
       await client.dismiss()
       let thirdToast = await client.currentToast()
-      XCTAssertNotNil(thirdToast)
+      #expect(thirdToast != nil)
 
       await client.dismiss()
       let finalToast = await client.currentToast()
-      XCTAssertNil(finalToast)
+      #expect(finalToast == nil)
     }
   }
 
   // MARK: - Toast Actions
 
-  func testToastAction_ExecutesWhenInvoked() {
+  @Test
+  func testToastActionExecutesWhenInvoked() {
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -301,13 +310,14 @@ final class ToastClientTests: XCTestCase {
 
       toast.action?()
 
-      XCTAssertTrue(actionExecuted.value)
+      #expect(actionExecuted.value)
     }
   }
 
   // MARK: - Edge Cases
 
-  func testDismiss_WhenNoCurrentToast_DoesNothing() async {
+  @Test
+  func testDismissWhenNoCurrentToastDoesNothing() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -316,11 +326,12 @@ final class ToastClientTests: XCTestCase {
       await client.dismiss()
 
       let currentToast = await client.currentToast()
-      XCTAssertNil(currentToast)
+      #expect(currentToast == nil)
     }
   }
 
-  func testShow_WithZeroDuration_StillShowsToast() async {
+  @Test
+  func testShowWithZeroDurationStillShowsToast() async {
     await withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
@@ -335,7 +346,7 @@ final class ToastClientTests: XCTestCase {
       await client.show(toast)
 
       let currentToast = await client.currentToast()
-      XCTAssertEqual(currentToast?.message, "Zero duration")
+      #expect(currentToast?.message == "Zero duration")
     }
   }
 }

--- a/PlayolaRadio/Extensions/Version+Comparison/VersionComparisonTests.swift
+++ b/PlayolaRadio/Extensions/Version+Comparison/VersionComparisonTests.swift
@@ -3,52 +3,62 @@
 //  PlayolaRadio
 //
 
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-class VersionComparisonTests: XCTestCase {
+struct VersionComparisonTests {
+  @Test
   func testEqualVersionsReturnsFalse() {
-    XCTAssertFalse(isVersion("1.0.0", lessThan: "1.0.0"))
+    #expect(!isVersion("1.0.0", lessThan: "1.0.0"))
   }
 
+  @Test
   func testLessThanMajorReturnsTrue() {
-    XCTAssertTrue(isVersion("1.0.0", lessThan: "2.0.0"))
+    #expect(isVersion("1.0.0", lessThan: "2.0.0"))
   }
 
+  @Test
   func testGreaterThanMajorReturnsFalse() {
-    XCTAssertFalse(isVersion("2.0.0", lessThan: "1.0.0"))
+    #expect(!isVersion("2.0.0", lessThan: "1.0.0"))
   }
 
+  @Test
   func testLessThanMinorReturnsTrue() {
-    XCTAssertTrue(isVersion("1.1.0", lessThan: "1.2.0"))
+    #expect(isVersion("1.1.0", lessThan: "1.2.0"))
   }
 
+  @Test
   func testGreaterThanMinorReturnsFalse() {
-    XCTAssertFalse(isVersion("1.2.0", lessThan: "1.1.0"))
+    #expect(!isVersion("1.2.0", lessThan: "1.1.0"))
   }
 
+  @Test
   func testLessThanPatchReturnsTrue() {
-    XCTAssertTrue(isVersion("1.0.1", lessThan: "1.0.2"))
+    #expect(isVersion("1.0.1", lessThan: "1.0.2"))
   }
 
+  @Test
   func testGreaterThanPatchReturnsFalse() {
-    XCTAssertFalse(isVersion("1.0.2", lessThan: "1.0.1"))
+    #expect(!isVersion("1.0.2", lessThan: "1.0.1"))
   }
 
+  @Test
   func testMissingPatchTreatedAsZero() {
-    XCTAssertFalse(isVersion("1.0", lessThan: "1.0.0"))
-    XCTAssertTrue(isVersion("1.0", lessThan: "1.0.1"))
+    #expect(!isVersion("1.0", lessThan: "1.0.0"))
+    #expect(isVersion("1.0", lessThan: "1.0.1"))
   }
 
+  @Test
   func testMissingPatchOnRequiredTreatedAsZero() {
-    XCTAssertFalse(isVersion("1.0.0", lessThan: "1.0"))
-    XCTAssertFalse(isVersion("1.0.1", lessThan: "1.0"))
+    #expect(!isVersion("1.0.0", lessThan: "1.0"))
+    #expect(!isVersion("1.0.1", lessThan: "1.0"))
   }
 
+  @Test
   func testTwoComponentVersions() {
-    XCTAssertTrue(isVersion("1.0", lessThan: "1.1"))
-    XCTAssertFalse(isVersion("1.1", lessThan: "1.0"))
+    #expect(isVersion("1.0", lessThan: "1.1"))
+    #expect(!isVersion("1.1", lessThan: "1.0"))
   }
 }

--- a/PlayolaRadio/Models/SongSeed/SongSeedTests.swift
+++ b/PlayolaRadio/Models/SongSeed/SongSeedTests.swift
@@ -5,12 +5,15 @@
 //  Created by Brian D Keane on 12/15/25.
 //
 
-import XCTest
+import CustomDump
+import Foundation
+import Testing
 
 @testable import PlayolaRadio
 
-final class SongRequestTests: XCTestCase {
+struct SongRequestTests {
 
+  @Test
   func testSongRequestDecodesFromJSON() throws {
     let jsonString = """
       {
@@ -30,19 +33,10 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertEqual(songRequest.title, "Like a Rolling Stone")
-    XCTAssertEqual(songRequest.artist, "Bob Dylan")
-    XCTAssertEqual(songRequest.album, "Highway 61 Revisited")
-    XCTAssertEqual(songRequest.durationMS, 369600)
-    XCTAssertEqual(songRequest.popularity, 78)
-    XCTAssertEqual(songRequest.releaseDate, "1965-08-30")
-    XCTAssertEqual(songRequest.isrc, "USSM16500213")
-    XCTAssertEqual(songRequest.appleId, "1440806768")
-    XCTAssertEqual(songRequest.spotifyId, "3AhXZa8sUQht0UEdBJgpGc")
-    XCTAssertEqual(songRequest.imageUrl, URL(string: "https://i.scdn.co/image/test"))
-    XCTAssertNil(songRequest.requestId)
+    expectNoDifference(songRequest, SongRequest.mockWith())
   }
 
+  @Test
   func testSongRequestDecodesWithRequestId() throws {
     let jsonString = """
       {
@@ -63,9 +57,10 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertEqual(songRequest.requestId, "request-abc-123")
+    #expect(songRequest.requestId == "request-abc-123")
   }
 
+  @Test
   func testSongRequestDecodesWithNullImageUrl() throws {
     let jsonString = """
       {
@@ -84,9 +79,10 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertNil(songRequest.imageUrl)
+    #expect(songRequest.imageUrl == nil)
   }
 
+  @Test
   func testSongRequestDecodesWithMissingImageUrl() throws {
     let jsonString = """
       {
@@ -104,9 +100,10 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertNil(songRequest.imageUrl)
+    #expect(songRequest.imageUrl == nil)
   }
 
+  @Test
   func testSongRequestDecodesWithNullOptionalFields() throws {
     let jsonString = """
       {
@@ -122,12 +119,13 @@ final class SongRequestTests: XCTestCase {
 
     let songRequest = try JSONDecoder().decode(SongRequest.self, from: json)
 
-    XCTAssertNil(songRequest.popularity)
-    XCTAssertNil(songRequest.isrc)
-    XCTAssertNil(songRequest.spotifyId)
-    XCTAssertNil(songRequest.imageUrl)
+    #expect(songRequest.popularity == nil)
+    #expect(songRequest.isrc == nil)
+    #expect(songRequest.spotifyId == nil)
+    #expect(songRequest.imageUrl == nil)
   }
 
+  @Test
   func testSongRequestMockWithReturnsValidInstance() {
     let songRequest = SongRequest.mockWith(
       title: "Custom Title",
@@ -135,14 +133,15 @@ final class SongRequestTests: XCTestCase {
       appleId: "custom-apple-id"
     )
 
-    XCTAssertEqual(songRequest.title, "Custom Title")
-    XCTAssertEqual(songRequest.artist, "Custom Artist")
-    XCTAssertEqual(songRequest.appleId, "custom-apple-id")
+    #expect(songRequest.title == "Custom Title")
+    #expect(songRequest.artist == "Custom Artist")
+    #expect(songRequest.appleId == "custom-apple-id")
   }
 
+  @Test
   func testSongRequestIdentifiableUsesAppleIdAsId() {
     let songRequest = SongRequest.mockWith(appleId: "unique-apple-id")
 
-    XCTAssertEqual(songRequest.id, "unique-apple-id")
+    #expect(songRequest.id == "unique-apple-id")
   }
 }

--- a/PlayolaRadio/Models/StagingItem/StagingItemTests.swift
+++ b/PlayolaRadio/Models/StagingItem/StagingItemTests.swift
@@ -5,17 +5,19 @@
 //  Created by Brian D Keane on 12/15/25.
 //
 
+import Foundation
 import PlayolaPlayer
 import SwiftUI
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
-final class StagingItemTests: XCTestCase {
+struct StagingItemTests {
 
   // MARK: - LocalVoicetrack Conformance Tests
 
-  func testLocalVoicetrack_StagingId_ReturnsUUIDString() {
+  @Test
+  func testLocalVoicetrackStagingIdReturnsUUIDString() {
     let id = UUID()
     let voicetrack = LocalVoicetrack(
       id: id,
@@ -23,117 +25,129 @@ final class StagingItemTests: XCTestCase {
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.stagingId, id.uuidString)
+    #expect(voicetrack.stagingId == id.uuidString)
   }
 
-  func testLocalVoicetrack_TitleText_ReturnsTitle() {
+  @Test
+  func testLocalVoicetrackTitleTextReturnsTitle() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       title: "Voice Track 10:00am"
     )
 
-    XCTAssertEqual(voicetrack.titleText, "Voice Track 10:00am")
+    #expect(voicetrack.titleText == "Voice Track 10:00am")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenConverting_ReturnsConverting() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenConvertingReturnsConverting() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .converting,
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Converting...")
+    #expect(voicetrack.subtitleText == "Converting...")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenUploading_ReturnsProgress() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenUploadingReturnsProgress() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .uploading(progress: 0.5),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Uploading 50%")
+    #expect(voicetrack.subtitleText == "Uploading 50%")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenFinalizing_ReturnsFinalizing() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenFinalizingReturnsFinalizing() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .finalizing,
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Finalizing...")
+    #expect(voicetrack.subtitleText == "Finalizing...")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenCompleted_ReturnsReady() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenCompletedReturnsReady() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .completed,
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Ready")
+    #expect(voicetrack.subtitleText == "Ready")
   }
 
-  func testLocalVoicetrack_SubtitleText_WhenFailed_ReturnsErrorMessage() {
+  @Test
+  func testLocalVoicetrackSubtitleTextWhenFailedReturnsErrorMessage() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .failed(error: "Upload failed"),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleText, "Upload failed")
+    #expect(voicetrack.subtitleText == "Upload failed")
   }
 
-  func testLocalVoicetrack_SubtitleColor_WhenCompleted_ReturnsGreen() {
+  @Test
+  func testLocalVoicetrackSubtitleColorWhenCompletedReturnsGreen() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .completed,
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleColor, .green)
+    #expect(voicetrack.subtitleColor == .green)
   }
 
-  func testLocalVoicetrack_SubtitleColor_WhenFailed_ReturnsRed() {
+  @Test
+  func testLocalVoicetrackSubtitleColorWhenFailedReturnsRed() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .failed(error: "Error"),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleColor, .playolaRed)
+    #expect(voicetrack.subtitleColor == .playolaRed)
   }
 
-  func testLocalVoicetrack_SubtitleColor_WhenProcessing_ReturnsGray() {
+  @Test
+  func testLocalVoicetrackSubtitleColorWhenProcessingReturnsGray() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .uploading(progress: 0.5),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.subtitleColor, .playolaGray)
+    #expect(voicetrack.subtitleColor == .playolaGray)
   }
 
-  func testLocalVoicetrack_AlbumImageUrl_ReturnsNil() {
+  @Test
+  func testLocalVoicetrackAlbumImageUrlReturnsNil() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       title: "Test"
     )
 
-    XCTAssertNil(voicetrack.albumImageUrl)
+    #expect(voicetrack.albumImageUrl == nil)
   }
 
-  func testLocalVoicetrack_Icon_ReturnsMicFill() {
+  @Test
+  func testLocalVoicetrackIconReturnsMicFill() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       title: "Test"
     )
 
-    XCTAssertEqual(voicetrack.icon, "mic.fill")
+    #expect(voicetrack.icon == "mic.fill")
   }
 
-  func testLocalVoicetrack_IsReady_WhenCompleted_ReturnsTrue() {
+  @Test
+  func testLocalVoicetrackIsReadyWhenCompletedReturnsTrue() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .completed,
@@ -141,20 +155,22 @@ final class StagingItemTests: XCTestCase {
       audioBlockId: "audio-block-123"
     )
 
-    XCTAssertTrue(voicetrack.isReady)
+    #expect(voicetrack.isReady)
   }
 
-  func testLocalVoicetrack_IsReady_WhenProcessing_ReturnsFalse() {
+  @Test
+  func testLocalVoicetrackIsReadyWhenProcessingReturnsFalse() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .uploading(progress: 0.5),
       title: "Test"
     )
 
-    XCTAssertFalse(voicetrack.isReady)
+    #expect(!voicetrack.isReady)
   }
 
-  func testLocalVoicetrack_IsReady_WhenCompletedButNoAudioBlockId_ReturnsFalse() {
+  @Test
+  func testLocalVoicetrackIsReadyWhenCompletedButNoAudioBlockIdReturnsFalse() {
     let voicetrack = LocalVoicetrack(
       originalURL: URL(fileURLWithPath: "/tmp/test.wav"),
       status: .completed,
@@ -162,63 +178,72 @@ final class StagingItemTests: XCTestCase {
       audioBlockId: nil
     )
 
-    XCTAssertFalse(voicetrack.isReady)
+    #expect(!voicetrack.isReady)
   }
 
   // MARK: - AudioBlock Conformance Tests
 
-  func testAudioBlock_StagingId_ReturnsId() {
+  @Test
+  func testAudioBlockStagingIdReturnsId() {
     let audioBlock = AudioBlock.mockWith(id: "song-123")
 
-    XCTAssertEqual(audioBlock.stagingId, "song-123")
+    #expect(audioBlock.stagingId == "song-123")
   }
 
-  func testAudioBlock_TitleText_ReturnsTitle() {
+  @Test
+  func testAudioBlockTitleTextReturnsTitle() {
     let audioBlock = AudioBlock.mockWith(title: "Blowin' in the Wind")
 
-    XCTAssertEqual(audioBlock.titleText, "Blowin' in the Wind")
+    #expect(audioBlock.titleText == "Blowin' in the Wind")
   }
 
-  func testAudioBlock_SubtitleText_ReturnsArtist() {
+  @Test
+  func testAudioBlockSubtitleTextReturnsArtist() {
     let audioBlock = AudioBlock.mockWith(artist: "Bob Dylan")
 
-    XCTAssertEqual(audioBlock.subtitleText, "Bob Dylan")
+    #expect(audioBlock.subtitleText == "Bob Dylan")
   }
 
-  func testAudioBlock_SubtitleColor_ReturnsGray() {
+  @Test
+  func testAudioBlockSubtitleColorReturnsGray() {
     let audioBlock = AudioBlock.mockWith()
 
-    XCTAssertEqual(audioBlock.subtitleColor, .playolaGray)
+    #expect(audioBlock.subtitleColor == .playolaGray)
   }
 
-  func testAudioBlock_AlbumImageUrl_ReturnsImageUrl() {
+  @Test
+  func testAudioBlockAlbumImageUrlReturnsImageUrl() {
     let imageUrl = URL(string: "https://example.com/album.jpg")!
     let audioBlock = AudioBlock.mockWith(imageUrl: imageUrl)
 
-    XCTAssertEqual(audioBlock.albumImageUrl, imageUrl)
+    #expect(audioBlock.albumImageUrl == imageUrl)
   }
 
-  func testAudioBlock_Icon_ReturnsNil() {
+  @Test
+  func testAudioBlockIconReturnsNil() {
     let audioBlock = AudioBlock.mockWith()
 
-    XCTAssertNil(audioBlock.icon)
+    #expect(audioBlock.icon == nil)
   }
 
-  func testAudioBlock_AudioBlockId_ReturnsId() {
+  @Test
+  func testAudioBlockAudioBlockIdReturnsId() {
     let audioBlock = AudioBlock.mockWith(id: "song-456")
 
-    XCTAssertEqual(audioBlock.audioBlockId, "song-456")
+    #expect(audioBlock.audioBlockId == "song-456")
   }
 
-  func testAudioBlock_IsReady_ReturnsTrue() {
+  @Test
+  func testAudioBlockIsReadyReturnsTrue() {
     let audioBlock = AudioBlock.mockWith()
 
-    XCTAssertTrue(audioBlock.isReady)
+    #expect(audioBlock.isReady)
   }
 
-  func testAudioBlock_IsProcessing_ReturnsFalse() {
+  @Test
+  func testAudioBlockIsProcessingReturnsFalse() {
     let audioBlock = AudioBlock.mockWith()
 
-    XCTAssertFalse(audioBlock.isProcessing)
+    #expect(!audioBlock.isProcessing)
   }
 }

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -152,7 +152,8 @@ struct PlayolaRadioApp: App {
     // Register SVG coder for SDWebImage
     SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
 
-    NowPlayingUpdater.shared.setupRemoteControlCenter()
+    @Dependency(\.nowPlayingUpdater) var nowPlayingUpdater
+    nowPlayingUpdater.setupRemoteControlCenter()
 
     // Initialize analytics
     Task {

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
@@ -242,7 +242,7 @@ class AskQuestionPageModel: ViewModel {
     if let url = recordingURL {
       await audioRecorder.deleteRecording(url)
     }
-    resumeStationIfNeeded()
+    await resumeStationIfNeeded()
     mainContainerNavigationCoordinator.pop()
   }
 
@@ -291,8 +291,10 @@ class AskQuestionPageModel: ViewModel {
       // Step 8: Show success and dismiss
       uploadPhase = .completed
       presentedAlert = .questionSentSuccess(curatorName: station.curatorName) { [weak self] in
-        self?.resumeStationIfNeeded()
-        self?.mainContainerNavigationCoordinator.popToRoot()
+        Task { @MainActor in
+          await self?.resumeStationIfNeeded()
+          self?.mainContainerNavigationCoordinator.popToRoot()
+        }
       }
 
     } catch {
@@ -326,9 +328,9 @@ class AskQuestionPageModel: ViewModel {
     }
   }
 
-  private func resumeStationIfNeeded() {
+  private func resumeStationIfNeeded() async {
     if let station = stationToResume {
-      stationPlayer.play(station: station)
+      await stationPlayer.play(station: station)
       stationToResume = nil
     }
   }

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
@@ -51,10 +51,13 @@ class AskQuestionPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.date.now) var now
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
+
+  // MARK: - Shared State
+
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
-  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
   // MARK: - Computed Properties
 

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
@@ -49,6 +49,8 @@ class AskQuestionPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.audioPlayer) var audioPlayer
   @ObservationIgnored @Dependency(\.audioConverter) var audioConverter
   @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.continuousClock) var clock
+  @ObservationIgnored @Dependency(\.date.now) var now
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
@@ -166,32 +168,26 @@ class AskQuestionPageModel: ViewModel {
 
   // MARK: - Playback Actions
 
-  func playPauseTapped() {
-    Task {
-      if isPlaying {
-        await audioPlayer.pause()
-        stopPlaybackUpdates()
-        isPlaying = false
-      } else {
-        await audioPlayer.play()
-        startPlaybackUpdates()
-        isPlaying = true
-      }
+  func playPauseTapped() async {
+    if isPlaying {
+      await audioPlayer.pause()
+      stopPlaybackUpdates()
+      isPlaying = false
+    } else {
+      await audioPlayer.play()
+      startPlaybackUpdates()
+      isPlaying = true
     }
   }
 
-  func rewindTapped() {
-    Task {
-      await audioPlayer.seek(0)
-      playbackPosition = 0
-    }
+  func rewindTapped() async {
+    await audioPlayer.seek(0)
+    playbackPosition = 0
   }
 
-  func seekTo(_ time: TimeInterval) {
-    Task {
-      await audioPlayer.seek(time)
-      playbackPosition = time
-    }
+  func seekTo(_ time: TimeInterval) async {
+    await audioPlayer.seek(time)
+    playbackPosition = time
   }
 
   private func startPlaybackUpdates() {
@@ -216,13 +212,11 @@ class AskQuestionPageModel: ViewModel {
 
   // MARK: - Review Actions
 
-  func reRecordTapped() {
+  func reRecordTapped() async {
     stopPlaybackUpdates()
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     recordingURL = nil
     recordingDuration = 0
@@ -232,23 +226,21 @@ class AskQuestionPageModel: ViewModel {
     recordingPhase = .idle
   }
 
-  func cancelTapped() {
+  func cancelTapped() async {
     if recordingPhase == .review {
       presentedAlert = .discardRecordingConfirmation { [weak self] in
-        self?.confirmCancel()
+        Task { await self?.confirmCancel() }
       }
     } else {
-      confirmCancel()
+      await confirmCancel()
     }
   }
 
-  func confirmCancel() {
+  func confirmCancel() async {
     stopPlaybackUpdates()
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     resumeStationIfNeeded()
     mainContainerNavigationCoordinator.pop()
@@ -310,16 +302,16 @@ class AskQuestionPageModel: ViewModel {
   }
 
   private func waitForNormalization(jwt: String, s3Key: String) async throws {
-    let maxWaitTimeSeconds = 120
-    let pollIntervalSeconds: UInt64 = 2
-    let startTime = Date()
+    let maxWaitTime: TimeInterval = 120
+    let pollInterval: Duration = .seconds(2)
+    let startTime = now
 
-    while Date().timeIntervalSince(startTime) < Double(maxWaitTimeSeconds) {
+    while now.timeIntervalSince(startTime) < maxWaitTime {
       let status = try await api.getVoicetrackStatus(jwt, station.id, s3Key)
       if status.ready {
         return
       }
-      try await Task.sleep(nanoseconds: pollIntervalSeconds * 1_000_000_000)
+      try await clock.sleep(for: pollInterval)
     }
 
     throw AskQuestionError.normalizationTimeout

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
@@ -54,7 +54,7 @@ class AskQuestionPageModel: ViewModel {
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
   // MARK: - Computed Properties
 
@@ -101,9 +101,8 @@ class AskQuestionPageModel: ViewModel {
 
   // MARK: - Init
 
-  init(station: Station, stationPlayer: StationPlayer? = nil) {
+  init(station: Station) {
     self.station = station
-    self.stationPlayer = stationPlayer ?? .shared
     super.init()
   }
 

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
@@ -108,7 +108,7 @@ final class AskQuestionPageTests: XCTestCase {
 
   // MARK: - Re-record
 
-  func testReRecordTappedResetsToIdleState() {
+  func testReRecordTappedResetsToIdleState() async {
     let model = AskQuestionPageModel(station: .mock)
     model.recordingPhase = .review
     model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -116,7 +116,7 @@ final class AskQuestionPageTests: XCTestCase {
     model.playbackPosition = 5.0
     model.isPlaying = true
 
-    model.reRecordTapped()
+    await model.reRecordTapped()
 
     XCTAssertEqual(model.recordingPhase, .idle)
     XCTAssertNil(model.recordingURL)
@@ -127,35 +127,35 @@ final class AskQuestionPageTests: XCTestCase {
 
   // MARK: - Cancel
 
-  func testCancelTappedShowsConfirmationWhenInReview() {
+  func testCancelTappedShowsConfirmationWhenInReview() async {
     let model = AskQuestionPageModel(station: .mock)
     model.recordingPhase = .review
 
     XCTAssertNil(model.presentedAlert)
 
-    model.cancelTapped()
+    await model.cancelTapped()
 
     XCTAssertNotNil(model.presentedAlert)
     XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
   }
 
-  func testCancelTappedPopsNavigationWhenIdle() {
+  func testCancelTappedPopsNavigationWhenIdle() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
     let model = AskQuestionPageModel(station: .mock)
     coordinator.path = [.askQuestionPage(model)]
     model.recordingPhase = .idle
 
-    model.cancelTapped()
+    await model.cancelTapped()
 
     XCTAssertTrue(coordinator.path.isEmpty)
   }
 
-  func testConfirmCancelPopsNavigation() {
+  func testConfirmCancelPopsNavigation() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
     let model = AskQuestionPageModel(station: .mock)
     coordinator.path = [.askQuestionPage(model)]
 
-    model.confirmCancel()
+    await model.confirmCancel()
 
     XCTAssertTrue(coordinator.path.isEmpty)
   }
@@ -173,8 +173,7 @@ final class AskQuestionPageTests: XCTestCase {
       let model = AskQuestionPageModel(station: .mock)
       model.isPlaying = false
 
-      model.playPauseTapped()
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.playPauseTapped()
 
       XCTAssertTrue(playCalled.value)
       XCTAssertTrue(model.isPlaying)
@@ -190,8 +189,7 @@ final class AskQuestionPageTests: XCTestCase {
       let model = AskQuestionPageModel(station: .mock)
       model.isPlaying = true
 
-      model.playPauseTapped()
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.playPauseTapped()
 
       XCTAssertTrue(pauseCalled.value)
       XCTAssertFalse(model.isPlaying)
@@ -207,8 +205,7 @@ final class AskQuestionPageTests: XCTestCase {
       let model = AskQuestionPageModel(station: .mock)
       model.playbackPosition = 30.0
 
-      model.rewindTapped()
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.rewindTapped()
 
       XCTAssertEqual(seekTime.value, 0)
       XCTAssertEqual(model.playbackPosition, 0)
@@ -278,7 +275,7 @@ final class AskQuestionPageTests: XCTestCase {
       await model.viewAppeared()
       stationPlayerMock.callsToPlay = []
 
-      model.confirmCancel()
+      await model.confirmCancel()
 
       XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
       XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, playingStation.id)
@@ -298,7 +295,7 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      model.confirmCancel()
+      await model.confirmCancel()
 
       XCTAssertEqual(stationPlayerMock.callsToPlay.count, 0)
     }

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
@@ -5,41 +5,39 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class AskQuestionPageTests: XCTestCase {
-  override func setUp() {
-    super.setUp()
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
-    coordinator.path = []
-  }
-
+struct AskQuestionPageTests {
   // MARK: - Init
 
+  @Test
   func testInitStoresStation() {
     let station = Station.mockWith(id: "station-123", curatorName: "Test Curator")
 
     let model = AskQuestionPageModel(station: station)
 
-    XCTAssertEqual(model.station.id, "station-123")
-    XCTAssertEqual(model.station.curatorName, "Test Curator")
+    #expect(model.station.id == "station-123")
+    #expect(model.station.curatorName == "Test Curator")
   }
 
+  @Test
   func testCuratorNameReturnsCuratorName() {
     let station = Station.mockWith(curatorName: "Bri Bagwell")
 
     let model = AskQuestionPageModel(station: station)
 
-    XCTAssertEqual(model.curatorName, "Bri Bagwell")
+    #expect(model.curatorName == "Bri Bagwell")
   }
 
   // MARK: - Recording
 
+  @Test
   func testRecordTappedRequestsPermissionBeforeRecording() async {
     let requestPermissionCalled = LockIsolated(false)
     let startRecordingCalled = LockIsolated(false)
@@ -50,22 +48,23 @@ final class AskQuestionPageTests: XCTestCase {
         return true
       }
       $0.audioRecorder.startRecording = {
-        XCTAssertTrue(
+        #expect(
           requestPermissionCalled.value, "Permission should be requested before recording starts")
         startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = AskQuestionPageModel(station: .mock)
-      XCTAssertEqual(model.recordingPhase, .idle)
+      #expect(model.recordingPhase == .idle)
 
       await model.recordTapped()
 
-      XCTAssertTrue(requestPermissionCalled.value)
-      XCTAssertTrue(startRecordingCalled.value)
-      XCTAssertEqual(model.recordingPhase, .recording)
+      #expect(requestPermissionCalled.value)
+      #expect(startRecordingCalled.value)
+      #expect(model.recordingPhase == .recording)
     }
   }
 
+  @Test
   func testRecordTappedShowsAlertWhenPermissionDenied() async {
     let startRecordingCalled = LockIsolated(false)
 
@@ -79,13 +78,14 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.recordTapped()
 
-      XCTAssertFalse(startRecordingCalled.value)
-      XCTAssertEqual(model.recordingPhase, .idle)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Microphone Access Required")
+      #expect(!startRecordingCalled.value)
+      #expect(model.recordingPhase == .idle)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Microphone Access Required")
     }
   }
 
+  @Test
   func testStopTappedTransitionsToReview() async {
     let expectedURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
 
@@ -100,14 +100,15 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.stopTapped()
 
-      XCTAssertEqual(model.recordingPhase, .review)
-      XCTAssertEqual(model.recordingURL, expectedURL)
-      XCTAssertEqual(model.recordingDuration, 5.0)
+      #expect(model.recordingPhase == .review)
+      #expect(model.recordingURL == expectedURL)
+      #expect(model.recordingDuration == 5.0)
     }
   }
 
   // MARK: - Re-record
 
+  @Test
   func testReRecordTappedResetsToIdleState() async {
     let model = AskQuestionPageModel(station: .mock)
     model.recordingPhase = .review
@@ -118,50 +119,56 @@ final class AskQuestionPageTests: XCTestCase {
 
     await model.reRecordTapped()
 
-    XCTAssertEqual(model.recordingPhase, .idle)
-    XCTAssertNil(model.recordingURL)
-    XCTAssertEqual(model.recordingDuration, 0)
-    XCTAssertEqual(model.playbackPosition, 0)
-    XCTAssertFalse(model.isPlaying)
+    #expect(model.recordingPhase == .idle)
+    #expect(model.recordingURL == nil)
+    #expect(model.recordingDuration == 0)
+    #expect(model.playbackPosition == 0)
+    #expect(!model.isPlaying)
   }
 
   // MARK: - Cancel
 
+  @Test
   func testCancelTappedShowsConfirmationWhenInReview() async {
     let model = AskQuestionPageModel(station: .mock)
     model.recordingPhase = .review
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
 
     await model.cancelTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Discard Recording?")
   }
 
+  @Test
   func testCancelTappedPopsNavigationWhenIdle() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
     let model = AskQuestionPageModel(station: .mock)
     coordinator.path = [.askQuestionPage(model)]
     model.recordingPhase = .idle
 
     await model.cancelTapped()
 
-    XCTAssertTrue(coordinator.path.isEmpty)
+    #expect(coordinator.path.isEmpty)
   }
 
+  @Test
   func testConfirmCancelPopsNavigation() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
     let model = AskQuestionPageModel(station: .mock)
     coordinator.path = [.askQuestionPage(model)]
 
     await model.confirmCancel()
 
-    XCTAssertTrue(coordinator.path.isEmpty)
+    #expect(coordinator.path.isEmpty)
   }
 
   // MARK: - Playback
 
+  @Test
   func testPlayPauseTappedPlaysWhenNotPlaying() async {
     let playCalled = LockIsolated(false)
 
@@ -175,11 +182,12 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.playPauseTapped()
 
-      XCTAssertTrue(playCalled.value)
-      XCTAssertTrue(model.isPlaying)
+      #expect(playCalled.value)
+      #expect(model.isPlaying)
     }
   }
 
+  @Test
   func testPlayPauseTappedPausesWhenPlaying() async {
     let pauseCalled = LockIsolated(false)
 
@@ -191,11 +199,12 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.playPauseTapped()
 
-      XCTAssertTrue(pauseCalled.value)
-      XCTAssertFalse(model.isPlaying)
+      #expect(pauseCalled.value)
+      #expect(!model.isPlaying)
     }
   }
 
+  @Test
   func testRewindTappedSeeksToZero() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
@@ -207,28 +216,30 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.rewindTapped()
 
-      XCTAssertEqual(seekTime.value, 0)
-      XCTAssertEqual(model.playbackPosition, 0)
+      #expect(seekTime.value == 0)
+      #expect(model.playbackPosition == 0)
     }
   }
 
   // MARK: - Display Time
 
+  @Test
   func testDisplayTimeFormatsCorrectly() {
     let model = AskQuestionPageModel(station: .mock)
 
     model.recordingDuration = 0
-    XCTAssertEqual(model.displayTime, "0:00")
+    #expect(model.displayTime == "0:00")
 
     model.recordingDuration = 65
-    XCTAssertEqual(model.displayTime, "1:05")
+    #expect(model.displayTime == "1:05")
 
     model.recordingDuration = 3661
-    XCTAssertEqual(model.displayTime, "1:01:01")
+    #expect(model.displayTime == "1:01:01")
   }
 
   // MARK: - Station Pause/Resume on Page Lifecycle
 
+  @Test
   func testViewAppearedPausesStationWhenPlaying() async {
     let playingStation = AnyStation.mock
     let stationPlayerMock = StationPlayerMock()
@@ -241,10 +252,11 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(stationPlayerMock.stopCalledCount, 1)
+      #expect(stationPlayerMock.stopCalledCount == 1)
     }
   }
 
+  @Test
   func testViewAppearedDoesNotPauseStationWhenNotPlaying() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .stopped)
@@ -256,15 +268,17 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(stationPlayerMock.stopCalledCount, 0)
+      #expect(stationPlayerMock.stopCalledCount == 0)
     }
   }
 
+  @Test
   func testConfirmCancelResumesStationIfWasPaused() async {
     let playingStation = AnyStation.mock
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .playing(playingStation))
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
@@ -277,15 +291,17 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.confirmCancel()
 
-      XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
-      XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, playingStation.id)
+      #expect(stationPlayerMock.callsToPlay.count == 1)
+      #expect(stationPlayerMock.callsToPlay.first?.id == playingStation.id)
     }
   }
 
+  @Test
   func testConfirmCancelDoesNotResumeStationIfWasNotPaused() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .stopped)
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
@@ -297,16 +313,17 @@ final class AskQuestionPageTests: XCTestCase {
 
       await model.confirmCancel()
 
-      XCTAssertEqual(stationPlayerMock.callsToPlay.count, 0)
+      #expect(stationPlayerMock.callsToPlay.count == 0)
     }
   }
 
   // MARK: - Alerts
 
+  @Test
   func testQuestionSentSuccessAlertIncludesCuratorName() {
     let alert = PlayolaAlert.questionSentSuccess(curatorName: "Bri Bagwell") {}
 
-    XCTAssertTrue(
+    #expect(
       alert.message?.contains("Bri Bagwell") ?? false,
       "Alert message should contain the curator name"
     )

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
@@ -247,8 +247,9 @@ struct AskQuestionPageTests {
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = AskQuestionPageModel(station: .mock, stationPlayer: stationPlayerMock)
+      let model = AskQuestionPageModel(station: .mock)
 
       await model.viewAppeared()
 
@@ -263,8 +264,9 @@ struct AskQuestionPageTests {
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = AskQuestionPageModel(station: .mock, stationPlayer: stationPlayerMock)
+      let model = AskQuestionPageModel(station: .mock)
 
       await model.viewAppeared()
 
@@ -282,8 +284,9 @@ struct AskQuestionPageTests {
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = AskQuestionPageModel(station: .mock, stationPlayer: stationPlayerMock)
+      let model = AskQuestionPageModel(station: .mock)
       coordinator.path = [.askQuestionPage(model)]
 
       await model.viewAppeared()
@@ -305,8 +308,9 @@ struct AskQuestionPageTests {
 
     await withDependencies {
       $0.audioRecorder.prepareForRecording = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = AskQuestionPageModel(station: .mock, stationPlayer: stationPlayerMock)
+      let model = AskQuestionPageModel(station: .mock)
       coordinator.path = [.askQuestionPage(model)]
 
       await model.viewAppeared()

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageView.swift
@@ -47,7 +47,7 @@ struct AskQuestionPageView: View {
       if !model.isUploading {
         ToolbarItem(placement: .navigationBarLeading) {
           Button("Cancel") {
-            model.cancelTapped()
+            Task { await model.cancelTapped() }
           }
           .foregroundColor(.white)
         }
@@ -162,7 +162,7 @@ struct AskQuestionPageView: View {
       }
     case .review:
       Button {
-        model.reRecordTapped()
+        Task { await model.reRecordTapped() }
       } label: {
         ZStack {
           Circle()
@@ -205,9 +205,9 @@ struct AskQuestionPageView: View {
         currentTime: model.playbackPosition,
         totalTime: model.recordingDuration,
         isPlaying: model.isPlaying,
-        onPlayPause: { model.playPauseTapped() },
-        onRewind: { model.rewindTapped() },
-        onSeek: { model.seekTo($0) }
+        onPlayPause: { Task { await model.playPauseTapped() } },
+        onRewind: { Task { await model.rewindTapped() } },
+        onSeek: { time in Task { await model.seekTo(time) } }
       )
       .disabled(model.isUploading)
       .opacity(model.isUploading ? 0.5 : 1)

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageModel.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageModel.swift
@@ -90,24 +90,10 @@ class BroadcastPageModel: ViewModel {
     self.stationId = stationId
     self.providedStationName = stationName
     super.init()
-
-    scheduleUpdateCancellable = NotificationCenter.default.publisher(
-      for: .scheduleUpdated
-    )
-    .compactMap { notification -> String? in
-      guard let id = notification.userInfo?["stationId"] as? String,
-        id == stationId
-      else { return nil }
-      return notification.userInfo?["editorName"] as? String
-    }
-    .sink { [weak self] editorName in
-      Task { [weak self] in
-        await self?.refreshScheduleFromRemote(editorName: editorName)
-      }
-    }
   }
 
   func viewAppeared() async {
+    startObservingScheduleUpdates()
     await analytics.track(
       .viewedBroadcastScreen(
         stationId: stationId,
@@ -117,6 +103,25 @@ class BroadcastPageModel: ViewModel {
     await withTaskGroup(of: Void.self) { group in
       group.addTask { await self.loadSchedule() }
       group.addTask { await self.loadStation() }
+    }
+  }
+
+  private func startObservingScheduleUpdates() {
+    guard scheduleUpdateCancellable == nil else { return }
+    let observedStationId = stationId
+    scheduleUpdateCancellable = NotificationCenter.default.publisher(
+      for: .scheduleUpdated
+    )
+    .compactMap { notification -> String? in
+      guard let id = notification.userInfo?["stationId"] as? String,
+        id == observedStationId
+      else { return nil }
+      return notification.userInfo?["editorName"] as? String
+    }
+    .sink { [weak self] editorName in
+      Task { [weak self] in
+        await self?.refreshScheduleFromRemote(editorName: editorName)
+      }
     }
   }
 
@@ -288,40 +293,36 @@ class BroadcastPageModel: ViewModel {
     stagingItems[index] = voicetrack
   }
 
-  func onAddSongTapped() {
-    Task {
-      await analytics.track(
-        .broadcastSongSearchTapped(
-          stationId: stationId,
-          stationName: navigationTitle,
-          userName: userName
-        ))
-    }
+  func onAddSongTapped() async {
+    await analytics.track(
+      .broadcastSongSearchTapped(
+        stationId: stationId,
+        stationName: navigationTitle,
+        userName: userName
+      ))
     let model = SongSearchPageModel(searchMode: .all)
     model.onDismiss = { [weak self] in
       self?.mainContainerNavigationCoordinator.presentedSheet = nil
     }
     model.onSongSelected = { [weak self] audioBlock in
-      self?.addSongToStaging(audioBlock)
+      Task { await self?.addSongToStaging(audioBlock) }
       self?.mainContainerNavigationCoordinator.presentedSheet = nil
     }
     songSearchPageModel = model
     mainContainerNavigationCoordinator.presentedSheet = .songSearchPage(model)
   }
 
-  func addSongToStaging(_ audioBlock: AudioBlock) {
+  func addSongToStaging(_ audioBlock: AudioBlock) async {
     guard !stagingItems.contains(where: { $0.stagingId == audioBlock.id }) else { return }
     stagingItems.append(audioBlock)
-    Task {
-      await analytics.track(
-        .broadcastSongAdded(
-          stationId: stationId,
-          stationName: navigationTitle,
-          userName: userName,
-          songTitle: audioBlock.title,
-          artistName: audioBlock.artist
-        ))
-    }
+    await analytics.track(
+      .broadcastSongAdded(
+        stationId: stationId,
+        stationName: navigationTitle,
+        userName: userName,
+        songTitle: audioBlock.title,
+        artistName: audioBlock.artist
+      ))
   }
 
   func onNotifyListenersTapped() {

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -8,14 +8,15 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class BroadcastPageTests: XCTestCase {
+struct BroadcastPageTests {
   // MARK: - Test Helpers
 
   private let testStationId = "test-station-id"
@@ -54,27 +55,29 @@ final class BroadcastPageTests: XCTestCase {
 
   // MARK: - Schedule Loading Tests
 
-  func testViewAppeared_LoadsScheduleSuccessfully() async {
+  @Test
+  func testViewAppearedLoadsScheduleSuccessfully() async {
     let mockSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
 
     await withDependencies {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { requestedStationId, extended in
-        XCTAssertEqual(requestedStationId, self.testStationId)
-        XCTAssertTrue(extended)
+        #expect(requestedStationId == self.testStationId)
+        #expect(extended)
         return mockSpins
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNotNil(model.schedule)
-      XCTAssertNil(model.presentedAlert)
-      XCTAssertFalse(model.isLoading)
+      #expect(model.schedule != nil)
+      #expect(model.presentedAlert == nil)
+      #expect(!model.isLoading)
     }
   }
 
-  func testViewAppeared_ShowsErrorAlertOnFailure() async {
+  @Test
+  func testViewAppearedShowsErrorAlertOnFailure() async {
     await withDependencies {
       $0.api.fetchSchedule = { _, _ in
         throw TestError.networkError
@@ -83,17 +86,17 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNil(model.schedule)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Error")
-      XCTAssertFalse(model.isLoading)
+      #expect(model.schedule == nil)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Error")
+      #expect(!model.isLoading)
     }
   }
 
-  func testNowPlaying_ReturnsCurrentSpin() async {
+  @Test
+  func testNowPlayingReturnsCurrentSpin() async {
     let stationId = "test-station-id"
     let fixedNow = Date(timeIntervalSince1970: 1_000_000)
-    // Create audioBlock with 180 second (3 min) duration so spin is still playing
     let longAudioBlock = AudioBlock.mockWith(endOfMessageMS: 180_000)
     let mockSpins = [
       Spin.mockWith(
@@ -115,11 +118,12 @@ final class BroadcastPageTests: XCTestCase {
     } operation: {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
-      XCTAssertEqual(model.nowPlaying?.id, "spin-1")
+      #expect(model.nowPlaying?.id == "spin-1")
     }
   }
 
-  func testUpcomingSpins_ExcludesNowPlaying() async {
+  @Test
+  func testUpcomingSpinsExcludesNowPlaying() async {
     let stationId = "test-station-id"
     let fixedNow = Date(timeIntervalSince1970: 1_000_000)
     let mockSpins = [
@@ -148,18 +152,17 @@ final class BroadcastPageTests: XCTestCase {
       await model.viewAppeared()
 
       let upcomingIds = model.upcomingSpins.map { $0.id }
-      XCTAssertFalse(upcomingIds.contains("spin-1"))
-      XCTAssertTrue(upcomingIds.contains("spin-2"))
-      XCTAssertTrue(upcomingIds.contains("spin-3"))
+      #expect(!upcomingIds.contains("spin-1"))
+      #expect(upcomingIds.contains("spin-2"))
+      #expect(upcomingIds.contains("spin-3"))
     }
   }
 
-  func testTick_UpdatesCurrentNowPlayingIdWhenSpinChanges() async {
+  @Test
+  func testTickUpdatesCurrentNowPlayingIdWhenSpinChanges() async {
     let stationId = "test-station-id"
     let initialTime = Date(timeIntervalSince1970: 1_000_000)
 
-    // spin-1: started 60s ago, 90s duration (ends in 30s)
-    // spin-2: starts in 30s
     let spin1AudioBlock = AudioBlock.mockWith(endOfMessageMS: 90000)
     let spin2AudioBlock = AudioBlock.mockWith(endOfMessageMS: 180_000)
     let mockSpins = [
@@ -184,12 +187,10 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      // Initially spin-1 is playing
-      XCTAssertEqual(model.currentNowPlayingId, "spin-1")
-      XCTAssertEqual(model.upcomingSpins.first?.id, "spin-2")
+      #expect(model.currentNowPlayingId == "spin-1")
+      #expect(model.upcomingSpins.first?.id == "spin-2")
     }
 
-    // Advance time past spin-1's end
     let laterTime = initialTime.addingTimeInterval(35)
 
     await withDependencies {
@@ -199,18 +200,17 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      // Call tick - should detect spin change and update currentNowPlayingId
       model.tick()
 
-      XCTAssertEqual(model.currentNowPlayingId, "spin-2")
+      #expect(model.currentNowPlayingId == "spin-2")
     }
   }
 
-  func testTick_DoesNotChangeIdWhenNowPlayingUnchanged() async {
+  @Test
+  func testTickDoesNotChangeIdWhenNowPlayingUnchanged() async {
     let stationId = "test-station-id"
     let initialTime = Date(timeIntervalSince1970: 1_000_000)
 
-    // spin-1: started 10s ago, 180s duration (plenty of time left)
     let spin1AudioBlock = AudioBlock.mockWith(endOfMessageMS: 180_000)
     let mockSpins = [
       Spin.mockWith(
@@ -228,18 +228,18 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.currentNowPlayingId, "spin-1")
+      #expect(model.currentNowPlayingId == "spin-1")
 
-      // Tick should not change the ID since spin hasn't changed
       model.tick()
 
-      XCTAssertEqual(model.currentNowPlayingId, "spin-1")
+      #expect(model.currentNowPlayingId == "spin-1")
     }
   }
 
   // MARK: - Station Name Tests
 
-  func testNavigationTitle_UsesStationNameWhenProvided() async {
+  @Test
+  func testNavigationTitleUsesStationNameWhenProvided() async {
     let stationId = "test-station-id"
     let stationName = "My Awesome Station"
 
@@ -250,11 +250,12 @@ final class BroadcastPageTests: XCTestCase {
     } operation: {
       let model = BroadcastPageModel(stationId: stationId, stationName: stationName)
 
-      XCTAssertEqual(model.navigationTitle, stationName)
+      #expect(model.navigationTitle == stationName)
     }
   }
 
-  func testNavigationTitle_FetchesStationNameOnLoad() async {
+  @Test
+  func testNavigationTitleFetchesStationNameOnLoad() async {
     let stationId = "test-station-id"
     let fetchedStationName = "Fetched Station Name"
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -263,20 +264,21 @@ final class BroadcastPageTests: XCTestCase {
       $0.date.now = Date()
       $0.api.fetchSchedule = { _, _ in [] }
       $0.api.fetchStation = { _, requestedId in
-        XCTAssertEqual(requestedId, stationId)
+        #expect(requestedId == stationId)
         return Station.mockWith(name: fetchedStationName)
       }
     } operation: {
       let model = BroadcastPageModel(stationId: stationId)
-      XCTAssertEqual(model.navigationTitle, "My Station")  // Default before load
+      #expect(model.navigationTitle == "My Station")
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.navigationTitle, fetchedStationName)
+      #expect(model.navigationTitle == fetchedStationName)
     }
   }
 
-  func testNavigationTitle_FallsBackToDefaultWhenFetchFails() async {
+  @Test
+  func testNavigationTitleFallsBackToDefaultWhenFetchFails() async {
     let stationId = "test-station-id"
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -288,13 +290,14 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.navigationTitle, "My Station")
+      #expect(model.navigationTitle == "My Station")
     }
   }
 
   // MARK: - Grouped Spin Tests
 
-  func testMoveSpins_MovesUngroupedSpinNormally() async {
+  @Test
+  func testMoveSpinsMovesUngroupedSpinNormally() async {
     let mockSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     let reorderedSpins = makeSpins(ids: ["spin-2", "spin-1", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -307,15 +310,15 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      // Move spin-1 to position 2 (after spin-2)
       await model.moveSpins(from: IndexSet(integer: 0), to: 2)
 
       let ids = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(ids, ["spin-2", "spin-1", "spin-3"])
+      #expect(ids == ["spin-2", "spin-1", "spin-3"])
     }
   }
 
-  func testMoveSpins_MovesEntireGroupTogether() async {
+  @Test
+  func testMoveSpinsMovesEntireGroupTogether() async {
     let groupId = "group-1"
     let mockSpins =
       makeSpins(ids: ["spin-1", "spin-2"], groupId: groupId)
@@ -334,16 +337,15 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      // Move spin-1 (part of group) to position 3 (after spin-3)
-      // Should move both spin-1 and spin-2 together
       await model.moveSpins(from: IndexSet(integer: 0), to: 3)
 
       let ids = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(ids, ["spin-3", "spin-1", "spin-2", "spin-4"])
+      #expect(ids == ["spin-3", "spin-1", "spin-2", "spin-4"])
     }
   }
 
-  func testMoveSpins_PreservesRelativeOrderWithinGroup() async {
+  @Test
+  func testMoveSpinsPreservesRelativeOrderWithinGroup() async {
     let stationId = "test-station-id"
     let fixedNow = Date(timeIntervalSince1970: 1_000_000)
     let groupId = "group-1"
@@ -383,71 +385,73 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      // Move spin-2 (middle of group) to the end
-      // Should move entire group (spin-1, spin-2, spin-3) and preserve their order
       await model.moveSpins(from: IndexSet(integer: 2), to: 5)
 
       let ids = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(ids, ["spin-A", "spin-B", "spin-1", "spin-2", "spin-3"])
+      #expect(ids == ["spin-A", "spin-B", "spin-1", "spin-2", "spin-3"])
     }
   }
 
   // MARK: - Coming Soon Alert Tests
 
-  func testOnAddVoiceTrackTapped_PresentsRecordPageSheet() {
+  @Test
+  func testOnAddVoiceTrackTappedPresentsRecordPageSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     let model = BroadcastPageModel(stationId: "test-station")
 
-    XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
 
     model.onAddVoiceTrackTapped()
 
-    XCTAssertNotNil(model.recordPageModel)
+    #expect(model.recordPageModel != nil)
     if case .recordPage = mainContainerNavigationCoordinator.presentedSheet {
       // Success - presented record page sheet
     } else {
-      XCTFail("Expected recordPage sheet presentation")
+      Issue.record("Expected recordPage sheet presentation")
     }
   }
 
+  @Test
   func testOnAddSongTappedPresentsSongSearchPageSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     let model = BroadcastPageModel(stationId: "test-station")
 
-    XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
-    XCTAssertNil(model.songSearchPageModel)
+    #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
+    #expect(model.songSearchPageModel == nil)
 
     await model.onAddSongTapped()
 
-    XCTAssertNotNil(model.songSearchPageModel)
+    #expect(model.songSearchPageModel != nil)
     if case .songSearchPage = mainContainerNavigationCoordinator.presentedSheet {
     } else {
-      XCTFail("Expected songSearchPage sheet presentation")
+      Issue.record("Expected songSearchPage sheet presentation")
     }
   }
 
+  @Test
   func testOnAddSongTappedUsesAllSearchMode() async {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     let model = BroadcastPageModel(stationId: "test-station")
 
     await model.onAddSongTapped()
 
-    XCTAssertEqual(model.songSearchPageModel?.searchMode, .all)
+    #expect(model.songSearchPageModel?.searchMode == .all)
   }
 
+  @Test
   func testOnAddSongTappedSongSelectedCallbackAddsSongToStaging() async {
     await withMainSerialExecutor {
       @Shared(.mainContainerNavigationCoordinator)
-      var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+      var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
       let model = BroadcastPageModel(stationId: "test-station")
-      XCTAssertTrue(model.stagingItems.isEmpty)
+      #expect(model.stagingItems.isEmpty)
 
       await model.onAddSongTapped()
 
@@ -456,27 +460,29 @@ final class BroadcastPageTests: XCTestCase {
       model.songSearchPageModel?.onSongSelected?(testSong)
       await Task.yield()
 
-      XCTAssertEqual(model.stagingItems.count, 1)
-      XCTAssertEqual(model.stagingItems.first?.stagingId, "test-song-123")
-      XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
+      #expect(model.stagingItems.count == 1)
+      #expect(model.stagingItems.first?.stagingId == "test-song-123")
+      #expect(model.stagingItems.first?.titleText == "Test Song")
     }
   }
 
+  @Test
   func testOnAddSongTappedSongSelectedCallbackDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     let model = BroadcastPageModel(stationId: "test-station")
     await model.onAddSongTapped()
 
-    XCTAssertNotNil(mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerNavigationCoordinator.presentedSheet != nil)
 
     let testSong = AudioBlock.mockWith(id: "test-song-123")
     model.songSearchPageModel?.onSongSelected?(testSong)
 
-    XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
   }
 
+  @Test
   func testAddSongToStagingDoesNotAddDuplicates() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let testSong = AudioBlock.mockWith(id: "test-song-123")
@@ -484,9 +490,10 @@ final class BroadcastPageTests: XCTestCase {
     await model.addSongToStaging(testSong)
     await model.addSongToStaging(testSong)
 
-    XCTAssertEqual(model.stagingItems.count, 1)
+    #expect(model.stagingItems.count == 1)
   }
 
+  @Test
   func testAddSongToStagingAddsMultipleDifferentSongs() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let song1 = AudioBlock.mockWith(id: "song-1", title: "First Song")
@@ -495,11 +502,12 @@ final class BroadcastPageTests: XCTestCase {
     await model.addSongToStaging(song1)
     await model.addSongToStaging(song2)
 
-    XCTAssertEqual(model.stagingItems.count, 2)
-    XCTAssertEqual(model.stagingItems[0].stagingId, "song-1")
-    XCTAssertEqual(model.stagingItems[1].stagingId, "song-2")
+    #expect(model.stagingItems.count == 2)
+    #expect(model.stagingItems[0].stagingId == "song-1")
+    #expect(model.stagingItems[1].stagingId == "song-2")
   }
 
+  @Test
   func testRecordingAcceptedAddsToStagingArea() async {
     let calendar = Calendar.current
     let components = DateComponents(year: 2023, month: 12, day: 13, hour: 11, minute: 0)
@@ -515,23 +523,24 @@ final class BroadcastPageTests: XCTestCase {
       }
     } operation: {
       let model = BroadcastPageModel(stationId: "test-station")
-      XCTAssertTrue(model.stagingItems.isEmpty)
+      #expect(model.stagingItems.isEmpty)
 
       model.onAddVoiceTrackTapped()
       let recordingURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
       await model.recordPageModel?.onRecordingAccepted?(recordingURL)
 
-      XCTAssertEqual(model.stagingItems.count, 1)
+      #expect(model.stagingItems.count == 1)
       let voicetrack = model.stagingItems.first as? LocalVoicetrack
-      XCTAssertEqual(voicetrack?.originalURL, recordingURL)
-      XCTAssertEqual(voicetrack?.title, "Voice Track 11:00am")
-      XCTAssertEqual(voicetrack?.status, .completed)
+      #expect(voicetrack?.originalURL == recordingURL)
+      #expect(voicetrack?.title == "Voice Track 11:00am")
+      #expect(voicetrack?.status == .completed)
     }
   }
 
   // MARK: - Grouped Spin Tests
 
-  func testMoveSpins_MovesGroupToBeginning() async {
+  @Test
+  func testMoveSpinsMovesGroupToBeginning() async {
     let stationId = "test-station-id"
     let fixedNow = Date(timeIntervalSince1970: 1_000_000)
     let groupId = "group-1"
@@ -565,11 +574,10 @@ final class BroadcastPageTests: XCTestCase {
       let model = BroadcastPageModel(stationId: stationId)
       await model.viewAppeared()
 
-      // Move spin-1 (part of group) to position 0
       await model.moveSpins(from: IndexSet(integer: 2), to: 0)
 
       let ids = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(ids, ["spin-1", "spin-2", "spin-A", "spin-B"])
+      #expect(ids == ["spin-1", "spin-2", "spin-A", "spin-B"])
     }
   }
 
@@ -589,6 +597,7 @@ private enum TestError: Error, LocalizedError {
 // MARK: - canDeleteSpin Tests
 
 extension BroadcastPageTests {
+  @Test
   func testCanDeleteSpinReturnsTrueForSpinMoreThanTwoMinutesAway() async {
     let spinMoreThanTwoMinutesAway = makeSpins(ids: ["spin-1"], startOffset: 121).first!
 
@@ -599,10 +608,11 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertTrue(model.canDeleteSpin(spinMoreThanTwoMinutesAway))
+      #expect(model.canDeleteSpin(spinMoreThanTwoMinutesAway))
     }
   }
 
+  @Test
   func testCanDeleteSpinReturnsFalseForSpinExactlyTwoMinutesAway() async {
     let spinExactlyTwoMinutesAway = makeSpins(ids: ["spin-1"], startOffset: 120).first!
 
@@ -613,10 +623,11 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertFalse(model.canDeleteSpin(spinExactlyTwoMinutesAway))
+      #expect(!model.canDeleteSpin(spinExactlyTwoMinutesAway))
     }
   }
 
+  @Test
   func testCanDeleteSpinReturnsFalseForSpinLessThanTwoMinutesAway() async {
     let spinLessThanTwoMinutesAway = makeSpins(ids: ["spin-1"]).first!
 
@@ -627,7 +638,7 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertFalse(model.canDeleteSpin(spinLessThanTwoMinutesAway))
+      #expect(!model.canDeleteSpin(spinLessThanTwoMinutesAway))
     }
   }
 }
@@ -635,6 +646,7 @@ extension BroadcastPageTests {
 // MARK: - Move Spin Tests
 
 extension BroadcastPageTests {
+  @Test
   func testMoveSpinSuccessUpdatesScheduleWithReturnedSpins() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     let updatedSpins = makeSpins(ids: ["spin-2", "spin-1", "spin-3"])
@@ -644,25 +656,25 @@ extension BroadcastPageTests {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in initialSpins }
       $0.api.moveSpin = { _, spinId, placeAfterSpinId in
-        XCTAssertEqual(spinId, "spin-1")
-        XCTAssertEqual(placeAfterSpinId, "spin-2")
+        #expect(spinId == "spin-1")
+        #expect(placeAfterSpinId == "spin-2")
         return updatedSpins
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-1", "spin-2", "spin-3"])
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-1", "spin-2", "spin-3"])
 
-      // Move spin-1 to after spin-2
       await model.moveSpins(from: IndexSet(integer: 0), to: 2)
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-2", "spin-1", "spin-3"])
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-2", "spin-1", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.presentedAlert == nil)
     }
   }
 
+  @Test
   func testMoveSpinToBeginningCallsAPIWithNilPlaceAfterSpinId() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     let updatedSpins = makeSpins(ids: ["spin-3", "spin-1", "spin-2"])
@@ -672,21 +684,21 @@ extension BroadcastPageTests {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in initialSpins }
       $0.api.moveSpin = { _, spinId, placeAfterSpinId in
-        XCTAssertEqual(spinId, "spin-3")
-        XCTAssertNil(placeAfterSpinId)
+        #expect(spinId == "spin-3")
+        #expect(placeAfterSpinId == nil)
         return updatedSpins
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      // Move spin-3 to beginning
       await model.moveSpins(from: IndexSet(integer: 2), to: 0)
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-3", "spin-1", "spin-2"])
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-3", "spin-1", "spin-2"])
     }
   }
 
+  @Test
   func testMoveSpinMarksAllSpinsAsReschedulingDuringCall() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -707,7 +719,7 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
 
       let moveTask = Task {
         await model.moveSpins(from: IndexSet(integer: 0), to: 2)
@@ -717,8 +729,7 @@ extension BroadcastPageTests {
         await Task.yield()
       }
 
-      // During the call, all spins should be marked as rescheduling
-      XCTAssertEqual(model.spinIdsBeingRescheduled, ["spin-1", "spin-2", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled == ["spin-1", "spin-2", "spin-3"])
 
       moveContinuation.withValue { continuation in
         continuation?.resume()
@@ -727,11 +738,11 @@ extension BroadcastPageTests {
 
       await moveTask.value
 
-      // After the call completes, the set should be cleared
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
     }
   }
 
+  @Test
   func testMoveSpinErrorRestoresOriginalSchedule() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -747,16 +758,17 @@ extension BroadcastPageTests {
       await model.viewAppeared()
 
       let originalIds = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(originalIds, ["spin-1", "spin-2", "spin-3"])
+      #expect(originalIds == ["spin-1", "spin-2", "spin-3"])
 
       await model.moveSpins(from: IndexSet(integer: 0), to: 2)
 
       let restoredIds = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(restoredIds, ["spin-1", "spin-2", "spin-3"])
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(restoredIds == ["spin-1", "spin-2", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
     }
   }
 
+  @Test
   func testMoveSpinErrorShowsErrorAlert() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -771,12 +783,12 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.moveSpins(from: IndexSet(integer: 0), to: 2)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Error")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Error")
     }
   }
 }
@@ -784,6 +796,7 @@ extension BroadcastPageTests {
 // MARK: - Delete Spin Tests
 
 extension BroadcastPageTests {
+  @Test
   func testDeleteSpinSuccessUpdatesScheduleWithReturnedSpins() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     let updatedSpins = makeSpins(ids: ["spin-1", "spin-3"])
@@ -793,24 +806,25 @@ extension BroadcastPageTests {
       $0.date.now = fixedNow
       $0.api.fetchSchedule = { _, _ in initialSpins }
       $0.api.deleteSpin = { _, spinId in
-        XCTAssertEqual(spinId, "spin-2")
+        #expect(spinId == "spin-2")
         return updatedSpins
       }
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-1", "spin-2", "spin-3"])
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-1", "spin-2", "spin-3"])
 
       let spinToDelete = initialSpins[1]
       await model.deleteSpin(spinToDelete)
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-1", "spin-3"])
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-1", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.presentedAlert == nil)
     }
   }
 
+  @Test
   func testDeleteSpinMarksSpinsAfterDeletedAsReschedulingDuringCall() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -831,7 +845,7 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
 
       let deleteTask = Task {
         await model.deleteSpin(initialSpins[1])
@@ -841,8 +855,7 @@ extension BroadcastPageTests {
         await Task.yield()
       }
 
-      // During the call, spin-3 should have been marked as rescheduling (it comes after spin-2)
-      XCTAssertEqual(model.spinIdsBeingRescheduled, ["spin-3"])
+      #expect(model.spinIdsBeingRescheduled == ["spin-3"])
 
       deleteContinuation.withValue { continuation in
         continuation?.resume()
@@ -851,11 +864,11 @@ extension BroadcastPageTests {
 
       await deleteTask.value
 
-      // After the call completes, the set should be cleared
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
     }
   }
 
+  @Test
   func testDeleteSpinErrorRestoresOriginalSchedule() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -871,16 +884,17 @@ extension BroadcastPageTests {
       await model.viewAppeared()
 
       let originalIds = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(originalIds, ["spin-1", "spin-2", "spin-3"])
+      #expect(originalIds == ["spin-1", "spin-2", "spin-3"])
 
       await model.deleteSpin(initialSpins[1])
 
       let restoredIds = model.upcomingSpins.map { $0.id }
-      XCTAssertEqual(restoredIds, ["spin-1", "spin-2", "spin-3"])
-      XCTAssertTrue(model.spinIdsBeingRescheduled.isEmpty)
+      #expect(restoredIds == ["spin-1", "spin-2", "spin-3"])
+      #expect(model.spinIdsBeingRescheduled.isEmpty)
     }
   }
 
+  @Test
   func testDeleteSpinErrorShowsErrorAlert() async {
     let initialSpins = makeSpins(ids: ["spin-1"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -895,12 +909,12 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.deleteSpin(initialSpins[0])
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Error")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Error")
     }
   }
 }
@@ -908,6 +922,7 @@ extension BroadcastPageTests {
 // MARK: - Insert Voicetrack Tests
 
 extension BroadcastPageTests {
+  @Test
   func testInsertVoicetrackCallsAPIWithCorrectParameters() async {
     let voicetrackAudioBlockId = "voicetrack-audio-block-id"
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
@@ -933,14 +948,14 @@ extension BroadcastPageTests {
         makeStagingVoicetrack(id: voicetrackId, audioBlockId: voicetrackAudioBlockId)
       ]
 
-      // Drop voicetrack before spin-2 (should insert after spin-1)
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-2")
 
-      XCTAssertEqual(capturedAudioBlockId.value, voicetrackAudioBlockId)
-      XCTAssertEqual(capturedPlaceAfterSpinId.value, "spin-1")
+      #expect(capturedAudioBlockId.value == voicetrackAudioBlockId)
+      #expect(capturedPlaceAfterSpinId.value == "spin-1")
     }
   }
 
+  @Test
   func testInsertStagingItemRemovesFromStagingOnSuccess() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -956,14 +971,15 @@ extension BroadcastPageTests {
       let voicetrackId = UUID()
       model.stagingItems = [makeStagingVoicetrack(id: voicetrackId)]
 
-      XCTAssertEqual(model.stagingItems.count, 1)
+      #expect(model.stagingItems.count == 1)
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-2")
 
-      XCTAssertEqual(model.stagingItems.count, 0)
+      #expect(model.stagingItems.count == 0)
     }
   }
 
+  @Test
   func testInsertStagingItemUpdatesScheduleWithResponse() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"], interval: 120)
     let updatedSpins = makeSpins(ids: ["spin-1", "new-spin", "spin-2"])
@@ -982,10 +998,11 @@ extension BroadcastPageTests {
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-2")
 
-      XCTAssertEqual(model.upcomingSpins.map { $0.id }, ["spin-1", "new-spin", "spin-2"])
+      #expect(model.upcomingSpins.map { $0.id } == ["spin-1", "new-spin", "spin-2"])
     }
   }
 
+  @Test
   func testInsertStagingItemAtTopUsesNowPlayingAsPlaceAfter() async {
     let nowPlayingAudioBlock = AudioBlock.mockWith(endOfMessageMS: 180_000)
     let nowPlayingSpin = Spin.mockWith(
@@ -1011,19 +1028,20 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.nowPlaying?.id, "now-playing")
-      XCTAssertEqual(model.upcomingSpins.first?.id, "spin-1")
+      #expect(model.nowPlaying?.id == "now-playing")
+      #expect(model.upcomingSpins.first?.id == "spin-1")
 
       let voicetrackId = UUID()
       model.stagingItems = [makeStagingVoicetrack(id: voicetrackId)]
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-1")
 
-      XCTAssertEqual(capturedPlaceAfterSpinId.value, "now-playing")
-      XCTAssertNil(model.presentedAlert)
+      #expect(capturedPlaceAfterSpinId.value == "now-playing")
+      #expect(model.presentedAlert == nil)
     }
   }
 
+  @Test
   func testInsertStagingItemAtTopWithNoNowPlayingShowsError() async {
     let upcomingSpins = makeSpins(ids: ["spin-1", "spin-2"])
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -1041,16 +1059,16 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertNil(model.nowPlaying)
+      #expect(model.nowPlaying == nil)
 
       let voicetrackId = UUID()
       model.stagingItems = [makeStagingVoicetrack(id: voicetrackId)]
 
       await model.insertStagingItem(stagingId: voicetrackId.uuidString, beforeSpinId: "spin-1")
 
-      XCTAssertFalse(apiWasCalled.value)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Cannot Place Here")
+      #expect(!apiWasCalled.value)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Cannot Place Here")
     }
   }
 }
@@ -1058,16 +1076,18 @@ extension BroadcastPageTests {
 // MARK: - Notify Listeners Tests
 
 extension BroadcastPageTests {
+  @Test
   func testOnNotifyListenersTappedShowsSheet() {
     let model = BroadcastPageModel(stationId: testStationId)
 
-    XCTAssertFalse(model.showNotifyListenersSheet)
+    #expect(!model.showNotifyListenersSheet)
 
     model.onNotifyListenersTapped()
 
-    XCTAssertTrue(model.showNotifyListenersSheet)
+    #expect(model.showNotifyListenersSheet)
   }
 
+  @Test
   func testCancelNotifyListenersDismissesSheet() {
     let model = BroadcastPageModel(stationId: testStationId)
     model.showNotifyListenersSheet = true
@@ -1075,10 +1095,11 @@ extension BroadcastPageTests {
 
     model.cancelNotifyListeners()
 
-    XCTAssertFalse(model.showNotifyListenersSheet)
-    XCTAssertEqual(model.notifyMessage, "")
+    #expect(!model.showNotifyListenersSheet)
+    #expect(model.notifyMessage == "")
   }
 
+  @Test
   func testSendNotificationCallsAPIWithMessage() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let capturedStationId = LockIsolated<String?>(nil)
@@ -1096,11 +1117,12 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertEqual(capturedStationId.value, testStationId)
-      XCTAssertEqual(capturedMessage.value, "I'm going live from the van!")
+      #expect(capturedStationId.value == testStationId)
+      #expect(capturedMessage.value == "I'm going live from the van!")
     }
   }
 
+  @Test
   func testSendNotificationDismissesSheetAndClearsMessage() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -1114,11 +1136,12 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertFalse(model.showNotifyListenersSheet)
-      XCTAssertEqual(model.notifyMessage, "")
+      #expect(!model.showNotifyListenersSheet)
+      #expect(model.notifyMessage == "")
     }
   }
 
+  @Test
   func testSendNotificationUpdatesLastSentTime() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
@@ -1132,10 +1155,11 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertEqual(lastSent[testStationId], fixedNow)
+      #expect(lastSent[testStationId] == fixedNow)
     }
   }
 
+  @Test
   func testCanSendNotificationReturnsTrueWhenNeverSent() {
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
 
@@ -1144,10 +1168,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertTrue(model.canSendNotification)
+      #expect(model.canSendNotification)
     }
   }
 
+  @Test
   func testCanSendNotificationReturnsFalseWithin12Hours() {
     let elevenHoursAgo = fixedNow.addingTimeInterval(-11 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [testStationId: elevenHoursAgo]
@@ -1157,10 +1182,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertFalse(model.canSendNotification)
+      #expect(!model.canSendNotification)
     }
   }
 
+  @Test
   func testCanSendNotificationReturnsTrueAfter12Hours() {
     let thirteenHoursAgo = fixedNow.addingTimeInterval(-13 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [
@@ -1172,10 +1198,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertTrue(model.canSendNotification)
+      #expect(model.canSendNotification)
     }
   }
 
+  @Test
   func testTimeUntilNextNotificationReturnsNilWhenCanSend() {
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
 
@@ -1184,10 +1211,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertNil(model.timeUntilNextNotification)
+      #expect(model.timeUntilNextNotification == nil)
     }
   }
 
+  @Test
   func testTimeUntilNextNotificationReturnsRemainingTime() {
     let elevenHoursAgo = fixedNow.addingTimeInterval(-11 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [testStationId: elevenHoursAgo]
@@ -1197,12 +1225,12 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      // Should be approximately 1 hour (3600 seconds) remaining
-      XCTAssertNotNil(model.timeUntilNextNotification)
-      XCTAssertEqual(model.timeUntilNextNotification!, 3600, accuracy: 1)
+      #expect(model.timeUntilNextNotification != nil)
+      #expect(abs(model.timeUntilNextNotification! - 3600) < 1)
     }
   }
 
+  @Test
   func testSendNotificationShowsErrorAlertOnFailure() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -1215,15 +1243,16 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       model.notifyMessage = "Test"
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.sendNotification()
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Error")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Error")
     }
   }
 
+  @Test
   func testSendNotificationDoesNotUpdateLastSentOnFailure() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
@@ -1239,10 +1268,11 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertNil(lastSent[testStationId])
+      #expect(lastSent[testStationId] == nil)
     }
   }
 
+  @Test
   func testSendNotificationDoesNothingWhenMessageIsEmpty() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let apiWasCalled = LockIsolated(false)
@@ -1259,11 +1289,12 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertFalse(apiWasCalled.value)
-      XCTAssertTrue(model.showNotifyListenersSheet)
+      #expect(!apiWasCalled.value)
+      #expect(model.showNotifyListenersSheet)
     }
   }
 
+  @Test
   func testSendNotificationDoesNothingWhenMessageIsWhitespaceOnly() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let apiWasCalled = LockIsolated(false)
@@ -1280,11 +1311,12 @@ extension BroadcastPageTests {
 
       await model.sendNotification()
 
-      XCTAssertFalse(apiWasCalled.value)
-      XCTAssertTrue(model.showNotifyListenersSheet)
+      #expect(!apiWasCalled.value)
+      #expect(model.showNotifyListenersSheet)
     }
   }
 
+  @Test
   func testNotificationRestTimeRemainingStringReturnsNilWhenCanSend() {
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [:]
 
@@ -1293,10 +1325,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertNil(model.notificationRestTimeRemainingString)
+      #expect(model.notificationRestTimeRemainingString == nil)
     }
   }
 
+  @Test
   func testNotificationRestTimeRemainingStringShowsHoursAndMinutes() {
     let elevenHoursAgo = fixedNow.addingTimeInterval(-11 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [testStationId: elevenHoursAgo]
@@ -1306,10 +1339,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertEqual(model.notificationRestTimeRemainingString, "1h 0m")
+      #expect(model.notificationRestTimeRemainingString == "1h 0m")
     }
   }
 
+  @Test
   func testNotificationRestTimeRemainingStringShowsOnlyMinutesWhenUnderOneHour() {
     let elevenAndAHalfHoursAgo = fixedNow.addingTimeInterval(-11.5 * 60 * 60)
     @Shared(.lastNotificationSentAt) var lastSent: [String: Date] = [
@@ -1321,10 +1355,11 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: testStationId)
 
-      XCTAssertEqual(model.notificationRestTimeRemainingString, "30m")
+      #expect(model.notificationRestTimeRemainingString == "30m")
     }
   }
 
+  @Test
   func testIsSendingNotificationTracksLoadingState() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let requestStarted = LockIsolated(false)
@@ -1342,7 +1377,7 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       model.notifyMessage = "Test"
 
-      XCTAssertFalse(model.isSendingNotification)
+      #expect(!model.isSendingNotification)
 
       let sendTask = Task {
         await model.sendNotification()
@@ -1352,7 +1387,7 @@ extension BroadcastPageTests {
         await Task.yield()
       }
 
-      XCTAssertTrue(model.isSendingNotification)
+      #expect(model.isSendingNotification)
 
       requestContinuation.withValue { continuation in
         continuation?.resume()
@@ -1361,7 +1396,7 @@ extension BroadcastPageTests {
 
       await sendTask.value
 
-      XCTAssertFalse(model.isSendingNotification)
+      #expect(!model.isSendingNotification)
     }
   }
 }
@@ -1369,6 +1404,7 @@ extension BroadcastPageTests {
 // MARK: - Voicetrack Upload Tests
 
 extension BroadcastPageTests {
+  @Test
   func testVoicetrackStatusUpdatesAsUploadProgresses() async {
     let stationId = "test-station-id"
     let fixedDate = Date(timeIntervalSince1970: 1_702_486_800)
@@ -1401,18 +1437,19 @@ extension BroadcastPageTests {
       await model.recordPageModel?.onRecordingAccepted?(recordingURL)
 
       let statuses = capturedStatuses.value
-      XCTAssertEqual(statuses.count, 6)
-      XCTAssertEqual(statuses[0], .converting)
-      XCTAssertEqual(statuses[1], .uploading(progress: 0.0))
-      XCTAssertEqual(statuses[2], .uploading(progress: 0.5))
-      XCTAssertEqual(statuses[3], .uploading(progress: 1.0))
-      XCTAssertEqual(statuses[4], .finalizing)
-      XCTAssertEqual(statuses[5], .completed)
+      #expect(statuses.count == 6)
+      #expect(statuses[0] == .converting)
+      #expect(statuses[1] == .uploading(progress: 0.0))
+      #expect(statuses[2] == .uploading(progress: 0.5))
+      #expect(statuses[3] == .uploading(progress: 1.0))
+      #expect(statuses[4] == .finalizing)
+      #expect(statuses[5] == .completed)
       let voicetrack = model.stagingItems.first as? LocalVoicetrack
-      XCTAssertEqual(voicetrack?.status, .completed)
+      #expect(voicetrack?.status == .completed)
     }
   }
 
+  @Test
   func testVoicetrackUploadSuccessStoresAudioBlockId() async {
     let stationId = "test-station-id"
     let fixedDate = Date(timeIntervalSince1970: 1_702_486_800)
@@ -1435,13 +1472,14 @@ extension BroadcastPageTests {
       let recordingURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
       await model.recordPageModel?.onRecordingAccepted?(recordingURL)
 
-      XCTAssertEqual(model.stagingItems.count, 1)
+      #expect(model.stagingItems.count == 1)
       let voicetrack = model.stagingItems.first as? LocalVoicetrack
-      XCTAssertEqual(voicetrack?.audioBlockId, expectedAudioBlockId)
-      XCTAssertEqual(voicetrack?.status, .completed)
+      #expect(voicetrack?.audioBlockId == expectedAudioBlockId)
+      #expect(voicetrack?.status == .completed)
     }
   }
 
+  @Test
   func testVoicetrackUploadErrorShowsAlertWithServerErrorMessage() async {
     let stationId = "test-station-id"
     let fixedDate = Date(timeIntervalSince1970: 1_702_486_800)
@@ -1457,20 +1495,21 @@ extension BroadcastPageTests {
     } operation: {
       let model = BroadcastPageModel(stationId: stationId)
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       model.onAddVoiceTrackTapped()
       let recordingURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
       await model.recordPageModel?.onRecordingAccepted?(recordingURL)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Upload Failed")
-      XCTAssertEqual(model.presentedAlert?.message, serverErrorMessage)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Upload Failed")
+      #expect(model.presentedAlert?.message == serverErrorMessage)
     }
   }
 
   // MARK: - Analytics Tests
 
+  @Test
   func testViewAppearedTracksViewedBroadcastScreen() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let loggedInUser = LoggedInUser(
@@ -1500,10 +1539,11 @@ extension BroadcastPageTests {
         }
         return false
       }
-      XCTAssertTrue(hasViewedEvent)
+      #expect(hasViewedEvent)
     }
   }
 
+  @Test
   func testSendNotificationTracksNotificationSent() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let loggedInUser = LoggedInUser(
@@ -1537,10 +1577,11 @@ extension BroadcastPageTests {
         }
         return false
       }
-      XCTAssertTrue(hasNotificationEvent)
+      #expect(hasNotificationEvent)
     }
   }
 
+  @Test
   func testHandleAcceptedRecordingTracksVoicetrackRecorded() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let loggedInUser = LoggedInUser(
@@ -1575,10 +1616,11 @@ extension BroadcastPageTests {
         }
         return false
       }
-      XCTAssertTrue(hasRecordedEvent)
+      #expect(hasRecordedEvent)
     }
   }
 
+  @Test
   func testVoicetrackUploadCompletedTracksVoicetrackUploaded() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     let loggedInUser = LoggedInUser(
@@ -1614,14 +1656,14 @@ extension BroadcastPageTests {
         }
         return false
       }
-      XCTAssertTrue(hasUploadedEvent)
+      #expect(hasUploadedEvent)
     }
   }
 
+  @Test
   func testOnAddSongTappedTracksSongSearchTapped() async {
     await withMainSerialExecutor {
       let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-      let searchTappedExpectation = XCTestExpectation(description: "songSearchTapped tracked")
       let loggedInUser = LoggedInUser(
         id: "user-123",
         firstName: "Test",
@@ -1630,40 +1672,47 @@ extension BroadcastPageTests {
       )
       @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-      await withDependencies {
-        $0.date.now = fixedNow
-        $0.analytics.track = { event in
-          capturedEvents.withValue { $0.append(event) }
-          if case .broadcastSongSearchTapped = event {
-            searchTappedExpectation.fulfill()
+      await confirmation("songSearchTapped tracked") { confirm in
+        await withDependencies {
+          $0.date.now = fixedNow
+          $0.analytics.track = { event in
+            capturedEvents.withValue { $0.append(event) }
+            if case .broadcastSongSearchTapped = event {
+              confirm()
+            }
+          }
+        } operation: {
+          let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
+          await model.onAddSongTapped()
+
+          while !capturedEvents.value.contains(where: {
+            if case .broadcastSongSearchTapped = $0 { return true }
+            return false
+          }) {
+            await Task.yield()
           }
         }
-      } operation: {
-        let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
-        await model.onAddSongTapped()
-
-        await fulfillment(of: [searchTappedExpectation], timeout: 1.0)
-
-        let events = capturedEvents.value
-        let hasSearchEvent = events.contains { event in
-          if case .broadcastSongSearchTapped(
-            let stationId, let stationName, let userName
-          ) = event {
-            return stationId == testStationId
-              && stationName == "Test Station"
-              && userName == "Test User"
-          }
-          return false
-        }
-        XCTAssertTrue(hasSearchEvent)
       }
+
+      let events = capturedEvents.value
+      let hasSearchEvent = events.contains { event in
+        if case .broadcastSongSearchTapped(
+          let stationId, let stationName, let userName
+        ) = event {
+          return stationId == testStationId
+            && stationName == "Test Station"
+            && userName == "Test User"
+        }
+        return false
+      }
+      #expect(hasSearchEvent)
     }
   }
 
+  @Test
   func testAddSongToStagingTracksSongAdded() async {
     await withMainSerialExecutor {
       let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-      let songAddedExpectation = XCTestExpectation(description: "songAdded tracked")
       let loggedInUser = LoggedInUser(
         id: "user-123",
         firstName: "Test",
@@ -1672,45 +1721,53 @@ extension BroadcastPageTests {
       )
       @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-      await withDependencies {
-        $0.date.now = fixedNow
-        $0.analytics.track = { event in
-          capturedEvents.withValue { $0.append(event) }
-          if case .broadcastSongAdded = event {
-            songAddedExpectation.fulfill()
+      await confirmation("songAdded tracked") { confirm in
+        await withDependencies {
+          $0.date.now = fixedNow
+          $0.analytics.track = { event in
+            capturedEvents.withValue { $0.append(event) }
+            if case .broadcastSongAdded = event {
+              confirm()
+            }
+          }
+        } operation: {
+          let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
+          let audioBlock = AudioBlock.mockWith(
+            id: "song-123",
+            title: "Test Song",
+            artist: "Test Artist"
+          )
+          await model.addSongToStaging(audioBlock)
+
+          while !capturedEvents.value.contains(where: {
+            if case .broadcastSongAdded = $0 { return true }
+            return false
+          }) {
+            await Task.yield()
           }
         }
-      } operation: {
-        let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
-        let audioBlock = AudioBlock.mockWith(
-          id: "song-123",
-          title: "Test Song",
-          artist: "Test Artist"
-        )
-        await model.addSongToStaging(audioBlock)
-
-        await fulfillment(of: [songAddedExpectation], timeout: 1.0)
-
-        let events = capturedEvents.value
-        let hasSongAddedEvent = events.contains { event in
-          if case .broadcastSongAdded(
-            let stationId, let stationName, let userName, let songTitle, let artistName
-          ) = event {
-            return stationId == testStationId
-              && stationName == "Test Station"
-              && userName == "Test User"
-              && songTitle == "Test Song"
-              && artistName == "Test Artist"
-          }
-          return false
-        }
-        XCTAssertTrue(hasSongAddedEvent)
       }
+
+      let events = capturedEvents.value
+      let hasSongAddedEvent = events.contains { event in
+        if case .broadcastSongAdded(
+          let stationId, let stationName, let userName, let songTitle, let artistName
+        ) = event {
+          return stationId == testStationId
+            && stationName == "Test Station"
+            && userName == "Test User"
+            && songTitle == "Test Song"
+            && artistName == "Test Artist"
+        }
+        return false
+      }
+      #expect(hasSongAddedEvent)
     }
   }
 
   // MARK: - Schedule Update Notification Tests
 
+  @Test
   func testRefreshScheduleFromRemoteUpdatesSchedule() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     let updatedSpins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
@@ -1725,15 +1782,16 @@ extension BroadcastPageTests {
       let model = BroadcastPageModel(stationId: testStationId)
       await model.viewAppeared()
 
-      XCTAssertEqual(model.schedule?.current().count, 2)
+      #expect(model.schedule?.current().count == 2)
 
       useUpdatedSpins.setValue(true)
       await model.refreshScheduleFromRemote()
 
-      XCTAssertEqual(model.schedule?.current().count, 3)
+      #expect(model.schedule?.current().count == 3)
     }
   }
 
+  @Test
   func testRefreshScheduleFromRemoteClearsReorderedSpinIds() async {
     let spins = makeSpins(ids: ["spin-1", "spin-2", "spin-3"])
 
@@ -1746,10 +1804,11 @@ extension BroadcastPageTests {
 
       await model.refreshScheduleFromRemote()
 
-      XCTAssertNotNil(model.schedule)
+      #expect(model.schedule != nil)
     }
   }
 
+  @Test
   func testRefreshScheduleFromRemoteSilentlyFailsOnError() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     let shouldThrow = LockIsolated(false)
@@ -1767,11 +1826,12 @@ extension BroadcastPageTests {
       shouldThrow.setValue(true)
       await model.refreshScheduleFromRemote()
 
-      XCTAssertNotNil(model.schedule)
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.schedule != nil)
+      #expect(model.presentedAlert == nil)
     }
   }
 
+  @Test
   func testScheduleUpdateNotificationTriggersRefresh() async {
     let uniqueStationId = "notification-trigger-test-station"
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
@@ -1793,7 +1853,7 @@ extension BroadcastPageTests {
         let model = BroadcastPageModel(stationId: uniqueStationId)
         await model.viewAppeared()
 
-        XCTAssertEqual(fetchCount.value, 1)
+        #expect(fetchCount.value == 1)
 
         NotificationCenter.default.post(
           name: .scheduleUpdated,
@@ -1801,18 +1861,17 @@ extension BroadcastPageTests {
           userInfo: ["stationId": uniqueStationId, "editorName": "Jane Smith"]
         )
 
-        // The notification handler spawns a Task that calls refreshScheduleFromRemote.
-        // Suspension points: Task start + fetchSchedule + toast.show
         await Task.yield()
         await Task.yield()
         await Task.yield()
         await Task.yield()
 
-        XCTAssertEqual(fetchCount.value, 2)
+        #expect(fetchCount.value == 2)
       }
     }
   }
 
+  @Test
   func testRefreshScheduleFromRemoteShowsToastWithEditorName() async {
     let spins = makeSpins(ids: ["spin-1", "spin-2"])
     let shownToast = LockIsolated<PlayolaToast?>(nil)
@@ -1827,11 +1886,12 @@ extension BroadcastPageTests {
 
       await model.refreshScheduleFromRemote(editorName: "Jane Smith")
 
-      XCTAssertNotNil(shownToast.value)
-      XCTAssertEqual(shownToast.value?.message, "Edited by Jane Smith")
+      #expect(shownToast.value != nil)
+      #expect(shownToast.value?.message == "Edited by Jane Smith")
     }
   }
 
+  @Test
   func testRefreshScheduleFromRemoteNoToastWithoutEditorName() async {
     let spins = makeSpins(ids: ["spin-1", "spin-2"])
     let shownToast = LockIsolated<PlayolaToast?>(nil)
@@ -1846,10 +1906,11 @@ extension BroadcastPageTests {
 
       await model.refreshScheduleFromRemote()
 
-      XCTAssertNil(shownToast.value)
+      #expect(shownToast.value == nil)
     }
   }
 
+  @Test
   func testScheduleUpdateNotificationIgnoredForDifferentStation() async {
     let initialSpins = makeSpins(ids: ["spin-1", "spin-2"])
     let fetchCount = LockIsolated(0)
@@ -1874,7 +1935,7 @@ extension BroadcastPageTests {
 
       await Task.yield()
 
-      XCTAssertEqual(fetchCount.value, initialFetchCount)
+      #expect(fetchCount.value == initialFetchCount)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -442,22 +442,24 @@ final class BroadcastPageTests: XCTestCase {
   }
 
   func testOnAddSongTappedSongSelectedCallbackAddsSongToStaging() async {
-    @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator)
+      var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
-    let model = BroadcastPageModel(stationId: "test-station")
-    XCTAssertTrue(model.stagingItems.isEmpty)
+      let model = BroadcastPageModel(stationId: "test-station")
+      XCTAssertTrue(model.stagingItems.isEmpty)
 
-    await model.onAddSongTapped()
+      await model.onAddSongTapped()
 
-    let testSong = AudioBlock.mockWith(
-      id: "test-song-123", title: "Test Song", artist: "Test Artist")
-    model.songSearchPageModel?.onSongSelected?(testSong)
-    await Task.yield()
+      let testSong = AudioBlock.mockWith(
+        id: "test-song-123", title: "Test Song", artist: "Test Artist")
+      model.songSearchPageModel?.onSongSelected?(testSong)
+      await Task.yield()
 
-    XCTAssertEqual(model.stagingItems.count, 1)
-    XCTAssertEqual(model.stagingItems.first?.stagingId, "test-song-123")
-    XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
+      XCTAssertEqual(model.stagingItems.count, 1)
+      XCTAssertEqual(model.stagingItems.first?.stagingId, "test-song-123")
+      XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
+    }
   }
 
   func testOnAddSongTappedSongSelectedCallbackDismissesSheet() async {

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -412,7 +412,7 @@ final class BroadcastPageTests: XCTestCase {
     }
   }
 
-  func testOnAddSongTapped_PresentsSongSearchPageSheet() {
+  func testOnAddSongTapped_PresentsSongSearchPageSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
@@ -421,51 +421,51 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
     XCTAssertNil(model.songSearchPageModel)
 
-    model.onAddSongTapped()
+    await model.onAddSongTapped()
 
     XCTAssertNotNil(model.songSearchPageModel)
     if case .songSearchPage = mainContainerNavigationCoordinator.presentedSheet {
-      // Success - presented song search page sheet
     } else {
       XCTFail("Expected songSearchPage sheet presentation")
     }
   }
 
-  func testOnAddSongTappedUsesAllSearchMode() {
+  func testOnAddSongTappedUsesAllSearchMode() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     let model = BroadcastPageModel(stationId: "test-station")
 
-    model.onAddSongTapped()
+    await model.onAddSongTapped()
 
     XCTAssertEqual(model.songSearchPageModel?.searchMode, .all)
   }
 
-  func testOnAddSongTapped_SongSelectedCallbackAddsSongToStaging() {
+  func testOnAddSongTapped_SongSelectedCallbackAddsSongToStaging() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     let model = BroadcastPageModel(stationId: "test-station")
     XCTAssertTrue(model.stagingItems.isEmpty)
 
-    model.onAddSongTapped()
+    await model.onAddSongTapped()
 
     let testSong = AudioBlock.mockWith(
       id: "test-song-123", title: "Test Song", artist: "Test Artist")
     model.songSearchPageModel?.onSongSelected?(testSong)
+    await Task.yield()
 
     XCTAssertEqual(model.stagingItems.count, 1)
     XCTAssertEqual(model.stagingItems.first?.stagingId, "test-song-123")
     XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
   }
 
-  func testOnAddSongTapped_SongSelectedCallbackDismissesSheet() {
+  func testOnAddSongTapped_SongSelectedCallbackDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     let model = BroadcastPageModel(stationId: "test-station")
-    model.onAddSongTapped()
+    await model.onAddSongTapped()
 
     XCTAssertNotNil(mainContainerNavigationCoordinator.presentedSheet)
 
@@ -475,23 +475,23 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
   }
 
-  func testAddSongToStaging_DoesNotAddDuplicates() {
+  func testAddSongToStaging_DoesNotAddDuplicates() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let testSong = AudioBlock.mockWith(id: "test-song-123")
 
-    model.addSongToStaging(testSong)
-    model.addSongToStaging(testSong)
+    await model.addSongToStaging(testSong)
+    await model.addSongToStaging(testSong)
 
     XCTAssertEqual(model.stagingItems.count, 1)
   }
 
-  func testAddSongToStaging_AddsMultipleDifferentSongs() {
+  func testAddSongToStaging_AddsMultipleDifferentSongs() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let song1 = AudioBlock.mockWith(id: "song-1", title: "First Song")
     let song2 = AudioBlock.mockWith(id: "song-2", title: "Second Song")
 
-    model.addSongToStaging(song1)
-    model.addSongToStaging(song2)
+    await model.addSongToStaging(song1)
+    await model.addSongToStaging(song2)
 
     XCTAssertEqual(model.stagingItems.count, 2)
     XCTAssertEqual(model.stagingItems[0].stagingId, "song-1")
@@ -1638,7 +1638,7 @@ extension BroadcastPageTests {
         }
       } operation: {
         let model = BroadcastPageModel(stationId: testStationId, stationName: "Test Station")
-        model.onAddSongTapped()
+        await model.onAddSongTapped()
 
         await fulfillment(of: [searchTappedExpectation], timeout: 1.0)
 
@@ -1685,7 +1685,7 @@ extension BroadcastPageTests {
           title: "Test Song",
           artist: "Test Artist"
         )
-        model.addSongToStaging(audioBlock)
+        await model.addSongToStaging(audioBlock)
 
         await fulfillment(of: [songAddedExpectation], timeout: 1.0)
 

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -412,7 +412,7 @@ final class BroadcastPageTests: XCTestCase {
     }
   }
 
-  func testOnAddSongTapped_PresentsSongSearchPageSheet() async {
+  func testOnAddSongTappedPresentsSongSearchPageSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
@@ -441,7 +441,7 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertEqual(model.songSearchPageModel?.searchMode, .all)
   }
 
-  func testOnAddSongTapped_SongSelectedCallbackAddsSongToStaging() async {
+  func testOnAddSongTappedSongSelectedCallbackAddsSongToStaging() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
@@ -460,7 +460,7 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertEqual(model.stagingItems.first?.titleText, "Test Song")
   }
 
-  func testOnAddSongTapped_SongSelectedCallbackDismissesSheet() async {
+  func testOnAddSongTappedSongSelectedCallbackDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
@@ -475,7 +475,7 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
   }
 
-  func testAddSongToStaging_DoesNotAddDuplicates() async {
+  func testAddSongToStagingDoesNotAddDuplicates() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let testSong = AudioBlock.mockWith(id: "test-song-123")
 
@@ -485,7 +485,7 @@ final class BroadcastPageTests: XCTestCase {
     XCTAssertEqual(model.stagingItems.count, 1)
   }
 
-  func testAddSongToStaging_AddsMultipleDifferentSongs() async {
+  func testAddSongToStagingAddsMultipleDifferentSongs() async {
     let model = BroadcastPageModel(stationId: "test-station")
     let song1 = AudioBlock.mockWith(id: "song-1", title: "First Song")
     let song2 = AudioBlock.mockWith(id: "song-2", title: "Second Song")

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
@@ -33,7 +33,7 @@ struct BroadcastPageView: View {
           BroadcastActionButton(
             icon: .asset("BroadcastAddSongIcon", width: 40, height: 40),
             label: "Add Song",
-            action: model.onAddSongTapped
+            action: { Task { await model.onAddSongTapped() } }
           )
 
           BroadcastActionButton(

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageTests.swift
@@ -3,53 +3,61 @@
 //  PlayolaRadio
 //
 
+import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class BroadcastersListenerQuestionPageTests: XCTestCase {
+struct BroadcastersListenerQuestionPageTests {
   private let testStationId = "test-station-id"
   private let testJwt = "test-jwt-token"
 
   // MARK: - Initialization Tests
 
+  @Test
   func testInitSetsStationId() {
     let model = makeModel()
 
-    XCTAssertEqual(model.stationId, testStationId)
+    #expect(model.stationId == testStationId)
   }
 
+  @Test
   func testInitialStateIsNotLoading() {
     let model = makeModel()
 
-    XCTAssertFalse(model.isLoading)
+    #expect(!model.isLoading)
   }
 
+  @Test
   func testInitialStateHasNoExpandedQuestions() {
     let model = makeModel()
 
-    XCTAssertTrue(model.expandedQuestionIds.isEmpty)
+    #expect(model.expandedQuestionIds.isEmpty)
   }
 
+  @Test
   func testInitialStateHasNoPlayingQuestion() {
     let model = makeModel()
 
-    XCTAssertNil(model.playingQuestionId)
+    #expect(model.playingQuestionId == nil)
   }
 
+  @Test
   func testInitialStateHasEmptyQuestions() {
     let model = makeModel()
 
-    XCTAssertTrue(model.questions.isEmpty)
+    #expect(model.questions.isEmpty)
   }
 
   // MARK: - Fetch Tests
 
+  @Test
   func testViewAppearedCallsAPIWithStationId() async {
     let calledStationId = LockIsolated<String?>(nil)
 
@@ -66,9 +74,10 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertEqual(calledStationId.value, testStationId)
+    #expect(calledStationId.value == testStationId)
   }
 
+  @Test
   func testViewAppearedPopulatesQuestionsArray() async {
     let mockQuestions: [ListenerQuestion] = [
       .mockWith(id: "q1"),
@@ -85,11 +94,12 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertEqual(model.questions.count, 2)
-    XCTAssertEqual(model.questions[0].id, "q1")
-    XCTAssertEqual(model.questions[1].id, "q2")
+    #expect(model.questions.count == 2)
+    #expect(model.questions[0].id == "q1")
+    #expect(model.questions[1].id == "q2")
   }
 
+  @Test
   func testViewAppearedSetsIsLoadingDuringFetch() async {
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
@@ -101,13 +111,14 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
       BroadcastersListenerQuestionPageModel(stationId: testStationId)
     }
 
-    XCTAssertFalse(model.isLoading)
+    #expect(!model.isLoading)
 
     await model.viewAppeared()
 
-    XCTAssertFalse(model.isLoading)
+    #expect(!model.isLoading)
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
@@ -121,10 +132,11 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Error Loading Questions")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Error Loading Questions")
   }
 
+  @Test
   func testViewAppearedDoesNothingWithoutJwt() async {
     let apiCalled = LockIsolated(false)
 
@@ -141,9 +153,10 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertFalse(apiCalled.value)
+    #expect(!apiCalled.value)
   }
 
+  @Test
   func testViewAppearedCallsFetchQuestions() async {
     let fetchCalled = LockIsolated(false)
 
@@ -160,9 +173,10 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertTrue(fetchCalled.value)
+    #expect(fetchCalled.value)
   }
 
+  @Test
   func testRefreshPulledDownCallsFetchQuestions() async {
     let fetchCalled = LockIsolated(false)
 
@@ -179,38 +193,42 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.refreshPulledDown()
 
-    XCTAssertTrue(fetchCalled.value)
+    #expect(fetchCalled.value)
   }
 
   // MARK: - Expand/Collapse Tests
 
+  @Test
   func testIsExpandedReturnsFalseForCollapsedQuestion() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
-    XCTAssertFalse(model.isExpanded(questionId))
+    #expect(!model.isExpanded(questionId))
   }
 
+  @Test
   func testToggleExpandedExpandsCollapsedQuestion() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
     model.showMoreButtonTapped(questionId)
 
-    XCTAssertTrue(model.isExpanded(questionId))
+    #expect(model.isExpanded(questionId))
   }
 
+  @Test
   func testToggleExpandedCollapsesExpandedQuestion() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
     model.showMoreButtonTapped(questionId)
-    XCTAssertTrue(model.isExpanded(questionId))
+    #expect(model.isExpanded(questionId))
 
     model.showMoreButtonTapped(questionId)
-    XCTAssertFalse(model.isExpanded(questionId))
+    #expect(!model.isExpanded(questionId))
   }
 
+  @Test
   func testMultipleQuestionsCanBeExpandedSimultaneously() {
     let model = makeModelWithQuestions()
     let firstQuestionId = model.questions[0].id
@@ -219,28 +237,31 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
     model.showMoreButtonTapped(firstQuestionId)
     model.showMoreButtonTapped(secondQuestionId)
 
-    XCTAssertTrue(model.isExpanded(firstQuestionId))
-    XCTAssertTrue(model.isExpanded(secondQuestionId))
+    #expect(model.isExpanded(firstQuestionId))
+    #expect(model.isExpanded(secondQuestionId))
   }
 
   // MARK: - Playback Tests
 
+  @Test
   func testIsPlayingReturnsFalseWhenNotPlaying() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
-    XCTAssertFalse(model.isPlaying(questionId))
+    #expect(!model.isPlaying(questionId))
   }
 
+  @Test
   func testIsPlayingReturnsTrueForPlayingQuestion() {
     let model = makeModelWithQuestions()
     let questionId = model.questions.first!.id
 
     model.playingQuestionId = questionId
 
-    XCTAssertTrue(model.isPlaying(questionId))
+    #expect(model.isPlaying(questionId))
   }
 
+  @Test
   func testIsPlayingReturnsFalseForDifferentQuestion() {
     let model = makeModelWithQuestions()
     let firstQuestionId = model.questions[0].id
@@ -248,9 +269,10 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     model.playingQuestionId = firstQuestionId
 
-    XCTAssertFalse(model.isPlaying(secondQuestionId))
+    #expect(!model.isPlaying(secondQuestionId))
   }
 
+  @Test
   func testOnPlayTappedStartsPlaybackWhenNotPlaying() async {
     let loadFileCalled = LockIsolated(false)
     let playCalled = LockIsolated(false)
@@ -271,11 +293,12 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(question)
 
-    XCTAssertTrue(loadFileCalled.value)
-    XCTAssertTrue(playCalled.value)
-    XCTAssertEqual(model.playingQuestionId, question.id)
+    #expect(loadFileCalled.value)
+    #expect(playCalled.value)
+    #expect(model.playingQuestionId == question.id)
   }
 
+  @Test
   func testOnPlayTappedStopsPlaybackWhenAlreadyPlaying() async {
     let stopCalled = LockIsolated(false)
 
@@ -292,10 +315,11 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(question)
 
-    XCTAssertTrue(stopCalled.value)
-    XCTAssertNil(model.playingQuestionId)
+    #expect(stopCalled.value)
+    #expect(model.playingQuestionId == nil)
   }
 
+  @Test
   func testOnPlayTappedStopsPreviousBeforeStartingNew() async {
     let stopCallCount = LockIsolated(0)
     let loadFileCalled = LockIsolated(false)
@@ -318,11 +342,12 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(secondQuestion)
 
-    XCTAssertEqual(stopCallCount.value, 1)
-    XCTAssertTrue(loadFileCalled.value)
-    XCTAssertEqual(model.playingQuestionId, secondQuestion.id)
+    #expect(stopCallCount.value == 1)
+    #expect(loadFileCalled.value)
+    #expect(model.playingQuestionId == secondQuestion.id)
   }
 
+  @Test
   func testPlayButtonTappedOnSameQuestionStopsPlayback() async {
     let stopCalled = LockIsolated(false)
 
@@ -341,12 +366,13 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(question)
 
-    XCTAssertTrue(stopCalled.value)
-    XCTAssertNil(model.playingQuestionId)
+    #expect(stopCalled.value)
+    #expect(model.playingQuestionId == nil)
   }
 
   // MARK: - Error Handling Tests
 
+  @Test
   func testOnPlayTappedShowsAlertOnError() async {
     let model = withDependencies {
       $0.audioPlayer.loadFile = { _ in
@@ -359,14 +385,15 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     let question = model.questions.first!
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
 
     await model.playButtonTapped(question)
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Playback Error")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Playback Error")
   }
 
+  @Test
   func testOnPlayTappedDoesNothingWhenNoAudioBlock() async {
     let audioPlayerCalled = LockIsolated(false)
 
@@ -389,74 +416,84 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.playButtonTapped(questionWithoutAudio)
 
-    XCTAssertFalse(audioPlayerCalled.value)
+    #expect(!audioPlayerCalled.value)
   }
 
   // MARK: - Filter Tests
 
+  @Test
   func testDefaultFilterIsPending() {
     let model = makeModel()
 
-    XCTAssertEqual(model.selectedFilter, .pending)
+    #expect(model.selectedFilter == .pending)
   }
 
+  @Test
   func testFilterOptionsContainsAllExpectedValues() {
     let model = makeModel()
 
-    XCTAssertEqual(model.filterOptions, [.pending, .answered, .all])
+    #expect(model.filterOptions == [.pending, .answered, .all])
   }
 
+  @Test
   func testFilteredQuestionsReturnsOnlyPendingByDefault() {
     let model = makeModelWithMixedStatusQuestions()
 
     let filtered = model.filteredQuestions
 
-    XCTAssertEqual(filtered.count, 2)
-    XCTAssertTrue(filtered.allSatisfy { $0.status == .pending })
+    #expect(filtered.count == 2)
+    #expect(filtered.allSatisfy { $0.status == .pending })
   }
 
+  @Test
   func testFilteredQuestionsReturnsOnlyAnsweredWhenFilterIsAnswered() {
     let model = makeModelWithMixedStatusQuestions()
 
     model.selectedFilter = .answered
 
     let filtered = model.filteredQuestions
-    XCTAssertEqual(filtered.count, 1)
-    XCTAssertTrue(filtered.allSatisfy { $0.status == .answered })
+    #expect(filtered.count == 1)
+    #expect(filtered.allSatisfy { $0.status == .answered })
   }
 
+  @Test
   func testFilteredQuestionsReturnsAllExceptDeclinedWhenFilterIsAll() {
     let model = makeModelWithMixedStatusQuestions()
 
     model.selectedFilter = .all
 
     let filtered = model.filteredQuestions
-    XCTAssertEqual(filtered.count, 3)
-    XCTAssertTrue(filtered.allSatisfy { $0.status != .declined })
+    #expect(filtered.count == 3)
+    #expect(filtered.allSatisfy { $0.status != .declined })
   }
 
+  @Test
   func testFilterSelectedUpdatesSelectedFilter() {
     let model = makeModel()
 
     model.filterSelected(.answered)
 
-    XCTAssertEqual(model.selectedFilter, .answered)
+    #expect(model.selectedFilter == .answered)
   }
 
+  @Test
   func testFilterDisplayTextForPending() {
-    XCTAssertEqual(ListenerQuestionFilter.pending.displayText, "Pending")
+    #expect(ListenerQuestionFilter.pending.displayText == "Pending")
   }
 
+  @Test
   func testFilterDisplayTextForAnswered() {
-    XCTAssertEqual(ListenerQuestionFilter.answered.displayText, "Answered")
+    #expect(ListenerQuestionFilter.answered.displayText == "Answered")
   }
 
+  @Test
   func testFilterDisplayTextForAll() {
-    XCTAssertEqual(ListenerQuestionFilter.all.displayText, "All")
+    #expect(ListenerQuestionFilter.all.displayText == "All")
   }
 
   // MARK: - Decline Question Tests
 
+  @Test
   func testDeclineQuestionCallsAPI() async {
     let declineCalled = LockIsolated(false)
     let capturedStationId = LockIsolated<String?>(nil)
@@ -482,11 +519,12 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.declineQuestionSwiped(model.questions[0])
 
-    XCTAssertTrue(declineCalled.value)
-    XCTAssertEqual(capturedStationId.value, testStationId)
-    XCTAssertEqual(capturedQuestionId.value, "q1")
+    #expect(declineCalled.value)
+    #expect(capturedStationId.value == testStationId)
+    #expect(capturedQuestionId.value == "q1")
   }
 
+  @Test
   func testDeclineQuestionUpdatesLocalState() async {
     let declinedQuestion = ListenerQuestion.mockWith(
       id: "q1",
@@ -509,30 +547,34 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.declineQuestionSwiped(model.questions[0])
 
-    XCTAssertEqual(model.questions[id: "q1"]?.status, .declined)
+    #expect(model.questions[id: "q1"]?.status == .declined)
   }
 
+  @Test
   func testCanDeclineReturnsTrueForPendingQuestion() {
     let model = makeModel()
     let pendingQuestion = ListenerQuestion.mockWith(status: .pending)
 
-    XCTAssertTrue(model.canDecline(pendingQuestion))
+    #expect(model.canDecline(pendingQuestion))
   }
 
+  @Test
   func testCanDeclineReturnsFalseForAnsweredQuestion() {
     let model = makeModel()
     let answeredQuestion = ListenerQuestion.mockWith(status: .answered)
 
-    XCTAssertFalse(model.canDecline(answeredQuestion))
+    #expect(!model.canDecline(answeredQuestion))
   }
 
+  @Test
   func testCanDeclineReturnsFalseForDeclinedQuestion() {
     let model = makeModel()
     let declinedQuestion = ListenerQuestion.mockWith(status: .declined)
 
-    XCTAssertFalse(model.canDecline(declinedQuestion))
+    #expect(!model.canDecline(declinedQuestion))
   }
 
+  @Test
   func testDeclineQuestionShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(currentUser: nil, jwt: testJwt)
 
@@ -551,7 +593,7 @@ final class BroadcastersListenerQuestionPageTests: XCTestCase {
 
     await model.declineQuestionSwiped(model.questions[0])
 
-    XCTAssertNotNil(model.presentedAlert)
+    #expect(model.presentedAlert != nil)
   }
 
   // MARK: - Test Helpers

--- a/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageTests.swift
@@ -3,13 +3,15 @@
 //  PlayolaRadio
 //
 
+import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class ChooseStationPageTests: XCTestCase {
+struct ChooseStationPageTests {
+  @Test
   func testInitStoresStations() {
     let stations = [
       Station.mockWith(id: "station-1", name: "First Station"),
@@ -22,12 +24,13 @@ final class ChooseStationPageTests: XCTestCase {
       onStationSelected: { selectedStation = $0 }
     )
 
-    XCTAssertEqual(model.stations.count, 2)
-    XCTAssertEqual(model.stations[0].id, "station-1")
-    XCTAssertEqual(model.stations[1].id, "station-2")
-    XCTAssertNil(selectedStation)
+    #expect(model.stations.count == 2)
+    #expect(model.stations[0].id == "station-1")
+    #expect(model.stations[1].id == "station-2")
+    #expect(selectedStation == nil)
   }
 
+  @Test
   func testSortedStationsSortsByCuratorName() {
     let stations = [
       Station.mockWith(id: "station-z", curatorName: "Zack"),
@@ -40,11 +43,12 @@ final class ChooseStationPageTests: XCTestCase {
       onStationSelected: { _ in }
     )
 
-    XCTAssertEqual(model.sortedStations[0].curatorName, "Alice")
-    XCTAssertEqual(model.sortedStations[1].curatorName, "Mike")
-    XCTAssertEqual(model.sortedStations[2].curatorName, "Zack")
+    #expect(model.sortedStations[0].curatorName == "Alice")
+    #expect(model.sortedStations[1].curatorName == "Mike")
+    #expect(model.sortedStations[2].curatorName == "Zack")
   }
 
+  @Test
   func testSortedStationsFiltersOutInactiveStations() {
     let stations = [
       Station.mockWith(id: "active-1", curatorName: "Alice", active: true),
@@ -58,13 +62,14 @@ final class ChooseStationPageTests: XCTestCase {
       onStationSelected: { _ in }
     )
 
-    XCTAssertEqual(model.sortedStations.count, 3)
-    XCTAssertFalse(model.sortedStations.contains { $0.id == "inactive-1" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "active-1" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "active-2" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "nil-active" })
+    #expect(model.sortedStations.count == 3)
+    #expect(!model.sortedStations.contains { $0.id == "inactive-1" })
+    #expect(model.sortedStations.contains { $0.id == "active-1" })
+    #expect(model.sortedStations.contains { $0.id == "active-2" })
+    #expect(model.sortedStations.contains { $0.id == "nil-active" })
   }
 
+  @Test
   func testStationTappedCallsCallback() {
     let station = Station.mockWith(id: "station-123", curatorName: "Test Curator")
     var selectedStation: Station?
@@ -76,16 +81,17 @@ final class ChooseStationPageTests: XCTestCase {
 
     model.stationTapped(station)
 
-    XCTAssertEqual(selectedStation?.id, "station-123")
+    #expect(selectedStation?.id == "station-123")
   }
 
+  @Test
   func testEmptyStationsList() {
     let model = ChooseStationPageModel(
       stations: [],
       onStationSelected: { _ in }
     )
 
-    XCTAssertTrue(model.stations.isEmpty)
-    XCTAssertTrue(model.sortedStations.isEmpty)
+    #expect(model.stations.isEmpty)
+    #expect(model.sortedStations.isEmpty)
   }
 }

--- a/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
@@ -62,6 +62,9 @@ struct ChooseStationToBroadcastPageTests {
 
   @Test
   func testStationSelectedSwitchesToBroadcastMode() {
+    @Shared(.mainContainerNavigationCoordinator)
+    var coordinator = MainContainerNavigationCoordinator()
+
     let stations = [
       Station.mockWith(id: "station-1", name: "First Station"),
       Station.mockWith(id: "station-2", name: "Second Station"),

--- a/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
@@ -6,15 +6,17 @@
 //
 
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class ChooseStationToBroadcastPageTests: XCTestCase {
-  func testInit_StoresStationsList() {
+struct ChooseStationToBroadcastPageTests {
+  @Test
+  func testInitStoresStationsList() {
     let stations = [
       Station.mockWith(id: "station-1", name: "First Station"),
       Station.mockWith(id: "station-2", name: "Second Station"),
@@ -22,18 +24,20 @@ final class ChooseStationToBroadcastPageTests: XCTestCase {
 
     let model = ChooseStationToBroadcastPageModel(stations: stations)
 
-    XCTAssertEqual(model.stations.count, 2)
-    XCTAssertEqual(model.stations[0].id, "station-1")
-    XCTAssertEqual(model.stations[1].id, "station-2")
+    #expect(model.stations.count == 2)
+    #expect(model.stations[0].id == "station-1")
+    #expect(model.stations[1].id == "station-2")
   }
 
-  func testInit_WithEmptyStationsList() {
+  @Test
+  func testInitWithEmptyStationsList() {
     let model = ChooseStationToBroadcastPageModel(stations: [])
 
-    XCTAssertTrue(model.stations.isEmpty)
+    #expect(model.stations.isEmpty)
   }
 
-  func testStations_AreSortedByCuratorName() {
+  @Test
+  func testStationsAreSortedByCuratorName() {
     let stations = [
       Station.mockWith(id: "station-z", name: "Z Station", curatorName: "Zack"),
       Station.mockWith(id: "station-a", name: "A Station", curatorName: "Alice"),
@@ -42,20 +46,22 @@ final class ChooseStationToBroadcastPageTests: XCTestCase {
 
     let model = ChooseStationToBroadcastPageModel(stations: stations)
 
-    XCTAssertEqual(model.sortedStations[0].curatorName, "Alice")
-    XCTAssertEqual(model.sortedStations[1].curatorName, "Mike")
-    XCTAssertEqual(model.sortedStations[2].curatorName, "Zack")
+    #expect(model.sortedStations[0].curatorName == "Alice")
+    #expect(model.sortedStations[1].curatorName == "Mike")
+    #expect(model.sortedStations[2].curatorName == "Zack")
   }
 
-  func testDisplayName_ReturnsCuratorNameDashName() {
+  @Test
+  func testDisplayNameReturnsCuratorNameDashName() {
     let station = Station.mockWith(id: "test", name: "Cool Station", curatorName: "DJ Awesome")
 
     let model = ChooseStationToBroadcastPageModel(stations: [station])
 
-    XCTAssertEqual(model.displayName(for: station), "DJ Awesome - Cool Station")
+    #expect(model.displayName(for: station) == "DJ Awesome - Cool Station")
   }
 
-  func testStationSelected_SwitchesToBroadcastMode() {
+  @Test
+  func testStationSelectedSwitchesToBroadcastMode() {
     let stations = [
       Station.mockWith(id: "station-1", name: "First Station"),
       Station.mockWith(id: "station-2", name: "Second Station"),
@@ -63,18 +69,18 @@ final class ChooseStationToBroadcastPageTests: XCTestCase {
 
     let model = ChooseStationToBroadcastPageModel(stations: stations)
 
-    XCTAssertEqual(model.mainContainerNavigationCoordinator.appMode, .listening)
+    #expect(model.mainContainerNavigationCoordinator.appMode == .listening)
 
     model.stationSelected(stations[1])
 
-    XCTAssertEqual(
-      model.mainContainerNavigationCoordinator.appMode,
-      .broadcasting(stationId: "station-2")
-    )
-    XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+    #expect(
+      model.mainContainerNavigationCoordinator.appMode
+        == .broadcasting(stationId: "station-2"))
+    #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
   }
 
-  func testSortedStations_FiltersOutInactiveStations() {
+  @Test
+  func testSortedStationsFiltersOutInactiveStations() {
     let stations = [
       Station.mockWith(id: "active-1", name: "Active Station", curatorName: "Alice", active: true),
       Station.mockWith(
@@ -87,10 +93,10 @@ final class ChooseStationToBroadcastPageTests: XCTestCase {
 
     let model = ChooseStationToBroadcastPageModel(stations: stations)
 
-    XCTAssertEqual(model.sortedStations.count, 3)
-    XCTAssertFalse(model.sortedStations.contains { $0.id == "inactive-1" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "active-1" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "active-2" })
-    XCTAssertTrue(model.sortedStations.contains { $0.id == "nil-active" })
+    #expect(model.sortedStations.count == 3)
+    #expect(!model.sortedStations.contains { $0.id == "inactive-1" })
+    #expect(model.sortedStations.contains { $0.id == "active-1" })
+    #expect(model.sortedStations.contains { $0.id == "active-2" })
+    #expect(model.sortedStations.contains { $0.id == "nil-active" })
   }
 }

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -14,13 +14,21 @@ import SwiftUI
 @MainActor
 @Observable
 class ContactPageModel: ViewModel {
+  // MARK: - Dependencies
+
+  @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
+
+  // MARK: - Shared State
+
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.stationLists) var stationLists
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
-  @ObservationIgnored @Dependency(\.api) var api
-  @ObservationIgnored @Dependency(\.analytics) var analytics
+
+  // MARK: - Properties
+
   var editProfilePageModel: EditProfilePageModel = EditProfilePageModel()
   var likedSongsPageModel: LikedSongsPageModel = LikedSongsPageModel()
   var notificationsSettingsPageModel: NotificationsSettingsPageModel =

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -14,7 +14,7 @@ import SwiftUI
 @MainActor
 @Observable
 class ContactPageModel: ViewModel {
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.stationLists) var stationLists
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
@@ -66,12 +66,6 @@ class ContactPageModel: ViewModel {
 
   func switchToListeningMode() {
     mainContainerNavigationCoordinator.switchToListeningMode()
-  }
-
-  init(
-    stationPlayer: StationPlayer? = nil
-  ) {
-    self.stationPlayer = stationPlayer ?? .shared
   }
 
   func onViewAppeared() async {

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -42,8 +42,9 @@ struct ContactPageTests {
       }
       $0.analytics = .noop
       $0.analytics.reset = { resetCallCount.withValue { $0 += 1 } }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      await ContactPageModel(stationPlayer: stationPlayerMock).onLogOutTapped()
+      await ContactPageModel().onLogOutTapped()
     }
 
     #expect(stationPlayerMock.stopCalledCount == 1)
@@ -485,8 +486,9 @@ struct ContactPageTests {
     await withDependencies {
       $0.api.unregisterDevice = { _, _ in }
       $0.analytics = .noop
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      let model = ContactPageModel(stationPlayer: stationPlayerMock)
+      let model = ContactPageModel()
       await model.onLogOutTapped()
     }
 
@@ -508,7 +510,7 @@ struct ContactPageTests {
       }
       $0.analytics = .noop
     } operation: {
-      let model = ContactPageModel(stationPlayer: StationPlayerMock())
+      let model = ContactPageModel()
       await model.onLogOutTapped()
     }
 
@@ -527,7 +529,7 @@ struct ContactPageTests {
       $0.api.unregisterDevice = { _, _ in throw UnregisterError() }
       $0.analytics = .noop
     } operation: {
-      let model = ContactPageModel(stationPlayer: StationPlayerMock())
+      let model = ContactPageModel()
       await model.onLogOutTapped()
     }
 

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -6,20 +6,17 @@
 //
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class ContactPageTests: XCTestCase {
-  override static func setUp() {
-    super.setUp()
-    @Shared(.auth) var auth
-  }
-
+struct ContactPageTests {
+  @Test
   func testOnLogOutTappedStopsPlayerAndClearsAllUserState() async {
     let audioBlock = AudioBlock.mock
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
@@ -49,22 +46,23 @@ final class ContactPageTests: XCTestCase {
       await ContactPageModel(stationPlayer: stationPlayerMock).onLogOutTapped()
     }
 
-    XCTAssertEqual(stationPlayerMock.stopCalledCount, 1)
-    XCTAssertEqual(unregisterCalls.value.count, 1)
-    XCTAssertEqual(unregisterCalls.value.first?.0, "test-jwt")
-    XCTAssertEqual(unregisterCalls.value.first?.1, "device-xyz")
-    XCTAssertEqual(resetCallCount.value, 1)
-    XCTAssertFalse(auth.isLoggedIn)
-    XCTAssertNil(registeredDeviceId)
-    XCTAssertTrue(userLikes.isEmpty)
-    XCTAssertTrue(pendingLikeOperations.isEmpty)
-    XCTAssertTrue(airings.isEmpty)
-    XCTAssertTrue(lastNotificationSentAt.isEmpty)
-    XCTAssertFalse(isBroadcaster)
-    XCTAssertNil(UserDefaults.standard.object(forKey: "analytics_session_paused_at"))
+    #expect(stationPlayerMock.stopCalledCount == 1)
+    #expect(unregisterCalls.value.count == 1)
+    #expect(unregisterCalls.value.first?.0 == "test-jwt")
+    #expect(unregisterCalls.value.first?.1 == "device-xyz")
+    #expect(resetCallCount.value == 1)
+    #expect(!auth.isLoggedIn)
+    #expect(registeredDeviceId == nil)
+    #expect(userLikes.isEmpty)
+    #expect(pendingLikeOperations.isEmpty)
+    #expect(airings.isEmpty)
+    #expect(lastNotificationSentAt.isEmpty)
+    #expect(!isBroadcaster)
+    #expect(UserDefaults.standard.object(forKey: "analytics_session_paused_at") == nil)
   }
 
-  func testNameDisplay_ReturnsFullNameWhenLoggedIn() {
+  @Test
+  func testNameDisplayReturnsFullNameWhenLoggedIn() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "Jane",
@@ -76,18 +74,20 @@ final class ContactPageTests: XCTestCase {
 
     let model = ContactPageModel()
 
-    XCTAssertEqual(model.name, "Jane Smith")
+    #expect(model.name == "Jane Smith")
   }
 
-  func testNameDisplay_ReturnsAnonymousWhenNotLoggedIn() {
+  @Test
+  func testNameDisplayReturnsAnonymousWhenNotLoggedIn() {
     @Shared(.auth) var auth = Auth()
 
     let model = ContactPageModel()
 
-    XCTAssertEqual(model.name, "Anonymous")
+    #expect(model.name == "Anonymous")
   }
 
-  func testEmailDisplay_ReturnsEmailWhenLoggedIn() {
+  @Test
+  func testEmailDisplayReturnsEmailWhenLoggedIn() {
     let loggedInUser = LoggedInUser(
       id: "456",
       firstName: "Bob",
@@ -99,59 +99,62 @@ final class ContactPageTests: XCTestCase {
 
     let model = ContactPageModel()
 
-    XCTAssertEqual(model.email, "bob@test.com")
+    #expect(model.email == "bob@test.com")
   }
 
-  func testEmailDisplay_ReturnsUnknownWhenNotLoggedIn() {
+  @Test
+  func testEmailDisplayReturnsUnknownWhenNotLoggedIn() {
     @Shared(.auth) var auth = Auth()
 
     let model = ContactPageModel()
 
-    XCTAssertEqual(model.email, "Unknown")
+    #expect(model.email == "Unknown")
   }
 
-  func testOnLikedSongsTapped_NavigatesToLikedSongsPage() {
+  @Test
+  func testOnLikedSongsTappedNavigatesToLikedSongsPage() {
     let model = ContactPageModel()
 
     // Verify initial navigation state
-    XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+    #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
 
     // Tap liked songs button
     model.onLikedSongsTapped()
 
     // Verify navigation occurred
-    XCTAssertEqual(model.mainContainerNavigationCoordinator.path.count, 1)
+    #expect(model.mainContainerNavigationCoordinator.path.count == 1)
 
     if case .likedSongsPage = model.mainContainerNavigationCoordinator.path.first {
       // Successfully navigated to liked songs page
     } else {
-      XCTFail("Expected navigation to liked songs page")
+      Issue.record("Expected navigation to liked songs page")
     }
   }
 
-  func testOnNotificationsTapped_NavigatesToNotificationsSettingsPage() {
+  @Test
+  func testOnNotificationsTappedNavigatesToNotificationsSettingsPage() {
     let model = ContactPageModel()
 
     // Verify initial navigation state
-    XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+    #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
 
     // Tap notifications button
     model.onNotificationsTapped()
 
     // Verify navigation occurred
-    XCTAssertEqual(model.mainContainerNavigationCoordinator.path.count, 1)
+    #expect(model.mainContainerNavigationCoordinator.path.count == 1)
 
     if case .notificationsSettingsPage = model.mainContainerNavigationCoordinator.path.first {
       // Successfully navigated to notifications settings page
     } else {
-      XCTFail("Expected navigation to notifications settings page")
+      Issue.record("Expected navigation to notifications settings page")
     }
   }
 
-  func testOnMyStationTapped_SwitchesToBroadcastMode() async {
+  @Test
+  func testOnMyStationTappedSwitchesToBroadcastMode() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     await withMainSerialExecutor {
-      @Shared(.auth) var auth
-      $auth.withLock { $0 = Auth(jwt: "test-jwt") }
       let mockStations = [Station.mockWith(id: "test-station-id")]
 
       await withDependencies {
@@ -162,31 +165,33 @@ final class ContactPageTests: XCTestCase {
 
         await model.onViewAppeared()
 
-        XCTAssertEqual(model.mainContainerNavigationCoordinator.appMode, .listening)
+        #expect(model.mainContainerNavigationCoordinator.appMode == .listening)
 
         await model.onMyStationTapped()
 
-        XCTAssertEqual(
-          model.mainContainerNavigationCoordinator.appMode,
-          .broadcasting(stationId: "test-station-id")
+        #expect(
+          model.mainContainerNavigationCoordinator.appMode
+            == .broadcasting(stationId: "test-station-id")
         )
-        XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+        #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
       }
     }
   }
 
   // MARK: - My Station Button Visibility Tests
 
-  func testMyStationButtonVisible_IsFalseInitially() {
+  @Test
+  func testMyStationButtonVisibleIsFalseInitially() {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
     let model = ContactPageModel()
 
-    XCTAssertFalse(model.myStationButtonVisible)
-    XCTAssertNil(model.stationIdToTransitionTo)
+    #expect(!model.myStationButtonVisible)
+    #expect(model.stationIdToTransitionTo == nil)
   }
 
-  func testMyStationButtonVisible_IsFalseWhenUserHasNoStations() async {
+  @Test
+  func testMyStationButtonVisibleIsFalseWhenUserHasNoStations() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
     await withDependencies {
@@ -196,12 +201,13 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertFalse(model.myStationButtonVisible)
-      XCTAssertNil(model.stationIdToTransitionTo)
+      #expect(!model.myStationButtonVisible)
+      #expect(model.stationIdToTransitionTo == nil)
     }
   }
 
-  func testMyStationButtonVisible_IsTrueWhenUserHasStations() async {
+  @Test
+  func testMyStationButtonVisibleIsTrueWhenUserHasStations() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-1", name: "First Station"),
@@ -215,12 +221,13 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertTrue(model.myStationButtonVisible)
-      XCTAssertEqual(model.stationIdToTransitionTo, "station-1")
+      #expect(model.myStationButtonVisible)
+      #expect(model.stationIdToTransitionTo == "station-1")
     }
   }
 
-  func testStationIdToTransitionTo_IsFirstStationId() async {
+  @Test
+  func testStationIdToTransitionToIsFirstStationId() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "first-station-id", name: "First Station"),
@@ -235,11 +242,12 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertEqual(model.stationIdToTransitionTo, "first-station-id")
+      #expect(model.stationIdToTransitionTo == "first-station-id")
     }
   }
 
-  func testOnMyStationTapped_WithSingleStation_SwitchesToBroadcastMode() async {
+  @Test
+  func testOnMyStationTappedWithSingleStationSwitchesToBroadcastMode() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "single-station-id", name: "My Only Station")
@@ -253,15 +261,16 @@ final class ContactPageTests: XCTestCase {
       await model.onViewAppeared()
       await model.onMyStationTapped()
 
-      XCTAssertEqual(
-        model.mainContainerNavigationCoordinator.appMode,
-        .broadcasting(stationId: "single-station-id")
+      #expect(
+        model.mainContainerNavigationCoordinator.appMode
+          == .broadcasting(stationId: "single-station-id")
       )
-      XCTAssertTrue(model.mainContainerNavigationCoordinator.path.isEmpty)
+      #expect(model.mainContainerNavigationCoordinator.path.isEmpty)
     }
   }
 
-  func testOnMyStationTapped_WithMultipleStations_NavigatesToChooseStationPage() async {
+  @Test
+  func testOnMyStationTappedWithMultipleStationsNavigatesToChooseStationPage() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-1", name: "First Station"),
@@ -277,23 +286,24 @@ final class ContactPageTests: XCTestCase {
       await model.onViewAppeared()
       await model.onMyStationTapped()
 
-      XCTAssertEqual(model.mainContainerNavigationCoordinator.path.count, 1)
+      #expect(model.mainContainerNavigationCoordinator.path.count == 1)
 
       if case .chooseStationToBroadcastPage(let chooseModel) = model
         .mainContainerNavigationCoordinator
         .path.first
       {
-        XCTAssertEqual(chooseModel.stations.count, 3)
-        XCTAssertEqual(chooseModel.stations[0].id, "station-1")
-        XCTAssertEqual(chooseModel.stations[1].id, "station-2")
-        XCTAssertEqual(chooseModel.stations[2].id, "station-3")
+        #expect(chooseModel.stations.count == 3)
+        #expect(chooseModel.stations[0].id == "station-1")
+        #expect(chooseModel.stations[1].id == "station-2")
+        #expect(chooseModel.stations[2].id == "station-3")
       } else {
-        XCTFail("Expected navigation to choose station page")
+        Issue.record("Expected navigation to choose station page")
       }
     }
   }
 
-  func testOnMyStationTapped_WithTwoStations_NavigatesToChooseStationPage() async {
+  @Test
+  func testOnMyStationTappedWithTwoStationsNavigatesToChooseStationPage() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-a", name: "Station A"),
@@ -308,22 +318,23 @@ final class ContactPageTests: XCTestCase {
       await model.onViewAppeared()
       await model.onMyStationTapped()
 
-      XCTAssertEqual(model.mainContainerNavigationCoordinator.path.count, 1)
+      #expect(model.mainContainerNavigationCoordinator.path.count == 1)
 
       if case .chooseStationToBroadcastPage(let chooseModel) = model
         .mainContainerNavigationCoordinator
         .path.first
       {
-        XCTAssertEqual(chooseModel.stations.count, 2)
+        #expect(chooseModel.stations.count == 2)
       } else {
-        XCTFail("Expected navigation to choose station page")
+        Issue.record("Expected navigation to choose station page")
       }
     }
   }
 
   // MARK: - My Station Button Label Tests
 
-  func testMyStationButtonLabel_ReturnsSingularWhenOneStation() async {
+  @Test
+  func testMyStationButtonLabelReturnsSingularWhenOneStation() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [Station.mockWith(id: "station-1", name: "My Only Station")]
 
@@ -334,11 +345,12 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertEqual(model.myStationButtonLabel, "My Station")
+      #expect(model.myStationButtonLabel == "My Station")
     }
   }
 
-  func testMyStationButtonLabel_ReturnsPluralWhenMultipleStations() async {
+  @Test
+  func testMyStationButtonLabelReturnsPluralWhenMultipleStations() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-1", name: "First Station"),
@@ -352,13 +364,14 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertEqual(model.myStationButtonLabel, "My Stations")
+      #expect(model.myStationButtonLabel == "My Stations")
     }
   }
 
   // MARK: - Analytics Tests
 
-  func testOnMyStationTapped_WithSingleStation_TracksAnalyticsEvent() async {
+  @Test
+  func testOnMyStationTappedWithSingleStationTracksAnalyticsEvent() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStation = Station.mockWith(id: "my-station-id", name: "My Station")
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
@@ -381,11 +394,12 @@ final class ContactPageTests: XCTestCase {
         }
         return false
       }
-      XCTAssertTrue(hasViewedBroadcastEvent)
+      #expect(hasViewedBroadcastEvent)
     }
   }
 
-  func testOnMyStationTapped_WithMultipleStations_DoesNotTrackAnalyticsEvent() async {
+  @Test
+  func testOnMyStationTappedWithMultipleStationsDoesNotTrackAnalyticsEvent() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let mockStations = [
       Station.mockWith(id: "station-1", name: "Station 1"),
@@ -411,12 +425,13 @@ final class ContactPageTests: XCTestCase {
         }
         return false
       }
-      XCTAssertFalse(hasViewedBroadcastEvent)
+      #expect(!hasViewedBroadcastEvent)
     }
   }
 
   // MARK: - Broadcast Mode Tests
 
+  @Test
   func testIsInBroadcastModeReturnsFalseWhenListening() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -424,9 +439,10 @@ final class ContactPageTests: XCTestCase {
 
     let model = ContactPageModel()
 
-    XCTAssertFalse(model.isInBroadcastMode)
+    #expect(!model.isInBroadcastMode)
   }
 
+  @Test
   func testIsInBroadcastModeReturnsTrueWhenBroadcasting() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -434,9 +450,10 @@ final class ContactPageTests: XCTestCase {
 
     let model = ContactPageModel()
 
-    XCTAssertTrue(model.isInBroadcastMode)
+    #expect(model.isInBroadcastMode)
   }
 
+  @Test
   func testSwitchToListeningModeSwitchesMode() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -445,9 +462,10 @@ final class ContactPageTests: XCTestCase {
     let model = ContactPageModel()
     model.switchToListeningMode()
 
-    XCTAssertEqual(coordinator.appMode, .listening)
+    #expect(coordinator.appMode == .listening)
   }
 
+  @Test
   func testLogoutResetsAppModeToListening() async {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -472,11 +490,12 @@ final class ContactPageTests: XCTestCase {
       await model.onLogOutTapped()
     }
 
-    XCTAssertEqual(coordinator.appMode, .listening)
+    #expect(coordinator.appMode == .listening)
   }
 
   // MARK: - Sign Out Edge Cases
 
+  @Test
   func testOnLogOutTappedSkipsServerCallWhenDeviceNotRegistered() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt-abc")
     @Shared(.registeredDeviceId) var registeredDeviceId = String?.none
@@ -493,10 +512,11 @@ final class ContactPageTests: XCTestCase {
       await model.onLogOutTapped()
     }
 
-    XCTAssertEqual(unregisterCallCount.value, 0)
-    XCTAssertFalse(auth.isLoggedIn)
+    #expect(unregisterCallCount.value == 0)
+    #expect(!auth.isLoggedIn)
   }
 
+  @Test
   func testOnLogOutTappedStillClearsLocalStateWhenServerCallFails() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt-abc")
     @Shared(.registeredDeviceId) var registeredDeviceId = "device-xyz"
@@ -511,10 +531,11 @@ final class ContactPageTests: XCTestCase {
       await model.onLogOutTapped()
     }
 
-    XCTAssertFalse(auth.isLoggedIn)
-    XCTAssertNil(registeredDeviceId)
+    #expect(!auth.isLoggedIn)
+    #expect(registeredDeviceId == nil)
   }
 
+  @Test
   func testMyStationButtonHiddenWhenInBroadcastMode() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.mainContainerNavigationCoordinator)
@@ -530,7 +551,7 @@ final class ContactPageTests: XCTestCase {
 
       await model.onViewAppeared()
 
-      XCTAssertFalse(model.myStationButtonVisible)
+      #expect(!model.myStationButtonVisible)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -24,12 +24,17 @@ struct ContentView: View {
   @State private var hasTrackedAppOpen = false
   @State private var requiresUpdate = false
 
+  @Dependency(\.stationPlayer) private var stationPlayer
+  @Dependency(\.nowPlayingUpdater) private var nowPlayingUpdater
+
   var mainContainerModel = MainContainerModel()
 
   init() {
-    // Ensure StationPlayer and NowPlayingUpdater are initialized early
-    _ = StationPlayer.shared
-    _ = NowPlayingUpdater.shared
+    // Resolve audio playback dependencies eagerly so the live singletons are
+    // wired (state sinks, FRadioPlayer observers, remote-control center) by
+    // the time the first view appears.
+    _ = stationPlayer
+    _ = nowPlayingUpdater
   }
 
   private let appStoreURL = URL(

--- a/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageTests.swift
+++ b/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageTests.swift
@@ -6,14 +6,16 @@
 //
 
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class EditProfilePageTests: XCTestCase {
-  func testInit_WithLoggedInUser_SetsInitialValues() async {
+struct EditProfilePageTests {
+  @Test
+  func testInitWithLoggedInUserSetsInitialValues() async {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -26,46 +28,43 @@ final class EditProfilePageTests: XCTestCase {
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    XCTAssertEqual(model.firstName, "John")
-    XCTAssertEqual(model.lastName, "Doe")
-    XCTAssertEqual(model.email, "john@example.com")
+    #expect(model.firstName == "John")
+    #expect(model.lastName == "Doe")
+    #expect(model.email == "john@example.com")
   }
 
-  func testInit_WithNoLoggedInUser_SetsEmptyValues() {
+  @Test
+  func testInitWithNoLoggedInUserSetsEmptyValues() {
     @Shared(.auth) var auth = Auth()
 
-    // When: Creating the model
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    // Then: Model should be initialized with empty values
-    XCTAssertEqual(model.firstName, "")
-    XCTAssertEqual(model.lastName, "")
-    XCTAssertEqual(model.email, "")
+    #expect(model.firstName == "")
+    #expect(model.lastName == "")
+    #expect(model.email == "")
   }
 
-  func testInit_WithPartialUserData_SetsAvailableValues() {
-    // Given: A logged in user with only some profile data
+  @Test
+  func testInitWithPartialUserDataSetsAvailableValues() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "Jane",
-      lastName: nil,  // No last name
+      lastName: nil,
       email: "jane@example.com"
     )
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-    // When: Creating the model
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    // Then: Model should be initialized with available data
-    XCTAssertEqual(model.firstName, "Jane")
-    XCTAssertEqual(model.lastName, "")
-    XCTAssertEqual(model.email, "jane@example.com")
+    #expect(model.firstName == "Jane")
+    #expect(model.lastName == "")
+    #expect(model.email == "jane@example.com")
   }
 
-  func testSaveButtonEnabled_NoChanges_ReturnsFalse() {
-    // Given: A logged in user
+  @Test
+  func testSaveButtonEnabledNoChangesReturnsFalse() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -74,16 +73,14 @@ final class EditProfilePageTests: XCTestCase {
     )
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-    // When: Creating the model with no changes
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    // Then: Save button should be disabled
-    XCTAssertFalse(model.isSaveButtonEnabled)
+    #expect(!model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_FirstNameChanged_ReturnsTrue() {
-    // Given: A logged in user
+  @Test
+  func testSaveButtonEnabledFirstNameChangedReturnsTrue() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -92,16 +89,15 @@ final class EditProfilePageTests: XCTestCase {
     )
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
 
-    // When: Creating the model and changing firstName
     let model = EditProfilePageModel()
     model.viewAppeared()
     model.firstName = "Jane"
 
-    // Then: Save button should be enabled
-    XCTAssertTrue(model.isSaveButtonEnabled)
+    #expect(model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_LastNameChanged_ReturnsTrue() {
+  @Test
+  func testSaveButtonEnabledLastNameChangedReturnsTrue() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -114,10 +110,11 @@ final class EditProfilePageTests: XCTestCase {
     model.viewAppeared()
     model.lastName = "Smith"
 
-    XCTAssertTrue(model.isSaveButtonEnabled)
+    #expect(model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_LastNameNilToEmpty_ReturnsFalse() {
+  @Test
+  func testSaveButtonEnabledLastNameNilToEmptyReturnsFalse() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -129,10 +126,11 @@ final class EditProfilePageTests: XCTestCase {
     let model = EditProfilePageModel()
     model.viewAppeared()
 
-    XCTAssertFalse(model.isSaveButtonEnabled)
+    #expect(!model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_LastNameEmptyToValue_ReturnsTrue() {
+  @Test
+  func testSaveButtonEnabledLastNameEmptyToValueReturnsTrue() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -145,10 +143,11 @@ final class EditProfilePageTests: XCTestCase {
     model.viewAppeared()
     model.lastName = "Doe"
 
-    XCTAssertTrue(model.isSaveButtonEnabled)
+    #expect(model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonEnabled_RevertChanges_ReturnsFalse() {
+  @Test
+  func testSaveButtonEnabledRevertChangesReturnsFalse() {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -160,14 +159,15 @@ final class EditProfilePageTests: XCTestCase {
     let model = EditProfilePageModel()
     model.viewAppeared()
     model.firstName = "Jane"
-    XCTAssertTrue(model.isSaveButtonEnabled)  // Should be enabled after change
+    #expect(model.isSaveButtonEnabled)
 
-    model.firstName = "John"  // Revert back
+    model.firstName = "John"
 
-    XCTAssertFalse(model.isSaveButtonEnabled)
+    #expect(!model.isSaveButtonEnabled)
   }
 
-  func testSaveButtonTapped_UpdateUserIsSuccessful() async {
+  @Test
+  func testSaveButtonTappedUpdateUserIsSuccessful() async {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -187,9 +187,9 @@ final class EditProfilePageTests: XCTestCase {
 
     let model = withDependencies {
       $0.api.updateUser = { jwtToken, firstName, lastName, _ in
-        XCTAssertEqual(jwtToken, expectedJwt)
-        XCTAssertEqual(firstName, "Joe")
-        XCTAssertEqual(lastName, "Jones")
+        #expect(jwtToken == expectedJwt)
+        #expect(firstName == "Joe")
+        #expect(lastName == "Jones")
         return expectedAuth
       }
       $0.continuousClock = ImmediateClock()
@@ -203,14 +203,15 @@ final class EditProfilePageTests: XCTestCase {
 
     await model.saveButtonTapped()
 
-    XCTAssertEqual(auth.currentUser?.firstName, "Jane")
-    XCTAssertEqual(auth.currentUser?.lastName, "Smith")
-    XCTAssertEqual(auth.jwt, "new-jwt-token")
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert, PlayolaAlert.updateProfileSuccessfullAlert)
+    #expect(auth.currentUser?.firstName == "Jane")
+    #expect(auth.currentUser?.lastName == "Smith")
+    #expect(auth.jwt == "new-jwt-token")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert == PlayolaAlert.updateProfileSuccessfullAlert)
   }
 
-  func testSaveButtonTapped_UpdateUserFails() async {
+  @Test
+  func testSaveButtonTappedUpdateUserFails() async {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -234,17 +235,16 @@ final class EditProfilePageTests: XCTestCase {
 
     await model.saveButtonTapped()
 
-    // Auth should remain unchanged on error
-    XCTAssertEqual(auth.currentUser?.firstName, "John")
-    XCTAssertEqual(auth.currentUser?.lastName, "Doe")
-    XCTAssertEqual(auth.jwt, loggedInUser.jwt)
+    #expect(auth.currentUser?.firstName == "John")
+    #expect(auth.currentUser?.lastName == "Doe")
+    #expect(auth.jwt == loggedInUser.jwt)
 
-    // Error alert should be presented
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert, PlayolaAlert.updateProfileErrorAlert)
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert == PlayolaAlert.updateProfileErrorAlert)
   }
 
-  func testSaveButtonTapped_NavigationPopsAfterSuccess() async {
+  @Test
+  func testSaveButtonTappedNavigationPopsAfterSuccess() async {
     let loggedInUser = LoggedInUser(
       id: "123",
       firstName: "John",
@@ -252,9 +252,9 @@ final class EditProfilePageTests: XCTestCase {
       email: "john@example.com"
     )
     @Shared(.auth) var auth = Auth(loggedInUser: loggedInUser)
-    @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator
+    @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
+      MainContainerNavigationCoordinator()
 
-    // Clear navigation and add a test path
     navigationCoordinator.popToRoot()
 
     let updatedUser = LoggedInUser(
@@ -274,9 +274,8 @@ final class EditProfilePageTests: XCTestCase {
       EditProfilePageModel()
     }
 
-    // Add the model to the navigation stack
     navigationCoordinator.push(.editProfilePage(model))
-    XCTAssertEqual(navigationCoordinator.path.count, 1)
+    #expect(navigationCoordinator.path.count == 1)
 
     model.viewAppeared()
     model.firstName = "Jane"
@@ -284,10 +283,8 @@ final class EditProfilePageTests: XCTestCase {
 
     await model.saveButtonTapped()
 
-    // Verify navigation was popped
-    XCTAssertEqual(navigationCoordinator.path.count, 0)
+    #expect(navigationCoordinator.path.count == 0)
 
-    // Clean up
     navigationCoordinator.popToRoot()
   }
 }

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -19,7 +19,7 @@ class HomePageModel: ViewModel {
   @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored @Dependency(\.date.now) var now
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
   // MARK: - Shared State
 
@@ -33,12 +33,6 @@ class HomePageModel: ViewModel {
   var mainContainerNavigationCoordinator
   @ObservationIgnored @Shared(.unreadSupportCount) var unreadSupportCount
   @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
-
-  // MARK: - Initialization
-
-  init(stationPlayer: StationPlayer? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
-  }
 
   // MARK: - Properties
 

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -170,7 +170,7 @@ class HomePageModel: ViewModel {
         station: StationInfo(from: station),
         entryPoint: "home_recommendations"
       ))
-    stationPlayer.play(station: station)
+    await stationPlayer.play(station: station)
   }
 
   // MARK: - View Helpers

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -5,8 +5,6 @@
 //  Created by Brian D Keane on 6/10/25.
 //
 
-// swiftlint:disable force_try
-
 import ConcurrencyExtras
 import Dependencies
 import Foundation
@@ -682,5 +680,3 @@ struct HomePageTests {
   }
 
 }
-
-// swiftlint:enable force_try

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -9,29 +9,71 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
+// Helper function to create valid JWT tokens for testing
+private func createTestJWT(
+  id: String = "test-user-123",
+  firstName: String = "John",
+  lastName: String? = "Doe",
+  email: String = "john@example.com",
+  profileImageUrl: String? = nil,
+  role: String = "user"
+) -> String {
+  let header = ["alg": "HS256", "typ": "JWT"]
+  var payload: [String: Any] = [
+    "id": id,
+    "firstName": firstName,
+    "email": email,
+    "role": role,
+  ]
+  if let lastName = lastName {
+    payload["lastName"] = lastName
+  }
+  if let profileImageUrl = profileImageUrl {
+    payload["profileImageUrl"] = profileImageUrl
+  }
+
+  let headerData = try! JSONSerialization.data(withJSONObject: header)
+  let payloadData = try! JSONSerialization.data(withJSONObject: payload)
+
+  let headerString = headerData.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+
+  let payloadString = payloadData.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+
+  return "\(headerString).\(payloadString).fake_signature"
+}
+
 @MainActor
-final class HomePageTests: XCTestCase {
+struct HomePageTests {
   // MARK: - ViewAppeared Tests
 
-  func testViewAppeared_PopulatesForYouStationsBasedOnInitialValueOfSharedStationLists() async {
+  @Test
+  func testViewAppearedPopulatesForYouStationsBasedOnInitialValueOfSharedStationLists() async {
     @Shared(.stationLists) var stationLists = StationList.mocks
     let artistStations = stationLists.first {
       $0.slug == StationList.artistListSlug
     }
-    XCTAssertNotNil(artistStations)
+    #expect(artistStations != nil)
     let model = HomePageModel()
     await model.viewAppeared()
-    XCTAssertEqual(model.forYouStations.elements, artistStations!.stations)
+    #expect(model.forYouStations.elements == artistStations!.stations)
   }
 
-  func testViewAppeared_RepopulatesForYouStationsWhenSharedStationListsChanges() async {
+  @Test
+  func testViewAppearedRepopulatesForYouStationsWhenSharedStationListsChanges() async {
     @Shared(.stationLists) var stationLists = StationList.mocks
     let artistStations = stationLists.first {
       $0.slug == StationList.artistListSlug
@@ -39,14 +81,14 @@ final class HomePageTests: XCTestCase {
     let inDevelopmentStations = stationLists.first {
       $0.id == StationList.inDevelopmentListId
     }
-    XCTAssertNotNil(artistStations)
-    XCTAssertNotNil(inDevelopmentStations)
-    XCTAssertNotEqual(artistStations!.stations, inDevelopmentStations!.stations)
+    #expect(artistStations != nil)
+    #expect(inDevelopmentStations != nil)
+    #expect(artistStations!.stations != inDevelopmentStations!.stations)
 
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.elements, artistStations!.stations)
+    #expect(model.forYouStations.elements == artistStations!.stations)
 
     $stationLists.withLock {
       $0 = IdentifiedArray(
@@ -80,11 +122,12 @@ final class HomePageTests: XCTestCase {
         ])
     }
 
-    XCTAssertEqual(model.forYouStations.elements.count, 1)
-    XCTAssertEqual(model.forYouStations.elements.first?.id, "different-station")
+    #expect(model.forYouStations.elements.count == 1)
+    #expect(model.forYouStations.elements.first?.id == "different-station")
   }
 
-  func testViewAppeared_ExcludesComingSoonStationsFromForYouList() async {
+  @Test
+  func testViewAppearedExcludesComingSoonStationsFromForYouList() async {
     let visibleStation = Station.mockWith(
       id: "visible-station", name: "Visible Station", curatorName: "DJ Visible")
     let artistList = StationList.mockArtistList(items: [
@@ -98,11 +141,12 @@ final class HomePageTests: XCTestCase {
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.count, 1)
-    XCTAssertEqual(model.forYouStations.first?.id, visibleStation.id)
-    XCTAssertNil(model.forYouStations[id: "coming-soon-station"])
+    #expect(model.forYouStations.count == 1)
+    #expect(model.forYouStations.first?.id == visibleStation.id)
+    #expect(model.forYouStations[id: "coming-soon-station"] == nil)
   }
 
+  @Test
   func testShowSecretStationsIncludesActiveComingSoonStations() async {
     let visibleStation = Station.mockWith(id: "visible-station", curatorName: "DJ Visible")
     let comingSoonStation = Station.mockWith(id: "coming-soon-station", curatorName: "DJ Soon")
@@ -117,15 +161,16 @@ final class HomePageTests: XCTestCase {
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.count, 1)
-    XCTAssertNil(model.forYouStations[id: comingSoonStation.id])
+    #expect(model.forYouStations.count == 1)
+    #expect(model.forYouStations[id: comingSoonStation.id] == nil)
 
     $showSecretStations.withLock { $0 = true }
 
-    XCTAssertNotNil(model.forYouStations[id: comingSoonStation.id])
-    XCTAssertEqual(model.forYouStations.count, 2)
+    #expect(model.forYouStations[id: comingSoonStation.id] != nil)
+    #expect(model.forYouStations.count == 2)
   }
 
+  @Test
   func testShowSecretStationsStillHidesInactiveComingSoonStations() async {
     let visibleStation = Station.mockWith(id: "visible-station", curatorName: "DJ Visible")
     let inactiveStation = Station.mockWith(
@@ -141,22 +186,25 @@ final class HomePageTests: XCTestCase {
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.count, 1)
-    XCTAssertNil(model.forYouStations[id: inactiveStation.id])
+    #expect(model.forYouStations.count == 1)
+    #expect(model.forYouStations[id: inactiveStation.id] == nil)
   }
 
+  @Test
   func testStationListItemVisibilityDecodesKnownValue() throws {
     let jsonData = Data("\"coming-soon\"".utf8)
     let visibility = try JSONDecoder().decode(StationListItemVisibility.self, from: jsonData)
-    XCTAssertEqual(visibility, .comingSoon)
+    #expect(visibility == .comingSoon)
   }
 
+  @Test
   func testStationListItemVisibilityDecodesUnknownValueAsUnknown() throws {
     let jsonData = Data("\"future-release\"".utf8)
     let visibility = try JSONDecoder().decode(StationListItemVisibility.self, from: jsonData)
-    XCTAssertEqual(visibility, .unknown)
+    #expect(visibility == .unknown)
   }
 
+  @Test
   func testStationListStationsFiltersByVisibility() {
     let visiblePlayola = Station.mockWith(id: "visible-playola")
     let unknownPlayola = Station.mockWith(id: "unknown-playola")
@@ -175,124 +223,91 @@ final class HomePageTests: XCTestCase {
     )
 
     let visibleItems = list.stationItems(includeHidden: false)
-    XCTAssertEqual(visibleItems.map(\.visibility), [.visible, .comingSoon, .unknown])
+    #expect(visibleItems.map(\.visibility) == [.visible, .comingSoon, .unknown])
 
     let visibleStations = visibleItems.map { $0.anyStation }
-    XCTAssertEqual(visibleStations.count, 3)
+    #expect(visibleStations.count == 3)
     if case .playola(let station) = visibleStations[0] {
-      XCTAssertEqual(station.id, visiblePlayola.id)
+      #expect(station.id == visiblePlayola.id)
     } else {
-      XCTFail("Expected first visible station to be playola")
+      Issue.record("Expected first visible station to be playola")
     }
 
     if case .url(let station) = visibleStations[1] {
-      XCTAssertEqual(station.id, comingSoonUrl.id)
+      #expect(station.id == comingSoonUrl.id)
     } else {
-      XCTFail("Expected second visible station to be coming soon url station")
+      Issue.record("Expected second visible station to be coming soon url station")
     }
 
     if case .playola(let station) = visibleStations[2] {
-      XCTAssertEqual(station.id, unknownPlayola.id)
+      #expect(station.id == unknownPlayola.id)
     } else {
-      XCTFail("Expected second visible station to be playola")
+      Issue.record("Expected second visible station to be playola")
     }
 
     let allItemsIncludingHidden = list.stationItems(includeHidden: true)
     let comingSoonItems = allItemsIncludingHidden.filter { $0.visibility == .comingSoon }
-    XCTAssertEqual(comingSoonItems.count, 1)
-    XCTAssertEqual(comingSoonItems.first?.urlStation?.id, comingSoonUrl.id)
+    #expect(comingSoonItems.count == 1)
+    #expect(comingSoonItems.first?.urlStation?.id == comingSoonUrl.id)
 
     let hiddenItems = allItemsIncludingHidden.filter { $0.visibility == .hidden }
-    XCTAssertEqual(hiddenItems.count, 1)
-    XCTAssertEqual(hiddenItems.first?.urlStation?.id, hiddenUrl.id)
+    #expect(hiddenItems.count == 1)
+    #expect(hiddenItems.first?.urlStation?.id == hiddenUrl.id)
   }
 
   // MARK: - Welcome Message Tests
 
-  func testWelcomeMessage_ShowsGenericWelcomeMessageWhenNoUserIsLoggedIn() {
+  @Test
+  func testWelcomeMessageShowsGenericWelcomeMessageWhenNoUserIsLoggedIn() {
     @Shared(.auth) var auth = Auth()
     let model = HomePageModel()
-    XCTAssertEqual(model.welcomeMessage, "Welcome to Playola")
+    #expect(model.welcomeMessage == "Welcome to Playola")
   }
 
-  // Helper function to create valid JWT tokens for testing
-  static func createTestJWT(
-    id: String = "test-user-123",
-    firstName: String = "John",
-    lastName: String? = "Doe",
-    email: String = "john@example.com",
-    profileImageUrl: String? = nil,
-    role: String = "user"
-  ) -> String {
-    let header = ["alg": "HS256", "typ": "JWT"]
-    var payload: [String: Any] = [
-      "id": id,
-      "firstName": firstName,
-      "email": email,
-      "role": role,
-    ]
-    if let lastName = lastName {
-      payload["lastName"] = lastName
-    }
-    if let profileImageUrl = profileImageUrl {
-      payload["profileImageUrl"] = profileImageUrl
-    }
-
-    let headerData = try! JSONSerialization.data(withJSONObject: header)
-    let payloadData = try! JSONSerialization.data(withJSONObject: payload)
-
-    let headerString = headerData.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-
-    let payloadString = payloadData.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-
-    return "\(headerString).\(payloadString).fake_signature"
-  }
-
-  func testWelcomeMessage_ShowsPersonalizedWelcomeMessageWhenUserIsLoggedIn() {
-    let mockJWT = HomePageTests.createTestJWT(firstName: "John")
+  @Test
+  func testWelcomeMessageShowsPersonalizedWelcomeMessageWhenUserIsLoggedIn() {
+    let mockJWT = createTestJWT(firstName: "John")
     @Shared(.auth) var auth = Auth(jwtToken: mockJWT)
     let model = HomePageModel()
-    XCTAssertEqual(model.welcomeMessage, "Welcome, John")
+    #expect(model.welcomeMessage == "Welcome, John")
   }
 
-  func testWelcomeMessage_UpdatesWelcomeMessageWhenAuthChanges() {
+  @Test
+  func testWelcomeMessageUpdatesWelcomeMessageWhenAuthChanges() {
     @Shared(.auth) var auth = Auth()
     let model = HomePageModel()
-    XCTAssertEqual(model.welcomeMessage, "Welcome to Playola")
+    #expect(model.welcomeMessage == "Welcome to Playola")
 
-    let mockJWT = HomePageTests.createTestJWT(firstName: "John")
+    let mockJWT = createTestJWT(firstName: "John")
     $auth.withLock { $0 = Auth(jwtToken: mockJWT) }
-    XCTAssertEqual(model.welcomeMessage, "Welcome, John")
+    #expect(model.welcomeMessage == "Welcome, John")
   }
 
   // MARK: - Tapping The P Tests
 
-  func testTappingTheP_TurnsOnTheSecretStations() {
+  @Test
+  func testTappingThePTurnsOnTheSecretStations() {
     let homePage = HomePageModel()
-    XCTAssertFalse(homePage.showSecretStations)
+    #expect(!homePage.showSecretStations)
     homePage.playolaIconTapped10Times()
-    XCTAssertTrue(homePage.showSecretStations)
-    XCTAssertEqual(homePage.presentedAlert, .secretStationsTurnedOnAlert)
+    #expect(homePage.showSecretStations)
+    #expect(homePage.presentedAlert == .secretStationsTurnedOnAlert)
   }
 
-  func testTappingTheP_HidesTheSecretStations() {
+  @Test
+  func testTappingThePHidesTheSecretStations() {
     @Shared(.showSecretStations) var showSecretStations = true
     let homePage = HomePageModel()
-    XCTAssertTrue(homePage.showSecretStations)
+    #expect(homePage.showSecretStations)
     homePage.playolaIconTapped10Times()
-    XCTAssertFalse(homePage.showSecretStations)
-    XCTAssertEqual(homePage.presentedAlert, .secretStationsHiddenAlert)
+    #expect(!homePage.showSecretStations)
+    #expect(homePage.presentedAlert == .secretStationsHiddenAlert)
   }
 
   // MARK: - Listening Tile Navigation Tests
 
-  func testListeningTile_NavigationToRewardsTracksAnalytics() async {
+  @Test
+  func testListeningTileNavigationToRewardsTracksAnalytics() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
     @Shared(.activeTab) var activeTab = MainContainerModel.ActiveTab.home
 
@@ -304,21 +319,19 @@ final class HomePageTests: XCTestCase {
       HomePageModel()
     }
 
-    // Call the button action on the listening tile model
     await homePageModel.listeningTimeTileModel.buttonAction?()
 
-    // Verify navigation happened
-    XCTAssertEqual(activeTab, .rewards)
+    #expect(activeTab == .rewards)
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
-    XCTAssertEqual(events.first, .navigatedToRewardsFromListeningTile)
+    #expect(events.count == 1)
+    #expect(events.first == .navigatedToRewardsFromListeningTile)
   }
 
   // MARK: - Player Interaction Tests
 
-  func testPlayerInteraction_PlaysAStationWhenItIsTapped() async {
+  @Test
+  func testPlayerInteractionPlaysAStationWhenItIsTapped() async {
     let stationPlayerMock: StationPlayerMock = .mockStoppedPlayer()
     let station: AnyStation = .mock
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
@@ -333,21 +346,21 @@ final class HomePageTests: XCTestCase {
 
     await homePageModel.stationTapped(station)
 
-    XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
-    XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, station.id)
+    #expect(stationPlayerMock.callsToPlay.count == 1)
+    #expect(stationPlayerMock.callsToPlay.first?.id == station.id)
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .startedStation(let stationInfo, let entryPoint) = events.first {
-      XCTAssertEqual(stationInfo.id, station.id)
-      XCTAssertEqual(stationInfo.name, station.name)
-      XCTAssertEqual(entryPoint, "home_recommendations")
+      #expect(stationInfo.id == station.id)
+      #expect(stationInfo.name == station.name)
+      #expect(entryPoint == "home_recommendations")
     } else {
-      XCTFail("Expected startedStation event, got: \(String(describing: events.first))")
+      Issue.record("Expected startedStation event, got: \(String(describing: events.first))")
     }
   }
 
+  @Test
   func testShowSecretStationsToggleUpdatesForYouStations() async {
     let artistList = StationList.mockArtistList(items: [
       .mockWith(sortOrder: 0, visibility: .visible, station: .mockWith(id: "visible-playola")),
@@ -359,17 +372,18 @@ final class HomePageTests: XCTestCase {
     let model = HomePageModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.forYouStations.count, 1)
+    #expect(model.forYouStations.count == 1)
 
     $showSecretStations.withLock { $0 = true }
-    XCTAssertEqual(model.forYouStations.count, 2)
+    #expect(model.forYouStations.count == 2)
 
     $showSecretStations.withLock { $0 = false }
-    XCTAssertEqual(model.forYouStations.count, 1)
+    #expect(model.forYouStations.count == 1)
   }
 
   // MARK: - Scheduled Shows Tests
 
+  @Test
   func testViewAppearedSetsHasScheduledShowsToTrueWhenAiringsExist() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let now = Date()
@@ -388,10 +402,11 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertTrue(model.hasScheduledShows)
+      #expect(model.hasScheduledShows)
     }
   }
 
+  @Test
   func testViewAppearedSetsHasScheduledShowsToFalseWhenNoAirings() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -402,10 +417,11 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(model.hasScheduledShows)
+      #expect(!model.hasScheduledShows)
     }
   }
 
+  @Test
   func testViewAppearedSetsHasScheduledShowsToFalseOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -418,10 +434,11 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(model.hasScheduledShows)
+      #expect(!model.hasScheduledShows)
     }
   }
 
+  @Test
   func testScheduledShowsTileNavigatesToSeriesListPage() async {
     @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
       MainContainerNavigationCoordinator()
@@ -430,15 +447,16 @@ final class HomePageTests: XCTestCase {
 
     await model.scheduledShowsTileModel.buttonAction?()
 
-    XCTAssertEqual(navigationCoordinator.path.count, 1)
+    #expect(navigationCoordinator.path.count == 1)
     if case .seriesListPage = navigationCoordinator.path.first {
       // Success
     } else {
-      XCTFail(
+      Issue.record(
         "Expected seriesListPage, got: \(String(describing: navigationCoordinator.path.first))")
     }
   }
 
+  @Test
   func testViewAppearedSetsHasScheduledShowsToFalseWhenAllAiringsEnded() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let now = Date()
@@ -464,12 +482,13 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(model.hasScheduledShows)
+      #expect(!model.hasScheduledShows)
     }
   }
 
   // MARK: - Listener Question Airing Tests
 
+  @Test
   func testViewAppearedSetsUpcomingQuestionAiringWhenAiringsExist() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let futureDate = Date().addingTimeInterval(2 * 24 * 60 * 60)
@@ -486,12 +505,13 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNotNil(model.upcomingQuestionAiring)
-      XCTAssertEqual(model.upcomingQuestionAiring?.id, expectedAiring.id)
-      XCTAssertTrue(model.hasUpcomingQuestionAiring)
+      #expect(model.upcomingQuestionAiring != nil)
+      #expect(model.upcomingQuestionAiring?.id == expectedAiring.id)
+      #expect(model.hasUpcomingQuestionAiring)
     }
   }
 
+  @Test
   func testViewAppearedSetsUpcomingQuestionAiringToNilWhenNoAirings() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -502,11 +522,12 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNil(model.upcomingQuestionAiring)
-      XCTAssertFalse(model.hasUpcomingQuestionAiring)
+      #expect(model.upcomingQuestionAiring == nil)
+      #expect(!model.hasUpcomingQuestionAiring)
     }
   }
 
+  @Test
   func testViewAppearedSetsUpcomingQuestionAiringToNilOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -519,11 +540,12 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNil(model.upcomingQuestionAiring)
-      XCTAssertFalse(model.hasUpcomingQuestionAiring)
+      #expect(model.upcomingQuestionAiring == nil)
+      #expect(!model.hasUpcomingQuestionAiring)
     }
   }
 
+  @Test
   func testViewAppearedDoesNotCheckAiringsWhenNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     let apiCalled = LockIsolated(false)
@@ -538,11 +560,12 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(apiCalled.value)
-      XCTAssertNil(model.upcomingQuestionAiring)
+      #expect(!apiCalled.value)
+      #expect(model.upcomingQuestionAiring == nil)
     }
   }
 
+  @Test
   func testQuestionAiringTileShowsStationNameAndAirtime() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let futureDate = Date().addingTimeInterval(2 * 24 * 60 * 60)
@@ -558,8 +581,8 @@ final class HomePageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.questionAiringTileModel.content, "You're On Air Soon!")
-      XCTAssertTrue(
+      #expect(model.questionAiringTileModel.content == "You're On Air Soon!")
+      #expect(
         model.questionAiringTileModel.paragraph!.contains("DJ Awesome picked your question!"))
     }
   }
@@ -568,6 +591,7 @@ final class HomePageTests: XCTestCase {
 
   private static let appStoreUrl = "https://apps.apple.com/us/app/playola-radio/id6480465361"
 
+  @Test
   func testQuestionAiringShareButtonPresentsShareSheetWithAppStoreUrl() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
@@ -588,14 +612,15 @@ final class HomePageTests: XCTestCase {
       await model.questionAiringTileModel.buttonAction?()
 
       if case .share(let shareModel) = navigationCoordinator.presentedSheet {
-        XCTAssertTrue(shareModel.items[0].contains("Jason Eady's radio station"))
-        XCTAssertEqual(shareModel.items[1], Self.appStoreUrl)
+        #expect(shareModel.items[0].contains("Jason Eady's radio station"))
+        #expect(shareModel.items[1] == Self.appStoreUrl)
       } else {
-        XCTFail("Expected share sheet to be presented")
+        Issue.record("Expected share sheet to be presented")
       }
     }
   }
 
+  @Test
   func testQuestionAiringShareButtonUsesGenericMessageWhenNoCuratorName() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
@@ -616,16 +641,17 @@ final class HomePageTests: XCTestCase {
       await model.questionAiringTileModel.buttonAction?()
 
       if case .share(let shareModel) = navigationCoordinator.presentedSheet {
-        XCTAssertTrue(shareModel.items[0].contains("an internet radio station"))
-        XCTAssertEqual(shareModel.items[1], Self.appStoreUrl)
+        #expect(shareModel.items[0].contains("an internet radio station"))
+        #expect(shareModel.items[1] == Self.appStoreUrl)
       } else {
-        XCTFail("Expected share sheet to be presented")
+        Issue.record("Expected share sheet to be presented")
       }
     }
   }
 
   // MARK: - Invite Friends Tile Tests
 
+  @Test
   func testCanInviteFriendsIsTrueWhenUserHasTwoOrMoreHours() {
     let rewardsProfile = RewardsProfile(
       totalTimeListenedMS: 2 * 60 * 60 * 1000,  // 2 hours
@@ -637,9 +663,10 @@ final class HomePageTests: XCTestCase {
 
     let model = HomePageModel()
 
-    XCTAssertTrue(model.canInviteFriends)
+    #expect(model.canInviteFriends)
   }
 
+  @Test
   func testCanInviteFriendsIsFalseWhenUserHasLessThanTwoHours() {
     let rewardsProfile = RewardsProfile(
       totalTimeListenedMS: 1 * 60 * 60 * 1000,  // 1 hour
@@ -651,26 +678,29 @@ final class HomePageTests: XCTestCase {
 
     let model = HomePageModel()
 
-    XCTAssertFalse(model.canInviteFriends)
+    #expect(!model.canInviteFriends)
   }
 
+  @Test
   func testCanInviteFriendsIsFalseWhenListeningTrackerIsNil() {
     @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
 
     let model = HomePageModel()
 
-    XCTAssertFalse(model.canInviteFriends)
+    #expect(!model.canInviteFriends)
   }
 
+  @Test
   func testInviteFriendsTileHasCorrectContent() {
     let model = HomePageModel()
 
-    XCTAssertEqual(model.inviteFriendsTileModel.label, "Power Listener Reward")
-    XCTAssertEqual(model.inviteFriendsTileModel.content, "Invite Your Friends")
-    XCTAssertEqual(model.inviteFriendsTileModel.buttonText, "Invite")
-    XCTAssertNotNil(model.inviteFriendsTileModel.paragraph)
+    #expect(model.inviteFriendsTileModel.label == "Power Listener Reward")
+    #expect(model.inviteFriendsTileModel.content == "Invite Your Friends")
+    #expect(model.inviteFriendsTileModel.buttonText == "Invite")
+    #expect(model.inviteFriendsTileModel.paragraph != nil)
   }
 
+  @Test
   func testInviteFriendsTilePresentsShareSheetWithAppStoreUrl() async {
     @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
       MainContainerNavigationCoordinator()
@@ -680,10 +710,10 @@ final class HomePageTests: XCTestCase {
     await model.inviteFriendsTileModel.buttonAction?()
 
     if case .share(let shareModel) = navigationCoordinator.presentedSheet {
-      XCTAssertEqual(shareModel.items.count, 1)
-      XCTAssertEqual(shareModel.items[0], Self.appStoreUrl)
+      #expect(shareModel.items.count == 1)
+      #expect(shareModel.items[0] == Self.appStoreUrl)
     } else {
-      XCTFail("Expected share sheet to be presented")
+      Issue.record("Expected share sheet to be presented")
     }
   }
 

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -17,44 +17,8 @@ import Testing
 
 @testable import PlayolaRadio
 
-// Helper function to create valid JWT tokens for testing
-private func createTestJWT(
-  id: String = "test-user-123",
-  firstName: String = "John",
-  lastName: String? = "Doe",
-  email: String = "john@example.com",
-  profileImageUrl: String? = nil,
-  role: String = "user"
-) -> String {
-  let header = ["alg": "HS256", "typ": "JWT"]
-  var payload: [String: Any] = [
-    "id": id,
-    "firstName": firstName,
-    "email": email,
-    "role": role,
-  ]
-  if let lastName = lastName {
-    payload["lastName"] = lastName
-  }
-  if let profileImageUrl = profileImageUrl {
-    payload["profileImageUrl"] = profileImageUrl
-  }
-
-  let headerData = try! JSONSerialization.data(withJSONObject: header)
-  let payloadData = try! JSONSerialization.data(withJSONObject: payload)
-
-  let headerString = headerData.base64EncodedString()
-    .replacingOccurrences(of: "+", with: "-")
-    .replacingOccurrences(of: "/", with: "_")
-    .replacingOccurrences(of: "=", with: "")
-
-  let payloadString = payloadData.base64EncodedString()
-    .replacingOccurrences(of: "+", with: "-")
-    .replacingOccurrences(of: "/", with: "_")
-    .replacingOccurrences(of: "=", with: "")
-
-  return "\(headerString).\(payloadString).fake_signature"
-}
+// `createTestJWT` is defined in MainContainerTests.swift and shared
+// across the test target.
 
 @MainActor
 struct HomePageTests {

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -302,8 +302,9 @@ struct HomePageTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      HomePageModel(stationPlayer: stationPlayerMock)
+      HomePageModel()
     }
 
     await homePageModel.stationTapped(station)

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
@@ -661,7 +661,7 @@ struct LibraryPageTests {
   @Test
   func testAddSongButtonTappedPresentsSongSearchPageSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     withModel { model in
       #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
@@ -711,7 +711,7 @@ struct LibraryPageTests {
   @Test
   func testAddSongButtonTappedOnAddedToLibraryCallbackDismissesSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     withModel { model in
       model.addSongButtonTapped()
@@ -727,7 +727,7 @@ struct LibraryPageTests {
   @Test
   func testAddSongButtonTappedOnDismissCallbackDismissesSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     withModel { model in
       model.addSongButtonTapped()
@@ -797,7 +797,7 @@ struct LibraryPageTests {
   @Test
   func testRecordIntroButtonTappedPresentsRecordIntroSheet() {
     @Shared(.mainContainerNavigationCoordinator)
-    var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
+    var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
 
     withModel { model in
       let song = LibrarySong.mockWith(id: "song-1", title: "Test Song", artist: "Test Artist")

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
@@ -5,13 +5,14 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class LibraryPageTests: XCTestCase {
+struct LibraryPageTests {
   // MARK: - Helpers
 
   private func withModel(
@@ -50,38 +51,44 @@ final class LibraryPageTests: XCTestCase {
 
   // MARK: - Initial State Tests
 
+  @Test
   func testInitialStateLibrarySongsAreEmpty() {
     withModel { model in
-      XCTAssertTrue(model.librarySongs.isEmpty)
+      #expect(model.librarySongs.isEmpty)
     }
   }
 
+  @Test
   func testInitialStateLibraryRequestsAreEmpty() {
     withModel { model in
-      XCTAssertTrue(model.libraryRequests.isEmpty)
+      #expect(model.libraryRequests.isEmpty)
     }
   }
 
+  @Test
   func testInitialStateIsNotLoading() {
     withModel { model in
-      XCTAssertFalse(model.isLoading)
+      #expect(!model.isLoading)
     }
   }
 
+  @Test
   func testInitialStateSearchTextIsEmpty() {
     withModel { model in
-      XCTAssertEqual(model.searchText, "")
+      #expect(model.searchText == "")
     }
   }
 
+  @Test
   func testNavigationTitle() {
     withModel { model in
-      XCTAssertEqual(model.navigationTitle, "Library")
+      #expect(model.navigationTitle == "Library")
     }
   }
 
   // MARK: - View Appeared Tests
 
+  @Test
   func testViewAppearedFetchesLibrarySongs() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Song One"),
@@ -89,12 +96,13 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(songs: mockSongs) { model in
-      XCTAssertEqual(model.librarySongs.count, 2)
-      XCTAssertEqual(model.librarySongs[0].id, "song-1")
-      XCTAssertEqual(model.librarySongs[1].id, "song-2")
+      #expect(model.librarySongs.count == 2)
+      #expect(model.librarySongs[0].id == "song-1")
+      #expect(model.librarySongs[1].id == "song-2")
     }
   }
 
+  @Test
   func testViewAppearedFetchesLibraryRequests() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", title: "Request One"),
@@ -102,12 +110,13 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertEqual(model.libraryRequests.count, 2)
-      XCTAssertEqual(model.libraryRequests[0].id, "request-1")
-      XCTAssertEqual(model.libraryRequests[1].id, "request-2")
+      #expect(model.libraryRequests.count == 2)
+      #expect(model.libraryRequests[0].id == "request-1")
+      #expect(model.libraryRequests[1].id == "request-2")
     }
   }
 
+  @Test
   func testViewAppearedPassesCorrectStationId() async {
     let capturedStationId = LockIsolated<String?>(nil)
 
@@ -120,11 +129,12 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { _ in
-        XCTAssertEqual(capturedStationId.value, "my-station-123")
+        #expect(capturedStationId.value == "my-station-123")
       }
     )
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     await withLoadedModel(
       configure: {
@@ -133,14 +143,15 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertNotNil(model.presentedAlert)
-        XCTAssertEqual(model.presentedAlert?.title, "Error")
+        #expect(model.presentedAlert != nil)
+        #expect(model.presentedAlert?.title == "Error")
       }
     )
   }
 
   // MARK: - Search/Filter Tests
 
+  @Test
   func testFilteredSongsReturnsAllWhenSearchTextIsEmpty() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Alpha", artist: "Artist A"),
@@ -149,10 +160,11 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = ""
-      XCTAssertEqual(model.filteredSongs.count, 2)
+      #expect(model.filteredSongs.count == 2)
     }
   }
 
+  @Test
   func testFilteredSongsFiltersByTitle() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Bohemian Rhapsody", artist: "Queen"),
@@ -161,11 +173,12 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = "Bohemian"
-      XCTAssertEqual(model.filteredSongs.count, 1)
-      XCTAssertEqual(model.filteredSongs[0].title, "Bohemian Rhapsody")
+      #expect(model.filteredSongs.count == 1)
+      #expect(model.filteredSongs[0].title == "Bohemian Rhapsody")
     }
   }
 
+  @Test
   func testFilteredSongsFiltersByArtist() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Bohemian Rhapsody", artist: "Queen"),
@@ -174,11 +187,12 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = "Eagles"
-      XCTAssertEqual(model.filteredSongs.count, 1)
-      XCTAssertEqual(model.filteredSongs[0].artist, "Eagles")
+      #expect(model.filteredSongs.count == 1)
+      #expect(model.filteredSongs[0].artist == "Eagles")
     }
   }
 
+  @Test
   func testFilteredSongsIsCaseInsensitive() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Bohemian Rhapsody", artist: "Queen")
@@ -186,12 +200,13 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = "QUEEN"
-      XCTAssertEqual(model.filteredSongs.count, 1)
+      #expect(model.filteredSongs.count == 1)
     }
   }
 
   // MARK: - Request Filtering Tests
 
+  @Test
   func testPendingRequestsReturnsOnlyPendingRequests() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .pending),
@@ -200,11 +215,12 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertEqual(model.pendingRequests.count, 1)
-      XCTAssertEqual(model.pendingRequests[0].id, "request-1")
+      #expect(model.pendingRequests.count == 1)
+      #expect(model.pendingRequests[0].id == "request-1")
     }
   }
 
+  @Test
   func testFulfilledRequestsReturnsOnlyCompletedRequests() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .pending),
@@ -213,31 +229,34 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertEqual(model.fulfilledRequests.count, 1)
-      XCTAssertEqual(model.fulfilledRequests[0].id, "request-2")
+      #expect(model.fulfilledRequests.count == 1)
+      #expect(model.fulfilledRequests[0].id == "request-2")
     }
   }
 
+  @Test
   func testHasActiveRequestsReturnsTrueWhenPendingExists() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .pending)
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertTrue(model.hasActiveRequests)
+      #expect(model.hasActiveRequests)
     }
   }
 
+  @Test
   func testHasActiveRequestsReturnsTrueWhenFulfilledExists() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .completed)
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertTrue(model.hasActiveRequests)
+      #expect(model.hasActiveRequests)
     }
   }
 
+  @Test
   func testHasActiveRequestsReturnsFalseWhenAllDismissed() async {
     let mockRequests = [
       StationLibraryRequest.mockWith(id: "request-1", status: .dismissed),
@@ -245,12 +264,13 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(requests: mockRequests) { model in
-      XCTAssertFalse(model.hasActiveRequests)
+      #expect(!model.hasActiveRequests)
     }
   }
 
   // MARK: - Remove Song Tests
 
+  @Test
   func testRemoveSongButtonTappedCreatesRemoveRequest() async {
     let capturedAudioBlockId = LockIsolated<String?>(nil)
     let mockSong = LibrarySong.mockWith(id: "song-to-remove")
@@ -265,11 +285,12 @@ final class LibraryPageTests: XCTestCase {
       },
       perform: { model in
         await model.removeSongButtonTapped(mockSong)
-        XCTAssertEqual(capturedAudioBlockId.value, "song-to-remove")
+        #expect(capturedAudioBlockId.value == "song-to-remove")
       }
     )
   }
 
+  @Test
   func testRemoveSongButtonTappedAddsRequestToList() async {
     let mockSong = LibrarySong.mockWith(id: "song-to-remove", title: "Song to Remove")
     let mockRequest = StationLibraryRequest.mockWith(
@@ -285,16 +306,17 @@ final class LibraryPageTests: XCTestCase {
         $0.api.createRemoveLibraryRequest = { _, _, _ in mockRequest }
       },
       perform: { model in
-        XCTAssertEqual(model.libraryRequests.count, 0)
+        #expect(model.libraryRequests.count == 0)
         await model.removeSongButtonTapped(mockSong)
-        XCTAssertEqual(model.libraryRequests.count, 1)
-        XCTAssertEqual(model.libraryRequests[0].id, "new-request")
+        #expect(model.libraryRequests.count == 1)
+        #expect(model.libraryRequests[0].id == "new-request")
       }
     )
   }
 
   // MARK: - Pending Request Check Tests
 
+  @Test
   func testHasPendingRequestReturnsTrueForSongWithPendingRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
     let mockRequest = StationLibraryRequest.mockWith(
@@ -304,28 +326,31 @@ final class LibraryPageTests: XCTestCase {
     )
 
     await withLoadedModel(songs: [mockSong], requests: [mockRequest]) { model in
-      XCTAssertTrue(model.hasPendingRequest(for: mockSong))
+      #expect(model.hasPendingRequest(for: mockSong))
     }
   }
 
+  @Test
   func testHasPendingRequestReturnsFalseForSongWithoutRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     await withLoadedModel(songs: [mockSong]) { model in
-      XCTAssertFalse(model.hasPendingRequest(for: mockSong))
+      #expect(!model.hasPendingRequest(for: mockSong))
     }
   }
 
   // MARK: - Processing Removal Tests
 
+  @Test
   func testIsProcessingRemovalReturnsFalseInitially() {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     withModel { model in
-      XCTAssertFalse(model.isProcessingRemoval(for: mockSong))
+      #expect(!model.isProcessingRemoval(for: mockSong))
     }
   }
 
+  @Test
   func testIsProcessingRemovalReturnsFalseAfterCompletion() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
@@ -337,15 +362,16 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertFalse(model.isProcessingRemoval(for: mockSong))
+        #expect(!model.isProcessingRemoval(for: mockSong))
         await model.removeSongButtonTapped(mockSong)
-        XCTAssertFalse(model.isProcessingRemoval(for: mockSong))
+        #expect(!model.isProcessingRemoval(for: mockSong))
       }
     )
   }
 
   // MARK: - Dismiss Request Tests
 
+  @Test
   func testDismissRequestButtonTappedCallsAPI() async {
     let capturedRequestId = LockIsolated<String?>(nil)
     let mockRequest = StationLibraryRequest.mockWith(id: "request-to-dismiss", status: .completed)
@@ -360,11 +386,12 @@ final class LibraryPageTests: XCTestCase {
       },
       perform: { model in
         await model.dismissRequestButtonTapped(mockRequest)
-        XCTAssertEqual(capturedRequestId.value, "request-to-dismiss")
+        #expect(capturedRequestId.value == "request-to-dismiss")
       }
     )
   }
 
+  @Test
   func testDismissRequestButtonTappedUpdatesRequestInList() async {
     let mockRequest = StationLibraryRequest.mockWith(id: "request-1", status: .completed)
 
@@ -376,15 +403,16 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertEqual(model.fulfilledRequests.count, 1)
+        #expect(model.fulfilledRequests.count == 1)
         await model.dismissRequestButtonTapped(mockRequest)
-        XCTAssertEqual(model.fulfilledRequests.count, 0)
+        #expect(model.fulfilledRequests.count == 0)
       }
     )
   }
 
   // MARK: - Refresh Tests
 
+  @Test
   func testRefreshPulledDownReloadsData() async {
     let fetchCount = LockIsolated(0)
 
@@ -396,15 +424,16 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertEqual(fetchCount.value, 1)
+        #expect(fetchCount.value == 1)
         await model.refreshPulledDown()
-        XCTAssertEqual(fetchCount.value, 2)
+        #expect(fetchCount.value == 2)
       }
     )
   }
 
   // MARK: - View Helper Tests
 
+  @Test
   func testSongsSectionHeaderIncludesCount() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1"),
@@ -413,10 +442,11 @@ final class LibraryPageTests: XCTestCase {
     ]
 
     await withLoadedModel(songs: mockSongs) { model in
-      XCTAssertEqual(model.songsSectionHeader, "SONGS (3)")
+      #expect(model.songsSectionHeader == "SONGS (3)")
     }
   }
 
+  @Test
   func testSongsSectionHeaderReflectsFilteredCount() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1", title: "Alpha", artist: "Artist A"),
@@ -426,95 +456,107 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: mockSongs) { model in
       model.searchText = "Artist A"
-      XCTAssertEqual(model.songsSectionHeader, "SONGS (2)")
+      #expect(model.songsSectionHeader == "SONGS (2)")
     }
   }
 
+  @Test
   func testRequestTypeLabelReturnsAddForAddRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(type: .add)
-      XCTAssertEqual(model.requestTypeLabel(for: request), "Add")
+      #expect(model.requestTypeLabel(for: request) == "Add")
     }
   }
 
+  @Test
   func testRequestTypeLabelReturnsRemoveForRemoveRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(type: .remove)
-      XCTAssertEqual(model.requestTypeLabel(for: request), "Remove")
+      #expect(model.requestTypeLabel(for: request) == "Remove")
     }
   }
 
+  @Test
   func testRequestTypeColorReturnsSuccessForAddRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(type: .add)
-      XCTAssertEqual(model.requestTypeColor(for: request), .success)
+      #expect(model.requestTypeColor(for: request) == .success)
     }
   }
 
+  @Test
   func testRequestTypeColorReturnsWarningForRemoveRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(type: .remove)
-      XCTAssertEqual(model.requestTypeColor(for: request), .warning)
+      #expect(model.requestTypeColor(for: request) == .warning)
     }
   }
 
+  @Test
   func testRequestStatusLabelReturnsCapitalizedStatus() {
     withModel { model in
       let pendingRequest = StationLibraryRequest.mockWith(status: .pending)
-      XCTAssertEqual(model.requestStatusLabel(for: pendingRequest), "Pending")
+      #expect(model.requestStatusLabel(for: pendingRequest) == "Pending")
 
       let completedRequest = StationLibraryRequest.mockWith(status: .completed)
-      XCTAssertEqual(model.requestStatusLabel(for: completedRequest), "Completed")
+      #expect(model.requestStatusLabel(for: completedRequest) == "Completed")
 
       let dismissedRequest = StationLibraryRequest.mockWith(status: .dismissed)
-      XCTAssertEqual(model.requestStatusLabel(for: dismissedRequest), "Dismissed")
+      #expect(model.requestStatusLabel(for: dismissedRequest) == "Dismissed")
     }
   }
 
+  @Test
   func testCanDismissRequestReturnsTrueForCompletedRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .completed)
-      XCTAssertTrue(model.canDismissRequest(request))
+      #expect(model.canDismissRequest(request))
     }
   }
 
+  @Test
   func testCanDismissRequestReturnsFalseForPendingRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .pending)
-      XCTAssertFalse(model.canDismissRequest(request))
+      #expect(!model.canDismissRequest(request))
     }
   }
 
+  @Test
   func testCanDismissRequestReturnsFalseForDismissedRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .dismissed)
-      XCTAssertFalse(model.canDismissRequest(request))
+      #expect(!model.canDismissRequest(request))
     }
   }
 
+  @Test
   func testCanCancelRequestReturnsTrueForPendingRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .pending)
-      XCTAssertTrue(model.canCancelRequest(request))
+      #expect(model.canCancelRequest(request))
     }
   }
 
+  @Test
   func testCanCancelRequestReturnsFalseForCompletedRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .completed)
-      XCTAssertFalse(model.canCancelRequest(request))
+      #expect(!model.canCancelRequest(request))
     }
   }
 
+  @Test
   func testCanCancelRequestReturnsFalseForDismissedRequest() {
     withModel { model in
       let request = StationLibraryRequest.mockWith(status: .dismissed)
-      XCTAssertFalse(model.canCancelRequest(request))
+      #expect(!model.canCancelRequest(request))
     }
   }
 
   // MARK: - Pending Request Helper Tests
 
+  @Test
   func testPendingRequestReturnsRequestForSongWithPendingRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
     let mockRequest = StationLibraryRequest.mockWith(
@@ -526,20 +568,22 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: [mockSong], requests: [mockRequest]) { model in
       let result = model.pendingRequest(for: mockSong)
-      XCTAssertNotNil(result)
-      XCTAssertEqual(result?.id, "pending-request-1")
+      #expect(result != nil)
+      #expect(result?.id == "pending-request-1")
     }
   }
 
+  @Test
   func testPendingRequestReturnsNilForSongWithoutPendingRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     await withLoadedModel(songs: [mockSong]) { model in
       let result = model.pendingRequest(for: mockSong)
-      XCTAssertNil(result)
+      #expect(result == nil)
     }
   }
 
+  @Test
   func testPendingRequestReturnsNilForSongWithCompletedRequest() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
     let mockRequest = StationLibraryRequest.mockWith(
@@ -550,12 +594,13 @@ final class LibraryPageTests: XCTestCase {
 
     await withLoadedModel(songs: [mockSong], requests: [mockRequest]) { model in
       let result = model.pendingRequest(for: mockSong)
-      XCTAssertNil(result)
+      #expect(result == nil)
     }
   }
 
   // MARK: - Cancel Request Tests
 
+  @Test
   func testCancelRequestButtonTappedCallsAPI() async {
     let capturedRequestId = LockIsolated<String?>(nil)
     let mockRequest = StationLibraryRequest.mockWith(id: "request-to-cancel", status: .pending)
@@ -569,11 +614,12 @@ final class LibraryPageTests: XCTestCase {
       },
       perform: { model in
         await model.cancelRequestButtonTapped(mockRequest)
-        XCTAssertEqual(capturedRequestId.value, "request-to-cancel")
+        #expect(capturedRequestId.value == "request-to-cancel")
       }
     )
   }
 
+  @Test
   func testCancelRequestButtonTappedRemovesRequestFromList() async {
     let mockRequest = StationLibraryRequest.mockWith(id: "request-1", status: .pending)
 
@@ -583,13 +629,14 @@ final class LibraryPageTests: XCTestCase {
         $0.api.cancelStationLibraryRequest = { _, _, _ in }
       },
       perform: { model in
-        XCTAssertEqual(model.libraryRequests.count, 1)
+        #expect(model.libraryRequests.count == 1)
         await model.cancelRequestButtonTapped(mockRequest)
-        XCTAssertEqual(model.libraryRequests.count, 0)
+        #expect(model.libraryRequests.count == 0)
       }
     )
   }
 
+  @Test
   func testCancelRequestButtonTappedShowsAlertOnError() async {
     let mockRequest = StationLibraryRequest.mockWith(id: "request-1", status: .pending)
 
@@ -601,99 +648,107 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertNil(model.presentedAlert)
+        #expect(model.presentedAlert == nil)
         await model.cancelRequestButtonTapped(mockRequest)
-        XCTAssertNotNil(model.presentedAlert)
-        XCTAssertEqual(model.presentedAlert?.title, "Error")
+        #expect(model.presentedAlert != nil)
+        #expect(model.presentedAlert?.title == "Error")
       }
     )
   }
 
   // MARK: - Add Song Button Tests
 
+  @Test
   func testAddSongButtonTappedPresentsSongSearchPageSheet() {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     withModel { model in
-      XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
-      XCTAssertNil(model.songSearchPageModel)
+      #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
+      #expect(model.songSearchPageModel == nil)
 
       model.addSongButtonTapped()
 
-      XCTAssertNotNil(model.songSearchPageModel)
+      #expect(model.songSearchPageModel != nil)
       if case .songSearchPage = mainContainerNavigationCoordinator.presentedSheet {
         // Success
       } else {
-        XCTFail("Expected songSearchPage sheet presentation")
+        Issue.record("Expected songSearchPage sheet presentation")
       }
     }
   }
 
+  @Test
   func testAddSongButtonTappedUsesSeedsOnlySearchMode() {
     withModel { model in
       model.addSongButtonTapped()
-      XCTAssertEqual(model.songSearchPageModel?.searchMode, .seedsOnly)
+      #expect(model.songSearchPageModel?.searchMode == .seedsOnly)
     }
   }
 
+  @Test
   func testAddSongButtonTappedPassesStationId() {
     withModel(stationId: "my-station-456") { model in
       model.addSongButtonTapped()
-      XCTAssertEqual(model.songSearchPageModel?.stationId, "my-station-456")
+      #expect(model.songSearchPageModel?.stationId == "my-station-456")
     }
   }
 
+  @Test
   func testAddSongButtonTappedOnAddedToLibraryCallbackAddsRequestToList() {
     withModel { model in
       model.addSongButtonTapped()
-      XCTAssertTrue(model.libraryRequests.isEmpty)
+      #expect(model.libraryRequests.isEmpty)
 
       let mockRequest = StationLibraryRequest.mockWith(id: "new-add-request", type: .add)
       model.songSearchPageModel?.onAddedToLibrary?(mockRequest)
 
-      XCTAssertEqual(model.libraryRequests.count, 1)
-      XCTAssertEqual(model.libraryRequests[0].id, "new-add-request")
+      #expect(model.libraryRequests.count == 1)
+      #expect(model.libraryRequests[0].id == "new-add-request")
     }
   }
 
+  @Test
   func testAddSongButtonTappedOnAddedToLibraryCallbackDismissesSheet() {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     withModel { model in
       model.addSongButtonTapped()
-      XCTAssertNotNil(mainContainerNavigationCoordinator.presentedSheet)
+      #expect(mainContainerNavigationCoordinator.presentedSheet != nil)
 
       let mockRequest = StationLibraryRequest.mockWith(id: "new-add-request", type: .add)
       model.songSearchPageModel?.onAddedToLibrary?(mockRequest)
 
-      XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
+      #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
     }
   }
 
+  @Test
   func testAddSongButtonTappedOnDismissCallbackDismissesSheet() {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
 
     withModel { model in
       model.addSongButtonTapped()
-      XCTAssertNotNil(mainContainerNavigationCoordinator.presentedSheet)
+      #expect(mainContainerNavigationCoordinator.presentedSheet != nil)
 
       model.songSearchPageModel?.onDismiss?()
 
-      XCTAssertNil(mainContainerNavigationCoordinator.presentedSheet)
+      #expect(mainContainerNavigationCoordinator.presentedSheet == nil)
     }
   }
 
   // MARK: - Song Intro Tests
 
+  @Test
   func testInitialStateSongIdsWithSongIntrosIsEmpty() {
     withModel { model in
-      XCTAssertTrue(model.songIdsWithSongIntros.isEmpty)
+      #expect(model.songIdsWithSongIntros.isEmpty)
     }
   }
 
+  @Test
   func testViewAppearedPopulatesSongIdsWithSongIntros() async {
     let mockSongs = [
       LibrarySong.mockWith(id: "song-1"),
@@ -707,11 +762,12 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertEqual(model.songIdsWithSongIntros, Set(["song-1"]))
+        #expect(model.songIdsWithSongIntros == Set(["song-1"]))
       }
     )
   }
 
+  @Test
   func testHasSongIntroReturnsTrueForSongWithIntro() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
@@ -722,21 +778,23 @@ final class LibraryPageTests: XCTestCase {
         }
       },
       perform: { model in
-        XCTAssertTrue(model.hasSongIntro(for: mockSong))
+        #expect(model.hasSongIntro(for: mockSong))
       }
     )
   }
 
+  @Test
   func testHasSongIntroReturnsFalseForSongWithoutIntro() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     await withLoadedModel(songs: [mockSong]) { model in
-      XCTAssertFalse(model.hasSongIntro(for: mockSong))
+      #expect(!model.hasSongIntro(for: mockSong))
     }
   }
 
   // MARK: - Intro Upload Tests
 
+  @Test
   func testRecordIntroButtonTappedPresentsRecordIntroSheet() {
     @Shared(.mainContainerNavigationCoordinator)
     var mainContainerNavigationCoordinator: MainContainerNavigationCoordinator
@@ -749,18 +807,19 @@ final class LibraryPageTests: XCTestCase {
       if case .recordIntroPage = mainContainerNavigationCoordinator.presentedSheet {
         // Success
       } else {
-        XCTFail("Expected recordIntroPage sheet")
+        Issue.record("Expected recordIntroPage sheet")
       }
     }
   }
 
+  @Test
   func testHasSongIntroReturnsTrueForLocallyUploadedIntro() async {
     let mockSong = LibrarySong.mockWith(id: "song-1")
 
     await withLoadedModel(songs: [mockSong]) { model in
-      XCTAssertFalse(model.hasSongIntro(for: mockSong))
+      #expect(!model.hasSongIntro(for: mockSong))
       model.uploadedIntroSongIds.insert("song-1")
-      XCTAssertTrue(model.hasSongIntro(for: mockSong))
+      #expect(model.hasSongIntro(for: mockSong))
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
@@ -100,7 +100,7 @@ struct LikedSongsPage: View {
     // Remove from data after animation completes
     Task { @MainActor in
       try? await Task.sleep(nanoseconds: 300_000_000)  // 0.3 seconds
-      model.removeSong(audioBlock)
+      model.removeSongTapped(audioBlock)
       removingAudioBlockIds.remove(audioBlock.id)
     }
   }

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageModel.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageModel.swift
@@ -11,6 +11,7 @@ class LikedSongsPageModel: ViewModel {
   // MARK: - Dependencies
 
   @ObservationIgnored @Dependency(\.likesManager) var likesManager: LikesManager
+  @ObservationIgnored @Dependency(\.date.now) var now
 
   // MARK: - Properties
 
@@ -50,7 +51,7 @@ class LikedSongsPageModel: ViewModel {
     presentedSongActionSheet = SongActionSheet(audioBlock: audioBlock, likedDate: likedDate)
   }
 
-  func removeSong(_ audioBlock: AudioBlock) {
+  func removeSongTapped(_ audioBlock: AudioBlock) {
     likesManager.unlike(audioBlock)
   }
 
@@ -66,7 +67,6 @@ class LikedSongsPageModel: ViewModel {
 
   private func formatSectionTitle(for date: Date) -> String {
     let calendar = Calendar.current
-    let now = Date()
 
     if calendar.isDate(date, equalTo: now, toGranularity: .weekOfYear) {
       return "Last Week"
@@ -79,7 +79,7 @@ class LikedSongsPageModel: ViewModel {
 
   private func parseSectionTitle(_ title: String) -> Date {
     if title == "Last Week" {
-      return Date()
+      return now
     } else {
       let formatter = DateFormatter()
       formatter.dateFormat = "MMMM yyyy"

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
@@ -1,32 +1,32 @@
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class LikedSongsPageTests: XCTestCase {
-
-  override func setUp() async throws {
-    try await super.setUp()
+struct LikedSongsPageTests {
+  @Test
+  func testGroupedLikedSongsEmptyWhenNoLikes() {
     @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
     @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
-    $userLikes.withLock { $0 = [:] }
-    $pendingOperations.withLock { $0 = [] }
-  }
 
-  func testGroupedLikedSongs_EmptyWhenNoLikes() {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
       let model = LikedSongsPageModel()
 
-      XCTAssertTrue(model.groupedLikedSongs.isEmpty)
+      #expect(model.groupedLikedSongs.isEmpty)
     }
   }
 
-  func testGroupedLikedSongs_GroupsBySectionTitle() async {
+  @Test
+  func testGroupedLikedSongsGroupsBySectionTitle() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let audioBlock1 = AudioBlock.mock
     let audioBlock2 = AudioBlock.mockWith(id: "different-id")
 
@@ -39,12 +39,16 @@ final class LikedSongsPageTests: XCTestCase {
     } operation: {
       let model = LikedSongsPageModel()
 
-      XCTAssertFalse(model.groupedLikedSongs.isEmpty)
-      XCTAssertEqual(model.groupedLikedSongs.first?.1.count, 2)
+      #expect(!model.groupedLikedSongs.isEmpty)
+      #expect(model.groupedLikedSongs.first?.1.count == 2)
     }
   }
 
+  @Test
   func testFormatTimestamp() {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
@@ -53,12 +57,16 @@ final class LikedSongsPageTests: XCTestCase {
 
       let result = model.formatTimestamp(for: testDate)
 
-      XCTAssertFalse(result.isEmpty)
-      XCTAssertTrue(result.contains("at"))
+      #expect(!result.isEmpty)
+      #expect(result.contains("at"))
     }
   }
 
+  @Test
   func testRemoveSong() async {
+    @Shared(.userLikes) var userLikes: [String: UserSongLike] = [:]
+    @Shared(.pendingLikeOperations) var pendingOperations: [LikeOperation] = []
+
     let audioBlock = AudioBlock.mock
 
     withDependencies {
@@ -69,14 +77,11 @@ final class LikedSongsPageTests: XCTestCase {
     } operation: {
       let model = LikedSongsPageModel()
 
-      // Verify song is initially liked
-      XCTAssertFalse(model.groupedLikedSongs.isEmpty)
+      #expect(!model.groupedLikedSongs.isEmpty)
 
-      // Remove the song
       model.removeSongTapped(audioBlock)
 
-      // Verify song is no longer liked
-      XCTAssertTrue(model.groupedLikedSongs.isEmpty)
+      #expect(model.groupedLikedSongs.isEmpty)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
@@ -31,6 +31,7 @@ final class LikedSongsPageTests: XCTestCase {
     let audioBlock2 = AudioBlock.mockWith(id: "different-id")
 
     withDependencies {
+      $0.date.now = Date()
       let likesManager = LikesManager()
       likesManager.like(audioBlock1)
       likesManager.like(audioBlock2)
@@ -61,6 +62,7 @@ final class LikedSongsPageTests: XCTestCase {
     let audioBlock = AudioBlock.mock
 
     withDependencies {
+      $0.date.now = Date()
       let likesManager = LikesManager()
       likesManager.like(audioBlock)
       $0.likesManager = likesManager

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
@@ -71,7 +71,7 @@ final class LikedSongsPageTests: XCTestCase {
       XCTAssertFalse(model.groupedLikedSongs.isEmpty)
 
       // Remove the song
-      model.removeSong(audioBlock)
+      model.removeSongTapped(audioBlock)
 
       // Verify song is no longer liked
       XCTAssertTrue(model.groupedLikedSongs.isEmpty)

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageModel.swift
@@ -56,6 +56,7 @@ class ListenerQuestionDetailPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.audioRecorder) var audioRecorder
   @ObservationIgnored @Dependency(\.voicetrackUploadService) var voicetrackUploadService
   @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.date.now) var now
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
@@ -101,7 +102,7 @@ class ListenerQuestionDetailPageModel: ViewModel {
   var timeAgoText: String {
     let formatter = RelativeDateTimeFormatter()
     formatter.unitsStyle = .full
-    return formatter.localizedString(for: question.createdAt, relativeTo: Date())
+    return formatter.localizedString(for: question.createdAt, relativeTo: now)
   }
 
   // MARK: - Question Playback Display

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageTests.swift
@@ -5,432 +5,498 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
 import Testing
-import XCTest
 
 @testable import PlayolaRadio
 
 @MainActor
-final class ListenerQuestionDetailPageTests: XCTestCase {
+struct ListenerQuestionDetailPageTests {
 
   // MARK: - Display Text Tests
 
+  @Test
   func testNavigationTitleIsListenerQuestion() {
     let model = makeModel()
-    XCTAssertEqual(model.navigationTitle, "Listener Question")
+    #expect(model.navigationTitle == "Listener Question")
   }
 
+  @Test
   func testQuestionSectionTitleIsQUESTION() {
     let model = makeModel()
-    XCTAssertEqual(model.questionSectionTitle, "QUESTION")
+    #expect(model.questionSectionTitle == "QUESTION")
   }
 
+  @Test
   func testResponseSectionTitleIsYOURRESPONSE() {
     let model = makeModel()
-    XCTAssertEqual(model.responseSectionTitle, "YOUR RESPONSE")
+    #expect(model.responseSectionTitle == "YOUR RESPONSE")
   }
 
+  @Test
   func testDiscardButtonTitleIsDiscard() {
     let model = makeModel()
-    XCTAssertEqual(model.discardButtonTitle, "Discard")
+    #expect(model.discardButtonTitle == "Discard")
   }
 
+  @Test
   func testUploadButtonTitleIsUploadResponse() {
     let model = makeModel()
-    XCTAssertEqual(model.uploadButtonTitle, "Upload Response")
+    #expect(model.uploadButtonTitle == "Upload Response")
   }
 
   // MARK: - Listener Info Display Tests
 
+  @Test
   func testListenerNameShowsFullName() {
     let model = makeModel(
       question: .mockWith(
         listener: .mockWith(firstName: "John", lastName: "Doe")
       ))
-    XCTAssertEqual(model.listenerName, "John Doe")
+    #expect(model.listenerName == "John Doe")
   }
 
+  @Test
   func testListenerNameShowsFirstNameOnlyWhenNoLastName() {
     let model = makeModel(
       question: .mockWith(
         listener: .mockWith(firstName: "John", lastName: nil)
       ))
-    XCTAssertEqual(model.listenerName, "John")
+    #expect(model.listenerName == "John")
   }
 
+  @Test
   func testListenerNameShowsUnknownWhenNoListener() {
     let model = makeModel(question: .mockWith(listener: nil))
-    XCTAssertEqual(model.listenerName, "Unknown Listener")
+    #expect(model.listenerName == "Unknown Listener")
   }
 
+  @Test
   func testListenerInitialsShowsBothInitials() {
     let model = makeModel(
       question: .mockWith(
         listener: .mockWith(firstName: "John", lastName: "Doe")
       ))
-    XCTAssertEqual(model.listenerInitials, "JD")
+    #expect(model.listenerInitials == "JD")
   }
 
+  @Test
   func testListenerInitialsShowsFirstInitialOnlyWhenNoLastName() {
     let model = makeModel(
       question: .mockWith(
         listener: .mockWith(firstName: "John", lastName: nil)
       ))
-    XCTAssertEqual(model.listenerInitials, "J")
+    #expect(model.listenerInitials == "J")
   }
 
+  @Test
   func testListenerInitialsShowsQuestionMarkWhenNoListener() {
     let model = makeModel(question: .mockWith(listener: nil))
-    XCTAssertEqual(model.listenerInitials, "?")
+    #expect(model.listenerInitials == "?")
   }
 
+  @Test
   func testListenerProfileImageUrlReturnsUrlWhenPresent() {
     let model = makeModel(
       question: .mockWith(
         listener: .mockWith(profileImageUrl: "https://example.com/image.jpg")
       ))
-    XCTAssertEqual(model.listenerProfileImageUrl?.absoluteString, "https://example.com/image.jpg")
+    #expect(model.listenerProfileImageUrl?.absoluteString == "https://example.com/image.jpg")
   }
 
+  @Test
   func testListenerProfileImageUrlReturnsNilWhenNoUrl() {
     let model = makeModel(
       question: .mockWith(
         listener: .mockWith(profileImageUrl: nil)
       ))
-    XCTAssertNil(model.listenerProfileImageUrl)
+    #expect(model.listenerProfileImageUrl == nil)
   }
 
+  @Test
   func testListenerProfileImageUrlReturnsNilWhenNoListener() {
     let model = makeModel(question: .mockWith(listener: nil))
-    XCTAssertNil(model.listenerProfileImageUrl)
+    #expect(model.listenerProfileImageUrl == nil)
   }
 
   // MARK: - Transcription Tests
 
+  @Test
   func testTranscriptionShowsAudioBlockTranscription() {
     let audioBlock = AudioBlock.mockWith(transcription: "What's your favorite song?")
     let model = makeModel(question: .mockWith(audioBlock: audioBlock))
-    XCTAssertEqual(model.transcription, "What's your favorite song?")
+    #expect(model.transcription == "What's your favorite song?")
   }
 
+  @Test
   func testTranscriptionShowsFallbackWhenNoAudioBlock() {
     let model = makeModel(question: .mockWith(audioBlock: nil))
-    XCTAssertEqual(model.transcription, "No transcription available")
+    #expect(model.transcription == "No transcription available")
   }
 
   // MARK: - Recording Phase Tests
 
+  @Test
   func testRecordButtonLabelInIdlePhase() {
     let model = makeModel()
     model.recordingPhase = .idle
-    XCTAssertEqual(model.recordButtonLabel, "Tap to Record")
+    #expect(model.recordButtonLabel == "Tap to Record")
   }
 
+  @Test
   func testRecordButtonLabelInRecordingPhase() {
     let model = makeModel()
     model.recordingPhase = .recording
-    XCTAssertEqual(model.recordButtonLabel, "Tap to Stop")
+    #expect(model.recordButtonLabel == "Tap to Stop")
   }
 
+  @Test
   func testRecordButtonLabelInReviewPhase() {
     let model = makeModel()
     model.recordingPhase = .review
-    XCTAssertEqual(model.recordButtonLabel, "Try Again")
+    #expect(model.recordButtonLabel == "Try Again")
   }
 
+  @Test
   func testRecordButtonIconInIdlePhase() {
     let model = makeModel()
     model.recordingPhase = .idle
-    XCTAssertEqual(model.recordButtonIcon, "mic.fill")
+    #expect(model.recordButtonIcon == "mic.fill")
   }
 
+  @Test
   func testRecordButtonIconInRecordingPhase() {
     let model = makeModel()
     model.recordingPhase = .recording
-    XCTAssertEqual(model.recordButtonIcon, "stop.fill")
+    #expect(model.recordButtonIcon == "stop.fill")
   }
 
+  @Test
   func testRecordButtonIconInReviewPhase() {
     let model = makeModel()
     model.recordingPhase = .review
-    XCTAssertEqual(model.recordButtonIcon, "mic.fill")
+    #expect(model.recordButtonIcon == "mic.fill")
   }
 
+  @Test
   func testShowRecordingIndicatorTrueWhenRecording() {
     let model = makeModel()
     model.recordingPhase = .recording
-    XCTAssertTrue(model.showRecordingIndicator)
+    #expect(model.showRecordingIndicator)
   }
 
+  @Test
   func testShowRecordingIndicatorFalseWhenIdle() {
     let model = makeModel()
     model.recordingPhase = .idle
-    XCTAssertFalse(model.showRecordingIndicator)
+    #expect(!model.showRecordingIndicator)
   }
 
+  @Test
   func testShowRecordingIndicatorFalseWhenReview() {
     let model = makeModel()
     model.recordingPhase = .review
-    XCTAssertFalse(model.showRecordingIndicator)
+    #expect(!model.showRecordingIndicator)
   }
 
   // MARK: - Waveform Display Tests
 
+  @Test
   func testShowWaveformPlaceholderTrueWhenIdleAndNoSamples() {
     let model = makeModel()
     model.recordingPhase = .idle
     model.recordingState = .idle
-    XCTAssertTrue(model.showWaveformPlaceholder)
+    #expect(model.showWaveformPlaceholder)
   }
 
+  @Test
   func testShowWaveformPlaceholderFalseWhenRecording() {
     let model = makeModel()
     model.recordingPhase = .recording
-    XCTAssertFalse(model.showWaveformPlaceholder)
+    #expect(!model.showWaveformPlaceholder)
   }
 
+  @Test
   func testShowWaveformPlaceholderFalseWhenHasSamples() {
     let model = makeModel()
     model.recordingPhase = .idle
     model.recordingState = RecordingState(
       currentTime: 1.0, waveformSamples: [0.5], isRecording: false)
-    XCTAssertFalse(model.showWaveformPlaceholder)
+    #expect(!model.showWaveformPlaceholder)
   }
 
+  @Test
   func testWaveformPlaceholderText() {
     let model = makeModel()
-    XCTAssertEqual(model.waveformPlaceholderText, "Your recording will appear here")
+    #expect(model.waveformPlaceholderText == "Your recording will appear here")
   }
 
   // MARK: - Answer Playback Display Tests
 
+  @Test
   func testShowAnswerPlaybackControlsTrueWhenReview() {
     let model = makeModel()
     model.recordingPhase = .review
-    XCTAssertTrue(model.showAnswerPlaybackControls)
+    #expect(model.showAnswerPlaybackControls)
   }
 
+  @Test
   func testShowAnswerPlaybackControlsFalseWhenIdle() {
     let model = makeModel()
     model.recordingPhase = .idle
-    XCTAssertFalse(model.showAnswerPlaybackControls)
+    #expect(!model.showAnswerPlaybackControls)
   }
 
+  @Test
   func testShowAnswerPlaybackControlsFalseWhenRecording() {
     let model = makeModel()
     model.recordingPhase = .recording
-    XCTAssertFalse(model.showAnswerPlaybackControls)
+    #expect(!model.showAnswerPlaybackControls)
   }
 
+  @Test
   func testShowAnswerActionButtonsTrueWhenReviewAndNotUploading() {
     let model = makeModel()
     model.recordingPhase = .review
     model.uploadPhase = .notStarted
-    XCTAssertTrue(model.showAnswerActionButtons)
+    #expect(model.showAnswerActionButtons)
   }
 
+  @Test
   func testShowAnswerActionButtonsFalseWhenUploading() {
     let model = makeModel()
     model.recordingPhase = .review
     model.uploadPhase = .uploading(progress: 0.5)
-    XCTAssertFalse(model.showAnswerActionButtons)
+    #expect(!model.showAnswerActionButtons)
   }
 
+  @Test
   func testShowAnswerActionButtonsFalseWhenCompleted() {
     let model = makeModel()
     model.recordingPhase = .review
     model.uploadPhase = .completed
-    XCTAssertFalse(model.showAnswerActionButtons)
+    #expect(!model.showAnswerActionButtons)
   }
 
   // MARK: - Upload Phase Tests
 
+  @Test
   func testIsUploadingFalseWhenNotStarted() {
     let model = makeModel()
     model.uploadPhase = .notStarted
-    XCTAssertFalse(model.isUploading)
+    #expect(!model.isUploading)
   }
 
+  @Test
   func testIsUploadingTrueWhenConverting() {
     let model = makeModel()
     model.uploadPhase = .converting
-    XCTAssertTrue(model.isUploading)
+    #expect(model.isUploading)
   }
 
+  @Test
   func testIsUploadingTrueWhenUploading() {
     let model = makeModel()
     model.uploadPhase = .uploading(progress: 0.5)
-    XCTAssertTrue(model.isUploading)
+    #expect(model.isUploading)
   }
 
+  @Test
   func testIsUploadingTrueWhenNormalizing() {
     let model = makeModel()
     model.uploadPhase = .normalizing
-    XCTAssertTrue(model.isUploading)
+    #expect(model.isUploading)
   }
 
+  @Test
   func testIsUploadingTrueWhenFinalizing() {
     let model = makeModel()
     model.uploadPhase = .finalizing
-    XCTAssertTrue(model.isUploading)
+    #expect(model.isUploading)
   }
 
+  @Test
   func testIsUploadingFalseWhenCompleted() {
     let model = makeModel()
     model.uploadPhase = .completed
-    XCTAssertFalse(model.isUploading)
+    #expect(!model.isUploading)
   }
 
+  @Test
   func testIsUploadingFalseWhenFailed() {
     let model = makeModel()
     model.uploadPhase = .failed(error: "Some error")
-    XCTAssertFalse(model.isUploading)
+    #expect(!model.isUploading)
   }
 
+  @Test
   func testUploadStatusTextNotStarted() {
     let model = makeModel()
     model.uploadPhase = .notStarted
-    XCTAssertEqual(model.uploadStatusText, "")
+    #expect(model.uploadStatusText == "")
   }
 
+  @Test
   func testUploadStatusTextConverting() {
     let model = makeModel()
     model.uploadPhase = .converting
-    XCTAssertEqual(model.uploadStatusText, "Converting audio...")
+    #expect(model.uploadStatusText == "Converting audio...")
   }
 
+  @Test
   func testUploadStatusTextUploading() {
     let model = makeModel()
     model.uploadPhase = .uploading(progress: 0.5)
-    XCTAssertEqual(model.uploadStatusText, "Uploading 50%")
+    #expect(model.uploadStatusText == "Uploading 50%")
   }
 
+  @Test
   func testUploadStatusTextNormalizing() {
     let model = makeModel()
     model.uploadPhase = .normalizing
-    XCTAssertEqual(model.uploadStatusText, "Processing...")
+    #expect(model.uploadStatusText == "Processing...")
   }
 
+  @Test
   func testUploadStatusTextFinalizing() {
     let model = makeModel()
     model.uploadPhase = .finalizing
-    XCTAssertEqual(model.uploadStatusText, "Finalizing...")
+    #expect(model.uploadStatusText == "Finalizing...")
   }
 
+  @Test
   func testUploadStatusTextCompleted() {
     let model = makeModel()
     model.uploadPhase = .completed
-    XCTAssertEqual(model.uploadStatusText, "Complete!")
+    #expect(model.uploadStatusText == "Complete!")
   }
 
+  @Test
   func testUploadStatusTextFailed() {
     let model = makeModel()
     model.uploadPhase = .failed(error: "Network error")
-    XCTAssertEqual(model.uploadStatusText, "Failed: Network error")
+    #expect(model.uploadStatusText == "Failed: Network error")
   }
 
+  @Test
   func testUploadProgressNotStarted() {
     let model = makeModel()
     model.uploadPhase = .notStarted
-    XCTAssertEqual(model.uploadProgress, 0)
+    #expect(model.uploadProgress == 0)
   }
 
+  @Test
   func testUploadProgressConverting() {
     let model = makeModel()
     model.uploadPhase = .converting
-    XCTAssertEqual(model.uploadProgress, 0.1)
+    #expect(model.uploadProgress == 0.1)
   }
 
+  @Test
   func testUploadProgressUploading() {
     let model = makeModel()
     model.uploadPhase = .uploading(progress: 0.5)
-    XCTAssertEqual(model.uploadProgress, 0.35, accuracy: 0.01)
+    #expect(abs(model.uploadProgress - 0.35) < 0.01)
   }
 
+  @Test
   func testUploadProgressNormalizing() {
     let model = makeModel()
     model.uploadPhase = .normalizing
-    XCTAssertEqual(model.uploadProgress, 0.65)
+    #expect(model.uploadProgress == 0.65)
   }
 
+  @Test
   func testUploadProgressFinalizing() {
     let model = makeModel()
     model.uploadPhase = .finalizing
-    XCTAssertEqual(model.uploadProgress, 0.75)
+    #expect(model.uploadProgress == 0.75)
   }
 
+  @Test
   func testUploadProgressCompleted() {
     let model = makeModel()
     model.uploadPhase = .completed
-    XCTAssertEqual(model.uploadProgress, 1.0)
+    #expect(model.uploadProgress == 1.0)
   }
 
+  @Test
   func testUploadProgressFailed() {
     let model = makeModel()
     model.uploadPhase = .failed(error: "Error")
-    XCTAssertEqual(model.uploadProgress, 0)
+    #expect(model.uploadProgress == 0)
   }
 
+  @Test
   func testCanRecordTrueWhenNotUploadingAndNotCompleted() {
     let model = makeModel()
     model.uploadPhase = .notStarted
-    XCTAssertTrue(model.canRecord)
+    #expect(model.canRecord)
   }
 
+  @Test
   func testCanRecordFalseWhenUploading() {
     let model = makeModel()
     model.uploadPhase = .uploading(progress: 0.5)
-    XCTAssertFalse(model.canRecord)
+    #expect(!model.canRecord)
   }
 
+  @Test
   func testCanRecordFalseWhenCompleted() {
     let model = makeModel()
     model.uploadPhase = .completed
-    XCTAssertFalse(model.canRecord)
+    #expect(!model.canRecord)
   }
 
+  @Test
   func testShowUploadStatusFalseWhenNotStarted() {
     let model = makeModel()
     model.uploadPhase = .notStarted
-    XCTAssertFalse(model.showUploadStatus)
+    #expect(!model.showUploadStatus)
   }
 
+  @Test
   func testShowUploadStatusTrueWhenUploading() {
     let model = makeModel()
     model.uploadPhase = .uploading(progress: 0.5)
-    XCTAssertTrue(model.showUploadStatus)
+    #expect(model.showUploadStatus)
   }
 
+  @Test
   func testShowUploadStatusTrueWhenLinkingAnswer() {
     let model = makeModel()
     model.uploadPhase = .linkingAnswer
-    XCTAssertTrue(model.showUploadStatus)
+    #expect(model.showUploadStatus)
   }
 
   // MARK: - Linking Answer Phase Tests
 
+  @Test
   func testIsUploadingTrueWhenLinkingAnswer() {
     let model = makeModel()
     model.uploadPhase = .linkingAnswer
-    XCTAssertTrue(model.isUploading)
+    #expect(model.isUploading)
   }
 
+  @Test
   func testUploadStatusTextLinkingAnswer() {
     let model = makeModel()
     model.uploadPhase = .linkingAnswer
-    XCTAssertEqual(model.uploadStatusText, "Registering response...")
+    #expect(model.uploadStatusText == "Registering response...")
   }
 
+  @Test
   func testUploadProgressLinkingAnswer() {
     let model = makeModel()
     model.uploadPhase = .linkingAnswer
-    XCTAssertEqual(model.uploadProgress, 0.85)
+    #expect(model.uploadProgress == 0.85)
   }
 
   // MARK: - Upload Answer API Integration Tests
 
+  @Test
   func testUploadButtonTappedCallsRegisterListenerQuestionAnswerAPI() async {
     let registerAnswerCalled = LockIsolated(false)
     let capturedStationId = LockIsolated<String?>(nil)
@@ -470,12 +536,13 @@ final class ListenerQuestionDetailPageTests: XCTestCase {
 
     await model.uploadButtonTapped()
 
-    XCTAssertTrue(registerAnswerCalled.value)
-    XCTAssertEqual(capturedStationId.value, "test-station-789")
-    XCTAssertEqual(capturedQuestionId.value, "test-question-123")
-    XCTAssertEqual(capturedAudioBlockId.value, "uploaded-audio-block-456")
+    #expect(registerAnswerCalled.value)
+    #expect(capturedStationId.value == "test-station-789")
+    #expect(capturedQuestionId.value == "test-question-123")
+    #expect(capturedAudioBlockId.value == "uploaded-audio-block-456")
   }
 
+  @Test
   func testUploadButtonTappedSetsLinkingAnswerPhase() async {
     let testQuestion = ListenerQuestion.mockWith(
       id: "test-question-123",
@@ -506,9 +573,10 @@ final class ListenerQuestionDetailPageTests: XCTestCase {
 
     await model.uploadButtonTapped()
 
-    XCTAssertEqual(model.uploadPhase, AnswerUploadPhase.completed)
+    #expect(model.uploadPhase == AnswerUploadPhase.completed)
   }
 
+  @Test
   func testUploadButtonTappedSetsFailedPhaseOnAPIError() async {
     let testQuestion = ListenerQuestion.mockWith(
       id: "test-question-123",
@@ -540,42 +608,47 @@ final class ListenerQuestionDetailPageTests: XCTestCase {
     await model.uploadButtonTapped()
 
     if case .failed(let error) = model.uploadPhase {
-      XCTAssertEqual(error, "Failed to link answer")
+      #expect(error == "Failed to link answer")
     } else {
-      XCTFail("Expected failed phase, got: \(model.uploadPhase)")
+      Issue.record("Expected failed phase, got: \(model.uploadPhase)")
     }
   }
 
   // MARK: - Question Playback Display Tests
 
+  @Test
   func testQuestionPlayButtonIconShowsPlayWhenNotPlaying() {
     let model = makeModel()
     model.questionPlaybackState = .idle
-    XCTAssertEqual(model.questionPlayButtonIcon, "play.fill")
+    #expect(model.questionPlayButtonIcon == "play.fill")
   }
 
+  @Test
   func testQuestionPlayButtonIconShowsStopWhenPlaying() {
     let model = makeModel()
     model.questionPlaybackState = PlaybackState(currentTime: 0, duration: 10, isPlaying: true)
-    XCTAssertEqual(model.questionPlayButtonIcon, "stop.fill")
+    #expect(model.questionPlayButtonIcon == "stop.fill")
   }
 
   // MARK: - Answer Playback Display Tests
 
+  @Test
   func testAnswerPlayButtonIconShowsPlayWhenNotPlaying() {
     let model = makeModel()
     model.answerPlaybackState = .idle
-    XCTAssertEqual(model.answerPlayButtonIcon, "play.fill")
+    #expect(model.answerPlayButtonIcon == "play.fill")
   }
 
+  @Test
   func testAnswerPlayButtonIconShowsPauseWhenPlaying() {
     let model = makeModel()
     model.answerPlaybackState = PlaybackState(currentTime: 0, duration: 10, isPlaying: true)
-    XCTAssertEqual(model.answerPlayButtonIcon, "pause.fill")
+    #expect(model.answerPlayButtonIcon == "pause.fill")
   }
 
   // MARK: - Recording Button Tapped Tests
 
+  @Test
   func testRecordButtonTappedRequestsPermissionWhenIdle() async {
     let startRecordingCalled = LockIsolated(false)
     let model = withDependencies {
@@ -602,9 +675,10 @@ final class ListenerQuestionDetailPageTests: XCTestCase {
     model.recordingPhase = .idle
     await model.recordButtonTapped()
 
-    XCTAssertTrue(startRecordingCalled.value)
+    #expect(startRecordingCalled.value)
   }
 
+  @Test
   func testRecordButtonTappedShowsPermissionAlertWhenDenied() async {
     let model = withDependencies {
       $0.audioPlayer = .testValue
@@ -628,7 +702,7 @@ final class ListenerQuestionDetailPageTests: XCTestCase {
     model.recordingPhase = .idle
     await model.recordButtonTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
+    #expect(model.presentedAlert != nil)
   }
 
   // MARK: - Helper

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -57,6 +57,8 @@ class MainContainerModel: ViewModel {
   var contactPageModel = ContactPageModel()
   var liveStationsPoller = LiveStationsPoller()
 
+  @ObservationIgnored private var toastObservationTask: Task<Void, Never>?
+
   // Broadcast mode models
   var broadcastPageModel: BroadcastPageModel?
   var libraryPageModel: LibraryPageModel?
@@ -323,14 +325,12 @@ class MainContainerModel: ViewModel {
   }
 
   func observeToasts() {
-    Task { @MainActor in
-      while true {
-        if let currentToast = await toast.currentToast() {
-          self.presentedToast = currentToast
-        } else {
-          self.presentedToast = nil
-        }
-        try? await Task.sleep(for: .milliseconds(100))
+    toastObservationTask?.cancel()
+    toastObservationTask = Task { [weak self] in
+      guard let stream = self?.toast.stream() else { return }
+      for await toast in stream {
+        guard !Task.isCancelled else { return }
+        self?.presentedToast = toast
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -329,6 +329,10 @@ class MainContainerModel: ViewModel {
       }
     }
   }
+
+  deinit {
+    toastObservationTask?.cancel()
+  }
 }
 
 extension PlayolaAlert {

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -22,7 +22,7 @@ class MainContainerModel: ViewModel {
   @ObservationIgnored @Dependency(\.toast) var toast
   @ObservationIgnored @Dependency(\.pushNotifications) var pushNotifications
   @ObservationIgnored @Dependency(\.appRating) var appRating
-  @ObservationIgnored var stationPlayer: StationPlayer!
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
   @ObservationIgnored @Shared(.stationLists) var stationLists
   @ObservationIgnored @Shared(.stationListsLoaded) var stationListsLoaded: Bool = false
   @ObservationIgnored @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
@@ -66,11 +66,6 @@ class MainContainerModel: ViewModel {
 
   var shouldShowSmallPlayer: Bool = false
   private var hasCheckedRatingPromptThisSession = false
-
-  init(stationPlayer: StationPlayer? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
-    super.init()
-  }
 
   // MARK: - Mode-Aware Properties
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -304,6 +304,9 @@ struct MainContainerTests {
 
   @Test
   func testProcessNewStationStateDoesNotPresentSheetForOtherStates() {
+    @Shared(.mainContainerNavigationCoordinator)
+    var coordinator = MainContainerNavigationCoordinator()
+
     let stationPlayerMock = StationPlayerMock()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -17,8 +17,9 @@ import Testing
 
 @testable import PlayolaRadio
 
-// Helper function to create valid JWT tokens for testing
-private func createTestJWT(
+// Helper function to create valid JWT tokens for testing.
+// Module-internal (not file-private) so HomePageTests can reuse it.
+func createTestJWT(
   id: String = "test-user-123",
   firstName: String = "Test",
   lastName: String? = "User",
@@ -787,42 +788,49 @@ struct MainContainerTests {
       let markShownCalled = LockIsolated(false)
       let markDismissedCalled = LockIsolated(false)
 
-      await confirmation("feedbackSheetPresented tracked") { feedbackSheetConfirmation in
-        let mainContainerModel = withDependencies {
-          $0.api.getStations = { [] }
-          $0.pushNotifications.registerForRemoteNotifications = {}
-          $0.appRating.shouldShowRatingPrompt = { _ in true }
-          $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
-          $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
-          $0.analytics.track = { @Sendable event in
-            capturedEvents.withValue { $0.append(event) }
-            if event == .feedbackSheetPresented { feedbackSheetConfirmation() }
-          }
-        } operation: {
-          MainContainerModel()
+      let mainContainerModel = withDependencies {
+        $0.api.getStations = { [] }
+        $0.pushNotifications.registerForRemoteNotifications = {}
+        $0.appRating.shouldShowRatingPrompt = { _ in true }
+        $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
+        $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
+        $0.analytics.track = { @Sendable event in
+          capturedEvents.withValue { $0.append(event) }
         }
+      } operation: {
+        MainContainerModel()
+      }
 
-        mainContainerModel.checkAndShowRatingPromptIfNeeded()
-        await mainContainerModel.presentedAlert?.secondaryAction?()
+      mainContainerModel.checkAndShowRatingPromptIfNeeded()
+      await mainContainerModel.presentedAlert?.secondaryAction?()
 
-        // showFeedbackSheet() spawns a Task that awaits analytics.track
-        // before presenting the sheet — yield enough times for it to drain.
-        for _ in 0..<10 { await Task.yield() }
-
-        #expect(markShownCalled.value)
-        #expect(
-          markDismissedCalled.value,
-          "Not really should also set dismiss date for 7-day cooldown")
-        #expect(capturedEvents.value.contains { $0 == .ratingPromptNotEnjoying })
-        #expect(
-          mainContainerModel.presentedAlert == nil,
-          "Alert should be dismissed before showing feedback sheet")
-        guard
-          case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet
-        else {
-          Issue.record("Expected feedback sheet to be presented")
-          return
+      // Drain the spawned Task in showFeedbackSheet() — it awaits
+      // analytics.track and then assigns presentedSheet. Polling on the
+      // observable end-state (presentedSheet being .feedbackSheet) is
+      // resilient to changes in the number of internal async hops.
+      for _ in 0..<50 {
+        if case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator
+          .presentedSheet
+        {
+          break
         }
+        await Task.yield()
+      }
+
+      #expect(markShownCalled.value)
+      #expect(
+        markDismissedCalled.value,
+        "Not really should also set dismiss date for 7-day cooldown")
+      #expect(capturedEvents.value.contains { $0 == .ratingPromptNotEnjoying })
+      #expect(capturedEvents.value.contains { $0 == .feedbackSheetPresented })
+      #expect(
+        mainContainerModel.presentedAlert == nil,
+        "Alert should be dismissed before showing feedback sheet")
+      guard
+        case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet
+      else {
+        Issue.record("Expected feedback sheet to be presented")
+        return
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -7,58 +7,60 @@
 
 // swiftlint:disable force_try
 
+import ConcurrencyExtras
 import Dependencies
 import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
-@MainActor
-final class MainContainerTests: XCTestCase {
-  // Helper function to create valid JWT tokens for testing
-  static func createTestJWT(
-    id: String = "test-user-123",
-    firstName: String = "Test",
-    lastName: String? = "User",
-    email: String = "test@example.com",
-    profileImageUrl: String? = nil,
-    role: String = "user"
-  ) -> String {
-    let header = ["alg": "HS256", "typ": "JWT"]
-    var payload: [String: Any] = [
-      "id": id,
-      "firstName": firstName,
-      "email": email,
-      "role": role,
-    ]
-    if let lastName = lastName {
-      payload["lastName"] = lastName
-    }
-    if let profileImageUrl = profileImageUrl {
-      payload["profileImageUrl"] = profileImageUrl
-    }
-
-    let headerData = try! JSONSerialization.data(withJSONObject: header)
-    let payloadData = try! JSONSerialization.data(withJSONObject: payload)
-
-    let headerString = headerData.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-
-    let payloadString = payloadData.base64EncodedString()
-      .replacingOccurrences(of: "+", with: "-")
-      .replacingOccurrences(of: "/", with: "_")
-      .replacingOccurrences(of: "=", with: "")
-
-    return "\(headerString).\(payloadString).fake_signature"
+// Helper function to create valid JWT tokens for testing
+private func createTestJWT(
+  id: String = "test-user-123",
+  firstName: String = "Test",
+  lastName: String? = "User",
+  email: String = "test@example.com",
+  profileImageUrl: String? = nil,
+  role: String = "user"
+) -> String {
+  let header = ["alg": "HS256", "typ": "JWT"]
+  var payload: [String: Any] = [
+    "id": id,
+    "firstName": firstName,
+    "email": email,
+    "role": role,
+  ]
+  if let lastName = lastName {
+    payload["lastName"] = lastName
+  }
+  if let profileImageUrl = profileImageUrl {
+    payload["profileImageUrl"] = profileImageUrl
   }
 
+  let headerData = try! JSONSerialization.data(withJSONObject: header)
+  let payloadData = try! JSONSerialization.data(withJSONObject: payload)
+
+  let headerString = headerData.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+
+  let payloadString = payloadData.base64EncodedString()
+    .replacingOccurrences(of: "+", with: "-")
+    .replacingOccurrences(of: "/", with: "_")
+    .replacingOccurrences(of: "=", with: "")
+
+  return "\(headerString).\(payloadString).fake_signature"
+}
+
+@MainActor
+struct MainContainerTests {
   // MARK: - ViewAppeared Tests
 
+  @Test
   func testViewAppearedRegistersForRemoteNotifications() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     let registerForRemoteNotificationsCalled = LockIsolated(false)
@@ -73,10 +75,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertTrue(registerForRemoteNotificationsCalled.value)
+    #expect(registerForRemoteNotificationsCalled.value)
   }
 
-  func testViewAppeared_CorrectlyRetrievesStationListsWhenApiIsSuccessful() async {
+  @Test
+  func testViewAppearedCorrectlyRetrievesStationListsWhenApiIsSuccessful() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     let getStationsCallCount = LockIsolated(0)
@@ -92,12 +95,13 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertEqual(getStationsCallCount.value, 1)
-    XCTAssertEqual(stationLists, StationList.mocks)
-    XCTAssertTrue(stationListsLoaded)
+    #expect(getStationsCallCount.value == 1)
+    #expect(stationLists == StationList.mocks)
+    #expect(stationListsLoaded)
   }
 
-  func testViewAppeared_DisplaysAnErrorAlertOnApiError() async {
+  @Test
+  func testViewAppearedDisplaysAnErrorAlertOnApiError() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     struct TestError: Error {
@@ -119,22 +123,22 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertEqual(mainContainerModel.presentedAlert, .errorLoadingStations)
-    XCTAssertFalse(stationListsLoaded)
+    #expect(mainContainerModel.presentedAlert == .errorLoadingStations)
+    #expect(!stationListsLoaded)
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .apiError(let endpoint, let error) = events.first {
-      XCTAssertEqual(endpoint, "getStations")
-      XCTAssertTrue(
+      #expect(endpoint == "getStations")
+      #expect(
         error.contains("TestError"), "Expected error to contain 'TestError', got: \(error)")
     } else {
-      XCTFail("Expected apiError event, got: \(String(describing: events.first))")
+      Issue.record("Expected apiError event, got: \(String(describing: events.first))")
     }
   }
 
-  func testViewAppeared_ExitsEarlyWhenStationListsAlreadyLoaded() async {
+  @Test
+  func testViewAppearedExitsEarlyWhenStationListsAlreadyLoaded() async {
     @Shared(.stationListsLoaded) var stationListsLoaded = true
     let getStationsCallCount = LockIsolated(0)
 
@@ -149,11 +153,12 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertEqual(getStationsCallCount.value, 0)
+    #expect(getStationsCallCount.value == 0)
   }
 
+  @Test
   func testViewAppearedLoadsAiringsWhenLoggedIn() async {
-    let testJWT = MainContainerTests.createTestJWT()
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
     @Shared(.stationListsLoaded) var stationListsLoaded = false
     @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
@@ -177,13 +182,14 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.viewAppeared()
 
-    XCTAssertEqual(getAiringsCallCount.value, 1)
-    XCTAssertEqual(airings.count, 2)
+    #expect(getAiringsCallCount.value == 1)
+    #expect(airings.count == 2)
   }
 
   // MARK: - Small Player Properties Tests
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenPlaying() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenPlaying() async {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
 
     let mainContainerModel = withDependencies {
@@ -194,10 +200,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertTrue(mainContainerModel.shouldShowSmallPlayer)
+    #expect(mainContainerModel.shouldShowSmallPlayer)
   }
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenLoading() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenLoading() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .loading(.mock))
 
@@ -209,10 +216,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertTrue(mainContainerModel.shouldShowSmallPlayer)
+    #expect(mainContainerModel.shouldShowSmallPlayer)
   }
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenStopped() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenStopped() async {
     let stationPlayerMock = StationPlayerMock.mockStoppedPlayer()
 
     let mainContainerModel = withDependencies {
@@ -223,10 +231,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertFalse(mainContainerModel.shouldShowSmallPlayer)
+    #expect(!mainContainerModel.shouldShowSmallPlayer)
   }
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenError() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenError() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .error)
 
@@ -238,10 +247,11 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertFalse(mainContainerModel.shouldShowSmallPlayer)
+    #expect(!mainContainerModel.shouldShowSmallPlayer)
   }
 
-  func testSmallPlayerProperties_ShouldShowSmallPlayerWhenStartingNewStation() async {
+  @Test
+  func testSmallPlayerPropertiesShouldShowSmallPlayerWhenStartingNewStation() async {
     let stationPlayerMock = StationPlayerMock()
     stationPlayerMock.state = StationPlayer.State(playbackStatus: .startingNewStation(.mock))
 
@@ -253,159 +263,148 @@ final class MainContainerTests: XCTestCase {
     }
 
     await mainContainerModel.viewAppeared()
-    XCTAssertTrue(mainContainerModel.shouldShowSmallPlayer)
+    #expect(mainContainerModel.shouldShowSmallPlayer)
   }
 
   // MARK: - Small Player Actions Tests
 
-  func testSmallPlayerActions_OnSmallPlayerTapped() {
+  @Test
+  func testSmallPlayerActionsOnSmallPlayerTapped() {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 
     mainContainerModel.onSmallPlayerTapped()
 
-    XCTAssertNotNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet != nil)
     if case .player = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet {
       // Test passes
     } else {
-      XCTFail("Expected player sheet to be presented")
+      Issue.record("Expected player sheet to be presented")
     }
   }
 
   // MARK: - Process New Station State Tests
 
-  func testProcessNewStationState_PresentsPlayerSheetWhenStartingNewStation() {
+  @Test
+  func testProcessNewStationStatePresentsPlayerSheetWhenStartingNewStation() {
     let stationPlayerMock = StationPlayerMock()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 
     let newState = StationPlayer.State(playbackStatus: .startingNewStation(.mock))
     mainContainerModel.processNewStationState(newState)
 
-    XCTAssertNotNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet != nil)
     if case .player = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet {
       // Test passes
     } else {
-      XCTFail("Expected player sheet to be presented")
+      Issue.record("Expected player sheet to be presented")
     }
   }
 
-  func testProcessNewStationState_DoesNotPresentSheetForOtherStates() {
+  @Test
+  func testProcessNewStationStateDoesNotPresentSheetForOtherStates() {
     let stationPlayerMock = StationPlayerMock()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 
     let playingState = StationPlayer.State(playbackStatus: .playing(.mock))
     mainContainerModel.processNewStationState(playingState)
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
 
     let stoppedState = StationPlayer.State(playbackStatus: .stopped)
     mainContainerModel.processNewStationState(stoppedState)
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
 
     let loadingState = StationPlayer.State(playbackStatus: .loading(.mock))
     mainContainerModel.processNewStationState(loadingState)
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
 
     let errorState = StationPlayer.State(playbackStatus: .error)
     mainContainerModel.processNewStationState(errorState)
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
   }
 
   // MARK: - Dismiss Button Tests
 
-  func testDismissButton_PlayerPageOnDismissClearsPresentedSheet() {
-    // @Shared(.mainContainerNavigationCoordinator)
-    // var mainContainerNavigationCoordinator = MainContainerNavigationCoordinator()
-    //
+  @Test
+  func testDismissButtonPlayerPageOnDismissClearsPresentedSheet() {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
     let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
 
-    // Trigger the presentation of the player sheet
     mainContainerModel.onSmallPlayerTapped()
 
-    // Verify the sheet is presented
-    XCTAssertNotNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet != nil)
 
-    // Extract the PlayerPageModel from the presented sheet
     guard
       case .player(let playerPageModel) = mainContainerModel.mainContainerNavigationCoordinator
         .presentedSheet
     else {
-      XCTFail("Expected player sheet to be presented")
+      Issue.record("Expected player sheet to be presented")
       return
     }
 
-    // Call the onDismiss callback
     playerPageModel.onDismiss?()
 
-    // Verify the sheet is now nil
-    XCTAssertNil(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet)
+    #expect(mainContainerModel.mainContainerNavigationCoordinator.presentedSheet == nil)
   }
 
   // MARK: - Playola Station Player Configuration Tests
 
-  func testPlayolaStationPlayer_ConfiguresPlayolaStationPlayerOnInit() async {
-    let testJWT = MainContainerTests.createTestJWT()
+  @Test
+  func testPlayolaStationPlayerConfiguresPlayolaStationPlayerOnInit() async {
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
-    // When MainContainerModel is created (user is logged in),
-    // it should configure PlayolaStationPlayer with authentication
-    let mainContainerModel = MainContainerModel()
-
-    XCTAssertNotNil(mainContainerModel, "MainContainerModel should be created successfully")
+    _ = MainContainerModel()
   }
 
-  func testPlayolaStationPlayer_UsesAuthenticatedSessionReporting() async {
-    let testJWT = MainContainerTests.createTestJWT()
+  @Test
+  func testPlayolaStationPlayerUsesAuthenticatedSessionReporting() async {
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
-    // MainContainerModel creation should configure PlayolaStationPlayer
-    // to use JWT tokens for session reporting
     _ = MainContainerModel()
 
-    XCTAssertTrue(auth.isLoggedIn)
-    XCTAssertEqual(auth.jwt, testJWT)
+    #expect(auth.isLoggedIn)
+    #expect(auth.jwt == testJWT)
   }
 
   // MARK: - Authentication State Lifecycle Tests
 
-  func testAuthStateLifecycle_MainContainerExistsOnlyWhenAuthenticated() async {
-    let testJWT = MainContainerTests.createTestJWT()
+  @Test
+  func testAuthStateLifecycleMainContainerExistsOnlyWhenAuthenticated() async {
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
-    // User is logged in - MainContainer can be created
-    XCTAssertTrue(auth.isLoggedIn)
-    let mainContainerModel = MainContainerModel()
-    XCTAssertNotNil(mainContainerModel)
+    #expect(auth.isLoggedIn)
+    _ = MainContainerModel()
 
-    // When user signs out, ContentView will destroy MainContainer
-    // and show SignInPage instead - this is handled by ContentView logic
     $auth.withLock { $0 = Auth() }
-    XCTAssertFalse(auth.isLoggedIn)
+    #expect(!auth.isLoggedIn)
   }
 
-  func testAuthStateLifecycle_MultipleLoginSessionsGetFreshConfig() async {
+  @Test
+  func testAuthStateLifecycleMultipleLoginSessionsGetFreshConfig() async {
     @Shared(.auth) var auth = Auth()
 
-    // First login session
-    let firstJWT = MainContainerTests.createTestJWT(
+    let firstJWT = createTestJWT(
       id: "user1", firstName: "First", lastName: "User")
     $auth.withLock { $0 = Auth(jwtToken: firstJWT) }
     _ = MainContainerModel()
-    XCTAssertEqual(auth.jwt, firstJWT)
+    #expect(auth.jwt == firstJWT)
 
-    // User logs out, logs back in with new token
     $auth.withLock { $0 = Auth() }
-    let secondJWT = MainContainerTests.createTestJWT(
+    let secondJWT = createTestJWT(
       id: "user2", firstName: "Second", lastName: "User")
     $auth.withLock { $0 = Auth(jwtToken: secondJWT) }
     _ = MainContainerModel()
-    XCTAssertEqual(auth.jwt, secondJWT)
+    #expect(auth.jwt == secondJWT)
   }
 
   // MARK: - Refresh On Foreground Tests
 
+  @Test
   func testRefreshOnForegroundRefreshesStationListsAndAirings() async {
-    let testJWT = MainContainerTests.createTestJWT()
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
     @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
@@ -432,14 +431,15 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.refreshOnForeground()
 
-    XCTAssertEqual(getStationsCallCount.value, 1)
-    XCTAssertEqual(getAiringsCallCount.value, 1)
-    XCTAssertEqual(stationLists, StationList.mocks)
-    XCTAssertEqual(airings.count, 2)
-    XCTAssertEqual(airings[id: "airing1"]?.id, "airing1")
-    XCTAssertEqual(airings[id: "airing2"]?.id, "airing2")
+    #expect(getStationsCallCount.value == 1)
+    #expect(getAiringsCallCount.value == 1)
+    #expect(stationLists == StationList.mocks)
+    #expect(airings.count == 2)
+    #expect(airings[id: "airing1"]?.id == "airing1")
+    #expect(airings[id: "airing2"]?.id == "airing2")
   }
 
+  @Test
   func testRefreshOnForegroundSkipsAiringsWhenNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
@@ -463,14 +463,15 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.refreshOnForeground()
 
-    XCTAssertEqual(getStationsCallCount.value, 1)
-    XCTAssertEqual(getAiringsCallCount.value, 0)
-    XCTAssertEqual(stationLists, StationList.mocks)
-    XCTAssertTrue(airings.isEmpty)
+    #expect(getStationsCallCount.value == 1)
+    #expect(getAiringsCallCount.value == 0)
+    #expect(stationLists == StationList.mocks)
+    #expect(airings.isEmpty)
   }
 
-  func testRefreshOnForeground_TracksAnalyticsOnStationsError() async {
-    let testJWT = MainContainerTests.createTestJWT()
+  @Test
+  func testRefreshOnForegroundTracksAnalyticsOnStationsError() async {
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
     struct TestError: Error {
@@ -494,7 +495,7 @@ final class MainContainerTests: XCTestCase {
     await mainContainerModel.refreshOnForeground()
 
     let events = capturedEvents.value
-    XCTAssertTrue(
+    #expect(
       events.contains { event in
         if case .apiError(let endpoint, _) = event {
           return endpoint == "getStations"
@@ -503,8 +504,9 @@ final class MainContainerTests: XCTestCase {
       })
   }
 
+  @Test
   func testRefreshOnForegroundRefreshesUnreadSupportCount() async {
-    let testJWT = MainContainerTests.createTestJWT()
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
     @Shared(.unreadSupportCount) var unreadSupportCount = 0
 
@@ -535,12 +537,13 @@ final class MainContainerTests: XCTestCase {
 
     await mainContainerModel.refreshOnForeground()
 
-    XCTAssertEqual(getSupportConversationCallCount.value, 1)
-    XCTAssertEqual(unreadSupportCount, 3)
+    #expect(getSupportConversationCallCount.value == 1)
+    #expect(unreadSupportCount == 3)
   }
 
+  @Test
   func testRefreshOnForegroundTracksAnalyticsOnAiringsError() async {
-    let testJWT = MainContainerTests.createTestJWT()
+    let testJWT = createTestJWT()
     @Shared(.auth) var auth = Auth(jwtToken: testJWT)
 
     struct TestError: Error {
@@ -564,7 +567,7 @@ final class MainContainerTests: XCTestCase {
     await mainContainerModel.refreshOnForeground()
 
     let events = capturedEvents.value
-    XCTAssertTrue(
+    #expect(
       events.contains { event in
         if case .apiError(let endpoint, _) = event {
           return endpoint == "getAirings"
@@ -572,8 +575,10 @@ final class MainContainerTests: XCTestCase {
         return false
       })
   }
+
   // MARK: - Rating Prompt Tests
 
+  @Test
   func testCheckRatingPromptShowsAlertWhenEligible() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -597,10 +602,11 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertNotNil(mainContainerModel.presentedAlert)
-    XCTAssertEqual(mainContainerModel.presentedAlert?.title, "Are you enjoying Playola Radio?")
+    #expect(mainContainerModel.presentedAlert != nil)
+    #expect(mainContainerModel.presentedAlert?.title == "Are you enjoying Playola Radio?")
   }
 
+  @Test
   func testCheckRatingPromptDoesNotShowWhenNotEligible() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -3, to: Date()
@@ -623,9 +629,10 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertNil(mainContainerModel.presentedAlert)
+    #expect(mainContainerModel.presentedAlert == nil)
   }
 
+  @Test
   func testCheckRatingPromptOnlyChecksOncePerSession() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -656,9 +663,10 @@ final class MainContainerTests: XCTestCase {
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertEqual(shouldShowCallCount.value, 1)
+    #expect(shouldShowCallCount.value == 1)
   }
 
+  @Test
   func testCheckRatingPromptDoesNotShowWhenNoListeningTracker() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -680,10 +688,11 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertFalse(shouldShowCalled.value)
-    XCTAssertNil(mainContainerModel.presentedAlert)
+    #expect(!shouldShowCalled.value)
+    #expect(mainContainerModel.presentedAlert == nil)
   }
 
+  @Test
   func testTabChangeChecksRatingPrompt() {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -711,13 +720,13 @@ final class MainContainerTests: XCTestCase {
       MainContainerModel(stationPlayer: stationPlayerMock)
     }
 
-    // Simulate tab change - this is what onChange(of: model.activeTab) responds to
     $activeTab.withLock { $0 = .stationsList }
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    XCTAssertTrue(shouldShowCalled.value)
+    #expect(shouldShowCalled.value)
   }
 
+  @Test
   func testRatingPromptEnjoyingTracksAnalyticsAndRequestsReview() async {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -750,17 +759,17 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    // Simulate tapping "Yes!"
     await mainContainerModel.presentedAlert?.primaryAction?()
 
-    XCTAssertTrue(markShownCalled.value)
-    XCTAssertTrue(requestReviewCalled.value)
-    XCTAssertTrue(capturedEvents.value.contains { $0 == .ratingPromptEnjoying })
+    #expect(markShownCalled.value)
+    #expect(requestReviewCalled.value)
+    #expect(capturedEvents.value.contains { $0 == .ratingPromptEnjoying })
   }
 
+  @Test
   func testRatingPromptNotEnjoyingTracksAnalyticsAndShowsFeedback() async {
     await withMainSerialExecutor {
-      let testJWT = MainContainerTests.createTestJWT()
+      let testJWT = createTestJWT()
       @Shared(.auth) var auth = Auth(jwtToken: testJWT)
       @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
         byAdding: .day, value: -10, to: Date()
@@ -777,43 +786,48 @@ final class MainContainerTests: XCTestCase {
       let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
       let markShownCalled = LockIsolated(false)
       let markDismissedCalled = LockIsolated(false)
-      let feedbackSheetExpectation = XCTestExpectation(
-        description: "feedbackSheetPresented tracked")
 
-      let mainContainerModel = withDependencies {
-        $0.api.getStations = { [] }
-        $0.pushNotifications.registerForRemoteNotifications = {}
-        $0.appRating.shouldShowRatingPrompt = { _ in true }
-        $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
-        $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
-        $0.analytics.track = { @Sendable event in
-          capturedEvents.withValue { $0.append(event) }
-          if event == .feedbackSheetPresented { feedbackSheetExpectation.fulfill() }
+      await confirmation("feedbackSheetPresented tracked") { feedbackSheetConfirmation in
+        let mainContainerModel = withDependencies {
+          $0.api.getStations = { [] }
+          $0.pushNotifications.registerForRemoteNotifications = {}
+          $0.appRating.shouldShowRatingPrompt = { _ in true }
+          $0.appRating.markRatingPromptShown = { markShownCalled.setValue(true) }
+          $0.appRating.markRatingPromptDismissed = { markDismissedCalled.setValue(true) }
+          $0.analytics.track = { @Sendable event in
+            capturedEvents.withValue { $0.append(event) }
+            if event == .feedbackSheetPresented { feedbackSheetConfirmation() }
+          }
+        } operation: {
+          MainContainerModel()
         }
-      } operation: {
-        MainContainerModel()
-      }
 
-      mainContainerModel.checkAndShowRatingPromptIfNeeded()
-      await mainContainerModel.presentedAlert?.secondaryAction?()
-      await fulfillment(of: [feedbackSheetExpectation], timeout: 1.0)
+        mainContainerModel.checkAndShowRatingPromptIfNeeded()
+        await mainContainerModel.presentedAlert?.secondaryAction?()
 
-      XCTAssertTrue(markShownCalled.value)
-      XCTAssertTrue(
-        markDismissedCalled.value, "Not really should also set dismiss date for 7-day cooldown")
-      XCTAssertTrue(capturedEvents.value.contains { $0 == .ratingPromptNotEnjoying })
-      XCTAssertNil(
-        mainContainerModel.presentedAlert, "Alert should be dismissed before showing feedback sheet"
-      )
-      guard
-        case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet
-      else {
-        XCTFail("Expected feedback sheet to be presented")
-        return
+        // showFeedbackSheet() spawns a Task that awaits analytics.track
+        // before presenting the sheet — yield enough times for it to drain.
+        for _ in 0..<10 { await Task.yield() }
+
+        #expect(markShownCalled.value)
+        #expect(
+          markDismissedCalled.value,
+          "Not really should also set dismiss date for 7-day cooldown")
+        #expect(capturedEvents.value.contains { $0 == .ratingPromptNotEnjoying })
+        #expect(
+          mainContainerModel.presentedAlert == nil,
+          "Alert should be dismissed before showing feedback sheet")
+        guard
+          case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator.presentedSheet
+        else {
+          Issue.record("Expected feedback sheet to be presented")
+          return
+        }
       }
     }
   }
 
+  @Test
   func testRatingPromptDismissedTracksAnalyticsAndMarksDismissed() async {
     @Shared(.appInstallDate) var appInstallDate = Calendar.current.date(
       byAdding: .day, value: -10, to: Date()
@@ -844,15 +858,15 @@ final class MainContainerTests: XCTestCase {
 
     mainContainerModel.checkAndShowRatingPromptIfNeeded()
 
-    // Simulate tapping "Not now"
     await mainContainerModel.presentedAlert?.tertiaryAction?()
 
-    XCTAssertTrue(markDismissedCalled.value)
-    XCTAssertTrue(capturedEvents.value.contains { $0 == .ratingPromptDismissed })
+    #expect(markDismissedCalled.value)
+    #expect(capturedEvents.value.contains { $0 == .ratingPromptDismissed })
   }
 
   // MARK: - Mode-Aware Properties Tests
 
+  @Test
   func testIsInBroadcastModeReturnsFalseWhenListening() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -860,9 +874,10 @@ final class MainContainerTests: XCTestCase {
 
     let mainContainerModel = MainContainerModel()
 
-    XCTAssertFalse(mainContainerModel.isInBroadcastMode)
+    #expect(!mainContainerModel.isInBroadcastMode)
   }
 
+  @Test
   func testIsInBroadcastModeReturnsTrueWhenBroadcasting() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -870,9 +885,10 @@ final class MainContainerTests: XCTestCase {
 
     let mainContainerModel = MainContainerModel()
 
-    XCTAssertTrue(mainContainerModel.isInBroadcastMode)
+    #expect(mainContainerModel.isInBroadcastMode)
   }
 
+  @Test
   func testBroadcastStationIdReturnsNilWhenListening() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -880,9 +896,10 @@ final class MainContainerTests: XCTestCase {
 
     let mainContainerModel = MainContainerModel()
 
-    XCTAssertNil(mainContainerModel.broadcastStationId)
+    #expect(mainContainerModel.broadcastStationId == nil)
   }
 
+  @Test
   func testBroadcastStationIdReturnsStationIdWhenBroadcasting() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -890,23 +907,25 @@ final class MainContainerTests: XCTestCase {
 
     let mainContainerModel = MainContainerModel()
 
-    XCTAssertEqual(mainContainerModel.broadcastStationId, "station-123")
+    #expect(mainContainerModel.broadcastStationId == "station-123")
   }
 
+  @Test
   func testEnsureBroadcastModelsCreatesBroadcastPageModel() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
     coordinator.appMode = .broadcasting(stationId: "station-123")
 
     let mainContainerModel = MainContainerModel()
-    XCTAssertNil(mainContainerModel.broadcastPageModel)
+    #expect(mainContainerModel.broadcastPageModel == nil)
 
     mainContainerModel.ensureBroadcastModels()
 
-    XCTAssertNotNil(mainContainerModel.broadcastPageModel)
-    XCTAssertEqual(mainContainerModel.broadcastPageModel?.stationId, "station-123")
+    #expect(mainContainerModel.broadcastPageModel != nil)
+    #expect(mainContainerModel.broadcastPageModel?.stationId == "station-123")
   }
 
+  @Test
   func testEnsureBroadcastModelsDoesNothingWhenListening() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -915,9 +934,10 @@ final class MainContainerTests: XCTestCase {
     let mainContainerModel = MainContainerModel()
     mainContainerModel.ensureBroadcastModels()
 
-    XCTAssertNil(mainContainerModel.broadcastPageModel)
+    #expect(mainContainerModel.broadcastPageModel == nil)
   }
 
+  @Test
   func testEnsureBroadcastModelsRecreatesModelsWhenStationIdChanges() {
     @Shared(.mainContainerNavigationCoordinator)
     var coordinator = MainContainerNavigationCoordinator()
@@ -927,13 +947,13 @@ final class MainContainerTests: XCTestCase {
     mainContainerModel.ensureBroadcastModels()
 
     let originalModel = mainContainerModel.broadcastPageModel
-    XCTAssertEqual(originalModel?.stationId, "station-123")
+    #expect(originalModel?.stationId == "station-123")
 
     coordinator.appMode = .broadcasting(stationId: "station-456")
     mainContainerModel.ensureBroadcastModels()
 
-    XCTAssertEqual(mainContainerModel.broadcastPageModel?.stationId, "station-456")
-    XCTAssertFalse(mainContainerModel.broadcastPageModel === originalModel)
+    #expect(mainContainerModel.broadcastPageModel?.stationId == "station-456")
+    #expect(!(mainContainerModel.broadcastPageModel === originalModel))
   }
 }
 // swiftlint:enable force_try

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -596,18 +596,18 @@ struct MainContainerTests {
       )
     )
 
-    let mainContainerModel = withDependencies {
+    withDependencies {
+      $0.date = .constant(Date())
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
       $0.appRating = .liveValue
     } operation: {
-      MainContainerModel()
+      let mainContainerModel = MainContainerModel()
+      mainContainerModel.checkAndShowRatingPromptIfNeeded()
+
+      #expect(mainContainerModel.presentedAlert != nil)
+      #expect(mainContainerModel.presentedAlert?.title == "Are you enjoying Playola Radio?")
     }
-
-    mainContainerModel.checkAndShowRatingPromptIfNeeded()
-
-    #expect(mainContainerModel.presentedAlert != nil)
-    #expect(mainContainerModel.presentedAlert?.title == "Are you enjoying Playola Radio?")
   }
 
   @Test
@@ -623,17 +623,17 @@ struct MainContainerTests {
       )
     )
 
-    let mainContainerModel = withDependencies {
+    withDependencies {
+      $0.date = .constant(Date())
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
       $0.appRating = .liveValue
     } operation: {
-      MainContainerModel()
+      let mainContainerModel = MainContainerModel()
+      mainContainerModel.checkAndShowRatingPromptIfNeeded()
+
+      #expect(mainContainerModel.presentedAlert == nil)
     }
-
-    mainContainerModel.checkAndShowRatingPromptIfNeeded()
-
-    #expect(mainContainerModel.presentedAlert == nil)
   }
 
   @Test

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -803,19 +803,7 @@ struct MainContainerTests {
 
       mainContainerModel.checkAndShowRatingPromptIfNeeded()
       await mainContainerModel.presentedAlert?.secondaryAction?()
-
-      // Drain the spawned Task in showFeedbackSheet() — it awaits
-      // analytics.track and then assigns presentedSheet. Polling on the
-      // observable end-state (presentedSheet being .feedbackSheet) is
-      // resilient to changes in the number of internal async hops.
-      for _ in 0..<50 {
-        if case .feedbackSheet = mainContainerModel.mainContainerNavigationCoordinator
-          .presentedSheet
-        {
-          break
-        }
-        await Task.yield()
-      }
+      await waitForFeedbackSheet(on: mainContainerModel.mainContainerNavigationCoordinator)
 
       #expect(markShownCalled.value)
       #expect(
@@ -962,6 +950,18 @@ struct MainContainerTests {
 
     #expect(mainContainerModel.broadcastPageModel?.stationId == "station-456")
     #expect(!(mainContainerModel.broadcastPageModel === originalModel))
+  }
+}
+
+// Drain the fire-and-forget Task in MainContainerModel.showFeedbackSheet()
+// (it awaits analytics.track then assigns presentedSheet). Polling on the
+// observable end-state is resilient to changes in the number of internal
+// async hops.
+@MainActor
+private func waitForFeedbackSheet(on coordinator: MainContainerNavigationCoordinator) async {
+  for _ in 0..<50 {
+    if case .feedbackSheet = coordinator.presentedSheet { return }
+    await Task.yield()
   }
 }
 // swiftlint:enable force_try

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -196,8 +196,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -212,8 +213,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -227,8 +229,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -243,8 +246,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -259,8 +263,9 @@ struct MainContainerTests {
     let mainContainerModel = withDependencies {
       $0.api.getStations = { [] }
       $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     await mainContainerModel.viewAppeared()
@@ -272,7 +277,11 @@ struct MainContainerTests {
   @Test
   func testSmallPlayerActionsOnSmallPlayerTapped() {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
-    let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
+    let mainContainerModel = withDependencies {
+      $0.stationPlayer = stationPlayerMock
+    } operation: {
+      MainContainerModel()
+    }
 
     mainContainerModel.onSmallPlayerTapped()
 
@@ -289,7 +298,11 @@ struct MainContainerTests {
   @Test
   func testProcessNewStationStatePresentsPlayerSheetWhenStartingNewStation() {
     let stationPlayerMock = StationPlayerMock()
-    let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
+    let mainContainerModel = withDependencies {
+      $0.stationPlayer = stationPlayerMock
+    } operation: {
+      MainContainerModel()
+    }
 
     let newState = StationPlayer.State(playbackStatus: .startingNewStation(.mock))
     mainContainerModel.processNewStationState(newState)
@@ -308,7 +321,11 @@ struct MainContainerTests {
     var coordinator = MainContainerNavigationCoordinator()
 
     let stationPlayerMock = StationPlayerMock()
-    let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
+    let mainContainerModel = withDependencies {
+      $0.stationPlayer = stationPlayerMock
+    } operation: {
+      MainContainerModel()
+    }
 
     let playingState = StationPlayer.State(playbackStatus: .playing(.mock))
     mainContainerModel.processNewStationState(playingState)
@@ -332,7 +349,11 @@ struct MainContainerTests {
   @Test
   func testDismissButtonPlayerPageOnDismissClearsPresentedSheet() {
     let stationPlayerMock = StationPlayerMock.mockPlayingPlayer()
-    let mainContainerModel = MainContainerModel(stationPlayer: stationPlayerMock)
+    let mainContainerModel = withDependencies {
+      $0.stationPlayer = stationPlayerMock
+    } operation: {
+      MainContainerModel()
+    }
 
     mainContainerModel.onSmallPlayerTapped()
 
@@ -720,8 +741,9 @@ struct MainContainerTests {
         shouldShowCalled.setValue(true)
         return false
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      MainContainerModel(stationPlayer: stationPlayerMock)
+      MainContainerModel()
     }
 
     $activeTab.withLock { $0 = .stationsList }

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageTests.swift
@@ -7,15 +7,17 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class NotificationsSettingsPageTests: XCTestCase {
+struct NotificationsSettingsPageTests {
+  @Test
   func testViewAppearedLoadsSubscriptions() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -30,12 +32,13 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.stationItems.count, 2)
-      XCTAssertTrue(model.isSubscribed(stationId: "station-1"))
-      XCTAssertFalse(model.isSubscribed(stationId: "station-2"))
+      #expect(model.stationItems.count == 2)
+      #expect(model.isSubscribed(stationId: "station-1"))
+      #expect(!model.isSubscribed(stationId: "station-2"))
     }
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -49,10 +52,11 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
+  @Test
   func testStationItemsShowsAllStations() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -66,18 +70,19 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertEqual(model.stationItems.count, 2)
+      #expect(model.stationItems.count == 2)
 
       let station1Item = model.stationItems.first { $0.station.id == "station-1" }
       let station2Item = model.stationItems.first { $0.station.id == "station-2" }
 
-      XCTAssertNotNil(station1Item)
-      XCTAssertNotNil(station2Item)
-      XCTAssertTrue(station1Item?.isSubscribed ?? false)
-      XCTAssertFalse(station2Item?.isSubscribed ?? true)
+      #expect(station1Item != nil)
+      #expect(station2Item != nil)
+      #expect(station1Item?.isSubscribed ?? false)
+      #expect(!(station2Item?.isSubscribed ?? true))
     }
   }
 
+  @Test
   func testStationItemStatusTextForNotSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -89,11 +94,12 @@ final class NotificationsSettingsPageTests: XCTestCase {
       await model.viewAppeared()
 
       let item = model.stationItems.first
-      XCTAssertEqual(item?.statusText, "Not subscribed")
-      XCTAssertFalse(item?.isSubscribed ?? true)
+      #expect(item?.statusText == "Not subscribed")
+      #expect(!(item?.isSubscribed ?? true))
     }
   }
 
+  @Test
   func testAllNotificationsEnabledWhenAllSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -108,10 +114,11 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertTrue(model.allNotificationsEnabled)
+      #expect(model.allNotificationsEnabled)
     }
   }
 
+  @Test
   func testAllNotificationsDisabledWhenSomeUnsubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -126,11 +133,12 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertFalse(model.allNotificationsEnabled)
-      XCTAssertTrue(model.someNotificationsEnabled)
+      #expect(!model.allNotificationsEnabled)
+      #expect(model.someNotificationsEnabled)
     }
   }
 
+  @Test
   func testToggleSubscriptionCallsUnsubscribeWhenSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -145,7 +153,7 @@ final class NotificationsSettingsPageTests: XCTestCase {
       $0.api.unsubscribeFromStationNotifications = { _, stationId in
         unsubscribeCalled.setValue(true)
         unsubscribedStationId.setValue(stationId)
-        return self.mockSubscription(stationId: stationId, isSubscribed: false)
+        return Self.mockSubscription(stationId: stationId, isSubscribed: false)
       }
     } operation: {
       let model = NotificationsSettingsPageModel()
@@ -153,11 +161,12 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.toggleSubscription(for: "station-1")
 
-      XCTAssertTrue(unsubscribeCalled.value)
-      XCTAssertEqual(unsubscribedStationId.value, "station-1")
+      #expect(unsubscribeCalled.value)
+      #expect(unsubscribedStationId.value == "station-1")
     }
   }
 
+  @Test
   func testToggleSubscriptionCallsSubscribeWhenNotSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -169,7 +178,7 @@ final class NotificationsSettingsPageTests: XCTestCase {
       $0.api.subscribeToStationNotifications = { _, stationId in
         subscribeCalled.setValue(true)
         subscribedStationId.setValue(stationId)
-        return self.mockSubscription(stationId: stationId, isSubscribed: true)
+        return Self.mockSubscription(stationId: stationId, isSubscribed: true)
       }
     } operation: {
       let model = NotificationsSettingsPageModel()
@@ -177,11 +186,12 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.toggleSubscription(for: "station-1")
 
-      XCTAssertTrue(subscribeCalled.value)
-      XCTAssertEqual(subscribedStationId.value, "station-1")
+      #expect(subscribeCalled.value)
+      #expect(subscribedStationId.value == "station-1")
     }
   }
 
+  @Test
   func testToggleSubscriptionShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationLists()
@@ -201,10 +211,11 @@ final class NotificationsSettingsPageTests: XCTestCase {
 
       await model.toggleSubscription(for: "station-1")
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
+  @Test
   func testInactiveStationsAreFilteredOut() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationListsWithInactiveStation()
@@ -215,13 +226,14 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertEqual(model.stationItems.count, 2)
-      XCTAssertNotNil(model.stationItems.first { $0.station.id == "station-1" })
-      XCTAssertNotNil(model.stationItems.first { $0.station.id == "station-2" })
-      XCTAssertNil(model.stationItems.first { $0.station.id == "inactive-station" })
+      #expect(model.stationItems.count == 2)
+      #expect(model.stationItems.first { $0.station.id == "station-1" } != nil)
+      #expect(model.stationItems.first { $0.station.id == "station-2" } != nil)
+      #expect(model.stationItems.first { $0.station.id == "inactive-station" } == nil)
     }
   }
 
+  @Test
   func testStationsAreSortedByCuratorName() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     @Shared(.stationLists) var stationLists = mockStationListsUnsorted()
@@ -232,10 +244,10 @@ final class NotificationsSettingsPageTests: XCTestCase {
       let model = NotificationsSettingsPageModel()
       await model.viewAppeared()
 
-      XCTAssertEqual(model.stationItems.count, 3)
-      XCTAssertEqual(model.stationItems[0].station.curatorName, "Alice")
-      XCTAssertEqual(model.stationItems[1].station.curatorName, "Bob")
-      XCTAssertEqual(model.stationItems[2].station.curatorName, "Charlie")
+      #expect(model.stationItems.count == 3)
+      #expect(model.stationItems[0].station.curatorName == "Alice")
+      #expect(model.stationItems[1].station.curatorName == "Bob")
+      #expect(model.stationItems[2].station.curatorName == "Charlie")
     }
   }
 
@@ -351,7 +363,7 @@ final class NotificationsSettingsPageTests: XCTestCase {
     ])
   }
 
-  nonisolated private func mockSubscription(stationId: String, isSubscribed: Bool)
+  nonisolated static func mockSubscription(stationId: String, isSubscribed: Bool)
     -> PushNotificationSubscription
   {
     PushNotificationSubscription(

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -183,10 +183,9 @@ class PlayerPageModel: ViewModel {
     return likesManager.isLiked(audioBlock.id) ? .filled : .empty
   }
 
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
-  init(stationPlayer: StationPlayer? = nil, onDismiss: (() -> Void)? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
+  init(onDismiss: (() -> Void)? = nil) {
     self.onDismiss = onDismiss
   }
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -382,6 +382,8 @@ struct PlayerPageTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
 
     withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
       $0.likesManager = LikesManager()
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
@@ -424,6 +426,8 @@ struct PlayerPageTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
 
     withDependencies {
+      $0.date = .constant(Date())
+      $0.uuid = .incrementing
       $0.likesManager = LikesManager()
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -10,59 +10,63 @@ import FRadioPlayer
 import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class PlayerPageTests: XCTestCase {
+struct PlayerPageTests {
   // MARK: - viewAppeared Tests
 
-  func testViewAppeared_PopulatesCorrectlyWhenLoadingNoProgress() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenLoadingNoProgress() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
-    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Station Loading...")
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenLoadingWithProgress() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenLoadingWithProgress() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station, 0.42))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
-    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
-    XCTAssertEqual(model.loadingPercentage, 0.42)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Station Loading...")
+    #expect(model.loadingPercentage == 0.42)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenSomethingIsPlaying() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenSomethingIsPlaying() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       artistPlaying: "Rachel Loy", titlePlaying: "Selfie", station: station)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Selfie - Rachel Loy")
-    XCTAssertEqual(model.stationArtUrl, station.imageUrl)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Selfie - Rachel Loy")
+    #expect(model.stationArtUrl == station.imageUrl)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenSomethingIsPlayingWithAudioBlock() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenSomethingIsPlayingWithAudioBlock() {
     let station = AnyStation.mock
     let audioBlock = AudioBlock.mockWith(title: "Selfie", artist: "Rachel Loy", type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
@@ -70,12 +74,13 @@ final class PlayerPageTests: XCTestCase {
       artistPlaying: "Rachel Loy", titlePlaying: "Selfie", spin: spin, station: station)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Selfie - Rachel Loy")
-    XCTAssertEqual(model.stationArtUrl, station.imageUrl)
-    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+    #expect(model.nowPlayingText == "Selfie - Rachel Loy")
+    #expect(model.stationArtUrl == station.imageUrl)
+    #expect(model.playolaAudioBlockPlaying == audioBlock)
   }
 
-  func testViewAppeared_PopulatesRelatedTextPrioritizingTheAudioBlockTranscription() {
+  @Test
+  func testViewAppearedPopulatesRelatedTextPrioritizingTheAudioBlockTranscription() {
     let transcription = "This is the transcription"
     let audioBlock = AudioBlock.mockWith(type: "song", transcription: transcription)
     let relatedTexts = [
@@ -86,12 +91,13 @@ final class PlayerPageTests: XCTestCase {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.relatedText?.title, "Why I chose this song")
-    XCTAssertEqual(model.relatedText?.body, transcription)
-    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+    #expect(model.relatedText?.title == "Why I chose this song")
+    #expect(model.relatedText?.body == transcription)
+    #expect(model.playolaAudioBlockPlaying == audioBlock)
   }
 
-  func testViewAppeared_PopulatesRelatedTextWhenRelatedTextButNoTranscription() {
+  @Test
+  func testViewAppearedPopulatesRelatedTextWhenRelatedTextButNoTranscription() {
     let audioBlock = AudioBlock.mockWith(type: "song", transcription: nil)
     let relatedTexts = [
       RelatedText(title: "title1", body: "body1"),
@@ -101,49 +107,53 @@ final class PlayerPageTests: XCTestCase {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertNotNil(model.relatedText)
-    XCTAssertTrue(model.relatedText == relatedTexts[0] || model.relatedText == relatedTexts[1])
-    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+    #expect(model.relatedText != nil)
+    #expect(model.relatedText == relatedTexts[0] || model.relatedText == relatedTexts[1])
+    #expect(model.playolaAudioBlockPlaying == audioBlock)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenStopped() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "")
-    XCTAssertNil(model.albumArtUrl)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "")
+    #expect(model.albumArtUrl == nil)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenError() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenError() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .error)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Error Playing Station")
-    XCTAssertEqual(model.primaryNavBarTitle, "")
-    XCTAssertEqual(model.secondaryNavBarTitle, "")
-    XCTAssertNil(model.albumArtUrl)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Error Playing Station")
+    #expect(model.primaryNavBarTitle == "")
+    #expect(model.secondaryNavBarTitle == "")
+    #expect(model.albumArtUrl == nil)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenStartingNewStation() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenStartingNewStation() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
-    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
-    XCTAssertEqual(model.loadingPercentage, 0.0)
-    XCTAssertNil(model.playolaAudioBlockPlaying)
+    #expect(model.nowPlayingText == "Station Loading...")
+    #expect(model.loadingPercentage == 0.0)
+    #expect(model.playolaAudioBlockPlaying == nil)
   }
 
-  func testViewAppeared_PopulatesCorrectlyWhenStartingNewStationWithAudioBlock() {
+  @Test
+  func testViewAppearedPopulatesCorrectlyWhenStartingNewStationWithAudioBlock() {
     let station = AnyStation.mock
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
@@ -151,18 +161,19 @@ final class PlayerPageTests: XCTestCase {
       spin: spin, station: station, status: .startingNewStation(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
-    XCTAssertEqual(model.nowPlayingText, "Station Loading...")
-    XCTAssertEqual(model.loadingPercentage, 0.0)
-    XCTAssertEqual(model.playolaAudioBlockPlaying, audioBlock)
+    #expect(model.nowPlayingText == "Station Loading...")
+    #expect(model.loadingPercentage == 0.0)
+    #expect(model.playolaAudioBlockPlaying == audioBlock)
   }
 
-  func testRelatedText_ReturnsConsistentValueForSameSpin() {
+  @Test
+  func testRelatedTextReturnsConsistentValueForSameSpin() {
     let audioBlock = AudioBlock.mockWith(type: "song", transcription: nil)
     let relatedTexts = [
       RelatedText(title: "title1", body: "body1"),
@@ -173,25 +184,27 @@ final class PlayerPageTests: XCTestCase {
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
     let firstResult = model.relatedText
-    XCTAssertNotNil(firstResult)
-    XCTAssertEqual(firstResult, model.relatedText)
-    XCTAssertEqual(firstResult, model.relatedText)
+    #expect(firstResult != nil)
+    #expect(firstResult == model.relatedText)
+    #expect(firstResult == model.relatedText)
   }
 
   // MARK: - playPauseButtonTapped Tests
 
-  func testPlayPauseButtonTapped_StopsWhenPlaying() {
+  @Test
+  func testPlayPauseButtonTappedStopsWhenPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()
     let spy = StationPlayerMock()
     let model = PlayerPageModel(stationPlayer: spy)
 
     model.playPauseButtonTapped()
 
-    XCTAssertEqual(spy.stopCalledCount, 1)
-    XCTAssertEqual(spy.callsToPlay.count, 0)
+    #expect(spy.stopCalledCount == 1)
+    #expect(spy.callsToPlay.count == 0)
   }
 
-  func testPlayPauseButtonTapped_DismissesWhenStopButtonPressed() {
+  @Test
+  func testPlayPauseButtonTappedDismissesWhenStopButtonPressed() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()
     let spy = StationPlayerMock()
     var dismissCalled = false
@@ -199,13 +212,14 @@ final class PlayerPageTests: XCTestCase {
 
     model.playPauseButtonTapped()
 
-    XCTAssertEqual(spy.stopCalledCount, 1)
-    XCTAssertTrue(dismissCalled)
+    #expect(spy.stopCalledCount == 1)
+    #expect(dismissCalled)
   }
 
   // MARK: - scenePhaseChanged Tests
 
-  func testScenePhaseChanged_DismissesWhenActiveAndPlayerStopped() {
+  @Test
+  func testScenePhaseChangedDismissesWhenActiveAndPlayerStopped() {
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
@@ -214,10 +228,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertTrue(dismissCalled)
+    #expect(dismissCalled)
   }
 
-  func testScenePhaseChanged_DismissesWhenActiveAndPlayerError() {
+  @Test
+  func testScenePhaseChangedDismissesWhenActiveAndPlayerError() {
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .error)
 
@@ -226,10 +241,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertTrue(dismissCalled)
+    #expect(dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenActiveAndPlayerPlaying() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenActiveAndPlayerPlaying() {
     let station = AnyStation.mock
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .playing(station))
@@ -239,10 +255,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenActiveAndPlayerLoading() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenActiveAndPlayerLoading() {
     let station = AnyStation.mock
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .loading(station))
@@ -252,10 +269,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenActiveAndPlayerStartingNewStation() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenActiveAndPlayerStartingNewStation() {
     let station = AnyStation.mock
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .startingNewStation(station))
@@ -265,10 +283,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .active)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenBackgroundPhase() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenBackgroundPhase() {
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
@@ -277,10 +296,11 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .background)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
-  func testScenePhaseChanged_DoesNotDismissWhenInactivePhase() {
+  @Test
+  func testScenePhaseChangedDoesNotDismissWhenInactivePhase() {
     let spy = StationPlayerMock()
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
@@ -289,21 +309,23 @@ final class PlayerPageTests: XCTestCase {
 
     model.scenePhaseChanged(newPhase: .inactive)
 
-    XCTAssertFalse(dismissCalled)
+    #expect(!dismissCalled)
   }
 
   // MARK: - Heart State Tests
 
-  func testHeartState_HiddenWhenNotPlayingPlayolaSong() {
+  @Test
+  func testHeartStateHiddenWhenNotPlayingPlayolaSong() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()  // No spin
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.heartState, .hidden)
-    XCTAssertEqual(model.heartState.imageName, "")
-    XCTAssertEqual(model.heartState.imageColorHex, "")
+    #expect(model.heartState == .hidden)
+    #expect(model.heartState.imageName == "")
+    #expect(model.heartState.imageColorHex == "")
   }
 
-  func testHeartState_EmptyWhenPlayingUnlikedSong() async {
+  @Test
+  func testHeartStateEmptyWhenPlayingUnlikedSong() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -313,13 +335,14 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .empty)
-      XCTAssertEqual(model.heartState.imageName, "heart")
-      XCTAssertEqual(model.heartState.imageColorHex, "#BABABA")
+      #expect(model.heartState == .empty)
+      #expect(model.heartState.imageName == "heart")
+      #expect(model.heartState.imageColorHex == "#BABABA")
     }
   }
 
-  func testHeartState_FilledWhenPlayingLikedSong() async {
+  @Test
+  func testHeartStateFilledWhenPlayingLikedSong() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -331,15 +354,16 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .filled)
-      XCTAssertEqual(model.heartState.imageName, "heart.fill")
-      XCTAssertEqual(model.heartState.imageColorHex, "#EF6962")
+      #expect(model.heartState == .filled)
+      #expect(model.heartState.imageName == "heart.fill")
+      #expect(model.heartState.imageColorHex == "#EF6962")
     }
   }
 
   // MARK: - Heart Button Tap Tests
 
-  func testHeartButtonTapped_DoesNothingWhenNoAudioBlock() async {
+  @Test
+  func testHeartButtonTappedDoesNothingWhenNoAudioBlock() async {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()  // No spin
 
     withDependencies {
@@ -347,11 +371,12 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
       model.heartButtonTapped()
-      XCTAssertEqual(model.likesManager.allLikedAudioBlocks.count, 0)
+      #expect(model.likesManager.allLikedAudioBlocks.count == 0)
     }
   }
 
-  func testHeartButtonTapped_LikesUnlikedSong() async {
+  @Test
+  func testHeartButtonTappedLikesUnlikedSong() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -361,16 +386,17 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .empty)
+      #expect(model.heartState == .empty)
       model.heartButtonTapped()
 
-      XCTAssertEqual(model.heartState, .filled)
-      XCTAssertTrue(model.likesManager.isLiked(audioBlock.id))
-      XCTAssertEqual(model.likesManager.allLikedAudioBlocks.count, 1)
+      #expect(model.heartState == .filled)
+      #expect(model.likesManager.isLiked(audioBlock.id))
+      #expect(model.likesManager.allLikedAudioBlocks.count == 1)
     }
   }
 
-  func testHeartButtonTapped_UnlikesLikedSong() async {
+  @Test
+  func testHeartButtonTappedUnlikesLikedSong() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -382,16 +408,17 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .filled)
+      #expect(model.heartState == .filled)
       model.heartButtonTapped()
 
-      XCTAssertEqual(model.heartState, .empty)
-      XCTAssertFalse(model.likesManager.isLiked(audioBlock.id))
-      XCTAssertEqual(model.likesManager.allLikedAudioBlocks.count, 0)
+      #expect(model.heartState == .empty)
+      #expect(!model.likesManager.isLiked(audioBlock.id))
+      #expect(model.likesManager.allLikedAudioBlocks.count == 0)
     }
   }
 
-  func testHeartButtonTapped_CreatesPendingOperation() async {
+  @Test
+  func testHeartButtonTappedCreatesPendingOperation() async {
     let audioBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -402,15 +429,16 @@ final class PlayerPageTests: XCTestCase {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
       model.heartButtonTapped()
 
-      XCTAssertEqual(model.likesManager.pendingOperations.count, 1)
-      XCTAssertEqual(model.likesManager.pendingOperations.first?.type, .like)
-      XCTAssertEqual(model.likesManager.pendingOperations.first?.audioBlock.id, audioBlock.id)
+      #expect(model.likesManager.pendingOperations.count == 1)
+      #expect(model.likesManager.pendingOperations.first?.type == .like)
+      #expect(model.likesManager.pendingOperations.first?.audioBlock.id == audioBlock.id)
     }
   }
 
   // MARK: - Button Visibility Tests (Type-based)
 
-  func testHeartState_HiddenWhenPlayingNonSongAudioBlock() async {
+  @Test
+  func testHeartStateHiddenWhenPlayingNonSongAudioBlock() async {
     let commercialBlock = AudioBlock.mockWith(type: "commercial")
     let spin = Spin.mockWith(audioBlock: commercialBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -420,13 +448,14 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .hidden)
-      XCTAssertEqual(model.heartState.imageName, "")
-      XCTAssertEqual(model.heartState.imageColorHex, "")
+      #expect(model.heartState == .hidden)
+      #expect(model.heartState.imageName == "")
+      #expect(model.heartState.imageColorHex == "")
     }
   }
 
-  func testHeartState_VisibleWhenPlayingSongAudioBlock() async {
+  @Test
+  func testHeartStateVisibleWhenPlayingSongAudioBlock() async {
     let songBlock = AudioBlock.mockWith(type: "song")
     let spin = Spin.mockWith(audioBlock: songBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -436,13 +465,14 @@ final class PlayerPageTests: XCTestCase {
     } operation: {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-      XCTAssertEqual(model.heartState, .empty)
-      XCTAssertEqual(model.heartState.imageName, "heart")
-      XCTAssertEqual(model.heartState.imageColorHex, "#BABABA")
+      #expect(model.heartState == .empty)
+      #expect(model.heartState.imageName == "heart")
+      #expect(model.heartState.imageColorHex == "#BABABA")
     }
   }
 
-  func testHeartButtonTapped_DoesNothingWhenPlayingNonSongAudioBlock() async {
+  @Test
+  func testHeartButtonTappedDoesNothingWhenPlayingNonSongAudioBlock() async {
     let commercialBlock = AudioBlock.mockWith(type: "commercial")
     let spin = Spin.mockWith(audioBlock: commercialBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
@@ -453,104 +483,114 @@ final class PlayerPageTests: XCTestCase {
       let model = PlayerPageModel(stationPlayer: StationPlayerMock())
       model.heartButtonTapped()
 
-      XCTAssertEqual(model.likesManager.allLikedAudioBlocks.count, 0)
-      XCTAssertEqual(model.likesManager.pendingOperations.count, 0)
+      #expect(model.likesManager.allLikedAudioBlocks.count == 0)
+      #expect(model.likesManager.pendingOperations.count == 0)
     }
   }
 
   // MARK: - Navigation Bar Title Tests
 
-  func testNavBarTitles_PlayolaStationLoading() {
+  @Test
+  func testNavBarTitlesPlayolaStationLoading() {
     let station = AnyStation.mockPlayola(name: "Test Radio Show", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "Test Curator")
-    XCTAssertEqual(model.secondaryNavBarTitle, "Test Radio Show")
+    #expect(model.primaryNavBarTitle == "Test Curator")
+    #expect(model.secondaryNavBarTitle == "Test Radio Show")
   }
 
-  func testNavBarTitles_PlayolaStationStartingNewStation() {
+  @Test
+  func testNavBarTitlesPlayolaStationStartingNewStation() {
     let station = AnyStation.mockPlayola(name: "Another Radio Show", curatorName: "Another Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "Another Curator")
-    XCTAssertEqual(model.secondaryNavBarTitle, "Another Radio Show")
+    #expect(model.primaryNavBarTitle == "Another Curator")
+    #expect(model.secondaryNavBarTitle == "Another Radio Show")
   }
 
-  func testNavBarTitles_UrlStationLoading() {
+  @Test
+  func testNavBarTitlesUrlStationLoading() {
     let station = AnyStation.mockUrl(name: "Test FM", location: "Test City, TX")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "Test FM")
-    XCTAssertEqual(model.secondaryNavBarTitle, "Test City, TX")
+    #expect(model.primaryNavBarTitle == "Test FM")
+    #expect(model.secondaryNavBarTitle == "Test City, TX")
   }
 
-  func testNavBarTitles_UrlStationStartingNewStation() {
+  @Test
+  func testNavBarTitlesUrlStationStartingNewStation() {
     let station = AnyStation.mockUrl(name: "Another FM", location: "Another City, CA")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "Another FM")
-    XCTAssertEqual(model.secondaryNavBarTitle, "Another City, CA")
+    #expect(model.primaryNavBarTitle == "Another FM")
+    #expect(model.secondaryNavBarTitle == "Another City, CA")
   }
 
-  func testNavBarTitles_UrlStationWithoutLocation() {
+  @Test
+  func testNavBarTitlesUrlStationWithoutLocation() {
     let station = AnyStation.mockUrl(name: "No Location FM", location: "")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "No Location FM")
-    XCTAssertEqual(model.secondaryNavBarTitle, "")
+    #expect(model.primaryNavBarTitle == "No Location FM")
+    #expect(model.secondaryNavBarTitle == "")
   }
 
-  func testNavBarTitles_WhenPlaying() {
+  @Test
+  func testNavBarTitlesWhenPlaying() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, station.name)
+    #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.stationName)
+      #expect(model.secondaryNavBarTitle == station.stationName)
     } else {
-      XCTAssertEqual(model.secondaryNavBarTitle, station.location ?? "")
+      #expect(model.secondaryNavBarTitle == station.location ?? "")
     }
   }
 
-  func testNavBarTitles_EmptyWhenStopped() {
+  @Test
+  func testNavBarTitlesEmptyWhenStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.primaryNavBarTitle, "")
-    XCTAssertEqual(model.secondaryNavBarTitle, "")
+    #expect(model.primaryNavBarTitle == "")
+    #expect(model.secondaryNavBarTitle == "")
   }
 
   // MARK: - Now Playing Text Tests
 
+  @Test
   func testNowPlayingTextShowsPlayolaPaysForCommercial() {
     let commercialBlock = AudioBlock.mockWith(type: "commercial")
     let spin = Spin.mockWith(audioBlock: commercialBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Playola Pays")
+    #expect(model.nowPlayingText == "Playola Pays")
   }
 
+  @Test
   func testNowPlayingTextShowsTitleArtistForSong() {
     let songBlock = AudioBlock.mockWith(title: "Test Song", artist: "Test Artist", type: "song")
     let spin = Spin.mockWith(audioBlock: songBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Test Song - Test Artist")
+    #expect(model.nowPlayingText == "Test Song - Test Artist")
   }
 
+  @Test
   func testNowPlayingTextShowsTitleArtistForSongEvenWithAiring() {
     let songBlock = AudioBlock.mockWith(
       title: "Airing Song",
@@ -566,9 +606,10 @@ final class PlayerPageTests: XCTestCase {
 
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Airing Song - Airing Artist")
+    #expect(model.nowPlayingText == "Airing Song - Airing Artist")
   }
 
+  @Test
   func testNowPlayingTextShowsEpisodeTitleForNonSongWithAiring() {
     let voiceTrackBlock = AudioBlock.mockWith(type: "voicetrack")
     let airing = Airing.mockWith(
@@ -580,9 +621,10 @@ final class PlayerPageTests: XCTestCase {
 
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "My Cool Episode")
+    #expect(model.nowPlayingText == "My Cool Episode")
   }
 
+  @Test
   func testNowPlayingTextShowsStationNameForNonSongWithoutAiring() {
     let station = AnyStation.mockPlayola(name: "Test Station Name")
     let voiceTrackBlock = AudioBlock.mockWith(type: "voicetrack")
@@ -592,43 +634,49 @@ final class PlayerPageTests: XCTestCase {
 
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
 
-    XCTAssertEqual(model.nowPlayingText, "Test Station Name")
+    #expect(model.nowPlayingText == "Test Station Name")
   }
 
   // MARK: - Ask Question Tests
 
+  @Test
   func testCanAskQuestionTrueForPlayolaStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockPlayola())
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertTrue(model.canAskQuestion)
+    #expect(model.canAskQuestion)
   }
 
+  @Test
   func testCanAskQuestionFalseForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertFalse(model.canAskQuestion)
+    #expect(!model.canAskQuestion)
   }
 
+  @Test
   func testCanAskQuestionFalseWhenNoStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertFalse(model.canAskQuestion)
+    #expect(!model.canAskQuestion)
   }
 
+  @Test
   func testCurrentPlayolaStationReturnsStationForPlayolaStation() {
     let station = AnyStation.mockPlayola(id: "test-id", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertEqual(model.currentPlayolaStation?.id, "test-id")
-    XCTAssertEqual(model.currentPlayolaStation?.curatorName, "Test Curator")
+    #expect(model.currentPlayolaStation?.id == "test-id")
+    #expect(model.currentPlayolaStation?.curatorName == "Test Curator")
   }
 
+  @Test
   func testCurrentPlayolaStationReturnsNilForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
-    XCTAssertNil(model.currentPlayolaStation)
+    #expect(model.currentPlayolaStation == nil)
   }
 
+  @Test
   func testAskQuestionButtonTappedNavigatesToAskQuestionPageAndDismisses() {
     let station = AnyStation.mockPlayola(id: "test-id", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
@@ -641,16 +689,17 @@ final class PlayerPageTests: XCTestCase {
 
     model.askQuestionButtonTapped()
 
-    XCTAssertEqual(navCoordinator.path.count, 1)
+    #expect(navCoordinator.path.count == 1)
     if case .askQuestionPage(let askModel) = navCoordinator.path.first {
-      XCTAssertEqual(askModel.station.id, "test-id")
-      XCTAssertEqual(askModel.curatorName, "Test Curator")
+      #expect(askModel.station.id == "test-id")
+      #expect(askModel.curatorName == "Test Curator")
     } else {
-      XCTFail("Expected askQuestionPage in navigation path")
+      Issue.record("Expected askQuestionPage in navigation path")
     }
-    XCTAssertTrue(dismissCalled)
+    #expect(dismissCalled)
   }
 
+  @Test
   func testAskQuestionButtonTappedDoesNothingForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
     @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
@@ -659,6 +708,6 @@ final class PlayerPageTests: XCTestCase {
     let model = PlayerPageModel(stationPlayer: StationPlayerMock())
     model.askQuestionButtonTapped()
 
-    XCTAssertTrue(navCoordinator.path.isEmpty)
+    #expect(navCoordinator.path.isEmpty)
   }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -23,7 +23,11 @@ struct PlayerPageTests {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -40,7 +44,11 @@ struct PlayerPageTests {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station, 0.42))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -58,7 +66,11 @@ struct PlayerPageTests {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       artistPlaying: "Rachel Loy", titlePlaying: "Selfie", station: station)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Selfie - Rachel Loy")
     #expect(model.stationArtUrl == station.imageUrl)
@@ -72,7 +84,11 @@ struct PlayerPageTests {
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       artistPlaying: "Rachel Loy", titlePlaying: "Selfie", spin: spin, station: station)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Selfie - Rachel Loy")
     #expect(model.stationArtUrl == station.imageUrl)
@@ -89,7 +105,11 @@ struct PlayerPageTests {
     ]
     let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.relatedText?.title == "Why I chose this song")
     #expect(model.relatedText?.body == transcription)
@@ -105,7 +125,11 @@ struct PlayerPageTests {
     ]
     let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.relatedText != nil)
     #expect(model.relatedText == relatedTexts[0] || model.relatedText == relatedTexts[1])
@@ -115,7 +139,11 @@ struct PlayerPageTests {
   @Test
   func testViewAppearedPopulatesCorrectlyWhenStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "")
     #expect(model.albumArtUrl == nil)
@@ -125,7 +153,11 @@ struct PlayerPageTests {
   @Test
   func testViewAppearedPopulatesCorrectlyWhenError() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .error)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Error Playing Station")
     #expect(model.primaryNavBarTitle == "")
@@ -139,7 +171,11 @@ struct PlayerPageTests {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -159,7 +195,11 @@ struct PlayerPageTests {
     let spin = Spin.mockWith(audioBlock: audioBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       spin: spin, station: station, status: .startingNewStation(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -181,7 +221,11 @@ struct PlayerPageTests {
     ]
     let spin = Spin.mockWith(audioBlock: audioBlock, relatedTexts: relatedTexts)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     let firstResult = model.relatedText
     #expect(firstResult != nil)
@@ -195,7 +239,11 @@ struct PlayerPageTests {
   func testPlayPauseButtonTappedStopsWhenPlaying() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()
     let spy = StationPlayerMock()
-    let model = PlayerPageModel(stationPlayer: spy)
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel()
+    }
 
     model.playPauseButtonTapped()
 
@@ -208,7 +256,11 @@ struct PlayerPageTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()
     let spy = StationPlayerMock()
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.playPauseButtonTapped()
 
@@ -224,7 +276,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -237,7 +293,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .error)
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -251,7 +311,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .playing(station))
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -265,7 +329,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .loading(station))
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -279,7 +347,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .startingNewStation(station))
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .active)
 
@@ -292,7 +364,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .background)
 
@@ -305,7 +381,11 @@ struct PlayerPageTests {
     spy.state = StationPlayer.State(playbackStatus: .stopped)
 
     var dismissCalled = false
-    let model = PlayerPageModel(stationPlayer: spy, onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = spy
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.scenePhaseChanged(newPhase: .inactive)
 
@@ -317,7 +397,11 @@ struct PlayerPageTests {
   @Test
   func testHeartStateHiddenWhenNotPlayingPlayolaSong() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith()  // No spin
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.heartState == .hidden)
     #expect(model.heartState.imageName == "")
@@ -333,7 +417,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .empty)
       #expect(model.heartState.imageName == "heart")
@@ -352,7 +440,11 @@ struct PlayerPageTests {
       likesManager.like(audioBlock)
       $0.likesManager = likesManager
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .filled)
       #expect(model.heartState.imageName == "heart.fill")
@@ -369,7 +461,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
       model.heartButtonTapped()
       #expect(model.likesManager.allLikedAudioBlocks.count == 0)
     }
@@ -386,7 +482,11 @@ struct PlayerPageTests {
       $0.uuid = .incrementing
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .empty)
       model.heartButtonTapped()
@@ -408,7 +508,11 @@ struct PlayerPageTests {
       likesManager.like(audioBlock)
       $0.likesManager = likesManager
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .filled)
       model.heartButtonTapped()
@@ -430,7 +534,11 @@ struct PlayerPageTests {
       $0.uuid = .incrementing
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
       model.heartButtonTapped()
 
       #expect(model.likesManager.pendingOperations.count == 1)
@@ -450,7 +558,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .hidden)
       #expect(model.heartState.imageName == "")
@@ -467,7 +579,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
 
       #expect(model.heartState == .empty)
       #expect(model.heartState.imageName == "heart")
@@ -484,7 +600,11 @@ struct PlayerPageTests {
     withDependencies {
       $0.likesManager = LikesManager()
     } operation: {
-      let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+      let model = withDependencies {
+        $0.stationPlayer = StationPlayerMock()
+      } operation: {
+        PlayerPageModel()
+      }
       model.heartButtonTapped()
 
       #expect(model.likesManager.allLikedAudioBlocks.count == 0)
@@ -499,7 +619,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockPlayola(name: "Test Radio Show", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "Test Curator")
     #expect(model.secondaryNavBarTitle == "Test Radio Show")
@@ -510,7 +634,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockPlayola(name: "Another Radio Show", curatorName: "Another Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "Another Curator")
     #expect(model.secondaryNavBarTitle == "Another Radio Show")
@@ -521,7 +649,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockUrl(name: "Test FM", location: "Test City, TX")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "Test FM")
     #expect(model.secondaryNavBarTitle == "Test City, TX")
@@ -532,7 +664,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockUrl(name: "Another FM", location: "Another City, CA")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .startingNewStation(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "Another FM")
     #expect(model.secondaryNavBarTitle == "Another City, CA")
@@ -543,7 +679,11 @@ struct PlayerPageTests {
     let station = AnyStation.mockUrl(name: "No Location FM", location: "")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(
       station: station, status: .loading(station))
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "No Location FM")
     #expect(model.secondaryNavBarTitle == "")
@@ -553,7 +693,11 @@ struct PlayerPageTests {
   func testNavBarTitlesWhenPlaying() {
     let station = AnyStation.mock
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == station.name)
     if station.isPlayolaStation {
@@ -566,7 +710,11 @@ struct PlayerPageTests {
   @Test
   func testNavBarTitlesEmptyWhenStopped() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.primaryNavBarTitle == "")
     #expect(model.secondaryNavBarTitle == "")
@@ -579,7 +727,11 @@ struct PlayerPageTests {
     let commercialBlock = AudioBlock.mockWith(type: "commercial")
     let spin = Spin.mockWith(audioBlock: commercialBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Playola Pays")
   }
@@ -589,7 +741,11 @@ struct PlayerPageTests {
     let songBlock = AudioBlock.mockWith(title: "Test Song", artist: "Test Artist", type: "song")
     let spin = Spin.mockWith(audioBlock: songBlock)
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Test Song - Test Artist")
   }
@@ -608,7 +764,11 @@ struct PlayerPageTests {
 
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
 
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Airing Song - Airing Artist")
   }
@@ -623,7 +783,11 @@ struct PlayerPageTests {
 
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin)
 
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "My Cool Episode")
   }
@@ -636,7 +800,11 @@ struct PlayerPageTests {
 
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(spin: spin, station: station)
 
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
 
     #expect(model.nowPlayingText == "Test Station Name")
   }
@@ -646,21 +814,33 @@ struct PlayerPageTests {
   @Test
   func testCanAskQuestionTrueForPlayolaStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockPlayola())
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(model.canAskQuestion)
   }
 
   @Test
   func testCanAskQuestionFalseForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(!model.canAskQuestion)
   }
 
   @Test
   func testCanAskQuestionFalseWhenNoStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: nil, status: .stopped)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(!model.canAskQuestion)
   }
 
@@ -668,7 +848,11 @@ struct PlayerPageTests {
   func testCurrentPlayolaStationReturnsStationForPlayolaStation() {
     let station = AnyStation.mockPlayola(id: "test-id", curatorName: "Test Curator")
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: station)
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(model.currentPlayolaStation?.id == "test-id")
     #expect(model.currentPlayolaStation?.curatorName == "Test Curator")
   }
@@ -676,7 +860,11 @@ struct PlayerPageTests {
   @Test
   func testCurrentPlayolaStationReturnsNilForUrlStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = .mockWith(station: .mockUrl())
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     #expect(model.currentPlayolaStation == nil)
   }
 
@@ -688,8 +876,11 @@ struct PlayerPageTests {
       MainContainerNavigationCoordinator()
 
     var dismissCalled = false
-    let model = PlayerPageModel(
-      stationPlayer: StationPlayerMock(), onDismiss: { dismissCalled = true })
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel(onDismiss: { dismissCalled = true })
+    }
 
     model.askQuestionButtonTapped()
 
@@ -709,7 +900,11 @@ struct PlayerPageTests {
     @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
       MainContainerNavigationCoordinator()
 
-    let model = PlayerPageModel(stationPlayer: StationPlayerMock())
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
     model.askQuestionButtonTapped()
 
     #expect(navCoordinator.path.isEmpty)

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageModel.swift
@@ -16,6 +16,7 @@ class RecordIntroPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.audioRecorder) var audioRecorder
   @ObservationIgnored @Dependency(\.audioPlayer) var audioPlayer
   @ObservationIgnored @Dependency(\.introUploadService) var introUploadService
+  @ObservationIgnored @Dependency(\.continuousClock) var clock
 
   // MARK: - Shared State
 
@@ -171,41 +172,33 @@ class RecordIntroPageModel: ViewModel {
     }
   }
 
-  func onPlayPauseTapped() {
-    Task {
-      if isPlaying {
-        await audioPlayer.pause()
-        stopPlaybackUpdates()
-        isPlaying = false
-      } else {
-        await audioPlayer.play()
-        startPlaybackUpdates()
-        isPlaying = true
-      }
+  func onPlayPauseTapped() async {
+    if isPlaying {
+      await audioPlayer.pause()
+      stopPlaybackUpdates()
+      isPlaying = false
+    } else {
+      await audioPlayer.play()
+      startPlaybackUpdates()
+      isPlaying = true
     }
   }
 
-  func onRewindTapped() {
-    Task {
-      await audioPlayer.seek(0)
-      playbackPosition = 0
-    }
+  func onRewindTapped() async {
+    await audioPlayer.seek(0)
+    playbackPosition = 0
   }
 
-  func seekTo(_ time: TimeInterval) {
-    Task {
-      await audioPlayer.seek(time)
-      playbackPosition = time
-    }
+  func seekTo(_ time: TimeInterval) async {
+    await audioPlayer.seek(time)
+    playbackPosition = time
   }
 
-  func onReRecordTapped() {
+  func onReRecordTapped() async {
     stopPlaybackUpdates()
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     recordingURL = nil
     recordingDuration = 0
@@ -218,31 +211,29 @@ class RecordIntroPageModel: ViewModel {
   func onDiscardTapped() {
     stopPlaybackUpdates()
     presentedAlert = .discardRecordingConfirmation { [weak self] in
-      self?.confirmDiscard()
+      Task { await self?.confirmDiscard() }
     }
   }
 
-  func confirmDiscard() {
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+  func confirmDiscard() async {
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     mainContainerNavigationCoordinator.presentedSheet = nil
   }
 
-  func onAcceptRecordingTapped() {
+  func onAcceptRecordingTapped() async {
     guard recordingURL != nil else { return }
     stopPlaybackUpdates()
-    Task { await audioPlayer.stop() }
+    await audioPlayer.stop()
     isPlaying = false
-    startUpload()
+    await startUpload()
   }
 
-  func onRetryTapped() {
+  func onRetryTapped() async {
     uploadStatus = nil
-    startUpload()
+    await startUpload()
   }
 
   func onDoneTapped() {
@@ -251,30 +242,27 @@ class RecordIntroPageModel: ViewModel {
 
   // MARK: - Private Helpers
 
-  private func startUpload() {
+  private func startUpload() async {
     guard let url = recordingURL, let jwt = auth.jwt else { return }
     uploadStatus = .converting
-    Task {
-      do {
-        try await introUploadService.uploadIntro(
-          jwt,
-          url,
-          stationId,
-          songTitle,
-          audioBlockId
-        ) { [weak self] status in
-          self?.uploadStatus = status
-        }
-        uploadStatus = .completed
-        onUploadCompleted?()
-        try? await Task.sleep(for: .seconds(1))
-        mainContainerNavigationCoordinator.presentedSheet = nil
-      } catch {
-        if case .failed = uploadStatus {
-          // Status already set by the callback
-        } else {
-          uploadStatus = .failed(error.localizedDescription)
-        }
+    do {
+      try await introUploadService.uploadIntro(
+        jwt,
+        url,
+        stationId,
+        songTitle,
+        audioBlockId
+      ) { [weak self] status in
+        self?.uploadStatus = status
+      }
+      uploadStatus = .completed
+      onUploadCompleted?()
+      try? await clock.sleep(for: .seconds(1))
+      mainContainerNavigationCoordinator.presentedSheet = nil
+    } catch {
+      if case .failed = uploadStatus {
+      } else {
+        uploadStatus = .failed(error.localizedDescription)
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
@@ -170,7 +170,7 @@ final class RecordIntroPageTests: XCTestCase {
 
   // MARK: - Re-record
 
-  func testOnReRecordTappedResetsToIdleState() {
+  func testOnReRecordTappedResetsToIdleState() async {
     let model = makeModel()
     model.recordingPhase = .review
     model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -178,7 +178,7 @@ final class RecordIntroPageTests: XCTestCase {
     model.playbackPosition = 5.0
     model.isPlaying = true
 
-    model.onReRecordTapped()
+    await model.onReRecordTapped()
 
     XCTAssertEqual(model.recordingPhase, .idle)
     XCTAssertNil(model.recordingURL)
@@ -201,13 +201,13 @@ final class RecordIntroPageTests: XCTestCase {
     XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
   }
 
-  func testConfirmDiscardDismissesSheet() {
+  func testConfirmDiscardDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let model = makeModel()
     coordinator.presentedSheet = .recordIntroPage(model)
 
-    model.confirmDiscard()
+    await model.confirmDiscard()
 
     XCTAssertNil(coordinator.presentedSheet)
   }
@@ -221,6 +221,7 @@ final class RecordIntroPageTests: XCTestCase {
     await withMainSerialExecutor {
       await withDependencies {
         $0.audioPlayer.stop = {}
+        $0.continuousClock = ImmediateClock()
         $0.introUploadService.uploadIntro = { _, _, _, _, _, onStatus in
           uploadCalled.setValue(true)
           await onStatus(.completed)
@@ -230,8 +231,7 @@ final class RecordIntroPageTests: XCTestCase {
         model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
         model.recordingPhase = .review
 
-        model.onAcceptRecordingTapped()
-        await Task.yield()
+        await model.onAcceptRecordingTapped()
 
         XCTAssertNotNil(model.uploadStatus)
         XCTAssertTrue(uploadCalled.value)
@@ -239,11 +239,11 @@ final class RecordIntroPageTests: XCTestCase {
     }
   }
 
-  func testOnAcceptRecordingTappedDoesNothingWithoutURL() {
+  func testOnAcceptRecordingTappedDoesNothingWithoutURL() async {
     let model = makeModel()
     model.recordingURL = nil
 
-    model.onAcceptRecordingTapped()
+    await model.onAcceptRecordingTapped()
 
     XCTAssertNil(model.uploadStatus)
   }
@@ -290,6 +290,7 @@ final class RecordIntroPageTests: XCTestCase {
     await withMainSerialExecutor {
       await withDependencies {
         $0.audioPlayer.stop = {}
+        $0.continuousClock = ImmediateClock()
         $0.introUploadService.uploadIntro = { _, _, _, _, _, onStatus in
           uploadCallCount.withValue { $0 += 1 }
           await onStatus(.completed)
@@ -299,8 +300,7 @@ final class RecordIntroPageTests: XCTestCase {
         model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
         model.uploadStatus = .failed("First attempt failed")
 
-        model.onRetryTapped()
-        await Task.yield()
+        await model.onRetryTapped()
 
         XCTAssertEqual(uploadCallCount.value, 1)
       }
@@ -314,6 +314,7 @@ final class RecordIntroPageTests: XCTestCase {
     await withMainSerialExecutor {
       await withDependencies {
         $0.audioPlayer.stop = {}
+        $0.continuousClock = ImmediateClock()
         $0.introUploadService.uploadIntro = { _, _, _, _, _, onStatus in
           await onStatus(.completed)
         }
@@ -324,8 +325,7 @@ final class RecordIntroPageTests: XCTestCase {
           completedCalled.setValue(true)
         }
 
-        model.onAcceptRecordingTapped()
-        await Task.yield()
+        await model.onAcceptRecordingTapped()
 
         XCTAssertTrue(completedCalled.value)
         XCTAssertEqual(model.uploadStatus, .completed)

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
@@ -5,19 +5,14 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class RecordIntroPageTests: XCTestCase {
-  override func setUp() {
-    super.setUp()
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
-    coordinator.presentedSheet = nil
-  }
-
+struct RecordIntroPageTests {
   private func makeModel() -> RecordIntroPageModel {
     RecordIntroPageModel(
       songTitle: "Test", songArtist: "Artist", songImageUrl: nil,
@@ -26,6 +21,7 @@ final class RecordIntroPageTests: XCTestCase {
 
   // MARK: - Initial Properties
 
+  @Test
   func testInitialProperties() {
     let model = RecordIntroPageModel(
       songTitle: "Bohemian Rhapsody",
@@ -35,17 +31,18 @@ final class RecordIntroPageTests: XCTestCase {
       audioBlockId: "block-1"
     )
 
-    XCTAssertEqual(model.songTitle, "Bohemian Rhapsody")
-    XCTAssertEqual(model.songArtist, "Queen")
-    XCTAssertEqual(model.songImageUrl, URL(string: "https://example.com/image.jpg"))
-    XCTAssertEqual(model.navigationTitle, "Record Intro")
-    XCTAssertEqual(model.instructionItems.count, 2)
-    XCTAssertEqual(model.recordingPhase, .idle)
-    XCTAssertNil(model.uploadStatus)
+    #expect(model.songTitle == "Bohemian Rhapsody")
+    #expect(model.songArtist == "Queen")
+    #expect(model.songImageUrl == URL(string: "https://example.com/image.jpg"))
+    #expect(model.navigationTitle == "Record Intro")
+    #expect(model.instructionItems.count == 2)
+    #expect(model.recordingPhase == .idle)
+    #expect(model.uploadStatus == nil)
   }
 
   // MARK: - Lifecycle
 
+  @Test
   func testViewAppearedPreparesForRecording() async {
     let prepareCalled = LockIsolated(false)
 
@@ -58,47 +55,52 @@ final class RecordIntroPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertTrue(prepareCalled.value)
+      #expect(prepareCalled.value)
     }
   }
 
   // MARK: - Done Button
 
+  @Test
   func testShouldShowDoneButtonTrueOnlyInIdlePhase() {
     let model = makeModel()
 
     model.recordingPhase = .idle
-    XCTAssertTrue(model.shouldShowDoneButton)
+    #expect(model.shouldShowDoneButton)
 
     model.recordingPhase = .recording
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
 
     model.recordingPhase = .review
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
   }
 
+  @Test
   func testShouldShowDoneButtonFalseWhenUploading() {
     let model = makeModel()
     model.recordingPhase = .idle
     model.uploadStatus = .converting
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
   }
 
+  @Test
   func testOnDoneTappedDismissesSheet() {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let model = makeModel()
     coordinator.presentedSheet = .recordIntroPage(model)
 
-    XCTAssertNotNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet != nil)
 
     model.onDoneTapped()
 
-    XCTAssertNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet == nil)
   }
 
   // MARK: - Recording
 
+  @Test
   func testOnRecordTappedRequestsPermissionBeforeRecording() async {
     let requestPermissionCalled = LockIsolated(false)
     let startRecordingCalled = LockIsolated(false)
@@ -109,22 +111,23 @@ final class RecordIntroPageTests: XCTestCase {
         return true
       }
       $0.audioRecorder.startRecording = {
-        XCTAssertTrue(
+        #expect(
           requestPermissionCalled.value, "Permission should be requested before recording starts")
         startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = makeModel()
-      XCTAssertEqual(model.recordingPhase, .idle)
+      #expect(model.recordingPhase == .idle)
 
       await model.onRecordTapped()
 
-      XCTAssertTrue(requestPermissionCalled.value)
-      XCTAssertTrue(startRecordingCalled.value)
-      XCTAssertEqual(model.recordingPhase, .recording)
+      #expect(requestPermissionCalled.value)
+      #expect(startRecordingCalled.value)
+      #expect(model.recordingPhase == .recording)
     }
   }
 
+  @Test
   func testOnRecordTappedDoesNotRecordWhenPermissionDenied() async {
     let startRecordingCalled = LockIsolated(false)
 
@@ -138,16 +141,17 @@ final class RecordIntroPageTests: XCTestCase {
 
       await model.onRecordTapped()
 
-      XCTAssertFalse(
-        startRecordingCalled.value, "Recording should not start when permission is denied")
-      XCTAssertEqual(model.recordingPhase, .idle)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Microphone Access Required")
+      #expect(
+        !startRecordingCalled.value, "Recording should not start when permission is denied")
+      #expect(model.recordingPhase == .idle)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Microphone Access Required")
     }
   }
 
   // MARK: - Stop Recording
 
+  @Test
   func testOnStopTappedStopsRecordingAndChangesPhase() async {
     let expectedURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
 
@@ -162,14 +166,15 @@ final class RecordIntroPageTests: XCTestCase {
 
       await model.onStopTapped()
 
-      XCTAssertEqual(model.recordingPhase, .review)
-      XCTAssertEqual(model.recordingURL, expectedURL)
-      XCTAssertEqual(model.recordingDuration, 5.0)
+      #expect(model.recordingPhase == .review)
+      #expect(model.recordingURL == expectedURL)
+      #expect(model.recordingDuration == 5.0)
     }
   }
 
   // MARK: - Re-record
 
+  @Test
   func testOnReRecordTappedResetsToIdleState() async {
     let model = makeModel()
     model.recordingPhase = .review
@@ -180,40 +185,44 @@ final class RecordIntroPageTests: XCTestCase {
 
     await model.onReRecordTapped()
 
-    XCTAssertEqual(model.recordingPhase, .idle)
-    XCTAssertNil(model.recordingURL)
-    XCTAssertEqual(model.recordingDuration, 0)
-    XCTAssertEqual(model.playbackPosition, 0)
-    XCTAssertFalse(model.isPlaying)
+    #expect(model.recordingPhase == .idle)
+    #expect(model.recordingURL == nil)
+    #expect(model.recordingDuration == 0)
+    #expect(model.playbackPosition == 0)
+    #expect(!model.isPlaying)
   }
 
   // MARK: - Discard
 
+  @Test
   func testOnDiscardTappedShowsConfirmationAlert() {
     let model = makeModel()
     model.recordingPhase = .review
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
 
     model.onDiscardTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Discard Recording?")
   }
 
+  @Test
   func testConfirmDiscardDismissesSheet() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let model = makeModel()
     coordinator.presentedSheet = .recordIntroPage(model)
 
     await model.confirmDiscard()
 
-    XCTAssertNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet == nil)
   }
 
   // MARK: - Accept Recording (Upload)
 
+  @Test
   func testOnAcceptRecordingTappedStartsUpload() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let uploadCalled = LockIsolated(false)
@@ -233,56 +242,59 @@ final class RecordIntroPageTests: XCTestCase {
 
         await model.onAcceptRecordingTapped()
 
-        XCTAssertNotNil(model.uploadStatus)
-        XCTAssertTrue(uploadCalled.value)
+        #expect(model.uploadStatus != nil)
+        #expect(uploadCalled.value)
       }
     }
   }
 
+  @Test
   func testOnAcceptRecordingTappedDoesNothingWithoutURL() async {
     let model = makeModel()
     model.recordingURL = nil
 
     await model.onAcceptRecordingTapped()
 
-    XCTAssertNil(model.uploadStatus)
+    #expect(model.uploadStatus == nil)
   }
 
+  @Test
   func testUploadStatusTransitionsReflectedInProperties() {
     let model = makeModel()
 
-    XCTAssertFalse(model.isUploading)
-    XCTAssertFalse(model.shouldShowUploadStatus)
-    XCTAssertFalse(model.shouldShowRetryButton)
-    XCTAssertNil(model.uploadProgress)
+    #expect(!model.isUploading)
+    #expect(!model.shouldShowUploadStatus)
+    #expect(!model.shouldShowRetryButton)
+    #expect(model.uploadProgress == nil)
 
     model.uploadStatus = .converting
-    XCTAssertTrue(model.isUploading)
-    XCTAssertTrue(model.shouldShowUploadStatus)
-    XCTAssertEqual(model.uploadStatusLabel, "Converting...")
-    XCTAssertNil(model.uploadProgress)
+    #expect(model.isUploading)
+    #expect(model.shouldShowUploadStatus)
+    #expect(model.uploadStatusLabel == "Converting...")
+    #expect(model.uploadProgress == nil)
 
     model.uploadStatus = .uploading(progress: 0.5)
-    XCTAssertTrue(model.isUploading)
-    XCTAssertEqual(model.uploadStatusLabel, "Uploading...")
-    XCTAssertEqual(model.uploadProgress, 0.5)
+    #expect(model.isUploading)
+    #expect(model.uploadStatusLabel == "Uploading...")
+    #expect(model.uploadProgress == 0.5)
 
     model.uploadStatus = .registering
-    XCTAssertTrue(model.isUploading)
-    XCTAssertEqual(model.uploadStatusLabel, "Registering...")
-    XCTAssertNil(model.uploadProgress)
+    #expect(model.isUploading)
+    #expect(model.uploadStatusLabel == "Registering...")
+    #expect(model.uploadProgress == nil)
 
     model.uploadStatus = .completed
-    XCTAssertFalse(model.isUploading)
-    XCTAssertTrue(model.shouldShowUploadStatus)
-    XCTAssertEqual(model.uploadStatusLabel, "Upload Complete!")
+    #expect(!model.isUploading)
+    #expect(model.shouldShowUploadStatus)
+    #expect(model.uploadStatusLabel == "Upload Complete!")
 
     model.uploadStatus = .failed("Network error")
-    XCTAssertFalse(model.isUploading)
-    XCTAssertTrue(model.shouldShowRetryButton)
-    XCTAssertEqual(model.uploadStatusLabel, "Upload Failed")
+    #expect(!model.isUploading)
+    #expect(model.shouldShowRetryButton)
+    #expect(model.uploadStatusLabel == "Upload Failed")
   }
 
+  @Test
   func testOnRetryTappedRestartsUpload() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let uploadCallCount = LockIsolated(0)
@@ -302,11 +314,12 @@ final class RecordIntroPageTests: XCTestCase {
 
         await model.onRetryTapped()
 
-        XCTAssertEqual(uploadCallCount.value, 1)
+        #expect(uploadCallCount.value == 1)
       }
     }
   }
 
+  @Test
   func testUploadSuccessCallsOnUploadCompleted() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let completedCalled = LockIsolated(false)
@@ -327,8 +340,8 @@ final class RecordIntroPageTests: XCTestCase {
 
         await model.onAcceptRecordingTapped()
 
-        XCTAssertTrue(completedCalled.value)
-        XCTAssertEqual(model.uploadStatus, .completed)
+        #expect(completedCalled.value)
+        #expect(model.uploadStatus == .completed)
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
@@ -225,7 +225,7 @@ struct RecordIntroPageView: View {
       }
     case .review:
       Button {
-        model.onReRecordTapped()
+        Task { await model.onReRecordTapped() }
       } label: {
         ZStack {
           Circle()
@@ -283,9 +283,9 @@ struct RecordIntroPageView: View {
         currentTime: model.playbackPosition,
         totalTime: model.recordingDuration,
         isPlaying: model.isPlaying,
-        onPlayPause: { model.onPlayPauseTapped() },
-        onRewind: { model.onRewindTapped() },
-        onSeek: { model.seekTo($0) }
+        onPlayPause: { Task { await model.onPlayPauseTapped() } },
+        onRewind: { Task { await model.onRewindTapped() } },
+        onSeek: { time in Task { await model.seekTo(time) } }
       )
 
       HStack(spacing: 12) {
@@ -307,7 +307,7 @@ struct RecordIntroPageView: View {
         }
 
         Button {
-          model.onAcceptRecordingTapped()
+          Task { await model.onAcceptRecordingTapped() }
         } label: {
           HStack(spacing: 6) {
             Image(systemName: "checkmark")
@@ -351,7 +351,7 @@ struct RecordIntroPageView: View {
       if model.shouldShowRetryButton {
         HStack(spacing: 12) {
           Button {
-            model.confirmDiscard()
+            Task { await model.confirmDiscard() }
           } label: {
             HStack(spacing: 6) {
               Image(systemName: "trash")
@@ -368,7 +368,7 @@ struct RecordIntroPageView: View {
           }
 
           Button {
-            model.onRetryTapped()
+            Task { await model.onRetryTapped() }
           } label: {
             HStack(spacing: 6) {
               Image(systemName: "arrow.clockwise")

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
@@ -116,32 +116,26 @@ class RecordPageModel: ViewModel {
 
   // MARK: - Playback Actions
 
-  func onPlayPauseTapped() {
-    Task {
-      if isPlaying {
-        await audioPlayer.pause()
-        stopPlaybackUpdates()
-        isPlaying = false
-      } else {
-        await audioPlayer.play()
-        startPlaybackUpdates()
-        isPlaying = true
-      }
+  func onPlayPauseTapped() async {
+    if isPlaying {
+      await audioPlayer.pause()
+      stopPlaybackUpdates()
+      isPlaying = false
+    } else {
+      await audioPlayer.play()
+      startPlaybackUpdates()
+      isPlaying = true
     }
   }
 
-  func onRewindTapped() {
-    Task {
-      await audioPlayer.seek(0)
-      playbackPosition = 0
-    }
+  func onRewindTapped() async {
+    await audioPlayer.seek(0)
+    playbackPosition = 0
   }
 
-  func seekTo(_ time: TimeInterval) {
-    Task {
-      await audioPlayer.seek(time)
-      playbackPosition = time
-    }
+  func seekTo(_ time: TimeInterval) async {
+    await audioPlayer.seek(time)
+    playbackPosition = time
   }
 
   private func startPlaybackUpdates() {
@@ -166,13 +160,11 @@ class RecordPageModel: ViewModel {
 
   // MARK: - Review Actions
 
-  func onReRecordTapped() {
+  func onReRecordTapped() async {
     stopPlaybackUpdates()
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     recordingURL = nil
     recordingDuration = 0
@@ -185,26 +177,22 @@ class RecordPageModel: ViewModel {
   func onDiscardTapped() {
     stopPlaybackUpdates()
     presentedAlert = .discardRecordingConfirmation { [weak self] in
-      self?.confirmDiscard()
+      Task { await self?.confirmDiscard() }
     }
   }
 
-  func confirmDiscard() {
-    Task {
-      await audioPlayer.stop()
-      if let url = recordingURL {
-        await audioRecorder.deleteRecording(url)
-      }
+  func confirmDiscard() async {
+    await audioPlayer.stop()
+    if let url = recordingURL {
+      await audioRecorder.deleteRecording(url)
     }
     mainContainerNavigationCoordinator.presentedSheet = nil
   }
 
-  func onAcceptRecordingTapped() {
+  func onAcceptRecordingTapped() async {
     guard let url = recordingURL else { return }
     mainContainerNavigationCoordinator.presentedSheet = nil
-    Task {
-      await onRecordingAccepted?(url)
-    }
+    await onRecordingAccepted?(url)
   }
 
   func onDoneTapped() {

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
@@ -171,7 +171,7 @@ final class RecordPageTests: XCTestCase {
 
   // MARK: - Re-record
 
-  func testOnReRecordTapped_ResetsToIdleState() async {
+  func testOnReRecordTappedResetsToIdleState() async {
     let model = RecordPageModel()
     model.recordingPhase = .review
     model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -202,7 +202,7 @@ final class RecordPageTests: XCTestCase {
     XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
   }
 
-  func testConfirmDiscard_DismissesSheet() async {
+  func testConfirmDiscardDismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let model = RecordPageModel()
@@ -215,7 +215,7 @@ final class RecordPageTests: XCTestCase {
 
   // MARK: - Accept Recording
 
-  func testOnAcceptRecordingTapped_CallsCallbackAndDismisses() async {
+  func testOnAcceptRecordingTappedCallsCallbackAndDismisses() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let expectedURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -234,7 +234,7 @@ final class RecordPageTests: XCTestCase {
     XCTAssertEqual(receivedURL.value, expectedURL)
   }
 
-  func testOnAcceptRecordingTapped_DoesNothingWithoutURL() async {
+  func testOnAcceptRecordingTappedDoesNothingWithoutURL() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let callbackCalled = LockIsolated(false)
@@ -254,7 +254,7 @@ final class RecordPageTests: XCTestCase {
 
   // MARK: - Playback
 
-  func testOnPlayPauseTapped_PlaysWhenNotPlaying() async {
+  func testOnPlayPauseTappedPlaysWhenNotPlaying() async {
     let playCalled = LockIsolated(false)
 
     await withDependencies {
@@ -272,7 +272,7 @@ final class RecordPageTests: XCTestCase {
     }
   }
 
-  func testOnPlayPauseTapped_PausesWhenPlaying() async {
+  func testOnPlayPauseTappedPausesWhenPlaying() async {
     let pauseCalled = LockIsolated(false)
 
     await withDependencies {
@@ -288,7 +288,7 @@ final class RecordPageTests: XCTestCase {
     }
   }
 
-  func testOnRewindTapped_SeeksToZero() async {
+  func testOnRewindTappedSeeksToZero() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
     await withDependencies {
@@ -304,7 +304,7 @@ final class RecordPageTests: XCTestCase {
     }
   }
 
-  func testSeekTo_UpdatesPlaybackPosition() async {
+  func testSeekToUpdatesPlaybackPosition() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
     await withDependencies {

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
@@ -7,22 +7,18 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class RecordPageTests: XCTestCase {
-  override func setUp() {
-    super.setUp()
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
-    coordinator.presentedSheet = nil
-  }
-
+struct RecordPageTests {
   // MARK: - Lifecycle
 
-  func testViewAppeared_PreparesForRecording() async {
+  @Test
+  func testViewAppearedPreparesForRecording() async {
     let prepareCalled = LockIsolated(false)
 
     await withDependencies {
@@ -34,40 +30,44 @@ final class RecordPageTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertTrue(prepareCalled.value)
+      #expect(prepareCalled.value)
     }
   }
 
   // MARK: - Done Button
 
-  func testShouldShowDoneButton_TrueOnlyInIdlePhase() {
+  @Test
+  func testShouldShowDoneButtonTrueOnlyInIdlePhase() {
     let model = RecordPageModel()
 
     model.recordingPhase = .idle
-    XCTAssertTrue(model.shouldShowDoneButton)
+    #expect(model.shouldShowDoneButton)
 
     model.recordingPhase = .recording
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
 
     model.recordingPhase = .review
-    XCTAssertFalse(model.shouldShowDoneButton)
+    #expect(!model.shouldShowDoneButton)
   }
 
-  func testOnDoneTapped_DismissesSheet() {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+  @Test
+  func testOnDoneTappedDismissesSheet() {
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let model = RecordPageModel()
     coordinator.presentedSheet = .recordPage(model)
 
-    XCTAssertNotNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet != nil)
 
     model.onDoneTapped()
 
-    XCTAssertNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet == nil)
   }
 
   // MARK: - Recording
 
+  @Test
   func testOnRecordTappedRequestsPermissionBeforeRecording() async {
     let requestPermissionCalled = LockIsolated(false)
     let startRecordingCalled = LockIsolated(false)
@@ -78,22 +78,23 @@ final class RecordPageTests: XCTestCase {
         return true
       }
       $0.audioRecorder.startRecording = {
-        XCTAssertTrue(
+        #expect(
           requestPermissionCalled.value, "Permission should be requested before recording starts")
         startRecordingCalled.setValue(true)
       }
     } operation: {
       let model = RecordPageModel()
-      XCTAssertEqual(model.recordingPhase, .idle)
+      #expect(model.recordingPhase == .idle)
 
       await model.onRecordTapped()
 
-      XCTAssertTrue(requestPermissionCalled.value)
-      XCTAssertTrue(startRecordingCalled.value)
-      XCTAssertEqual(model.recordingPhase, .recording)
+      #expect(requestPermissionCalled.value)
+      #expect(startRecordingCalled.value)
+      #expect(model.recordingPhase == .recording)
     }
   }
 
+  @Test
   func testOnRecordTappedDoesNotRecordWhenPermissionDenied() async {
     let startRecordingCalled = LockIsolated(false)
 
@@ -107,15 +108,16 @@ final class RecordPageTests: XCTestCase {
 
       await model.onRecordTapped()
 
-      XCTAssertFalse(
-        startRecordingCalled.value, "Recording should not start when permission is denied")
-      XCTAssertEqual(model.recordingPhase, .idle)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Microphone Access Required")
+      #expect(
+        !startRecordingCalled.value, "Recording should not start when permission is denied")
+      #expect(model.recordingPhase == .idle)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Microphone Access Required")
     }
   }
 
-  func testOnRecordTapped_ShowsAlertOnError() async {
+  @Test
+  func testOnRecordTappedShowsAlertOnError() async {
     await withDependencies {
       $0.audioRecorder.requestPermission = { true }
       $0.audioRecorder.startRecording = {
@@ -126,13 +128,14 @@ final class RecordPageTests: XCTestCase {
 
       await model.onRecordTapped()
 
-      XCTAssertEqual(model.recordingPhase, .idle)
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Recording Error")
+      #expect(model.recordingPhase == .idle)
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Recording Error")
     }
   }
 
-  func testOnStopTapped_StopsRecordingAndChangesPhase() async {
+  @Test
+  func testOnStopTappedStopsRecordingAndChangesPhase() async {
     let expectedURL = URL(fileURLWithPath: "/tmp/test-recording.wav")
 
     await withDependencies {
@@ -146,13 +149,14 @@ final class RecordPageTests: XCTestCase {
 
       await model.onStopTapped()
 
-      XCTAssertEqual(model.recordingPhase, .review)
-      XCTAssertEqual(model.recordingURL, expectedURL)
-      XCTAssertEqual(model.recordingDuration, 5.0)
+      #expect(model.recordingPhase == .review)
+      #expect(model.recordingURL == expectedURL)
+      #expect(model.recordingDuration == 5.0)
     }
   }
 
-  func testOnStopTapped_ShowsAlertOnError() async {
+  @Test
+  func testOnStopTappedShowsAlertOnError() async {
     await withDependencies {
       $0.audioRecorder.currentTime = { 0 }
       $0.audioRecorder.stopRecording = {
@@ -164,13 +168,14 @@ final class RecordPageTests: XCTestCase {
 
       await model.onStopTapped()
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Recording Error")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Recording Error")
     }
   }
 
   // MARK: - Re-record
 
+  @Test
   func testOnReRecordTappedResetsToIdleState() async {
     let model = RecordPageModel()
     model.recordingPhase = .review
@@ -181,42 +186,47 @@ final class RecordPageTests: XCTestCase {
 
     await model.onReRecordTapped()
 
-    XCTAssertEqual(model.recordingPhase, .idle)
-    XCTAssertNil(model.recordingURL)
-    XCTAssertEqual(model.recordingDuration, 0)
-    XCTAssertEqual(model.playbackPosition, 0)
-    XCTAssertFalse(model.isPlaying)
+    #expect(model.recordingPhase == .idle)
+    #expect(model.recordingURL == nil)
+    #expect(model.recordingDuration == 0)
+    #expect(model.playbackPosition == 0)
+    #expect(!model.isPlaying)
   }
 
   // MARK: - Discard
 
-  func testOnDiscardTapped_ShowsConfirmationAlert() {
+  @Test
+  func testOnDiscardTappedShowsConfirmationAlert() {
     let model = RecordPageModel()
     model.recordingPhase = .review
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
 
     model.onDiscardTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Discard Recording?")
   }
 
+  @Test
   func testConfirmDiscardDismissesSheet() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let model = RecordPageModel()
     coordinator.presentedSheet = .recordPage(model)
 
     await model.confirmDiscard()
 
-    XCTAssertNil(coordinator.presentedSheet)
+    #expect(coordinator.presentedSheet == nil)
   }
 
   // MARK: - Accept Recording
 
+  @Test
   func testOnAcceptRecordingTappedCallsCallbackAndDismisses() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let expectedURL = URL(fileURLWithPath: "/tmp/test.wav")
     let receivedURL = LockIsolated<URL?>(nil)
@@ -230,12 +240,14 @@ final class RecordPageTests: XCTestCase {
 
     await model.onAcceptRecordingTapped()
 
-    XCTAssertNil(coordinator.presentedSheet)
-    XCTAssertEqual(receivedURL.value, expectedURL)
+    #expect(coordinator.presentedSheet == nil)
+    #expect(receivedURL.value == expectedURL)
   }
 
+  @Test
   func testOnAcceptRecordingTappedDoesNothingWithoutURL() async {
-    @Shared(.mainContainerNavigationCoordinator) var coordinator
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
 
     let callbackCalled = LockIsolated(false)
 
@@ -248,12 +260,13 @@ final class RecordPageTests: XCTestCase {
 
     await model.onAcceptRecordingTapped()
 
-    XCTAssertFalse(callbackCalled.value)
-    XCTAssertNotNil(coordinator.presentedSheet)
+    #expect(!callbackCalled.value)
+    #expect(coordinator.presentedSheet != nil)
   }
 
   // MARK: - Playback
 
+  @Test
   func testOnPlayPauseTappedPlaysWhenNotPlaying() async {
     let playCalled = LockIsolated(false)
 
@@ -267,11 +280,12 @@ final class RecordPageTests: XCTestCase {
 
       await model.onPlayPauseTapped()
 
-      XCTAssertTrue(playCalled.value)
-      XCTAssertTrue(model.isPlaying)
+      #expect(playCalled.value)
+      #expect(model.isPlaying)
     }
   }
 
+  @Test
   func testOnPlayPauseTappedPausesWhenPlaying() async {
     let pauseCalled = LockIsolated(false)
 
@@ -283,11 +297,12 @@ final class RecordPageTests: XCTestCase {
 
       await model.onPlayPauseTapped()
 
-      XCTAssertTrue(pauseCalled.value)
-      XCTAssertFalse(model.isPlaying)
+      #expect(pauseCalled.value)
+      #expect(!model.isPlaying)
     }
   }
 
+  @Test
   func testOnRewindTappedSeeksToZero() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
@@ -299,11 +314,12 @@ final class RecordPageTests: XCTestCase {
 
       await model.onRewindTapped()
 
-      XCTAssertEqual(seekTime.value, 0)
-      XCTAssertEqual(model.playbackPosition, 0)
+      #expect(seekTime.value == 0)
+      #expect(model.playbackPosition == 0)
     }
   }
 
+  @Test
   func testSeekToUpdatesPlaybackPosition() async {
     let seekTime = LockIsolated<TimeInterval?>(nil)
 
@@ -315,8 +331,8 @@ final class RecordPageTests: XCTestCase {
 
       await model.seekTo(30.0)
 
-      XCTAssertEqual(seekTime.value, 30.0)
-      XCTAssertEqual(model.playbackPosition, 30.0)
+      #expect(seekTime.value == 30.0)
+      #expect(model.playbackPosition == 30.0)
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
@@ -171,7 +171,7 @@ final class RecordPageTests: XCTestCase {
 
   // MARK: - Re-record
 
-  func testOnReRecordTapped_ResetsToIdleState() {
+  func testOnReRecordTapped_ResetsToIdleState() async {
     let model = RecordPageModel()
     model.recordingPhase = .review
     model.recordingURL = URL(fileURLWithPath: "/tmp/test.wav")
@@ -179,7 +179,7 @@ final class RecordPageTests: XCTestCase {
     model.playbackPosition = 5.0
     model.isPlaying = true
 
-    model.onReRecordTapped()
+    await model.onReRecordTapped()
 
     XCTAssertEqual(model.recordingPhase, .idle)
     XCTAssertNil(model.recordingURL)
@@ -202,13 +202,13 @@ final class RecordPageTests: XCTestCase {
     XCTAssertEqual(model.presentedAlert?.title, "Discard Recording?")
   }
 
-  func testConfirmDiscard_DismissesSheet() {
+  func testConfirmDiscard_DismissesSheet() async {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let model = RecordPageModel()
     coordinator.presentedSheet = .recordPage(model)
 
-    model.confirmDiscard()
+    await model.confirmDiscard()
 
     XCTAssertNil(coordinator.presentedSheet)
   }
@@ -219,23 +219,18 @@ final class RecordPageTests: XCTestCase {
     @Shared(.mainContainerNavigationCoordinator) var coordinator
 
     let expectedURL = URL(fileURLWithPath: "/tmp/test.wav")
-    let callbackExpectation = XCTestExpectation(description: "onRecordingAccepted called")
     let receivedURL = LockIsolated<URL?>(nil)
 
     let model = RecordPageModel()
     model.recordingURL = expectedURL
     model.onRecordingAccepted = { url in
       receivedURL.setValue(url)
-      callbackExpectation.fulfill()
     }
     coordinator.presentedSheet = .recordPage(model)
 
-    model.onAcceptRecordingTapped()
+    await model.onAcceptRecordingTapped()
 
-    // Sheet dismisses immediately
     XCTAssertNil(coordinator.presentedSheet)
-
-    await fulfillment(of: [callbackExpectation], timeout: 1.0)
     XCTAssertEqual(receivedURL.value, expectedURL)
   }
 
@@ -251,10 +246,7 @@ final class RecordPageTests: XCTestCase {
     }
     coordinator.presentedSheet = .recordPage(model)
 
-    model.onAcceptRecordingTapped()
-
-    // Allow any spawned Task to complete
-    await Task.yield()
+    await model.onAcceptRecordingTapped()
 
     XCTAssertFalse(callbackCalled.value)
     XCTAssertNotNil(coordinator.presentedSheet)
@@ -273,9 +265,7 @@ final class RecordPageTests: XCTestCase {
       let model = RecordPageModel()
       model.isPlaying = false
 
-      model.onPlayPauseTapped()
-      // Allow Task to execute
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.onPlayPauseTapped()
 
       XCTAssertTrue(playCalled.value)
       XCTAssertTrue(model.isPlaying)
@@ -291,9 +281,7 @@ final class RecordPageTests: XCTestCase {
       let model = RecordPageModel()
       model.isPlaying = true
 
-      model.onPlayPauseTapped()
-      // Allow Task to execute
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.onPlayPauseTapped()
 
       XCTAssertTrue(pauseCalled.value)
       XCTAssertFalse(model.isPlaying)
@@ -309,9 +297,7 @@ final class RecordPageTests: XCTestCase {
       let model = RecordPageModel()
       model.playbackPosition = 30.0
 
-      model.onRewindTapped()
-      // Allow Task to execute
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.onRewindTapped()
 
       XCTAssertEqual(seekTime.value, 0)
       XCTAssertEqual(model.playbackPosition, 0)
@@ -327,9 +313,7 @@ final class RecordPageTests: XCTestCase {
       let model = RecordPageModel()
       model.recordingDuration = 60.0
 
-      model.seekTo(30.0)
-      // Allow Task to execute
-      try? await Task.sleep(for: .milliseconds(10))
+      await model.seekTo(30.0)
 
       XCTAssertEqual(seekTime.value, 30.0)
       XCTAssertEqual(model.playbackPosition, 30.0)

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
@@ -142,7 +142,7 @@ struct RecordPageView: View {
       }
     case .review:
       Button {
-        model.onReRecordTapped()
+        Task { await model.onReRecordTapped() }
       } label: {
         ZStack {
           Circle()
@@ -186,9 +186,9 @@ struct RecordPageView: View {
           currentTime: model.playbackPosition,
           totalTime: model.recordingDuration,
           isPlaying: model.isPlaying,
-          onPlayPause: { model.onPlayPauseTapped() },
-          onRewind: { model.onRewindTapped() },
-          onSeek: { model.seekTo($0) }
+          onPlayPause: { Task { await model.onPlayPauseTapped() } },
+          onRewind: { Task { await model.onRewindTapped() } },
+          onSeek: { time in Task { await model.seekTo(time) } }
         )
 
         HStack(spacing: 12) {
@@ -210,9 +210,7 @@ struct RecordPageView: View {
           }
 
           Button {
-            Task {
-              model.onAcceptRecordingTapped()
-            }
+            Task { await model.onAcceptRecordingTapped() }
           } label: {
             HStack(spacing: 6) {
               Image(systemName: "checkmark")

--- a/PlayolaRadio/Views/Pages/RewardsPage/RedeemPrizeSheetTests.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RedeemPrizeSheetTests.swift
@@ -3,16 +3,18 @@
 //  PlayolaRadio
 //
 
+import ConcurrencyExtras
 import Dependencies
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class RedeemPrizeSheetModelTests: XCTestCase {
+struct RedeemPrizeSheetModelTests {
 
+  @Test
   func testInitPreFillsVerifiedEmail() {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
@@ -21,10 +23,11 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
-    XCTAssertEqual(model.emailAddress, "test@example.com")
-    XCTAssertTrue(model.hasVerifiedEmail)
+    #expect(model.emailAddress == "test@example.com")
+    #expect(model.hasVerifiedEmail)
   }
 
+  @Test
   func testInitUsesUnverifiedEmailWhenNoVerifiedEmail() {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
@@ -32,33 +35,36 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
-    XCTAssertEqual(model.emailAddress, "apple@privaterelay.com")
-    XCTAssertFalse(model.hasVerifiedEmail)
+    #expect(model.emailAddress == "apple@privaterelay.com")
+    #expect(!model.hasVerifiedEmail)
   }
 
+  @Test
   func testInitLeavesEmailEmptyWhenNoAuth() {
     @Shared(.auth) var auth = Auth()
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
-    XCTAssertEqual(model.emailAddress, "")
+    #expect(model.emailAddress == "")
   }
 
+  @Test
   func testCanSubmitRequiresOptionAndEmail() {
     @Shared(.auth) var auth = Auth()
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
-    XCTAssertFalse(model.canSubmit)
+    #expect(!model.canSubmit)
 
     let option = model.redeemOptions[0]
     model.optionTapped(option)
-    XCTAssertFalse(model.canSubmit)
+    #expect(!model.canSubmit)
 
     model.emailAddress = "test@example.com"
-    XCTAssertTrue(model.canSubmit)
+    #expect(model.canSubmit)
   }
 
+  @Test
   func testOptionTappedSelectsOption() {
     @Shared(.auth) var auth = Auth()
 
@@ -67,26 +73,29 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     model.optionTapped(option)
 
-    XCTAssertEqual(model.selectedOption, option)
-    XCTAssertTrue(model.isSelected(option))
+    #expect(model.selectedOption == option)
+    #expect(model.isSelected(option))
   }
 
+  @Test
   func testRedeemOptionsIncludesRegularPrizes() {
     @Shared(.auth) var auth = Auth()
 
     let model = RedeemPrizeSheetModel(prizeTier: .mock)
 
     let options = model.redeemOptions
-    XCTAssertFalse(options.isEmpty)
-    XCTAssertTrue(options.allSatisfy { $0.stationId == nil })
+    #expect(!options.isEmpty)
+    #expect(options.allSatisfy { $0.stationId == nil })
   }
 
+  @Test
   func testSubmitWithVerifiedEmailSkipsUpdateUser() async {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
         id: "user-1", firstName: "Test", email: "test@example.com",
         verifiedEmail: "test@example.com"))
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
+      MainContainerNavigationCoordinator()
 
     let mockUserPrize = UserPrize(id: "up-1", userId: "user-1", prizeId: "p-1")
     let updateUserCalled = LockIsolated(false)
@@ -112,16 +121,18 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     await model.submitButtonTapped()
 
-    XCTAssertFalse(updateUserCalled.value)
-    XCTAssertTrue(successCalled.value)
-    XCTAssertFalse(model.isSubmitting)
+    #expect(!updateUserCalled.value)
+    #expect(successCalled.value)
+    #expect(!model.isSubmitting)
   }
 
+  @Test
   func testSubmitWithoutVerifiedEmailCallsUpdateUser() async {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
         id: "user-1", firstName: "Test", email: "apple@privaterelay.com"))
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
+      MainContainerNavigationCoordinator()
 
     let mockUserPrize = UserPrize(id: "up-1", userId: "user-1", prizeId: "p-1")
     let capturedVerifiedEmail = LockIsolated<String?>(nil)
@@ -151,11 +162,12 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     await model.submitButtonTapped()
 
-    XCTAssertEqual(capturedVerifiedEmail.value, "real@email.com")
-    XCTAssertTrue(successCalled.value)
-    XCTAssertFalse(model.isSubmitting)
+    #expect(capturedVerifiedEmail.value == "real@email.com")
+    #expect(successCalled.value)
+    #expect(!model.isSubmitting)
   }
 
+  @Test
   func testSubmitShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(
       loggedInUser: LoggedInUser(
@@ -174,7 +186,7 @@ final class RedeemPrizeSheetModelTests: XCTestCase {
 
     await model.submitButtonTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertFalse(model.isSubmitting)
+    #expect(model.presentedAlert != nil)
+    #expect(!model.isSubmitting)
   }
 }

--- a/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageTests.swift
@@ -6,17 +6,18 @@
 //
 
 import Combine
+import ConcurrencyExtras
 import Dependencies
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 // swiftlint:disable redundant_optional_initialization
 
 @MainActor
-final class RewardsPageModelTests: XCTestCase {
+struct RewardsPageModelTests {
   func createMockListeningTracker(totalTimeMS: Int) -> ListeningTracker {
     let rewardsProfile = RewardsProfile(
       totalTimeListenedMS: totalTimeMS,
@@ -28,7 +29,8 @@ final class RewardsPageModelTests: XCTestCase {
 
   // MARK: - Prize Tiers Loading Tests
 
-  func testOnViewAppeared_LoadsPrizeTiers() async {
+  @Test
+  func testOnViewAppearedLoadsPrizeTiers() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(totalTimeMS: 0)
     let mockPrizeTiers = PrizeTier.mocks
 
@@ -40,20 +42,20 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertEqual(model.prizeTiers.count, 3)  // Based on our mock data
+    #expect(model.prizeTiers.count == 3)
 
-    // Verify we have the expected tiers
     let tierNames = model.prizeTiers.map { $0.name }
-    XCTAssertTrue(tierNames.contains("Koozie"))
-    XCTAssertTrue(tierNames.contains("T-Shirt"))
-    XCTAssertTrue(tierNames.contains("Show Tix"))
+    #expect(tierNames.contains("Koozie"))
+    #expect(tierNames.contains("T-Shirt"))
+    #expect(tierNames.contains("Show Tix"))
   }
 
   // MARK: - Analytics Tests
 
-  func testOnViewAppeared_TracksRewardsScreenAnalytics() async {
+  @Test
+  func testOnViewAppearedTracksRewardsScreenAnalytics() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 54_000_000)  // 15 hours
+      totalTimeMS: 54_000_000)
     let mockPrizeTiers = PrizeTier.mocks
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
@@ -68,20 +70,21 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .viewedRewardsScreen(let currentHours) = events.first {
-      XCTAssertEqual(currentHours, 15.0, accuracy: 0.1)
+      #expect(abs(currentHours - 15.0) < 0.1)
     } else {
-      XCTFail("Expected viewedRewardsScreen event, got: \(String(describing: events.first))")
+      Issue.record("Expected viewedRewardsScreen event, got: \(String(describing: events.first))")
     }
   }
 
-  func testRedeemPrize_TracksRedeemAnalytics() async {
+  @Test
+  func testRedeemPrizeTracksRedeemAnalytics() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 108_000_000)  // 30 hours
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      totalTimeMS: 108_000_000)
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
+      MainContainerNavigationCoordinator()
     let mockPrizeTiers = PrizeTier.mocks
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
@@ -94,22 +97,23 @@ final class RewardsPageModelTests: XCTestCase {
       RewardsPageModel()
     }
 
-    await model.redeemPrizeTapped(for: mockPrizeTiers[0])  // Redeem Koozie
+    await model.redeemPrizeTapped(for: mockPrizeTiers[0])
 
-    // Verify analytics event was tracked
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 1)
+    #expect(events.count == 1)
     if case .tappedRedeemRewards(let currentHours) = events.first {
-      XCTAssertEqual(currentHours, 30.0, accuracy: 0.1)
+      #expect(abs(currentHours - 30.0) < 0.1)
     } else {
-      XCTFail("Expected tappedRedeemRewards event, got: \(String(describing: events.first))")
+      Issue.record("Expected tappedRedeemRewards event, got: \(String(describing: events.first))")
     }
   }
 
-  func testRedeemPrizeTapped_PresentsRedeemSheet() async {
+  @Test
+  func testRedeemPrizeTappedPresentsRedeemSheet() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
       totalTimeMS: 108_000_000)
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator =
+      MainContainerNavigationCoordinator()
     let mockPrizeTiers = PrizeTier.mocks
 
     let model = withDependencies {
@@ -121,14 +125,15 @@ final class RewardsPageModelTests: XCTestCase {
     await model.redeemPrizeTapped(for: mockPrizeTiers[0])
 
     if case .redeemPrize(let sheetModel) = navCoordinator.presentedSheet {
-      XCTAssertEqual(sheetModel.prizeTier.id, mockPrizeTiers[0].id)
+      #expect(sheetModel.prizeTier.id == mockPrizeTiers[0].id)
     } else {
-      XCTFail(
+      Issue.record(
         "Expected redeemPrize sheet, got \(String(describing: navCoordinator.presentedSheet))")
     }
   }
 
-  func testLoadUserPrizes_PopulatesRedeemedTierIds() async {
+  @Test
+  func testLoadUserPrizesPopulatesRedeemedTierIds() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(totalTimeMS: 0)
     @Shared(.auth) var auth = Auth(jwt: "test-token")
     let mockPrizeTiers = PrizeTier.mocks
@@ -147,14 +152,15 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertTrue(model.redeemedPrizeTierIds.contains(mockPrizeTiers[0].id))
+    #expect(model.redeemedPrizeTierIds.contains(mockPrizeTiers[0].id))
   }
 
   // MARK: - Redemption Status Tests
 
-  func testRedemptionStatus_Redeemed() async {
+  @Test
+  func testRedemptionStatusRedeemed() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 50 * 60 * 60 * 1000)  // 50 hours
+      totalTimeMS: 50 * 60 * 60 * 1000)
     let mockPrizeTiers = PrizeTier.mocks
 
     let model = withDependencies {
@@ -165,7 +171,6 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // Simulate the user has redeemed the first tier (Koozie - 10 hours)
     let koozieId = mockPrizeTiers[0].id
     model.redeemedPrizeTierIds.insert(koozieId)
 
@@ -174,13 +179,14 @@ final class RewardsPageModelTests: XCTestCase {
     if case .redeemed = status {
       // Test passes
     } else {
-      XCTFail("Expected redeemed status, got \(status)")
+      Issue.record("Expected redeemed status, got \(status)")
     }
   }
 
-  func testRedemptionStatus_Redeemable() async {
+  @Test
+  func testRedemptionStatusRedeemable() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 35 * 60 * 60 * 1000)  // 35 hours
+      totalTimeMS: 35 * 60 * 60 * 1000)
     let mockPrizeTiers = PrizeTier.mocks
 
     let model = withDependencies {
@@ -191,20 +197,20 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // User has 35 hours, T-Shirt requires 30 hours - should be redeemable
-    let tshirtTier = mockPrizeTiers[1]  // T-Shirt tier
+    let tshirtTier = mockPrizeTiers[1]
     let status = model.redemptionStatus(for: tshirtTier)
 
     if case .redeemable = status {
       // Test passes
     } else {
-      XCTFail("Expected redeemable status, got \(status)")
+      Issue.record("Expected redeemable status, got \(status)")
     }
   }
 
-  func testRedemptionStatus_MoreTimeRequired() async {
+  @Test
+  func testRedemptionStatusMoreTimeRequired() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(
-      totalTimeMS: 25 * 60 * 60 * 1000)  // 25 hours
+      totalTimeMS: 25 * 60 * 60 * 1000)
     let mockPrizeTiers = PrizeTier.mocks
 
     let model = withDependencies {
@@ -215,18 +221,18 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // User has 25 hours, Show Tix requires 70 hours - should need 45 more hours
-    let showTixTier = mockPrizeTiers[2]  // Show Tix tier (70 hours required)
+    let showTixTier = mockPrizeTiers[2]
     let status = model.redemptionStatus(for: showTixTier)
 
     if case .moreTimeRequired(let hoursToGo) = status {
-      XCTAssertEqual(hoursToGo, 45, "Expected 45 hours to go, got \(hoursToGo)")
+      #expect(hoursToGo == 45, "Expected 45 hours to go, got \(hoursToGo)")
     } else {
-      XCTFail("Expected moreTimeRequired status, got \(status)")
+      Issue.record("Expected moreTimeRequired status, got \(status)")
     }
   }
 
-  func testRedemptionStatus_ZeroListeningTime() async {
+  @Test
+  func testRedemptionStatusZeroListeningTime() async {
     @Shared(.listeningTracker) var listeningTracker = createMockListeningTracker(totalTimeMS: 0)
     let mockPrizeTiers = PrizeTier.mocks
 
@@ -238,18 +244,18 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // User has 0 hours, Koozie requires 10 hours - should need 10 more hours
-    let koozieIdTier = mockPrizeTiers[0]  // Koozie tier (10 hours required)
+    let koozieIdTier = mockPrizeTiers[0]
     let status = model.redemptionStatus(for: koozieIdTier)
 
     if case .moreTimeRequired(let hoursToGo) = status {
-      XCTAssertEqual(hoursToGo, 10, "Expected 10 hours to go, got \(hoursToGo)")
+      #expect(hoursToGo == 10, "Expected 10 hours to go, got \(hoursToGo)")
     } else {
-      XCTFail("Expected moreTimeRequired status, got \(status)")
+      Issue.record("Expected moreTimeRequired status, got \(status)")
     }
   }
 
-  func testRedemptionStatus_NilListeningTracker() async {
+  @Test
+  func testRedemptionStatusNilListeningTracker() async {
     @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let mockPrizeTiers = PrizeTier.mocks
 
@@ -261,17 +267,15 @@ final class RewardsPageModelTests: XCTestCase {
 
     await model.viewAppeared()
 
-    // With nil listening tracker, should default to 0 hours and need full requirement
-    let koozieIdTier = mockPrizeTiers[0]  // Koozie tier (10 hours required)
+    let koozieIdTier = mockPrizeTiers[0]
     let status = model.redemptionStatus(for: koozieIdTier)
 
     if case .moreTimeRequired(let hoursToGo) = status {
-      XCTAssertEqual(hoursToGo, 10, "Expected 10 hours to go with nil tracker, got \(hoursToGo)")
+      #expect(hoursToGo == 10, "Expected 10 hours to go with nil tracker, got \(hoursToGo)")
     } else {
-      XCTFail("Expected moreTimeRequired status with nil tracker, got \(status)")
+      Issue.record("Expected moreTimeRequired status with nil tracker, got \(status)")
     }
   }
-
 }
 
 // swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
@@ -9,13 +9,14 @@ import PlayolaPlayer
 
 @MainActor
 @Observable
-class EpisodeRowModel {
+class EpisodeRowModel: ViewModel {
   @ObservationIgnored @Dependency(\.date.now) var now
 
   let airing: Airing
 
   init(airing: Airing) {
     self.airing = airing
+    super.init()
   }
 
   var isUpcoming: Bool {

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowTests.swift
@@ -6,15 +6,16 @@
 import Dependencies
 import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class EpisodeRowModelTests: XCTestCase {
+struct EpisodeRowModelTests {
 
   // MARK: - Tune In Text Tests (This Week)
 
+  @Test
   func testTuneInTextThisWeekShowsDayOnly() {
     let friday = createDate(year: 2026, month: 1, day: 16, hour: 14, minute: 20)
     let saturday = createDate(year: 2026, month: 1, day: 17, hour: 14, minute: 20)
@@ -25,9 +26,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: saturday))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Saturday at 2:20pm")
+    #expect(model.tuneInText == "Tune in Saturday at 2:20pm")
   }
 
+  @Test
   func testTuneInTextThisWeekDifferentTime() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let wednesday = createDate(year: 2026, month: 1, day: 14, hour: 16, minute: 0)
@@ -38,11 +40,12 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: wednesday))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Wednesday at 4:00pm")
+    #expect(model.tuneInText == "Tune in Wednesday at 4:00pm")
   }
 
   // MARK: - Tune In Text Tests (Next Week)
 
+  @Test
   func testTuneInTextNextWeekShowsNextPrefix() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let nextFriday = createDate(year: 2026, month: 1, day: 23, hour: 14, minute: 20)
@@ -53,9 +56,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: nextFriday))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in next Friday at 2:20pm")
+    #expect(model.tuneInText == "Tune in next Friday at 2:20pm")
   }
 
+  @Test
   func testTuneInTextNextWeekDifferentDay() {
     let friday = createDate(year: 2026, month: 1, day: 16, hour: 9, minute: 0)
     let nextTuesday = createDate(year: 2026, month: 1, day: 20, hour: 19, minute: 30)
@@ -66,11 +70,12 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: nextTuesday))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in next Tuesday at 7:30pm")
+    #expect(model.tuneInText == "Tune in next Tuesday at 7:30pm")
   }
 
   // MARK: - Tune In Text Tests (Beyond Next Week)
 
+  @Test
   func testTuneInTextBeyondNextWeekShowsDayAndDate() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 3, hour: 14, minute: 20)
@@ -81,9 +86,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Tuesday the 3rd at 2:20pm")
+    #expect(model.tuneInText == "Tune in Tuesday the 3rd at 2:20pm")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinalSt() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 1, hour: 10, minute: 0)
@@ -94,9 +100,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Sunday the 1st at 10:00am")
+    #expect(model.tuneInText == "Tune in Sunday the 1st at 10:00am")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinalNd() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 2, hour: 15, minute: 45)
@@ -107,9 +114,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Monday the 2nd at 3:45pm")
+    #expect(model.tuneInText == "Tune in Monday the 2nd at 3:45pm")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinalTh() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 11, hour: 20, minute: 0)
@@ -120,9 +128,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Wednesday the 11th at 8:00pm")
+    #expect(model.tuneInText == "Tune in Wednesday the 11th at 8:00pm")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinal12th() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 12, hour: 12, minute: 0)
@@ -133,9 +142,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Thursday the 12th at 12:00pm")
+    #expect(model.tuneInText == "Tune in Thursday the 12th at 12:00pm")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinal13th() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 13, hour: 9, minute: 30)
@@ -146,9 +156,10 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Friday the 13th at 9:30am")
+    #expect(model.tuneInText == "Tune in Friday the 13th at 9:30am")
   }
 
+  @Test
   func testTuneInTextBeyondNextWeekWithOrdinal21st() {
     let monday = createDate(year: 2026, month: 1, day: 12, hour: 9, minute: 0)
     let farFuture = createDate(year: 2026, month: 2, day: 21, hour: 18, minute: 0)
@@ -159,7 +170,7 @@ final class EpisodeRowModelTests: XCTestCase {
       EpisodeRowModel(airing: .mockWith(airtime: farFuture))
     }
 
-    XCTAssertEqual(model.tuneInText, "Tune in Saturday the 21st at 6:00pm")
+    #expect(model.tuneInText == "Tune in Saturday the 21st at 6:00pm")
   }
 
   // MARK: - Helper

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
@@ -228,7 +228,8 @@ struct SubscriptionBadge: View {
                   createdAt: Date().addingTimeInterval(-86400 * 7)
                 )
               ),
-            ]
+            ],
+            now: Date()
           ),
           subscriptionStatus: .autoSubscribed
         )
@@ -253,7 +254,8 @@ struct SubscriptionBadge: View {
                   createdAt: Date()
                 )
               )
-            ]
+            ],
+            now: Date()
           ),
           subscriptionStatus: .subscribed
         )
@@ -285,7 +287,8 @@ struct SubscriptionBadge: View {
                   createdAt: Date().addingTimeInterval(-86400 * 30)
                 )
               ),
-            ]
+            ],
+            now: Date()
           ),
           subscriptionStatus: .notSubscribed
         )

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
@@ -145,7 +145,8 @@ final class SeriesCardModelTests: XCTestCase {
     ShowWithAirings(
       show: .mockWith(title: "Test Show"),
       station: stationId != nil ? .mockWith(id: stationId!) : nil,
-      airings: [.mockWith()]
+      airings: [.mockWith()],
+      now: Date()
     )
   }
 

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
@@ -5,14 +5,16 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SeriesCardModelTests: XCTestCase {
+struct SeriesCardModelTests {
+  @Test
   func testRemindMeTappedCallsSubscribeAPI() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let subscribeCalled = LockIsolated(false)
@@ -32,11 +34,12 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertTrue(subscribeCalled.value)
-      XCTAssertEqual(subscribedStationId.value, "station-123")
+      #expect(subscribeCalled.value)
+      #expect(subscribedStationId.value == "station-123")
     }
   }
 
+  @Test
   func testRemindMeTappedUpdatesStatusToSubscribed() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -52,10 +55,11 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertEqual(model.subscriptionStatus, .subscribed)
+      #expect(model.subscriptionStatus == .subscribed)
     }
   }
 
+  @Test
   func testRemindMeTappedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -71,10 +75,11 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
+  @Test
   func testRemindMeTappedDoesNotCallAPIWithoutJWT() async {
     @Shared(.auth) var auth = Auth(jwt: nil)
     let subscribeCalled = LockIsolated(false)
@@ -92,10 +97,11 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertFalse(subscribeCalled.value)
+      #expect(!subscribeCalled.value)
     }
   }
 
+  @Test
   func testRemindMeTappedDoesNotCallAPIWithoutStation() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let subscribeCalled = LockIsolated(false)
@@ -113,10 +119,11 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertFalse(subscribeCalled.value)
+      #expect(!subscribeCalled.value)
     }
   }
 
+  @Test
   func testRemindMeTappedSetsIsSubscribingDuringRequest() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let wasSubscribingDuringCall = LockIsolated(false)
@@ -134,8 +141,8 @@ final class SeriesCardModelTests: XCTestCase {
 
       await model.remindMeTapped()
 
-      XCTAssertTrue(wasSubscribingDuringCall.value)
-      XCTAssertFalse(model.isSubscribing)
+      #expect(wasSubscribingDuringCall.value)
+      #expect(!model.isSubscribing)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageModel.swift
@@ -52,42 +52,43 @@ class SeriesListPageModel: ViewModel {
   }
 
   private func groupAiringsByShow(_ airings: [Airing]) -> [ShowWithAirings] {
-    var showDict: [String: ShowWithAirings] = [:]
+    let currentTime = now
 
-    // Filter to only include airings that haven't ended yet
     let upcomingAirings = airings.filter { airing in
       let durationMS = airing.episode?.durationMS ?? 0
       let endTime = airing.airtime.addingTimeInterval(TimeInterval(durationMS) / 1000.0)
-      return endTime > now
+      return endTime > currentTime
     }
+
+    var airingsByShowId: [String: [Airing]] = [:]
+    var showsById: [String: Show] = [:]
+    var stationsByShowId: [String: Station?] = [:]
 
     for airing in upcomingAirings {
       guard let episode = airing.episode,
         let show = episode.show
       else { continue }
 
-      if var existing = showDict[show.id] {
-        existing.airings.append(airing)
-        showDict[show.id] = existing
-      } else {
-        showDict[show.id] = ShowWithAirings(
-          show: show,
-          station: airing.station,
-          airings: [airing]
-        )
+      airingsByShowId[show.id, default: []].append(airing)
+      showsById[show.id] = show
+      if stationsByShowId[show.id] == nil {
+        stationsByShowId[show.id] = airing.station
       }
     }
 
-    // Sort airings within each show by airtime
-    for (id, var showWithAirings) in showDict {
-      showWithAirings.airings.sort { $0.airtime < $1.airtime }
-      showDict[id] = showWithAirings
+    let shows = airingsByShowId.compactMap { showId, airings -> ShowWithAirings? in
+      guard let show = showsById[showId] else { return nil }
+      return ShowWithAirings(
+        show: show,
+        station: stationsByShowId[showId] ?? nil,
+        airings: airings.sorted { $0.airtime < $1.airtime },
+        now: currentTime
+      )
     }
 
-    return showDict.values
-      .sorted {
-        $0.nextAiring?.airtime ?? .distantFuture < $1.nextAiring?.airtime ?? .distantFuture
-      }
+    return shows.sorted {
+      $0.nextAiring?.airtime ?? .distantFuture < $1.nextAiring?.airtime ?? .distantFuture
+    }
   }
 }
 
@@ -96,19 +97,19 @@ class SeriesListPageModel: ViewModel {
 struct ShowWithAirings: Identifiable {
   let show: Show
   let station: Station?
-  var airings: [Airing]
+  let airings: [Airing]
+  let nextAiring: Airing?
+  let upcomingAiringsCount: Int
 
   var id: String { show.id }
 
-  var nextAiring: Airing? {
-    airings
-      .filter { $0.airtime > Date() }
-      .sorted { $0.airtime < $1.airtime }
-      .first
-  }
-
-  var upcomingAiringsCount: Int {
-    airings.filter { $0.airtime > Date() }.count
+  init(show: Show, station: Station?, airings: [Airing], now: Date) {
+    self.show = show
+    self.station = station
+    self.airings = airings
+    let upcoming = airings.filter { $0.airtime > now }
+    self.nextAiring = upcoming.sorted { $0.airtime < $1.airtime }.first
+    self.upcomingAiringsCount = upcoming.count
   }
 }
 

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
@@ -5,14 +5,16 @@
 
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SeriesListPageModelTests: XCTestCase {
+struct SeriesListPageModelTests {
+  @Test
   func testViewAppearedCallsGetAiringsAPI() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let apiCalled = LockIsolated(false)
@@ -30,11 +32,12 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertTrue(apiCalled.value)
-      XCTAssertEqual(passedJwt.value, "test-jwt")
+      #expect(apiCalled.value)
+      #expect(passedJwt.value == "test-jwt")
     }
   }
 
+  @Test
   func testViewAppearedPopulatesShowsGroupedByShow() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let now = Date()
@@ -67,14 +70,15 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.shows.count, 2)
+      #expect(model.shows.count == 2)
       let show1Group = model.shows.first { $0.show.id == "show-1" }
       let show2Group = model.shows.first { $0.show.id == "show-2" }
-      XCTAssertEqual(show1Group?.airings.count, 2)
-      XCTAssertEqual(show2Group?.airings.count, 1)
+      #expect(show1Group?.airings.count == 2)
+      #expect(show2Group?.airings.count == 1)
     }
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -87,10 +91,11 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
+  @Test
   func testViewAppearedDoesNotCallAPIWithoutJWT() async {
     @Shared(.auth) var auth = Auth(jwt: nil)
     let apiCalled = LockIsolated(false)
@@ -105,10 +110,11 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertFalse(apiCalled.value)
+      #expect(!apiCalled.value)
     }
   }
 
+  @Test
   func testViewAppearedFiltersOutEndedAirings() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let now = Date()
@@ -143,12 +149,12 @@ final class SeriesListPageModelTests: XCTestCase {
 
       await model.viewAppeared()
 
-      XCTAssertEqual(model.shows.count, 1)
+      #expect(model.shows.count == 1)
       let showGroup = model.shows.first
-      XCTAssertEqual(showGroup?.airings.count, 2)
-      XCTAssertTrue(showGroup?.airings.contains { $0.id == "live-airing" } ?? false)
-      XCTAssertTrue(showGroup?.airings.contains { $0.id == "upcoming-airing" } ?? false)
-      XCTAssertFalse(showGroup?.airings.contains { $0.id == "ended-airing" } ?? true)
+      #expect(showGroup?.airings.count == 2)
+      #expect(showGroup?.airings.contains { $0.id == "live-airing" } ?? false)
+      #expect(showGroup?.airings.contains { $0.id == "upcoming-airing" } ?? false)
+      #expect(!(showGroup?.airings.contains { $0.id == "ended-airing" } ?? true))
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
@@ -19,6 +19,7 @@ final class SeriesListPageModelTests: XCTestCase {
     let passedJwt = LockIsolated<String?>(nil)
 
     await withDependencies {
+      $0.date.now = Date()
       $0.api.getAirings = { jwt, _ in
         apiCalled.setValue(true)
         passedJwt.setValue(jwt)

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -45,10 +45,9 @@ class SignInPageModel: ViewModel {
     Task { await analytics.track(.signInStarted(method: .apple)) }
   }
 
-  func signInWithAppleCompleted(result: Result<ASAuthorization, any Error>) {
+  func signInWithAppleCompleted(result: Result<ASAuthorization, any Error>) async {
     switch result {
     case .success(let authorization):
-
       guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
         let identityTokenData = appleIDCredential.identityToken,
         let identityToken = String(data: identityTokenData, encoding: .utf8),
@@ -57,36 +56,32 @@ class SignInPageModel: ViewModel {
       else {
         print("Error decoding signin info from apple")
         presentedAlert = .signInError
-        Task {
-          await errorReporting.reportMessage(
-            "Error decoding sign-in info from Apple",
-            ["auth_method": "apple", "sign_in_step": "credential_decode"])
-        }
+        await errorReporting.reportMessage(
+          "Error decoding sign-in info from Apple",
+          ["auth_method": "apple", "sign_in_step": "credential_decode"])
         return
       }
 
       let email = appleIDCredential.email
 
-      Task {
-        do {
-          let firstName = appleIDCredential.fullName?.givenName ?? ""
-          let lastName = appleIDCredential.fullName?.familyName
-          let token = try await api.signInViaApple(
-            identityToken,
-            email,  // Now optional - can be nil
-            authCode,
-            firstName,
-            lastName)
-          $auth.withLock { $0 = Auth(jwtToken: token) }
-          appRating.recordInstallDateIfNeeded()
-          await analytics.track(.signInCompleted(method: .apple, userId: appleIDCredential.user))
-        } catch {
-          print("Sign in failed: \(error)")
-          await handleSignInAPIFailure(error, authMethod: .apple, step: "api_call")
-        }
+      do {
+        let firstName = appleIDCredential.fullName?.givenName ?? ""
+        let lastName = appleIDCredential.fullName?.familyName
+        let token = try await api.signInViaApple(
+          identityToken,
+          email,
+          authCode,
+          firstName,
+          lastName)
+        $auth.withLock { $0 = Auth(jwtToken: token) }
+        appRating.recordInstallDateIfNeeded()
+        await analytics.track(.signInCompleted(method: .apple, userId: appleIDCredential.user))
+      } catch {
+        print("Sign in failed: \(error)")
+        await handleSignInAPIFailure(error, authMethod: .apple, step: "api_call")
       }
     case .failure(let error):
-      handleAppleAuthorizationFailure(error)
+      await handleAppleAuthorizationFailure(error)
     }
   }
 
@@ -144,15 +139,13 @@ class SignInPageModel: ViewModel {
 
   // MARK: - Private Helpers
 
-  private func handleAppleAuthorizationFailure(_ error: any Error) {
+  private func handleAppleAuthorizationFailure(_ error: any Error) async {
     print(error)
     if let authError = error as? ASAuthorizationError, authError.code == .canceled {
       return
     }
     presentedAlert = .signInError
-    Task {
-      await reportSignInError(error, authMethod: .apple, step: "authorization_failure")
-    }
+    await reportSignInError(error, authMethod: .apple, step: "authorization_failure")
   }
 
   private func reportSignInError(_ error: Error, authMethod: AuthMethod, step: String) async {

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -94,33 +94,27 @@ final class SignInPageTests: XCTestCase {
     }
 
     let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
-    model.signInWithAppleCompleted(result: .failure(genericError))
-
-    await fulfillment(of: [expectation], timeout: 1.0)
+    await model.signInWithAppleCompleted(result: .failure(genericError))
 
     XCTAssertEqual(reportedErrors.value.count, 1, "Should call reportError exactly once")
     let tags = reportedErrors.value.first?.1 ?? [:]
     XCTAssertEqual(tags["auth_method"], "apple")
+    _ = expectation
   }
 
   func testSignInWithAppleCompletedDoesNotReportErrorOnUserCancel() async {
     let reportedErrors = LockIsolated<[(Error, [String: String])]>([])
-    let invertedExpectation = XCTestExpectation(description: "reportError must NOT be called")
-    invertedExpectation.isInverted = true
 
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { error, tags, _, _ in
         reportedErrors.withValue { $0.append((error, tags)) }
-        invertedExpectation.fulfill()
       }
     } operation: {
       SignInPageModel()
     }
 
     let cancelError = ASAuthorizationError(.canceled)
-    model.signInWithAppleCompleted(result: .failure(cancelError))
-
-    await fulfillment(of: [invertedExpectation], timeout: 0.2)
+    await model.signInWithAppleCompleted(result: .failure(cancelError))
 
     XCTAssertTrue(
       reportedErrors.value.isEmpty,
@@ -137,7 +131,7 @@ final class SignInPageTests: XCTestCase {
     }
 
     let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
-    model.signInWithAppleCompleted(result: .failure(genericError))
+    await model.signInWithAppleCompleted(result: .failure(genericError))
 
     XCTAssertEqual(model.presentedAlert, .signInError)
   }
@@ -150,7 +144,7 @@ final class SignInPageTests: XCTestCase {
     }
 
     let cancelError = ASAuthorizationError(.canceled)
-    model.signInWithAppleCompleted(result: .failure(cancelError))
+    await model.signInWithAppleCompleted(result: .failure(cancelError))
 
     XCTAssertNil(model.presentedAlert)
   }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -82,12 +82,10 @@ final class SignInPageTests: XCTestCase {
 
   func testSignInWithAppleCompletedReportsErrorOnAuthorizationFailure() async {
     let reportedErrors = LockIsolated<[(Error, [String: String])]>([])
-    let expectation = XCTestExpectation(description: "reportError called")
 
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { error, tags, _, _ in
         reportedErrors.withValue { $0.append((error, tags)) }
-        expectation.fulfill()
       }
     } operation: {
       SignInPageModel()
@@ -99,7 +97,6 @@ final class SignInPageTests: XCTestCase {
     XCTAssertEqual(reportedErrors.value.count, 1, "Should call reportError exactly once")
     let tags = reportedErrors.value.first?.1 ?? [:]
     XCTAssertEqual(tags["auth_method"], "apple")
-    _ = expectation
   }
 
   func testSignInWithAppleCompletedDoesNotReportErrorOnUserCancel() async {

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -29,27 +29,28 @@ struct SignInPageTests {
   func testSignInWithAppleTracksSignInStartedEvent() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
-    await confirmation("Apple sign-in started event tracked") { confirm in
-      let model = withDependencies {
-        $0.analytics.track = { event in
-          capturedEvents.withValue { $0.append(event) }
-          if case .signInStarted(let method) = event, method == .apple {
-            confirm()
+    await withMainSerialExecutor {
+      await confirmation("Apple sign-in started event tracked") { confirm in
+        let model = withDependencies {
+          $0.analytics.track = { event in
+            capturedEvents.withValue { $0.append(event) }
+            if case .signInStarted(let method) = event, method == .apple {
+              confirm()
+            }
           }
+        } operation: {
+          SignInPageModel()
         }
-      } operation: {
-        SignInPageModel()
-      }
 
-      let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
-      model.signInWithAppleButtonTapped(request: request)
+        let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
+        model.signInWithAppleButtonTapped(request: request)
 
-      // Yield to let the spawned Task run the analytics callback.
-      while !capturedEvents.value.contains(where: {
-        if case .signInStarted(let method) = $0 { return method == .apple }
-        return false
-      }) {
-        await Task.yield()
+        while !capturedEvents.value.contains(where: {
+          if case .signInStarted(let method) = $0 { return method == .apple }
+          return false
+        }) {
+          await Task.yield()
+        }
       }
     }
 

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -7,40 +7,51 @@
 
 import Alamofire
 import AuthenticationServices
+import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SignInPageTests: XCTestCase {
-  func testSignInWithApple_CorrectlyAddsScopeToTheAppleSignInRequest() async {
+struct SignInPageTests {
+  @Test
+  func testSignInWithAppleCorrectlyAddsScopeToTheAppleSignInRequest() async {
     let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
     let model = SignInPageModel()
     model.signInWithAppleButtonTapped(request: request)
-    XCTAssertEqual(request.requestedScopes, [.email, .fullName])
+    #expect(request.requestedScopes == [.email, .fullName])
   }
 
-  func testSignInWithApple_TracksSignInStartedEvent() async {
+  @Test
+  func testSignInWithAppleTracksSignInStartedEvent() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
-    let expectation = XCTestExpectation(description: "Analytics event tracked")
 
-    let model = withDependencies {
-      $0.analytics.track = { event in
-        capturedEvents.withValue { $0.append(event) }
-        if case .signInStarted(let method) = event, method == .apple {
-          expectation.fulfill()
+    await confirmation("Apple sign-in started event tracked") { confirm in
+      let model = withDependencies {
+        $0.analytics.track = { event in
+          capturedEvents.withValue { $0.append(event) }
+          if case .signInStarted(let method) = event, method == .apple {
+            confirm()
+          }
         }
+      } operation: {
+        SignInPageModel()
       }
-    } operation: {
-      SignInPageModel()
+
+      let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
+      model.signInWithAppleButtonTapped(request: request)
+
+      // Yield to let the spawned Task run the analytics callback.
+      while !capturedEvents.value.contains(where: {
+        if case .signInStarted(let method) = $0 { return method == .apple }
+        return false
+      }) {
+        await Task.yield()
+      }
     }
-
-    let request = ASAuthorizationAppleIDRequest(coder: NSCoder())!
-    model.signInWithAppleButtonTapped(request: request)
-
-    await fulfillment(of: [expectation], timeout: 1.0)
 
     let hasSignInStartedEvent = capturedEvents.value.contains { event in
       if case .signInStarted(let method) = event {
@@ -49,10 +60,11 @@ final class SignInPageTests: XCTestCase {
       return false
     }
 
-    XCTAssertTrue(hasSignInStartedEvent, "Should track signInStarted event for Apple")
+    #expect(hasSignInStartedEvent, "Should track signInStarted event for Apple")
   }
 
-  func testSignInWithGoogle_TracksSignInStartedEvent() async {
+  @Test
+  func testSignInWithGoogleTracksSignInStartedEvent() async {
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
     let model = withDependencies {
@@ -75,11 +87,12 @@ final class SignInPageTests: XCTestCase {
       return false
     }
 
-    XCTAssertTrue(hasSignInStartedEvent, "Should track signInStarted event for Google")
+    #expect(hasSignInStartedEvent, "Should track signInStarted event for Google")
   }
 
   // MARK: - signInWithAppleCompleted() Error Reporting Tests
 
+  @Test
   func testSignInWithAppleCompletedReportsErrorOnAuthorizationFailure() async {
     let reportedErrors = LockIsolated<[(Error, [String: String])]>([])
 
@@ -94,11 +107,12 @@ final class SignInPageTests: XCTestCase {
     let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
     await model.signInWithAppleCompleted(result: .failure(genericError))
 
-    XCTAssertEqual(reportedErrors.value.count, 1, "Should call reportError exactly once")
+    #expect(reportedErrors.value.count == 1, "Should call reportError exactly once")
     let tags = reportedErrors.value.first?.1 ?? [:]
-    XCTAssertEqual(tags["auth_method"], "apple")
+    #expect(tags["auth_method"] == "apple")
   }
 
+  @Test
   func testSignInWithAppleCompletedDoesNotReportErrorOnUserCancel() async {
     let reportedErrors = LockIsolated<[(Error, [String: String])]>([])
 
@@ -113,13 +127,14 @@ final class SignInPageTests: XCTestCase {
     let cancelError = ASAuthorizationError(.canceled)
     await model.signInWithAppleCompleted(result: .failure(cancelError))
 
-    XCTAssertTrue(
+    #expect(
       reportedErrors.value.isEmpty,
       "Should not report ASAuthorizationError.canceled (user cancellations are not bugs)")
   }
 
   // MARK: - presentedAlert Tests
 
+  @Test
   func testSignInWithAppleCompletedPresentsAlertOnAuthorizationFailure() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -130,9 +145,10 @@ final class SignInPageTests: XCTestCase {
     let genericError = NSError(domain: "test.domain", code: 42, userInfo: nil)
     await model.signInWithAppleCompleted(result: .failure(genericError))
 
-    XCTAssertEqual(model.presentedAlert, .signInError)
+    #expect(model.presentedAlert == .signInError)
   }
 
+  @Test
   func testSignInWithAppleCompletedDoesNotPresentAlertOnUserCancel() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -143,9 +159,10 @@ final class SignInPageTests: XCTestCase {
     let cancelError = ASAuthorizationError(.canceled)
     await model.signInWithAppleCompleted(result: .failure(cancelError))
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testSignInWithGooglePresentsAlertWhenNoKeyWindow() async {
     let model = withDependencies {
       $0.errorReporting.reportMessage = { _, _ in }
@@ -157,11 +174,12 @@ final class SignInPageTests: XCTestCase {
 
     await model.signInWithGoogleButtonTapped()
 
-    XCTAssertEqual(model.presentedAlert, .signInError)
+    #expect(model.presentedAlert == .signInError)
   }
 
   // MARK: - handleSignInAPIFailure Routing Tests
 
+  @Test
   func testHandleSignInAPIFailureShowsNetworkAlertOnAppleSSLError() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -175,10 +193,11 @@ final class SignInPageTests: XCTestCase {
 
     await model.handleSignInAPIFailure(afError, authMethod: .apple, step: "api_call")
 
-    XCTAssertEqual(model.presentedAlert, .signInNetworkError)
-    XCTAssertNotEqual(model.presentedAlert, .signInError)
+    #expect(model.presentedAlert == .signInNetworkError)
+    #expect(model.presentedAlert != .signInError)
   }
 
+  @Test
   func testHandleSignInAPIFailureShowsGenericAlertOnAppleUnknownError() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -191,10 +210,11 @@ final class SignInPageTests: XCTestCase {
 
     await model.handleSignInAPIFailure(genericError, authMethod: .apple, step: "api_call")
 
-    XCTAssertEqual(model.presentedAlert, .signInError)
-    XCTAssertEqual(model.presentedAlert?.title, "Sign-In Failed")
+    #expect(model.presentedAlert == .signInError)
+    #expect(model.presentedAlert?.title == "Sign-In Failed")
   }
 
+  @Test
   func testHandleSignInAPIFailureShowsNetworkAlertOnGoogleSSLError() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -208,9 +228,10 @@ final class SignInPageTests: XCTestCase {
 
     await model.handleSignInAPIFailure(afError, authMethod: .google, step: "google_sign_in_flow")
 
-    XCTAssertEqual(model.presentedAlert, .signInNetworkError)
+    #expect(model.presentedAlert == .signInNetworkError)
   }
 
+  @Test
   func testHandleSignInAPIFailureShowsGenericAlertOnGoogleUnknownError() async {
     let model = withDependencies {
       $0.errorReporting.reportErrorWithContext = { _, _, _, _ in }
@@ -224,12 +245,13 @@ final class SignInPageTests: XCTestCase {
     await model.handleSignInAPIFailure(
       genericError, authMethod: .google, step: "google_sign_in_flow")
 
-    XCTAssertEqual(model.presentedAlert, .signInError)
-    XCTAssertEqual(model.presentedAlert?.title, "Sign-In Failed")
+    #expect(model.presentedAlert == .signInError)
+    #expect(model.presentedAlert?.title == "Sign-In Failed")
   }
 
   // MARK: - Sign-in Error Reporting Context Tests
 
+  @Test
   func testSignInErrorReportIncludesNSErrorDomainAndCode() {
     let error = NSError(domain: "com.google.GIDSignIn", code: -4)
 
@@ -238,56 +260,63 @@ final class SignInPageTests: XCTestCase {
       authMethod: .google,
       step: "google_sign_in_flow")
 
-    XCTAssertEqual(report.tags["auth_method"], "google")
-    XCTAssertEqual(report.tags["sign_in_step"], "google_sign_in_flow")
-    XCTAssertEqual(report.tags["error_domain"], "com.google.GIDSignIn")
-    XCTAssertEqual(report.tags["error_code"], "-4")
-    XCTAssertEqual(report.contextKey, "sign_in")
+    #expect(report.tags["auth_method"] == "google")
+    #expect(report.tags["sign_in_step"] == "google_sign_in_flow")
+    #expect(report.tags["error_domain"] == "com.google.GIDSignIn")
+    #expect(report.tags["error_code"] == "-4")
+    #expect(report.contextKey == "sign_in")
   }
 
   // MARK: - SignInNetworkErrorClassifier Tests
 
+  @Test
   func testClassifierMatchesSecureConnectionFailed() {
     let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
-    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(error))
-    XCTAssertTrue(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
+    #expect(SignInNetworkErrorClassifier.isNetworkError(error))
+    #expect(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
   }
 
+  @Test
   func testClassifierMatchesNotConnectedToInternet() {
     let error = NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet)
-    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(error))
-    XCTAssertFalse(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
+    #expect(SignInNetworkErrorClassifier.isNetworkError(error))
+    #expect(!SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
   }
 
+  @Test
   func testClassifierMatchesTimedOutCannotConnectAndConnectionLost() {
     for code in [
       NSURLErrorTimedOut, NSURLErrorCannotConnectToHost, NSURLErrorNetworkConnectionLost,
     ] {
       let error = NSError(domain: NSURLErrorDomain, code: code)
-      XCTAssertTrue(
+      #expect(
         SignInNetworkErrorClassifier.isNetworkError(error),
         "Expected code \(code) to classify as network error")
     }
   }
 
+  @Test
   func testClassifierRejectsUnrelatedDomain() {
     let error = NSError(domain: "com.example.other", code: NSURLErrorSecureConnectionFailed)
-    XCTAssertFalse(SignInNetworkErrorClassifier.isNetworkError(error))
-    XCTAssertFalse(SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
+    #expect(!SignInNetworkErrorClassifier.isNetworkError(error))
+    #expect(!SignInNetworkErrorClassifier.isSecureConnectionFailed(error))
   }
 
+  @Test
   func testClassifierRejectsNSURLDomainWithUnrelatedCode() {
     let error = NSError(domain: NSURLErrorDomain, code: -9999)
-    XCTAssertFalse(SignInNetworkErrorClassifier.isNetworkError(error))
+    #expect(!SignInNetworkErrorClassifier.isNetworkError(error))
   }
 
+  @Test
   func testClassifierUnwrapsAFErrorSessionTaskFailed() {
     let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
     let afError = AFError.sessionTaskFailed(error: underlying)
-    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(afError))
-    XCTAssertTrue(SignInNetworkErrorClassifier.isSecureConnectionFailed(afError))
+    #expect(SignInNetworkErrorClassifier.isNetworkError(afError))
+    #expect(SignInNetworkErrorClassifier.isSecureConnectionFailed(afError))
   }
 
+  @Test
   func testClassifierUnwrapsSignInAPIErrorWrappingAFError() {
     let underlying = NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
     let afError = AFError.sessionTaskFailed(error: underlying)
@@ -297,10 +326,11 @@ final class SignInPageTests: XCTestCase {
       statusCode: nil,
       responseBody: nil,
       underlyingError: afError)
-    XCTAssertTrue(SignInNetworkErrorClassifier.isNetworkError(signInError))
-    XCTAssertTrue(SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
+    #expect(SignInNetworkErrorClassifier.isNetworkError(signInError))
+    #expect(SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
   }
 
+  @Test
   func testClassifierRejectsSignInAPIErrorWrappingNonNetworkError() {
     let signInError = SignInAPIError(
       authMethod: .google,
@@ -308,10 +338,11 @@ final class SignInPageTests: XCTestCase {
       statusCode: 500,
       responseBody: nil,
       underlyingError: NSError(domain: "decode", code: 7))
-    XCTAssertFalse(SignInNetworkErrorClassifier.isNetworkError(signInError))
-    XCTAssertFalse(SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
+    #expect(!SignInNetworkErrorClassifier.isNetworkError(signInError))
+    #expect(!SignInNetworkErrorClassifier.isSecureConnectionFailed(signInError))
   }
 
+  @Test
   func testSignInErrorReportIncludesHTTPContextAndRedactsTokens() {
     let responseBody = #"{"playolaToken":"secret-jwt","message":"unexpected shape"}"#
     let error = SignInAPIError(
@@ -323,17 +354,17 @@ final class SignInPageTests: XCTestCase {
 
     let report = SignInErrorReport(error: error, authMethod: .apple, step: "api_call")
 
-    XCTAssertEqual(report.tags["auth_method"], "apple")
-    XCTAssertEqual(report.tags["sign_in_step"], "api_call")
-    XCTAssertEqual(report.tags["http_status_code"], "200")
-    XCTAssertEqual(report.context["endpoint_path"], "/v1/auth/apple/mobile/signup")
-    XCTAssertEqual(
-      report.context["response_body_bytes"], "\(responseBody.lengthOfBytes(using: .utf8))")
-    XCTAssertEqual(report.context["response_body_top_level_keys"], "message,playolaToken")
-    XCTAssertTrue(
+    #expect(report.tags["auth_method"] == "apple")
+    #expect(report.tags["sign_in_step"] == "api_call")
+    #expect(report.tags["http_status_code"] == "200")
+    #expect(report.context["endpoint_path"] == "/v1/auth/apple/mobile/signup")
+    #expect(
+      report.context["response_body_bytes"] == "\(responseBody.lengthOfBytes(using: .utf8))")
+    #expect(report.context["response_body_top_level_keys"] == "message,playolaToken")
+    #expect(
       report.context["response_body"]?.contains(#""playolaToken":"[REDACTED]""#) ?? false)
-    XCTAssertTrue(
+    #expect(
       report.context["response_body"]?.contains(#""message":"unexpected shape""#) ?? false)
-    XCTAssertFalse(report.context["response_body"]?.contains("secret-jwt") ?? true)
+    #expect(!(report.context["response_body"]?.contains("secret-jwt") ?? true))
   }
 }

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -61,7 +61,7 @@ struct SignInPage: View {
             SignInWithAppleButton(.signIn) { request in
               model.signInWithAppleButtonTapped(request: request)
             } onCompletion: { result in
-              model.signInWithAppleCompleted(result: result)
+              Task { await model.signInWithAppleCompleted(result: result) }
             }
             .signInWithAppleButtonStyle(.white)
             .frame(height: 56)

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageModel.swift
@@ -33,6 +33,7 @@ class SongSearchPageModel: ViewModel {
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.date.now) var now
+  @ObservationIgnored @Dependency(\.uuid) var uuid
   @ObservationIgnored @Shared(.auth) var auth
 
   @ObservationIgnored private var debounceTask: Task<Void, Never>?
@@ -192,7 +193,7 @@ class SongSearchPageModel: ViewModel {
     else { return }
 
     let updatedSongRequest = SongRequest.mockWith(
-      requestId: UUID().uuidString,
+      requestId: uuid().uuidString,
       title: songRequest.title,
       artist: songRequest.artist,
       album: songRequest.album,

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
@@ -474,6 +474,7 @@ final class SongSearchPageTests: XCTestCase {
       await withDependencies {
         $0.continuousClock = clock
         $0.date = .constant(Date())
+        $0.uuid = .incrementing
         $0.api.searchSongs = { _, _ in [] }
         $0.api.searchSongRequests = { _, _ in mockSongRequests }
         $0.api.requestSong = { _, _ in }

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
@@ -8,14 +8,16 @@
 import Clocks
 import ConcurrencyExtras
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SongSearchPageTests: XCTestCase {
+struct SongSearchPageTests {
+  @Test
   func testOnCancelTappedCallsOnDismissCallback() {
     var dismissCalled = false
 
@@ -27,40 +29,44 @@ final class SongSearchPageTests: XCTestCase {
 
       model.onCancelTapped()
 
-      XCTAssertTrue(dismissCalled)
+      #expect(dismissCalled)
     }
   }
 
+  @Test
   func testInitialStateSearchTextIsEmpty() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertEqual(model.searchText, "")
+      #expect(model.searchText == "")
     }
   }
 
+  @Test
   func testInitialStateIsNotSearching() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertFalse(model.isSearching)
+      #expect(!model.isSearching)
     }
   }
 
+  @Test
   func testInitialStateSearchResultsAreEmpty() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertTrue(model.searchResults.isEmpty)
+      #expect(model.searchResults.isEmpty)
     }
   }
 
+  @Test
   func testOnSelectSongCallsOnSongSelectedCallback() {
     var selectedSong: AudioBlock?
 
@@ -73,11 +79,12 @@ final class SongSearchPageTests: XCTestCase {
 
       model.onSelectSong(testAudioBlock)
 
-      XCTAssertEqual(selectedSong?.id, "test-song-id")
-      XCTAssertEqual(selectedSong?.title, "Test Song")
+      #expect(selectedSong?.id == "test-song-id")
+      #expect(selectedSong?.title == "Test Song")
     }
   }
 
+  @Test
   func testPerformSearchUpdatesSearchResults() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -97,13 +104,14 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(model.searchResults.count, 2)
-        XCTAssertEqual(model.searchResults[0].id, "song-1")
-        XCTAssertEqual(model.searchResults[1].id, "song-2")
+        #expect(model.searchResults.count == 2)
+        #expect(model.searchResults[0].id == "song-1")
+        #expect(model.searchResults[1].id == "song-2")
       }
     }
   }
 
+  @Test
   func testPerformSearchClearsResultsWhenQueryIsEmpty() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -118,15 +126,16 @@ final class SongSearchPageTests: XCTestCase {
 
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
-        XCTAssertEqual(model.searchResults.count, 1)
+        #expect(model.searchResults.count == 1)
 
         model.searchText = ""
         await clock.advance(by: .milliseconds(300))
-        XCTAssertTrue(model.searchResults.isEmpty)
+        #expect(model.searchResults.isEmpty)
       }
     }
   }
 
+  @Test
   func testPerformSearchShowsAlertOnError() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -140,17 +149,18 @@ final class SongSearchPageTests: XCTestCase {
         }
       } operation: {
         let model = SongSearchPageModel()
-        XCTAssertNil(model.presentedAlert)
+        #expect(model.presentedAlert == nil)
 
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertNotNil(model.presentedAlert)
-        XCTAssertEqual(model.presentedAlert?.title, "Search Error")
+        #expect(model.presentedAlert != nil)
+        #expect(model.presentedAlert?.title == "Search Error")
       }
     }
   }
 
+  @Test
   func testPerformSearchShowsAlertWhenNotAuthenticated() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -161,17 +171,18 @@ final class SongSearchPageTests: XCTestCase {
         $0.date = .constant(Date())
       } operation: {
         let model = SongSearchPageModel()
-        XCTAssertNil(model.presentedAlert)
+        #expect(model.presentedAlert == nil)
 
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertNotNil(model.presentedAlert)
-        XCTAssertEqual(model.presentedAlert?.title, "Not Signed In")
+        #expect(model.presentedAlert != nil)
+        #expect(model.presentedAlert?.title == "Not Signed In")
       }
     }
   }
 
+  @Test
   func testPerformSearchPassesCorrectKeywordsToAPI() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -191,11 +202,12 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(capturedKeywords.value, "Bob Dylan")
+        #expect(capturedKeywords.value == "Bob Dylan")
       }
     }
   }
 
+  @Test
   func testPerformSearchTrimsWhitespace() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -215,11 +227,12 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(capturedKeywords.value, "Bob Dylan")
+        #expect(capturedKeywords.value == "Bob Dylan")
       }
     }
   }
 
+  @Test
   func testDebounceOnlySearchesOnceForRapidChanges() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -243,11 +256,12 @@ final class SongSearchPageTests: XCTestCase {
         model.searchText = "Bob"
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(searchCount.value, 1)
+        #expect(searchCount.value == 1)
       }
     }
   }
 
+  @Test
   func testDebounceDoesNotSearchBeforeDebounceTime() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -267,27 +281,29 @@ final class SongSearchPageTests: XCTestCase {
         model.searchText = "test"
         await clock.advance(by: .milliseconds(200))
 
-        XCTAssertEqual(searchCount.value, 0)
+        #expect(searchCount.value == 0)
 
         await clock.advance(by: .milliseconds(100))
 
-        XCTAssertEqual(searchCount.value, 1)
+        #expect(searchCount.value == 1)
       }
     }
   }
 
   // MARK: - Song Request Tests
 
+  @Test
   func testInitialStateSongRequestResultsAreEmpty() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertTrue(model.songRequestResults.isEmpty)
+      #expect(model.songRequestResults.isEmpty)
     }
   }
 
+  @Test
   func testPerformSearchUpdatesSongRequestResults() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -308,13 +324,14 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(model.songRequestResults.count, 2)
-        XCTAssertEqual(model.songRequestResults[0].appleId, "apple-1")
-        XCTAssertEqual(model.songRequestResults[1].appleId, "apple-2")
+        #expect(model.songRequestResults.count == 2)
+        #expect(model.songRequestResults[0].appleId == "apple-1")
+        #expect(model.songRequestResults[1].appleId == "apple-2")
       }
     }
   }
 
+  @Test
   func testPerformSearchSearchesBothSourcesSimultaneously() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -339,12 +356,13 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertTrue(songsSearchCalled.value)
-        XCTAssertTrue(songRequestsSearchCalled.value)
+        #expect(songsSearchCalled.value)
+        #expect(songRequestsSearchCalled.value)
       }
     }
   }
 
+  @Test
   func testPerformSearchClearsSongRequestResultsWhenQueryIsEmpty() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -360,15 +378,16 @@ final class SongSearchPageTests: XCTestCase {
 
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
-        XCTAssertEqual(model.songRequestResults.count, 1)
+        #expect(model.songRequestResults.count == 1)
 
         model.searchText = ""
         await clock.advance(by: .milliseconds(300))
-        XCTAssertTrue(model.songRequestResults.isEmpty)
+        #expect(model.songRequestResults.isEmpty)
       }
     }
   }
 
+  @Test
   func testOnRequestSongCallsOnSongRequestedCallback() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     var requestedSongRequest: SongRequest?
@@ -384,11 +403,12 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onRequestSong(testSongRequest)
 
-      XCTAssertEqual(requestedSongRequest?.appleId, "test-apple-id")
-      XCTAssertEqual(requestedSongRequest?.title, "Test Request")
+      #expect(requestedSongRequest?.appleId == "test-apple-id")
+      #expect(requestedSongRequest?.title == "Test Request")
     }
   }
 
+  @Test
   func testPerformSearchSongRequestErrorDoesNotAffectSongResults() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -408,31 +428,34 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertEqual(model.searchResults.count, 1)
-        XCTAssertTrue(model.songRequestResults.isEmpty)
+        #expect(model.searchResults.count == 1)
+        #expect(model.songRequestResults.isEmpty)
       }
     }
   }
 
   // MARK: - SongRequest Status Tests
 
+  @Test
   func testSongRequestWithNoRequestIdHasUnrequestedStatus() {
     let songRequest = SongRequest.mockWith(requestId: nil)
 
-    XCTAssertEqual(songRequest.requestStatus, .unrequested)
-    XCTAssertFalse(songRequest.requestStatus.isRequested)
-    XCTAssertNil(songRequest.requestStatus.displayText)
+    #expect(songRequest.requestStatus == .unrequested)
+    #expect(!songRequest.requestStatus.isRequested)
+    #expect(songRequest.requestStatus.displayText == nil)
   }
 
+  @Test
   func testSongRequestWithRequestIdAndCreatedAtHasRequestedStatus() {
     let requestDate = Date(timeIntervalSince1970: 1_000_000)
     let songRequest = SongRequest.mockWith(requestId: "request-123", createdAt: requestDate)
 
-    XCTAssertEqual(songRequest.requestStatus, .requested(requestDate))
-    XCTAssertTrue(songRequest.requestStatus.isRequested)
-    XCTAssertEqual(songRequest.requestStatus.requestedDate, requestDate)
+    #expect(songRequest.requestStatus == .requested(requestDate))
+    #expect(songRequest.requestStatus.isRequested)
+    #expect(songRequest.requestStatus.requestedDate == requestDate)
   }
 
+  @Test
   func testSongRequestRequestedStatusDisplaysFormattedDate() {
     var calendar = Calendar(identifier: .gregorian)
     calendar.timeZone = TimeZone.current
@@ -440,9 +463,10 @@ final class SongSearchPageTests: XCTestCase {
     let requestDate = calendar.date(from: components)!
     let songRequest = SongRequest.mockWith(requestId: "request-123", createdAt: requestDate)
 
-    XCTAssertEqual(songRequest.requestStatus.displayText, "Requested 9/14")
+    #expect(songRequest.requestStatus.displayText == "Requested 9/14")
   }
 
+  @Test
   func testOnRequestSongCallsAPIWithAppleId() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let capturedSongRequest = LockIsolated<SongRequest?>(nil)
@@ -458,10 +482,11 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onRequestSong(testSongRequest)
 
-      XCTAssertEqual(capturedSongRequest.value?.appleId, "test-apple-123")
+      #expect(capturedSongRequest.value?.appleId == "test-apple-123")
     }
   }
 
+  @Test
   func testOnRequestSongUpdatesSongRequestToRequested() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -483,15 +508,16 @@ final class SongSearchPageTests: XCTestCase {
         model.searchText = "test"
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertFalse(model.songRequestResults[0].requestStatus.isRequested)
+        #expect(!model.songRequestResults[0].requestStatus.isRequested)
 
         await model.onRequestSong(model.songRequestResults[0])
 
-        XCTAssertTrue(model.songRequestResults[0].requestStatus.isRequested)
+        #expect(model.songRequestResults[0].requestStatus.isRequested)
       }
     }
   }
 
+  @Test
   func testOnRequestSongShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -504,46 +530,50 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel()
       let testSongRequest = SongRequest.mockWith(appleId: "test-apple-123")
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.onRequestSong(testSongRequest)
 
-      XCTAssertNotNil(model.presentedAlert)
+      #expect(model.presentedAlert != nil)
     }
   }
 
   // MARK: - Search Mode Tests
 
+  @Test
   func testDefaultSearchModeIsAll() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertEqual(model.searchMode, .all)
+      #expect(model.searchMode == .all)
     }
   }
 
+  @Test
   func testInitWithSearchModeLibraryOnly() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel(searchMode: .libraryOnly)
 
-      XCTAssertEqual(model.searchMode, .libraryOnly)
+      #expect(model.searchMode == .libraryOnly)
     }
   }
 
+  @Test
   func testInitWithSearchModeSeedsOnly() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel(searchMode: .seedsOnly)
 
-      XCTAssertEqual(model.searchMode, .seedsOnly)
+      #expect(model.searchMode == .seedsOnly)
     }
   }
 
+  @Test
   func testLibraryOnlyModeOnlySearchesSongs() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -568,12 +598,13 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertTrue(songsSearchCalled.value)
-        XCTAssertFalse(songRequestsSearchCalled.value)
+        #expect(songsSearchCalled.value)
+        #expect(!songRequestsSearchCalled.value)
       }
     }
   }
 
+  @Test
   func testSeedsOnlyModeOnlySearchesSongRequests() async {
     await withMainSerialExecutor {
       let clock = TestClock()
@@ -598,24 +629,26 @@ final class SongSearchPageTests: XCTestCase {
 
         await clock.advance(by: .milliseconds(300))
 
-        XCTAssertFalse(songsSearchCalled.value)
-        XCTAssertTrue(songRequestsSearchCalled.value)
+        #expect(!songsSearchCalled.value)
+        #expect(songRequestsSearchCalled.value)
       }
     }
   }
 
   // MARK: - Library Add Mode Tests
 
+  @Test
   func testIsLibraryAddModeReturnsFalseByDefault() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertFalse(model.isLibraryAddMode)
+      #expect(!model.isLibraryAddMode)
     }
   }
 
+  @Test
   func testIsLibraryAddModeReturnsTrueWhenCallbackSet() {
     withDependencies {
       $0.date = .constant(Date())
@@ -623,20 +656,22 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel()
       model.onAddedToLibrary = { _ in }
 
-      XCTAssertTrue(model.isLibraryAddMode)
+      #expect(model.isLibraryAddMode)
     }
   }
 
+  @Test
   func testSongSeedsSectionHeaderReturnsRequestHeaderByDefault() {
     withDependencies {
       $0.date = .constant(Date())
     } operation: {
       let model = SongSearchPageModel()
 
-      XCTAssertEqual(model.songSeedsSectionHeader, "AVAILABLE SOON BY REQUEST")
+      #expect(model.songSeedsSectionHeader == "AVAILABLE SOON BY REQUEST")
     }
   }
 
+  @Test
   func testSongSeedsSectionHeaderReturnsAppleMusicHeaderWhenLibraryAddMode() {
     withDependencies {
       $0.date = .constant(Date())
@@ -644,12 +679,13 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel()
       model.onAddedToLibrary = { _ in }
 
-      XCTAssertEqual(model.songSeedsSectionHeader, "APPLE MUSIC")
+      #expect(model.songSeedsSectionHeader == "APPLE MUSIC")
     }
   }
 
   // MARK: - Add Song to Library Tests
 
+  @Test
   func testOnAddSongToLibraryCallsAPIWithCorrectParameters() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let capturedStationId = LockIsolated<String?>(nil)
@@ -674,15 +710,16 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertEqual(capturedStationId.value, "station-123")
-      XCTAssertEqual(capturedBody.value?.appleId, "apple-456")
-      XCTAssertEqual(capturedBody.value?.title, "Test Song")
-      XCTAssertEqual(capturedBody.value?.artist, "Test Artist")
-      XCTAssertEqual(capturedBody.value?.album, "Test Album")
-      XCTAssertEqual(capturedBody.value?.imageUrl, "https://example.com/image.jpg")
+      #expect(capturedStationId.value == "station-123")
+      #expect(capturedBody.value?.appleId == "apple-456")
+      #expect(capturedBody.value?.title == "Test Song")
+      #expect(capturedBody.value?.artist == "Test Artist")
+      #expect(capturedBody.value?.album == "Test Album")
+      #expect(capturedBody.value?.imageUrl == "https://example.com/image.jpg")
     }
   }
 
+  @Test
   func testOnAddSongToLibraryCallsOnAddedToLibraryCallback() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     var addedRequest: StationLibraryRequest?
@@ -698,10 +735,11 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertEqual(addedRequest?.id, "new-request")
+      #expect(addedRequest?.id == "new-request")
     }
   }
 
+  @Test
   func testOnAddSongToLibraryShowsAlertWhenNotAuthenticated() async {
     @Shared(.auth) var auth = Auth()
 
@@ -711,15 +749,16 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel(searchMode: .seedsOnly, stationId: "station-123")
       let testSongRequest = SongRequest.mockWith(appleId: "apple-456")
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Not Signed In")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Not Signed In")
     }
   }
 
+  @Test
   func testOnAddSongToLibraryShowsAlertWhenStationIdMissing() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -729,15 +768,16 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel(searchMode: .seedsOnly, stationId: nil)
       let testSongRequest = SongRequest.mockWith(appleId: "apple-456")
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Add Failed")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Add Failed")
     }
   }
 
+  @Test
   func testOnAddSongToLibraryShowsAlertOnAPIError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -750,17 +790,18 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel(searchMode: .seedsOnly, stationId: "station-123")
       let testSongRequest = SongRequest.mockWith(appleId: "apple-456")
 
-      XCTAssertNil(model.presentedAlert)
+      #expect(model.presentedAlert == nil)
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertNotNil(model.presentedAlert)
-      XCTAssertEqual(model.presentedAlert?.title, "Add Failed")
+      #expect(model.presentedAlert != nil)
+      #expect(model.presentedAlert?.title == "Add Failed")
     }
   }
 
   // MARK: - Processing Add State Tests
 
+  @Test
   func testIsProcessingAddReturnsFalseInitially() {
     withDependencies {
       $0.date = .constant(Date())
@@ -768,10 +809,11 @@ final class SongSearchPageTests: XCTestCase {
       let model = SongSearchPageModel()
       let testSongRequest = SongRequest.mockWith(appleId: "apple-456")
 
-      XCTAssertFalse(model.isProcessingAdd(for: testSongRequest))
+      #expect(!model.isProcessingAdd(for: testSongRequest))
     }
   }
 
+  @Test
   func testIsProcessingAddReturnsFalseAfterCompletion() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -784,10 +826,11 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertFalse(model.isProcessingAdd(for: testSongRequest))
+      #expect(!model.isProcessingAdd(for: testSongRequest))
     }
   }
 
+  @Test
   func testIsProcessingAddReturnsFalseAfterError() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
 
@@ -802,7 +845,7 @@ final class SongSearchPageTests: XCTestCase {
 
       await model.onAddSongToLibrary(testSongRequest)
 
-      XCTAssertFalse(model.isProcessingAdd(for: testSongRequest))
+      #expect(!model.isProcessingAdd(for: testSongRequest))
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -20,7 +20,7 @@ class StationListModel: ViewModel {
 
   @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.pushNotifications) var pushNotifications
-  @ObservationIgnored var stationPlayer: StationPlayer
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
   // MARK: - Shared State
 
@@ -32,12 +32,6 @@ class StationListModel: ViewModel {
   var hasAskedForNotificationPermission: Bool
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
-
-  // MARK: - Initialization
-
-  init(stationPlayer: StationPlayer? = nil) {
-    self.stationPlayer = stationPlayer ?? .shared
-  }
 
   // MARK: - Properties
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -166,7 +166,7 @@ class StationListModel: ViewModel {
         entryPoint: "station_list"
       ))
 
-    stationPlayer.play(station: station)
+    await stationPlayer.play(station: station)
   }
 
   // MARK: - View Helpers

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -5,54 +5,59 @@
 //  Created by Brian D Keane on 6/13/25.
 //
 
+import ConcurrencyExtras
 import Dependencies
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class StationListPageTests: XCTestCase {
+struct StationListPageTests {
   // MARK: - View Appeared Tests
 
-  func testViewAppeared_PopulatesFromInitialSharedStationLists() async {
+  @Test
+  func testViewAppearedPopulatesFromInitialSharedStationLists() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.stationLists) var stationLists = StationList.mocks
     let expectedVisibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
     let model = StationListModel()
     await model.viewAppeared()
-    XCTAssertEqual(model.stationListsForDisplay, expectedVisibleLists)
-    XCTAssertEqual(model.segmentTitles, ["All"] + expectedVisibleLists.map { $0.title })
-    XCTAssertEqual(model.selectedSegment, "All")
+    #expect(model.stationListsForDisplay == expectedVisibleLists)
+    #expect(model.segmentTitles == ["All"] + expectedVisibleLists.map { $0.title })
+    #expect(model.selectedSegment == "All")
   }
 
   // MARK: - Segment Selection Tests
 
-  func testSegmentSelection_FiltersWhenSegmentSelected() async {
+  @Test
+  func testSegmentSelectionFiltersWhenSegmentSelected() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.stationLists) var stationLists = StationList.mocks
     let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
     guard let firstList = visibleLists.first else {
-      XCTFail("StationList.mocks should have at least one non-development list")
+      Issue.record("StationList.mocks should have at least one non-development list")
       return
     }
     let model = StationListModel()
     await model.viewAppeared()
     await model.segmentSelected(firstList.title)
-    XCTAssertEqual(model.selectedSegment, firstList.title)
-    XCTAssertEqual(model.stationListsForDisplay, [firstList])
+    #expect(model.selectedSegment == firstList.title)
+    #expect(model.stationListsForDisplay == [firstList])
   }
 
   // MARK: - Shared stationLists Updates Tests
 
-  func testSharedStationListsUpdates_KeepsSelectedSegmentWhenStillPresent() async {
+  @Test
+  func testSharedStationListsUpdatesKeepsSelectedSegmentWhenStillPresent() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.stationLists) var stationLists = StationList.mocks
     let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
     guard let targetList = visibleLists.first else {
-      XCTFail("StationList.mocks should have at least one non-development list")
+      Issue.record("StationList.mocks should have at least one non-development list")
       return
     }
 
@@ -78,17 +83,18 @@ final class StationListPageTests: XCTestCase {
       )
     }
 
-    XCTAssertEqual(model.selectedSegment, targetList.title)
-    XCTAssertEqual(model.stationListsForDisplay.count, 1)
-    XCTAssertEqual(model.stationListsForDisplay.first?.title, targetList.title)
+    #expect(model.selectedSegment == targetList.title)
+    #expect(model.stationListsForDisplay.count == 1)
+    #expect(model.stationListsForDisplay.first?.title == targetList.title)
   }
 
-  func testSharedStationListsUpdates_ResetsSelectedSegmentWhenSegmentMissing() async {
+  @Test
+  func testSharedStationListsUpdatesResetsSelectedSegmentWhenSegmentMissing() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.stationLists) var stationLists = StationList.mocks
     let visibleLists = stationLists.filter { $0.id != StationList.inDevelopmentListId }
     guard let targetList = visibleLists.first else {
-      XCTFail("StationList.mocks should have at least one non-development list")
+      Issue.record("StationList.mocks should have at least one non-development list")
       return
     }
 
@@ -120,23 +126,25 @@ final class StationListPageTests: XCTestCase {
     let expectedVisibleAfterUpdate = stationLists.filter {
       $0.id != StationList.inDevelopmentListId
     }
-    XCTAssertEqual(model.selectedSegment, "All")
-    XCTAssertEqual(model.stationListsForDisplay, expectedVisibleAfterUpdate)
+    #expect(model.selectedSegment == "All")
+    #expect(model.stationListsForDisplay == expectedVisibleAfterUpdate)
   }
 
-  func testViewAppeared_IncludesHiddenListsWhenSecretsEnabled() async {
+  @Test
+  func testViewAppearedIncludesHiddenListsWhenSecretsEnabled() async {
     @Shared(.showSecretStations) var showSecretStations = true
     @Shared(.stationLists) var stationLists = StationList.mocks
     let model = StationListModel()
     await model.viewAppeared()
 
-    XCTAssertEqual(model.stationListsForDisplay, stationLists)
-    XCTAssertEqual(model.segmentTitles, ["All"] + stationLists.map { $0.title })
+    #expect(model.stationListsForDisplay == stationLists)
+    #expect(model.segmentTitles == ["All"] + stationLists.map { $0.title })
   }
 
   // MARK: - Player Interaction Tests
 
-  func testPlayerInteraction_PlaysAStationWhenItIsTapped() async {
+  @Test
+  func testPlayerInteractionPlaysAStationWhenItIsTapped() async {
     let stationPlayerMock: StationPlayerMock = .mockStoppedPlayer()
     let capturedEvents = LockIsolated<[AnalyticsEvent]>([])
 
@@ -150,11 +158,12 @@ final class StationListPageTests: XCTestCase {
 
     await stationListModel.stationSelected(item)
 
-    XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
-    XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, item.anyStation.id)
+    #expect(stationPlayerMock.callsToPlay.count == 1)
+    #expect(stationPlayerMock.callsToPlay.first?.id == item.anyStation.id)
     assertPlayedEvents(capturedEvents.value, stationId: item.anyStation.id)
   }
 
+  @Test
   func testComingSoonStationDoesNotPlayWhenSecretsHidden() async {
     @Shared(.showSecretStations) var showSecretStations = false
 
@@ -188,10 +197,11 @@ final class StationListPageTests: XCTestCase {
 
     await stationListModel.stationSelected(comingSoonItem)
 
-    XCTAssertTrue(stationPlayerMock.callsToPlay.isEmpty)
-    XCTAssertTrue(capturedEvents.value.isEmpty)
+    #expect(stationPlayerMock.callsToPlay.isEmpty)
+    #expect(capturedEvents.value.isEmpty)
   }
 
+  @Test
   func testComingSoonStationPlaysWhenSecretsShown() async {
     @Shared(.showSecretStations) var showSecretStations = true
 
@@ -225,23 +235,24 @@ final class StationListPageTests: XCTestCase {
 
     await stationListModel.stationSelected(comingSoonItem)
 
-    XCTAssertEqual(stationPlayerMock.callsToPlay.count, 1)
-    XCTAssertEqual(stationPlayerMock.callsToPlay.first?.id, comingSoonItem.anyStation.id)
+    #expect(stationPlayerMock.callsToPlay.count == 1)
+    #expect(stationPlayerMock.callsToPlay.first?.id == comingSoonItem.anyStation.id)
 
     let events = capturedEvents.value
-    XCTAssertEqual(events.count, 2)
+    #expect(events.count == 2)
     if case .tappedStationCard(let stationInfo, _, _) = events[0] {
-      XCTAssertEqual(stationInfo.id, comingSoonItem.anyStation.id)
+      #expect(stationInfo.id == comingSoonItem.anyStation.id)
     } else {
-      XCTFail("Expected tappedStationCard event")
+      Issue.record("Expected tappedStationCard event")
     }
     if case .startedStation(let stationInfo, _) = events[1] {
-      XCTAssertEqual(stationInfo.id, comingSoonItem.anyStation.id)
+      #expect(stationInfo.id == comingSoonItem.anyStation.id)
     } else {
-      XCTFail("Expected startedStation event")
+      Issue.record("Expected startedStation event")
     }
   }
 
+  @Test
   func testInactiveStationDoesNotPlay() async {
     @Shared(.showSecretStations) var showSecretStations = true
 
@@ -275,12 +286,13 @@ final class StationListPageTests: XCTestCase {
 
     await stationListModel.stationSelected(inactiveItem)
 
-    XCTAssertTrue(stationPlayerMock.callsToPlay.isEmpty)
-    XCTAssertTrue(capturedEvents.value.isEmpty)
+    #expect(stationPlayerMock.callsToPlay.isEmpty)
+    #expect(capturedEvents.value.isEmpty)
   }
 
   // MARK: - Hidden Station Filtering
 
+  @Test
   func testHiddenStationsFilteredWhenSecretsOff() async {
     @Shared(.showSecretStations) var showSecretStations = false
     let now = Date()
@@ -329,10 +341,11 @@ final class StationListPageTests: XCTestCase {
     let includeHidden = model.showSecretStations || !secretList.hidden
     let filteredItems = secretList.stationItems(includeHidden: includeHidden)
 
-    XCTAssertEqual(filteredItems.count, 1)
-    XCTAssertEqual(filteredItems.first?.visibility, .visible)
+    #expect(filteredItems.count == 1)
+    #expect(filteredItems.first?.visibility == .visible)
   }
 
+  @Test
   func testHiddenStationsIncludedWhenSecretsOn() async {
     @Shared(.showSecretStations) var showSecretStations = true
     let now = Date()
@@ -381,12 +394,13 @@ final class StationListPageTests: XCTestCase {
     let includeHidden = model.showSecretStations || !secretList.hidden
     let filteredItems = secretList.stationItems(includeHidden: includeHidden)
 
-    XCTAssertEqual(filteredItems.count, 2)
-    XCTAssertEqual(filteredItems.last?.visibility, .hidden)
+    #expect(filteredItems.count == 2)
+    #expect(filteredItems.last?.visibility == .hidden)
   }
 
   // MARK: - Live Station Tests
 
+  @Test
   func testLiveStatusForStationReturnsNilWhenNotLive() async {
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
 
@@ -395,9 +409,10 @@ final class StationListPageTests: XCTestCase {
 
     let status = model.liveStatusForStation("some-station-id")
 
-    XCTAssertNil(status)
+    #expect(status == nil)
   }
 
+  @Test
   func testLiveStatusForStationReturnsVoicetrackingStatus() async {
     let station = Station.mockWith(id: "live-station")
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = [
@@ -409,9 +424,10 @@ final class StationListPageTests: XCTestCase {
 
     let status = model.liveStatusForStation("live-station")
 
-    XCTAssertEqual(status, .voicetracking)
+    #expect(status == .voicetracking)
   }
 
+  @Test
   func testLiveStatusForStationReturnsShowAiringStatus() async {
     let station = Station.mockWith(id: "show-station")
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = [
@@ -423,9 +439,10 @@ final class StationListPageTests: XCTestCase {
 
     let status = model.liveStatusForStation("show-station")
 
-    XCTAssertEqual(status, .showAiring)
+    #expect(status == .showAiring)
   }
 
+  @Test
   func testSortedStationItemsPutsLiveStationsFirst() async {
     @Shared(.showSecretStations) var showSecretStations = false
     let now = Date()
@@ -458,10 +475,11 @@ final class StationListPageTests: XCTestCase {
 
     let sortedItems = model.sortedStationItems(for: list)
 
-    XCTAssertEqual(sortedItems.count, 3)
-    XCTAssertEqual(sortedItems[0].anyStation.id, "station-2")
+    #expect(sortedItems.count == 3)
+    #expect(sortedItems[0].anyStation.id == "station-2")
   }
 
+  @Test
   func testSortedStationItemsPutsVoicetrackingBeforeShowAiring() async {
     @Shared(.showSecretStations) var showSecretStations = false
     let now = Date()
@@ -495,12 +513,13 @@ final class StationListPageTests: XCTestCase {
 
     let sortedItems = model.sortedStationItems(for: list)
 
-    XCTAssertEqual(sortedItems.count, 3)
-    XCTAssertEqual(sortedItems[0].anyStation.id, "station-3")  // voicetracking first
-    XCTAssertEqual(sortedItems[1].anyStation.id, "station-1")  // showAiring second
-    XCTAssertEqual(sortedItems[2].anyStation.id, "station-2")  // not live last
+    #expect(sortedItems.count == 3)
+    #expect(sortedItems[0].anyStation.id == "station-3")  // voicetracking first
+    #expect(sortedItems[1].anyStation.id == "station-1")  // showAiring second
+    #expect(sortedItems[2].anyStation.id == "station-2")  // not live last
   }
 
+  @Test
   func testSortedStationItemsPreservesOrderWhenNoLiveStations() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -528,13 +547,14 @@ final class StationListPageTests: XCTestCase {
 
     let sortedItems = model.sortedStationItems(for: list)
 
-    XCTAssertEqual(sortedItems.count, 2)
-    XCTAssertEqual(sortedItems[0].anyStation.id, "station-1")
-    XCTAssertEqual(sortedItems[1].anyStation.id, "station-2")
+    #expect(sortedItems.count == 2)
+    #expect(sortedItems[0].anyStation.id == "station-1")
+    #expect(sortedItems[1].anyStation.id == "station-2")
   }
 
   // MARK: - Search Tests
 
+  @Test
   func testSearchByCuratorNameFiltersStations() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -554,10 +574,11 @@ final class StationListPageTests: XCTestCase {
     model.searchText = "Alice"
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 1)
-    XCTAssertEqual(items.first?.anyStation.id, "s1")
+    #expect(items.count == 1)
+    #expect(items.first?.anyStation.id == "s1")
   }
 
+  @Test
   func testSearchByStationNameFiltersStations() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -577,10 +598,11 @@ final class StationListPageTests: XCTestCase {
     model.searchText = "Moondog"
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 1)
-    XCTAssertEqual(items.first?.anyStation.id, "s1")
+    #expect(items.count == 1)
+    #expect(items.first?.anyStation.id == "s1")
   }
 
+  @Test
   func testSearchIsCaseInsensitive() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -598,10 +620,11 @@ final class StationListPageTests: XCTestCase {
     model.searchText = "alice"
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 1)
-    XCTAssertEqual(items.first?.anyStation.id, "s1")
+    #expect(items.count == 1)
+    #expect(items.first?.anyStation.id == "s1")
   }
 
+  @Test
   func testEmptySearchTextShowsAllStations() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -621,9 +644,10 @@ final class StationListPageTests: XCTestCase {
     model.searchText = ""
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 2)
+    #expect(items.count == 2)
   }
 
+  @Test
   func testIsShowingNoResultsTrueWhenSearchHasNoMatches() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -640,9 +664,10 @@ final class StationListPageTests: XCTestCase {
 
     model.searchText = "xyznonexistent"
 
-    XCTAssertTrue(model.isShowingNoResults)
+    #expect(model.isShowingNoResults)
   }
 
+  @Test
   func testIsShowingNoResultsFalseWhenSearchTextEmpty() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -659,9 +684,10 @@ final class StationListPageTests: XCTestCase {
 
     model.searchText = ""
 
-    XCTAssertFalse(model.isShowingNoResults)
+    #expect(!model.isShowingNoResults)
   }
 
+  @Test
   func testSearchWorksWithinSelectedSegment() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -692,12 +718,13 @@ final class StationListPageTests: XCTestCase {
     await model.segmentSelected("Hip Hop")
     model.searchText = "Alice"
 
-    XCTAssertEqual(model.stationListsForDisplay.count, 1)
+    #expect(model.stationListsForDisplay.count == 1)
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 1)
-    XCTAssertEqual(items.first?.anyStation.id, "s1")
+    #expect(items.count == 1)
+    #expect(items.first?.anyStation.id == "s1")
   }
 
+  @Test
   func testSearchTextClearedOnSegmentSwitch() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -723,12 +750,13 @@ final class StationListPageTests: XCTestCase {
     await model.viewAppeared()
 
     model.searchText = "Alice"
-    XCTAssertEqual(model.searchText, "Alice")
+    #expect(model.searchText == "Alice")
 
     await model.segmentSelected("Jazz")
-    XCTAssertEqual(model.searchText, "")
+    #expect(model.searchText == "")
   }
 
+  @Test
   func testSearchMatchesEitherCuratorNameOrStationName() async {
     @Shared(.showSecretStations) var showSecretStations = false
     @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
@@ -750,10 +778,10 @@ final class StationListPageTests: XCTestCase {
     model.searchText = "Moondog"
 
     let items = model.sortedStationItems(for: model.stationListsForDisplay.first!)
-    XCTAssertEqual(items.count, 2)
+    #expect(items.count == 2)
     let ids = items.map { $0.anyStation.id }
-    XCTAssertTrue(ids.contains("s1"))
-    XCTAssertTrue(ids.contains("s2"))
+    #expect(ids.contains("s1"))
+    #expect(ids.contains("s2"))
   }
 }
 
@@ -761,30 +789,34 @@ private func assertPlayedEvents(
   _ events: [AnalyticsEvent],
   stationId: String
 ) {
-  XCTAssertEqual(events.count, 2)
+  #expect(events.count == 2)
 
   guard let firstEvent = events.first else {
-    return XCTFail("Expected tappedStationCard event, but events were empty")
+    Issue.record("Expected tappedStationCard event, but events were empty")
+    return
   }
   guard
     case .tappedStationCard(let stationInfo, let position, let totalStations) = firstEvent
   else {
-    return XCTFail("Expected tappedStationCard event, got: \(String(describing: firstEvent))")
+    Issue.record("Expected tappedStationCard event, got: \(String(describing: firstEvent))")
+    return
   }
-  XCTAssertEqual(stationInfo.id, stationId)
-  XCTAssertEqual(position, 0)
-  XCTAssertEqual(totalStations, 1)
+  #expect(stationInfo.id == stationId)
+  #expect(position == 0)
+  #expect(totalStations == 1)
 
   guard let secondEvent = events.dropFirst().first else {
-    return XCTFail("Expected startedStation event, but only found one event")
+    Issue.record("Expected startedStation event, but only found one event")
+    return
   }
   guard
     case .startedStation(let startedInfo, let entryPoint) = secondEvent
   else {
-    return XCTFail("Expected startedStation event, got: \(String(describing: secondEvent))")
+    Issue.record("Expected startedStation event, got: \(String(describing: secondEvent))")
+    return
   }
-  XCTAssertEqual(startedInfo.id, stationId)
-  XCTAssertEqual(entryPoint, "station_list")
+  #expect(startedInfo.id == stationId)
+  #expect(entryPoint == "station_list")
 }
 
 private func makeComingSoonItem(active: Bool, date: Date) -> APIStationItem {
@@ -858,8 +890,9 @@ private func makeStationListModel(
 // MARK: - Notification Permission Prompt Tests
 
 @MainActor
-final class StationListNotificationPromptTests: XCTestCase {
+struct StationListNotificationPromptTests {
 
+  @Test
   func testViewAppearedShowsNotificationAlertOnFirstVisit() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
 
@@ -872,10 +905,11 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Stay in the Loop?")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Stay in the Loop?")
   }
 
+  @Test
   func testViewAppearedDoesNotShowAlertIfAlreadyAsked() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = true
 
@@ -888,9 +922,10 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertNil(model.presentedAlert)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testNotificationAlertYesTappedRequestsPermission() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
     let authorizationRequested = LockIsolated(false)
@@ -910,12 +945,13 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.notificationAlertYesTapped()
 
-    XCTAssertTrue(authorizationRequested.value)
-    XCTAssertTrue(registrationCalled.value)
-    XCTAssertTrue(hasAsked)
-    XCTAssertNil(model.presentedAlert)
+    #expect(authorizationRequested.value)
+    #expect(registrationCalled.value)
+    #expect(hasAsked)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testNotificationAlertNoTappedSetsHasAskedWithoutRequesting() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
     let authorizationRequested = LockIsolated(false)
@@ -932,11 +968,12 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.notificationAlertNoTapped()
 
-    XCTAssertFalse(authorizationRequested.value)
-    XCTAssertTrue(hasAsked)
-    XCTAssertNil(model.presentedAlert)
+    #expect(!authorizationRequested.value)
+    #expect(hasAsked)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testNotificationAlertDoesNotRegisterIfPermissionDenied() async {
     @Shared(.hasAskedForNotificationPermission) var hasAsked = false
     let registrationCalled = LockIsolated(false)
@@ -954,7 +991,7 @@ final class StationListNotificationPromptTests: XCTestCase {
 
     await model.notificationAlertYesTapped()
 
-    XCTAssertFalse(registrationCalled.value)
-    XCTAssertTrue(hasAsked)
+    #expect(!registrationCalled.value)
+    #expect(hasAsked)
   }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -174,8 +174,9 @@ struct StationListPageTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      StationListModel(stationPlayer: stationPlayerMock)
+      StationListModel()
     }
 
     let now = Date()
@@ -212,8 +213,9 @@ struct StationListPageTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      StationListModel(stationPlayer: stationPlayerMock)
+      StationListModel()
     }
 
     let now = Date()
@@ -263,8 +265,9 @@ struct StationListPageTests {
       $0.analytics.track = { event in
         capturedEvents.withValue { $0.append(event) }
       }
+      $0.stationPlayer = stationPlayerMock
     } operation: {
-      StationListModel(stationPlayer: stationPlayerMock)
+      StationListModel()
     }
 
     let now = Date()
@@ -879,11 +882,10 @@ private func makeStationListModel(
   stationPlayer: StationPlayerMock
 ) -> StationListModel {
   withDependencies {
-    $0.analytics.track = { event in
-      analyticsSink.withValue { $0.append(event) }
-    }
+    $0.analytics.track = { event in analyticsSink.withValue { $0.append(event) } }
+    $0.stationPlayer = stationPlayer
   } operation: {
-    StationListModel(stationPlayer: stationPlayer)
+    StationListModel()
   }
 }
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
@@ -5,15 +5,17 @@
 //  Created by Brian D Keane on 9/26/25.
 //
 
+import Foundation
 import PlayolaPlayer
 import Sharing
 import SwiftUI
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class StationListStationRowTests: XCTestCase {
+struct StationListStationRowTests {
+  @Test
   func testModelInitializationFromStation() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let stationList = StationList.mocks.first { !$0.visibleStationItems.isEmpty }!
@@ -22,12 +24,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, station.name)
-    XCTAssertEqual(model.subtitleText, station.stationName)
-    XCTAssertEqual(model.subtitleColor, Color.white)
-    XCTAssertEqual(model.imageUrl, station.imageUrl ?? station.processedImageURL())
+    #expect(model.titleText == station.name)
+    #expect(model.subtitleText == station.stationName)
+    #expect(model.subtitleColor == Color.white)
+    #expect(model.imageUrl == station.imageUrl ?? station.processedImageURL())
   }
 
+  @Test
   func testComingSoonItemShowsComingSoonWhenSecretsHidden() {
     @Shared(.showSecretStations) var showSecretStations: Bool = false
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -51,13 +54,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, comingSoonStation.curatorName)
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
-    XCTAssertEqual(
-      model.imageUrl, comingSoonStation.imageUrl)
+    #expect(model.titleText == comingSoonStation.curatorName)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
+    #expect(model.imageUrl == comingSoonStation.imageUrl)
   }
 
+  @Test
   func testComingSoonItemShowsComingSoonWhenSecretsShowingAndInactive() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -81,13 +84,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, comingSoonStation.curatorName)
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
-    XCTAssertEqual(
-      model.imageUrl, comingSoonStation.imageUrl)
+    #expect(model.titleText == comingSoonStation.curatorName)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
+    #expect(model.imageUrl == comingSoonStation.imageUrl)
   }
 
+  @Test
   func testComingSoonItemShowsNormallyWhenSecretsShowingAndActive() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -111,13 +114,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, comingSoonStation.curatorName)
-    XCTAssertEqual(model.subtitleText, comingSoonStation.name)
-    XCTAssertEqual(model.subtitleColor, Color.white)
-    XCTAssertEqual(
-      model.imageUrl, comingSoonStation.imageUrl)
+    #expect(model.titleText == comingSoonStation.curatorName)
+    #expect(model.subtitleText == comingSoonStation.name)
+    #expect(model.subtitleColor == Color.white)
+    #expect(model.imageUrl == comingSoonStation.imageUrl)
   }
 
+  @Test
   func testComingSoonItemShowsDateWhenItExists() {
     @Shared(.showSecretStations) var showSecretStations: Bool = false
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -142,13 +145,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.titleText, comingSoonStation.curatorName)
-    XCTAssertEqual(model.subtitleText, "Coming Dec 25th")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
-    XCTAssertEqual(
-      model.imageUrl, comingSoonStation.imageUrl)
+    #expect(model.titleText == comingSoonStation.curatorName)
+    #expect(model.subtitleText == "Coming Dec 25th")
+    #expect(model.subtitleColor == Color.playolaRed)
+    #expect(model.imageUrl == comingSoonStation.imageUrl)
   }
 
+  @Test
   func testComingSoonDateFormattingUsesUTCTimezone() {
     @Shared(.showSecretStations) var showSecretStations: Bool = false
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -181,9 +184,10 @@ final class StationListStationRowTests: XCTestCase {
     let model = StationListStationRowModel(item: item)
 
     // Should show Dec 25th (the UTC date), not Dec 24th (what it would be in US timezones)
-    XCTAssertEqual(model.subtitleText, "Coming Dec 25th")
+    #expect(model.subtitleText == "Coming Dec 25th")
   }
 
+  @Test
   func testInactiveVisibleStationShowsComingSoonWhenSecretsHidden() {
     @Shared(.showSecretStations) var showSecretStations: Bool = false
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -207,10 +211,11 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
   }
 
+  @Test
   func testInactiveVisibleStationShowsComingSoonWhenSecretsShowing() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let now = Date(timeIntervalSince1970: 1_758_915_200)
@@ -234,10 +239,11 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
   }
 
+  @Test
   func testInactiveUrlStationShowsComingSoonWhenSecretsShowing() {
     @Shared(.showSecretStations) var showSecretStations: Bool = true
     let inactiveUrlStation = UrlStation(
@@ -262,12 +268,13 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertEqual(model.subtitleText, "Coming Soon")
-    XCTAssertEqual(model.subtitleColor, Color.playolaRed)
+    #expect(model.subtitleText == "Coming Soon")
+    #expect(model.subtitleColor == Color.playolaRed)
   }
 
   // MARK: - Live Sort Priority Tests
 
+  @Test
   func testLiveSortPriorityReturnsZeroForVoicetracking() {
     let station = Station.mockWith(id: "live-station")
     let item = APIStationItem(
@@ -282,9 +289,10 @@ final class StationListStationRowTests: XCTestCase {
 
     let priority = item.liveSortPriority(liveStations)
 
-    XCTAssertEqual(priority, 0)
+    #expect(priority == 0)
   }
 
+  @Test
   func testLiveSortPriorityReturnsOneForShowAiring() {
     let station = Station.mockWith(id: "show-station")
     let item = APIStationItem(
@@ -299,9 +307,10 @@ final class StationListStationRowTests: XCTestCase {
 
     let priority = item.liveSortPriority(liveStations)
 
-    XCTAssertEqual(priority, 1)
+    #expect(priority == 1)
   }
 
+  @Test
   func testLiveSortPriorityReturnsTwoForNotLive() {
     let station = Station.mockWith(id: "not-live-station")
     let item = APIStationItem(
@@ -314,11 +323,12 @@ final class StationListStationRowTests: XCTestCase {
 
     let priority = item.liveSortPriority(liveStations)
 
-    XCTAssertEqual(priority, 2)
+    #expect(priority == 2)
   }
 
   // MARK: - Live Status in Row Model Tests
 
+  @Test
   func testRowModelStoresLiveStatus() {
     let station = Station.mockWith(id: "live-station")
     let item = APIStationItem(
@@ -330,9 +340,10 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item, liveStatus: .voicetracking)
 
-    XCTAssertEqual(model.liveStatus, .voicetracking)
+    #expect(model.liveStatus == .voicetracking)
   }
 
+  @Test
   func testRowModelLiveStatusDefaultsToNil() {
     let station = Station.mockWith(id: "station")
     let item = APIStationItem(
@@ -344,6 +355,6 @@ final class StationListStationRowTests: XCTestCase {
 
     let model = StationListStationRowModel(item: item)
 
-    XCTAssertNil(model.liveStatus)
+    #expect(model.liveStatus == nil)
   }
 }

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
@@ -5,14 +5,16 @@
 //  Created by Brian D Keane on 3/10/26.
 //
 
+import ConcurrencyExtras
 import Dependencies
+import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class StationSuggestionPageTests: XCTestCase {
+struct StationSuggestionPageTests {
 
   // MARK: - Test Data
 
@@ -64,25 +66,28 @@ final class StationSuggestionPageTests: XCTestCase {
 
   // MARK: - View Appeared Tests
 
+  @Test
   func testViewAppearedFetchesSuggestions() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel()
 
     await model.viewAppeared()
 
-    XCTAssertEqual(model.suggestions.count, 3)
-    XCTAssertEqual(model.suggestions.first?.artistName, "Bri Bagwell")
+    #expect(model.suggestions.count == 3)
+    #expect(model.suggestions.first?.artistName == "Bri Bagwell")
   }
 
+  @Test
   func testViewAppearedDoesNothingWithoutAuth() async {
     @Shared(.auth) var auth = Auth()
     let model = makeModel()
 
     await model.viewAppeared()
 
-    XCTAssertTrue(model.suggestions.isEmpty)
+    #expect(model.suggestions.isEmpty)
   }
 
+  @Test
   func testViewAppearedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel(onGetSuggestions: { _, _ in
@@ -91,12 +96,13 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.viewAppeared()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Error")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Error")
   }
 
   // MARK: - Search Tests
 
+  @Test
   func testSearchTextChangedFetchesWithQuery() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedSearches = LockIsolated<[String?]>([])
@@ -109,9 +115,10 @@ final class StationSuggestionPageTests: XCTestCase {
     await model.searchTextChanged()
 
     let searches = capturedSearches.value
-    XCTAssertEqual(searches.last, "Charley")
+    #expect(searches.last == "Charley")
   }
 
+  @Test
   func testSearchTextChangedSendsNilForEmptyQuery() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedSearches = LockIsolated<[String?]>([])
@@ -124,9 +131,10 @@ final class StationSuggestionPageTests: XCTestCase {
     await model.searchTextChanged()
 
     let searches = capturedSearches.value
-    XCTAssertNil(searches.last ?? nil)
+    #expect((searches.last ?? nil) == nil)
   }
 
+  @Test
   func testClearSearchTappedResetsTextAndFetches() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedSearches = LockIsolated<[String?]>([])
@@ -138,13 +146,14 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "Charley"
     await model.clearSearchTapped()
 
-    XCTAssertEqual(model.searchText, "")
-    XCTAssertNil(capturedSearches.value.last ?? nil)
-    XCTAssertEqual(model.suggestions.count, 3)
+    #expect(model.searchText == "")
+    #expect((capturedSearches.value.last ?? nil) == nil)
+    #expect(model.suggestions.count == 3)
   }
 
   // MARK: - Vote Tests
 
+  @Test
   func testVoteTappedCallsVoteForUnvotedSuggestion() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedVoteIds = LockIsolated<[String]>([])
@@ -158,9 +167,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertEqual(capturedVoteIds.value, ["s2"])
+    #expect(capturedVoteIds.value == ["s2"])
   }
 
+  @Test
   func testVoteTappedCallsRemoveVoteForVotedSuggestion() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedRemoveIds = LockIsolated<[String]>([])
@@ -174,9 +184,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(votedSuggestion)
 
-    XCTAssertEqual(capturedRemoveIds.value, ["s1"])
+    #expect(capturedRemoveIds.value == ["s1"])
   }
 
+  @Test
   func testVoteTappedRefetchesSuggestionsAfterSuccess() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let fetchCount = LockIsolated(0)
@@ -191,9 +202,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertGreaterThanOrEqual(fetchCount.value, 1)
+    #expect(fetchCount.value >= 1)
   }
 
+  @Test
   func testVoteTappedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
@@ -206,10 +218,11 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Error")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Error")
   }
 
+  @Test
   func testVoteTappedDoesNothingWithoutAuth() async {
     @Shared(.auth) var auth = Auth()
     let capturedVoteIds = LockIsolated<[String]>([])
@@ -223,11 +236,12 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(suggestion)
 
-    XCTAssertTrue(capturedVoteIds.value.isEmpty)
+    #expect(capturedVoteIds.value.isEmpty)
   }
 
   // MARK: - Suggest Tests
 
+  @Test
   func testSuggestTappedCreatesAndClearsSearch() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedNames = LockIsolated<[String]>([])
@@ -241,10 +255,11 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "Tyler Childers"
     await model.suggestTapped()
 
-    XCTAssertEqual(capturedNames.value, ["Tyler Childers"])
-    XCTAssertEqual(model.searchText, "")
+    #expect(capturedNames.value == ["Tyler Childers"])
+    #expect(model.searchText == "")
   }
 
+  @Test
   func testSuggestTappedTrimsWhitespace() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedNames = LockIsolated<[String]>([])
@@ -258,9 +273,10 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "  Tyler Childers  "
     await model.suggestTapped()
 
-    XCTAssertEqual(capturedNames.value, ["Tyler Childers"])
+    #expect(capturedNames.value == ["Tyler Childers"])
   }
 
+  @Test
   func testSuggestTappedDoesNothingForEmptySearch() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let capturedNames = LockIsolated<[String]>([])
@@ -274,9 +290,10 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "   "
     await model.suggestTapped()
 
-    XCTAssertTrue(capturedNames.value.isEmpty)
+    #expect(capturedNames.value.isEmpty)
   }
 
+  @Test
   func testSuggestTappedDoesNothingWithoutAuth() async {
     @Shared(.auth) var auth = Auth()
     let capturedNames = LockIsolated<[String]>([])
@@ -290,9 +307,10 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "Tyler Childers"
     await model.suggestTapped()
 
-    XCTAssertTrue(capturedNames.value.isEmpty)
+    #expect(capturedNames.value.isEmpty)
   }
 
+  @Test
   func testSuggestTappedShowsAlertOnError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel(onCreate: { _, _ in
@@ -302,112 +320,125 @@ final class StationSuggestionPageTests: XCTestCase {
     model.searchText = "Tyler Childers"
     await model.suggestTapped()
 
-    XCTAssertNotNil(model.presentedAlert)
-    XCTAssertEqual(model.presentedAlert?.title, "Error")
-    XCTAssertEqual(model.searchText, "Tyler Childers")
+    #expect(model.presentedAlert != nil)
+    #expect(model.presentedAlert?.title == "Error")
+    #expect(model.searchText == "Tyler Childers")
   }
 
   // MARK: - View Helper Tests
 
+  @Test
   func testShowSuggestButtonTrueWhenSearchDoesNotMatchExisting() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.searchText = "Tyler Childers"
 
-    XCTAssertTrue(model.showSuggestButton)
+    #expect(model.showSuggestButton)
   }
 
+  @Test
   func testShowSuggestButtonFalseWhenSearchMatchesExistingCaseInsensitive() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.searchText = "bri bagwell"
 
-    XCTAssertFalse(model.showSuggestButton)
+    #expect(!model.showSuggestButton)
   }
 
+  @Test
   func testShowSuggestButtonFalseWhenSearchIsEmpty() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.searchText = ""
 
-    XCTAssertFalse(model.showSuggestButton)
+    #expect(!model.showSuggestButton)
   }
 
+  @Test
   func testShowSuggestButtonFalseWhenSearchIsWhitespace() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.searchText = "   "
 
-    XCTAssertFalse(model.showSuggestButton)
+    #expect(!model.showSuggestButton)
   }
 
+  @Test
   func testShowEmptyStateTrueWhenNotLoadingAndEmpty() {
     let model = makeModel()
     model.suggestions = []
     model.isLoading = false
 
-    XCTAssertTrue(model.showEmptyState)
+    #expect(model.showEmptyState)
   }
 
+  @Test
   func testShowEmptyStateFalseWhenLoading() {
     let model = makeModel()
     model.suggestions = []
     model.isLoading = true
 
-    XCTAssertFalse(model.showEmptyState)
+    #expect(!model.showEmptyState)
   }
 
+  @Test
   func testShowEmptyStateFalseWhenSuggestionsExist() {
     let model = makeModel()
     model.suggestions = mockSuggestions()
     model.isLoading = false
 
-    XCTAssertFalse(model.showEmptyState)
+    #expect(!model.showEmptyState)
   }
 
+  @Test
   func testEmptyMessageShowsDefaultWhenSearchEmpty() {
     let model = makeModel()
     model.searchText = ""
 
-    XCTAssertEqual(model.emptyMessage, model.emptyStateMessage)
+    #expect(model.emptyMessage == model.emptyStateMessage)
   }
 
+  @Test
   func testEmptyMessageShowsSearchMessageWhenSearchActive() {
     let model = makeModel()
     model.searchText = "Nobody"
 
-    XCTAssertEqual(model.emptyMessage, model.emptySearchMessage)
+    #expect(model.emptyMessage == model.emptySearchMessage)
   }
 
+  @Test
   func testVoteButtonTextShowsVotedWhenHasVoted() {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
       voteCount: 5, hasVoted: true, createdAt: Date(), updatedAt: Date())
 
-    XCTAssertEqual(model.voteButtonText(suggestion), "Voted")
+    #expect(model.voteButtonText(suggestion) == "Voted")
   }
 
+  @Test
   func testVoteButtonTextShowsVoteWhenNotVoted() {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
       voteCount: 5, hasVoted: false, createdAt: Date(), updatedAt: Date())
 
-    XCTAssertEqual(model.voteButtonText(suggestion), "Vote")
+    #expect(model.voteButtonText(suggestion) == "Vote")
   }
 
+  @Test
   func testVoteCountText() {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
       voteCount: 42, hasVoted: false, createdAt: Date(), updatedAt: Date())
 
-    XCTAssertEqual(model.voteCountText(suggestion), "42")
+    #expect(model.voteCountText(suggestion) == "42")
   }
 
   // MARK: - Double-Tap Guard Tests
 
+  @Test
   func testVoteTappedIgnoredWhileVoteInProgress() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let voteCount = LockIsolated(0)
@@ -422,9 +453,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertEqual(voteCount.value, 0)
+    #expect(voteCount.value == 0)
   }
 
+  @Test
   func testSuggestTappedIgnoredWhileSubmitInProgress() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let createCount = LockIsolated(0)
@@ -439,9 +471,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.suggestTapped()
 
-    XCTAssertEqual(createCount.value, 0)
+    #expect(createCount.value == 0)
   }
 
+  @Test
   func testVoteTappedResetsIsVotingAfterCompletion() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
@@ -451,9 +484,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertFalse(model.isVoting)
+    #expect(!model.isVoting)
   }
 
+  @Test
   func testVoteTappedResetsIsVotingAfterError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
@@ -465,9 +499,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.voteTapped(unvotedSuggestion)
 
-    XCTAssertFalse(model.isVoting)
+    #expect(!model.isVoting)
   }
 
+  @Test
   func testSuggestTappedResetsIsSubmittingAfterCompletion() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel()
@@ -475,9 +510,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.suggestTapped()
 
-    XCTAssertFalse(model.isSubmitting)
+    #expect(!model.isSubmitting)
   }
 
+  @Test
   func testSuggestTappedResetsIsSubmittingAfterError() async {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let model = makeModel(onCreate: { _, _ in
@@ -487,11 +523,12 @@ final class StationSuggestionPageTests: XCTestCase {
 
     await model.suggestTapped()
 
-    XCTAssertFalse(model.isSubmitting)
+    #expect(!model.isSubmitting)
   }
 
   // MARK: - Dismiss Tests
 
+  @Test
   func testDismissTappedCallsOnDismiss() {
     let model = makeModel()
     var dismissed = false
@@ -499,9 +536,10 @@ final class StationSuggestionPageTests: XCTestCase {
 
     model.dismissTapped()
 
-    XCTAssertTrue(dismissed)
+    #expect(dismissed)
   }
 
+  @Test
   func testDismissTappedDoesNothingWithoutCallback() {
     let model = makeModel()
     model.onDismiss = nil

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
@@ -35,9 +35,7 @@ class SupportPageModel: ViewModel {
 
   func onViewAppeared() async {
     guard let jwt = auth.jwt else { return }
-    startListeningForRefresh()
 
-    // If conversation is already set (e.g., from ConversationListPage), refresh messages
     if conversation != nil {
       await refreshMessages()
       isLoading = false
@@ -58,6 +56,12 @@ class SupportPageModel: ViewModel {
     }
 
     isLoading = false
+  }
+
+  func observeRefreshNotifications() async {
+    for await _ in NotificationCenter.default.notifications(named: .refreshSupportMessages) {
+      await refreshMessages()
+    }
   }
 
   private func markAsRead() async {
@@ -112,18 +116,6 @@ class SupportPageModel: ViewModel {
   func handleScenePhaseChange(_ phase: ScenePhase) async {
     guard phase == .active else { return }
     await refreshMessages()
-  }
-
-  func startListeningForRefresh() {
-    NotificationCenter.default.addObserver(
-      forName: .refreshSupportMessages,
-      object: nil,
-      queue: .main
-    ) { [weak self] _ in
-      Task { @MainActor in
-        await self?.refreshMessages()
-      }
-    }
   }
 }
 

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
@@ -10,12 +10,12 @@ import Dependencies
 import Foundation
 import Sharing
 import SwiftUI
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SupportPageTests: XCTestCase {
+struct SupportPageTests {
   private func makeConversation(id: String) -> Conversation {
     Conversation(
       id: id,
@@ -43,6 +43,7 @@ final class SupportPageTests: XCTestCase {
     )
   }
 
+  @Test
   func testOnViewAppearedLoadsConversationAndMessages() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -88,17 +89,18 @@ final class SupportPageTests: XCTestCase {
       SupportPageModel()
     }
 
-    XCTAssertTrue(model.isLoading)
-    XCTAssertTrue(model.messages.isEmpty)
+    #expect(model.isLoading)
+    #expect(model.messages.isEmpty)
 
     await model.onViewAppeared()
 
-    XCTAssertFalse(model.isLoading)
-    XCTAssertEqual(model.conversation?.id, "conv-1")
-    XCTAssertEqual(model.messages.count, 1)
-    XCTAssertTrue(model.hasExistingMessages)
+    #expect(!model.isLoading)
+    #expect(model.conversation?.id == "conv-1")
+    #expect(model.messages.count == 1)
+    #expect(model.hasExistingMessages)
   }
 
+  @Test
   func testHasExistingMessagesReturnsFalseWhenEmpty() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -134,9 +136,10 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertFalse(model.hasExistingMessages)
+    #expect(!model.hasExistingMessages)
   }
 
+  @Test
   func testSendMessageAppendsToMessages() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -184,28 +187,30 @@ final class SupportPageTests: XCTestCase {
     await model.onViewAppeared()
     model.newMessage = "Test message"
 
-    XCTAssertTrue(model.canSend)
+    #expect(model.canSend)
 
     await model.sendMessage()
 
-    XCTAssertEqual(model.messages.count, 1)
-    XCTAssertEqual(model.messages.first?.message, "Test message")
-    XCTAssertTrue(model.newMessage.isEmpty)
+    #expect(model.messages.count == 1)
+    #expect(model.messages.first?.message == "Test message")
+    #expect(model.newMessage.isEmpty)
   }
 
+  @Test
   func testCanSendReturnsFalseWhenMessageEmpty() {
     let model = SupportPageModel()
 
     model.newMessage = ""
-    XCTAssertFalse(model.canSend)
+    #expect(!model.canSend)
 
     model.newMessage = "   "
-    XCTAssertFalse(model.canSend)
+    #expect(!model.canSend)
 
     model.newMessage = "Hello"
-    XCTAssertTrue(model.canSend)
+    #expect(model.canSend)
   }
 
+  @Test
   func testOnViewAppearedDoesNotOverwritePresetConversation() async {
     // Regression test: When navigating from ConversationListPage, the model
     // already has a conversation set. onViewAppeared should NOT overwrite it.
@@ -244,11 +249,12 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertEqual(model.conversation?.id, "preset-conv-id")
-    XCTAssertFalse(getSupportConversationCalled.value)
-    XCTAssertFalse(model.isLoading)
+    #expect(model.conversation?.id == "preset-conv-id")
+    #expect(!getSupportConversationCalled.value)
+    #expect(!model.isLoading)
   }
 
+  @Test
   func testOnViewAppearedRefreshesMessagesWhenConversationAlreadySet() async {
     // Regression test: When navigating to support page with conversation already set,
     // onViewAppeared should still refresh the messages to get any new ones.
@@ -290,12 +296,13 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertTrue(getConversationMessagesCalled.value)
-    XCTAssertEqual(model.messages.count, 2)
-    XCTAssertEqual(model.messages.last?.message, "New message")
-    XCTAssertFalse(model.isLoading)
+    #expect(getConversationMessagesCalled.value)
+    #expect(model.messages.count == 2)
+    #expect(model.messages.last?.message == "New message")
+    #expect(!model.isLoading)
   }
 
+  @Test
   func testHandleScenePhaseChangeRefreshesMessagesWhenActive() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -328,11 +335,12 @@ final class SupportPageTests: XCTestCase {
 
     await model.handleScenePhaseChange(.active)
 
-    XCTAssertTrue(getConversationMessagesCalled.value)
-    XCTAssertEqual(model.messages.count, 1)
-    XCTAssertEqual(model.messages.first?.message, "New reply")
+    #expect(getConversationMessagesCalled.value)
+    #expect(model.messages.count == 1)
+    #expect(model.messages.first?.message == "New reply")
   }
 
+  @Test
   func testOnViewAppearedDoesNotCreateConversationWhenGetReturnsNil() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -367,15 +375,16 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertFalse(
-      createCalled.value, "Should not create a conversation just from viewing the page")
-    XCTAssertFalse(getMessagesCalled.value, "No conversation = no messages to fetch")
-    XCTAssertNil(model.conversation)
-    XCTAssertTrue(model.messages.isEmpty)
-    XCTAssertFalse(model.isLoading)
-    XCTAssertNil(model.presentedAlert)
+    #expect(
+      !createCalled.value, "Should not create a conversation just from viewing the page")
+    #expect(!getMessagesCalled.value, "No conversation = no messages to fetch")
+    #expect(model.conversation == nil)
+    #expect(model.messages.isEmpty)
+    #expect(!model.isLoading)
+    #expect(model.presentedAlert == nil)
   }
 
+  @Test
   func testSendMessageCreatesConversationWhenNoneExists() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -405,8 +414,8 @@ final class SupportPageTests: XCTestCase {
           conversation: createdConversation, unreadCount: 0)
       }
       $0.api.sendConversationMessage = { _, conversationId, text in
-        XCTAssertEqual(conversationId, "lazy-conv")
-        XCTAssertEqual(text, "Hi there")
+        #expect(conversationId == "lazy-conv")
+        #expect(text == "Hi there")
         return sentMessage
       }
       $0.api.getConversationMessages = { _, _ in [] }
@@ -415,18 +424,19 @@ final class SupportPageTests: XCTestCase {
     }
 
     await model.onViewAppeared()
-    XCTAssertNil(model.conversation)
+    #expect(model.conversation == nil)
 
     model.newMessage = "Hi there"
     await model.sendMessage()
 
-    XCTAssertTrue(createCalled.value)
-    XCTAssertEqual(model.conversation?.id, "lazy-conv")
-    XCTAssertEqual(model.messages.count, 1)
-    XCTAssertEqual(model.messages.first?.message, "Hi there")
-    XCTAssertTrue(model.newMessage.isEmpty)
+    #expect(createCalled.value)
+    #expect(model.conversation?.id == "lazy-conv")
+    #expect(model.messages.count == 1)
+    #expect(model.messages.first?.message == "Hi there")
+    #expect(model.newMessage.isEmpty)
   }
 
+  @Test
   func testSendMessageRestoresMessageAndShowsAlertWhenCreateFails() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -466,13 +476,14 @@ final class SupportPageTests: XCTestCase {
     model.newMessage = "Hello"
     await model.sendMessage()
 
-    XCTAssertFalse(sendCalled.value, "Should not call send when create fails")
-    XCTAssertNil(model.conversation)
-    XCTAssertEqual(model.newMessage, "Hello", "newMessage should be restored")
-    XCTAssertEqual(model.presentedAlert, .errorSendingMessage)
-    XCTAssertFalse(model.isSending)
+    #expect(!sendCalled.value, "Should not call send when create fails")
+    #expect(model.conversation == nil)
+    #expect(model.newMessage == "Hello", "newMessage should be restored")
+    #expect(model.presentedAlert == .errorSendingMessage)
+    #expect(!model.isSending)
   }
 
+  @Test
   func testOnViewAppearedUsesExistingConversationFromGet() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -504,10 +515,11 @@ final class SupportPageTests: XCTestCase {
 
     await model.onViewAppeared()
 
-    XCTAssertFalse(createCalled.value)
-    XCTAssertEqual(model.conversation?.id, "existing-conv")
+    #expect(!createCalled.value)
+    #expect(model.conversation?.id == "existing-conv")
   }
 
+  @Test
   func testHandleScenePhaseChangeDoesNothingWhenNotActive() async {
     @Shared(.auth) var auth = Auth(
       currentUser: LoggedInUser(
@@ -533,9 +545,9 @@ final class SupportPageTests: XCTestCase {
     model.conversation = conversation
 
     await model.handleScenePhaseChange(.background)
-    XCTAssertFalse(getConversationMessagesCalled.value)
+    #expect(!getConversationMessagesCalled.value)
 
     await model.handleScenePhaseChange(.inactive)
-    XCTAssertFalse(getConversationMessagesCalled.value)
+    #expect(!getConversationMessagesCalled.value)
   }
 }

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageView.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageView.swift
@@ -30,6 +30,9 @@ struct SupportPageView: View {
     .task {
       await model.onViewAppeared()
     }
+    .task {
+      await model.observeRefreshNotifications()
+    }
     .alert(item: $model.presentedAlert) { $0.alert }
     .onChange(of: scenePhase) { _, newPhase in
       Task { await model.handleScenePhaseChange(newPhase) }

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
@@ -53,8 +53,9 @@ class ListeningTimeTileModel: ViewModel {
 
   func viewAppeared() {
     refreshTask?.cancel()
-    refreshTask = Task {
+    refreshTask = Task { [weak self] in
       while !Task.isCancelled {
+        guard let self else { return }
         if let ms = listeningTracker?.totalListenTimeMS {
           totalListeningTime = ms
         } else {

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
@@ -9,24 +9,14 @@ import Combine
 import Dependencies
 import Foundation
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 // swiftlint:disable redundant_optional_initialization
 
 @MainActor
-final class ListeningTimeTileModelTests: XCTestCase {
-
-  override func setUp() {
-    super.setUp()
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
-  }
-
-  override func tearDown() {
-    super.tearDown()
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
-  }
+struct ListeningTimeTileModelTests {
 
   func createMockListeningTracker(totalTimeMS: Int) -> ListeningTracker {
     let rewardsProfile = RewardsProfile(
@@ -39,65 +29,76 @@ final class ListeningTimeTileModelTests: XCTestCase {
 
   // MARK: - Display String Formatting Tests
 
-  func testListeningTimeDisplayString_FormatsZeroTime() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsZeroTime() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 0
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "00h 00m 00s")
+      #expect(model.listeningTimeDisplayString == "00h 00m 00s")
     }
   }
 
-  func testListeningTimeDisplayString_FormatsSeconds() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsSeconds() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 45000  // 45 seconds
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "00h 00m 45s")
+      #expect(model.listeningTimeDisplayString == "00h 00m 45s")
     }
   }
 
-  func testListeningTimeDisplayString_FormatsMinutes() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsMinutes() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 150000  // 2 minutes 30 seconds
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "00h 02m 30s")
+      #expect(model.listeningTimeDisplayString == "00h 02m 30s")
     }
   }
 
-  func testListeningTimeDisplayString_FormatsHours() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsHours() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 7_382_000  // 2 hours 3 minutes 2 seconds
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "02h 03m 02s")
+      #expect(model.listeningTimeDisplayString == "02h 03m 02s")
     }
   }
 
-  func testListeningTimeDisplayString_FormatsLargeHours() async {
+  @Test
+  func testListeningTimeDisplayStringFormatsLargeHours() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     withDependencies {
       $0.continuousClock = TestClock()
     } operation: {
       let model = ListeningTimeTileModel()
       model.totalListeningTime = 360_000_000  // 100 hours
 
-      XCTAssertEqual(model.listeningTimeDisplayString, "100h 00m 00s")
+      #expect(model.listeningTimeDisplayString == "100h 00m 00s")
     }
   }
 
   // MARK: - View Lifecycle Tests
 
-  func testViewAppeared_UpdatesFromListeningTracker() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+  @Test
+  func testViewAppearedUpdatesFromListeningTracker() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -105,7 +106,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
       ListeningTimeTileModel()
     }
 
-    XCTAssertEqual(model.totalListeningTime, 0)
+    #expect(model.totalListeningTime == 0)
 
     let tracker = createMockListeningTracker(totalTimeMS: 5000)
     $listeningTracker.withLock { $0 = tracker }
@@ -114,13 +115,14 @@ final class ListeningTimeTileModelTests: XCTestCase {
 
     // The initial update should happen immediately
     await clock.advance(by: .seconds(1))
-    XCTAssertEqual(model.totalListeningTime, 5000)
+    #expect(model.totalListeningTime == 5000)
 
     model.viewDisappeared()
   }
 
-  func testViewAppeared_HandlesNilTracker() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+  @Test
+  func testViewAppearedHandlesNilTracker() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -131,13 +133,14 @@ final class ListeningTimeTileModelTests: XCTestCase {
     model.viewAppeared()
 
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 0)
+    #expect(model.totalListeningTime == 0)
 
     model.viewDisappeared()
   }
 
-  func testViewDisappeared_CancelsRefreshTask() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+  @Test
+  func testViewDisappearedCancelsRefreshTask() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -151,7 +154,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
     model.viewAppeared()
 
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 1000)
+    #expect(model.totalListeningTime == 1000)
 
     model.viewDisappeared()
 
@@ -166,11 +169,12 @@ final class ListeningTimeTileModelTests: XCTestCase {
     await clock.advance(by: .seconds(1))
 
     // Should still be 1000 since task was cancelled
-    XCTAssertEqual(model.totalListeningTime, 1000)
+    #expect(model.totalListeningTime == 1000)
   }
 
-  func testMultipleViewAppeared_CancelsPreviousTask() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+  @Test
+  func testMultipleViewAppearedCancelsPreviousTask() async {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -184,7 +188,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
     // First viewAppeared
     model.viewAppeared()
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 1000)
+    #expect(model.totalListeningTime == 1000)
 
     // Second viewAppeared (should cancel first task)
     let session1 = LocalListeningSession(
@@ -204,7 +208,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
 
     model.viewAppeared()
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 11000)  // 1000 + 10000
+    #expect(model.totalListeningTime == 11000)  // 1000 + 10000
 
     // Advance clock to verify only one task is running
     let session2 = LocalListeningSession(
@@ -225,13 +229,14 @@ final class ListeningTimeTileModelTests: XCTestCase {
     // Allow shared state to propagate before advancing clock
     await Task.yield()
     await clock.advance(by: .seconds(1))
-    XCTAssertEqual(model.totalListeningTime, 16000)  // 1000 + 10000 + 5000
+    #expect(model.totalListeningTime == 16000)  // 1000 + 10000 + 5000
 
     model.viewDisappeared()
   }
 
+  @Test
   func testConcurrentUpdates() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -245,7 +250,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
     model.viewAppeared()
 
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 0)
+    #expect(model.totalListeningTime == 0)
 
     // Simulate rapid updates by adding sessions
     var sessions: [LocalListeningSession] = []
@@ -269,14 +274,15 @@ final class ListeningTimeTileModelTests: XCTestCase {
       // Allow shared state to propagate before advancing clock
       await Task.yield()
       await clock.advance(by: .seconds(1))
-      XCTAssertEqual(model.totalListeningTime, index * 1000)
+      #expect(model.totalListeningTime == index * 1000)
     }
 
     model.viewDisappeared()
   }
 
+  @Test
   func testIntegrationWithRealTimeTracking() async {
-    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = nil
     let clock = TestClock()
     let model = withDependencies {
       $0.continuousClock = clock
@@ -298,8 +304,8 @@ final class ListeningTimeTileModelTests: XCTestCase {
 
     // Initial state: 10 seconds from server
     await Task.yield()
-    XCTAssertEqual(model.totalListeningTime, 10000)
-    XCTAssertEqual(model.listeningTimeDisplayString, "00h 00m 10s")
+    #expect(model.totalListeningTime == 10000)
+    #expect(model.listeningTimeDisplayString == "00h 00m 10s")
 
     // Advance 5 seconds - the listening session should add time
     await clock.advance(by: .seconds(5))
@@ -308,7 +314,7 @@ final class ListeningTimeTileModelTests: XCTestCase {
     // Note: Due to the way ListeningTracker calculates time,
     // we might need to be flexible with exact timing
     let expectedTime = model.totalListeningTime
-    XCTAssertGreaterThanOrEqual(expectedTime, 10000)
+    #expect(expectedTime >= 10000)
 
     model.viewDisappeared()
   }

--- a/PlayolaRadio/Views/Reusable Components/NewFeatureTile/NewFeatureTileTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/NewFeatureTile/NewFeatureTileTests.swift
@@ -3,13 +3,14 @@
 //  PlayolaRadio
 //
 
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class NewFeatureTileModelTests: XCTestCase {
+struct NewFeatureTileModelTests {
 
+  @Test
   func testOnButtonTappedCallsButtonAction() async {
     var actionCalled = false
 
@@ -20,6 +21,6 @@ final class NewFeatureTileModelTests: XCTestCase {
 
     await model.onButtonTapped()
 
-    XCTAssertTrue(actionCalled)
+    #expect(actionCalled)
   }
 }

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -14,6 +14,7 @@ import SwiftUI
 struct SmallPlayer: View {
   @Shared(.nowPlaying) var nowPlaying: NowPlaying?
   @Dependency(\.likesManager) var likesManager
+  @Dependency(\.stationPlayer) var stationPlayer
 
   // Computed properties from nowPlaying data
   var mainTitle: String {
@@ -98,7 +99,7 @@ struct SmallPlayer: View {
         }
 
         Button(
-          action: { StationPlayer.shared.stop() },
+          action: { stationPlayer.stop() },
           label: {
             Image(systemName: "stop.fill")
               .foregroundColor(.black)

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
@@ -13,6 +13,8 @@ import Testing
 
 @testable import PlayolaRadio
 
+// swiftlint:disable redundant_optional_initialization
+
 @MainActor
 struct SmallPlayerTests {
 
@@ -302,3 +304,5 @@ struct SmallPlayerTests {
     #expect(smallPlayer.artworkURL == testImageUrl)
   }
 }
+
+// swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
@@ -6,52 +6,51 @@
 //
 
 import Dependencies
+import Foundation
 import PlayolaPlayer
 import Sharing
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SmallPlayerTests: XCTestCase {
-
-  override func setUp() {
-    super.setUp()
-    // Clear shared state before each test
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
-    $nowPlaying.withLock { $0 = nil }
-  }
+struct SmallPlayerTests {
 
   // MARK: - Main Title Tests
 
-  func testMainTitle_ReturnsStationNameWhenAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testMainTitleReturnsStationNameWhenAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock { $0 = NowPlaying(currentStation: mockStation) }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
+    #expect(smallPlayer.mainTitle == mockStation.name)
   }
 
-  func testMainTitle_ReturnsEmptyStringWhenNoStation() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testMainTitleReturnsEmptyStringWhenNoStation() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
 
     $nowPlaying.withLock { $0 = NowPlaying() }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, "")
+    #expect(smallPlayer.mainTitle == "")
   }
 
-  func testMainTitle_ReturnsEmptyStringWhenNowPlayingIsNil() {
+  @Test
+  func testMainTitleReturnsEmptyStringWhenNowPlayingIsNil() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, "")
+    #expect(smallPlayer.mainTitle == "")
   }
 
   // MARK: - Secondary Title Tests
 
-  func testSecondaryTitle_ReturnsArtistAndTitleWhenAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsArtistAndTitleWhenAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -63,21 +62,23 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Test Artist - Test Song")
+    #expect(smallPlayer.secondaryTitle == "Test Artist - Test Song")
   }
 
-  func testSecondaryTitle_ReturnsStationDescWhenNoArtistTitle() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsStationDescWhenNoArtistTitle() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock { $0 = NowPlaying(currentStation: mockStation) }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, mockStation.description)
+    #expect(smallPlayer.secondaryTitle == mockStation.description)
   }
 
-  func testSecondaryTitle_ReturnsLoadingWhenPlaybackStatusIsLoading() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsLoadingWhenPlaybackStatusIsLoading() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -88,11 +89,12 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Loading...")
+    #expect(smallPlayer.secondaryTitle == "Loading...")
   }
 
-  func testSecondaryTitle_ReturnsLoadingWhenLoadingEvenWithTrackInfo() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsLoadingWhenLoadingEvenWithTrackInfo() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -105,11 +107,12 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Loading...")
+    #expect(smallPlayer.secondaryTitle == "Loading...")
   }
 
-  func testSecondaryTitle_ReturnsStationDescWhenOnlyArtistAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsStationDescWhenOnlyArtistAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -120,11 +123,12 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, mockStation.description)
+    #expect(smallPlayer.secondaryTitle == mockStation.description)
   }
 
-  func testSecondaryTitle_ReturnsStationDescWhenOnlyTitleAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsStationDescWhenOnlyTitleAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock {
@@ -135,22 +139,24 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, mockStation.description)
+    #expect(smallPlayer.secondaryTitle == mockStation.description)
   }
 
-  func testSecondaryTitle_ReturnsEmptyStringWhenNothingAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSecondaryTitleReturnsEmptyStringWhenNothingAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
 
     $nowPlaying.withLock { $0 = NowPlaying() }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.secondaryTitle, "")
+    #expect(smallPlayer.secondaryTitle == "")
   }
 
   // MARK: - Artwork URL Tests
 
-  func testArtworkURL_ReturnsAlbumArtworkWhenAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testArtworkURLReturnsAlbumArtworkWhenAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let testURL = URL(string: "https://example.com/album.jpg")!
     let mockStation = AnyStation.mock
 
@@ -162,45 +168,50 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.artworkURL, testURL)
+    #expect(smallPlayer.artworkURL == testURL)
   }
 
-  func testArtworkURL_ReturnsStationImageWhenNoAlbumArtwork() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testArtworkURLReturnsStationImageWhenNoAlbumArtwork() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     $nowPlaying.withLock { $0 = NowPlaying(currentStation: mockStation) }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.artworkURL, mockStation.processedImageURL())
+    #expect(smallPlayer.artworkURL == mockStation.processedImageURL())
   }
 
-  func testArtworkURL_ReturnsFallbackWhenNothingAvailable() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testArtworkURLReturnsFallbackWhenNothingAvailable() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
 
     $nowPlaying.withLock { $0 = NowPlaying() }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.artworkURL, URL(string: "https://example.com")!)
+    #expect(smallPlayer.artworkURL == URL(string: "https://example.com")!)
   }
 
-  func testArtworkURL_ReturnsFallbackWhenNowPlayingIsNil() {
+  @Test
+  func testArtworkURLReturnsFallbackWhenNowPlayingIsNil() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.artworkURL, URL(string: "https://example.com")!)
+    #expect(smallPlayer.artworkURL == URL(string: "https://example.com")!)
   }
 
   // MARK: - State Change Tests
 
-  func testSmallPlayer_UpdatesWhenNowPlayingChanges() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSmallPlayerUpdatesWhenNowPlayingChanges() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     // Initial state - no track info
     $nowPlaying.withLock { $0 = NowPlaying(currentStation: mockStation) }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, mockStation.description)
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == mockStation.description)
 
     // Update with artist/title - should now show track info
     $nowPlaying.withLock {
@@ -211,19 +222,20 @@ final class SmallPlayerTests: XCTestCase {
       )
     }
 
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, "New Artist - New Song")
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == "New Artist - New Song")
   }
 
-  func testSmallPlayer_HandlesNilToDataTransition() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSmallPlayerHandlesNilToDataTransition() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     let smallPlayer = SmallPlayer()
 
     // Initially nil
-    XCTAssertEqual(smallPlayer.mainTitle, "")
-    XCTAssertEqual(smallPlayer.secondaryTitle, "")
+    #expect(smallPlayer.mainTitle == "")
+    #expect(smallPlayer.secondaryTitle == "")
 
     // Set data
     $nowPlaying.withLock {
@@ -234,12 +246,13 @@ final class SmallPlayerTests: XCTestCase {
       )
     }
 
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Test Artist - Test Song")
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == "Test Artist - Test Song")
   }
 
-  func testSmallPlayer_HandlesDataToNilTransition() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSmallPlayerHandlesDataToNilTransition() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
 
     // Start with data
@@ -252,20 +265,21 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, "Test Artist - Test Song")
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == "Test Artist - Test Song")
 
     // Clear data
     $nowPlaying.withLock { $0 = nil }
 
-    XCTAssertEqual(smallPlayer.mainTitle, "")
-    XCTAssertEqual(smallPlayer.secondaryTitle, "")
+    #expect(smallPlayer.mainTitle == "")
+    #expect(smallPlayer.secondaryTitle == "")
   }
 
   // MARK: - Integration Tests with Spin Data
 
-  func testSmallPlayer_DisplaysSpinDataCorrectly() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying?
+  @Test
+  func testSmallPlayerDisplaysSpinDataCorrectly() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let mockStation = AnyStation.mock
     let mockSpin = Spin.mock
     let testArtist = "Test Artist"
@@ -283,8 +297,8 @@ final class SmallPlayerTests: XCTestCase {
     }
 
     let smallPlayer = SmallPlayer()
-    XCTAssertEqual(smallPlayer.mainTitle, mockStation.name)
-    XCTAssertEqual(smallPlayer.secondaryTitle, "\(testArtist) - \(testTitle)")
-    XCTAssertEqual(smallPlayer.artworkURL, testImageUrl)
+    #expect(smallPlayer.mainTitle == mockStation.name)
+    #expect(smallPlayer.secondaryTitle == "\(testArtist) - \(testTitle)")
+    #expect(smallPlayer.artworkURL == testImageUrl)
   }
 }

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerModel.swift
@@ -42,6 +42,10 @@ class SongDrawerModel: ViewModel {
     return !audioBlock.title.isEmpty && !audioBlock.artist.isEmpty
   }
 
+  var appleMusicButtonLabel: String { "Listen on Apple Music" }
+  var spotifyButtonLabel: String { "Listen on Spotify" }
+  var removeFromLikedSongsButtonLabel: String { "Remove from Liked Songs" }
+
   func removeFromLikedSongsTapped() {
     if let onRemove = onRemove {
       // Use animated removal if callback is provided

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerModel.swift
@@ -31,6 +31,7 @@ class SongDrawerModel: ViewModel {
     self.likedDate = likedDate
     self.onDismiss = onDismiss
     self.onRemove = onRemove
+    super.init()
   }
 
   var shouldShowSpotify: Bool {
@@ -41,7 +42,7 @@ class SongDrawerModel: ViewModel {
     return !audioBlock.title.isEmpty && !audioBlock.artist.isEmpty
   }
 
-  func removeFromLikedSongs() {
+  func removeFromLikedSongsTapped() {
     if let onRemove = onRemove {
       // Use animated removal if callback is provided
       onRemove(audioBlock)
@@ -52,7 +53,7 @@ class SongDrawerModel: ViewModel {
     onDismiss()
   }
 
-  func openAppleMusic() {
+  func appleMusicTapped() {
     // Apple Music deep linking can use search if no direct ID is available
     let artist =
       audioBlock.artist.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed) ?? ""
@@ -74,7 +75,7 @@ class SongDrawerModel: ViewModel {
     onDismiss()
   }
 
-  func openSpotify() {
+  func spotifyTapped() {
     guard let spotifyId = audioBlock.spotifyId else {
       // No Spotify ID available, just dismiss
       onDismiss()

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
@@ -6,15 +6,17 @@
 //
 
 import Dependencies
+import Foundation
 import PlayolaPlayer
-import XCTest
+import Testing
 
 @testable import PlayolaRadio
 
 @MainActor
-final class SongDrawerTests: XCTestCase {
+struct SongDrawerTests {
 
-  func testOpenSpotify_WithSpotifyId_OpensCorrectURL() {
+  @Test
+  func testOpenSpotifyWithSpotifyIdOpensCorrectURL() {
     let audioBlock = AudioBlock.mockWith(spotifyId: "4iV5W9uYEdYUVa79Axb7Rh")
     var dismissCalled = false
 
@@ -28,10 +30,11 @@ final class SongDrawerTests: XCTestCase {
     // This test verifies the logic flow and that dismiss is called
     model.openSpotify()
 
-    XCTAssertTrue(dismissCalled, "Should call onDismiss after attempting to open Spotify")
+    #expect(dismissCalled, "Should call onDismiss after attempting to open Spotify")
   }
 
-  func testOpenSpotify_WithoutSpotifyId_JustDismisses() {
+  @Test
+  func testOpenSpotifyWithoutSpotifyIdJustDismisses() {
     let audioBlock = AudioBlock.mockWith(spotifyId: nil)
     var dismissCalled = false
 
@@ -43,10 +46,11 @@ final class SongDrawerTests: XCTestCase {
 
     model.openSpotify()
 
-    XCTAssertTrue(dismissCalled, "Should call onDismiss when no Spotify ID is available")
+    #expect(dismissCalled, "Should call onDismiss when no Spotify ID is available")
   }
 
-  func testOpenAppleMusic_OpensSearchURL() {
+  @Test
+  func testOpenAppleMusicOpensSearchURL() {
     let audioBlock = AudioBlock.mockWith(
       title: "Test Song",
       artist: "Test Artist"
@@ -61,10 +65,11 @@ final class SongDrawerTests: XCTestCase {
 
     model.openAppleMusic()
 
-    XCTAssertTrue(dismissCalled, "Should call onDismiss after attempting to open Apple Music")
+    #expect(dismissCalled, "Should call onDismiss after attempting to open Apple Music")
   }
 
-  func testOpenAppleMusic_HandlesSpecialCharacters() {
+  @Test
+  func testOpenAppleMusicHandlesSpecialCharacters() {
     let audioBlock = AudioBlock.mockWith(
       title: "Song & Title",
       artist: "Artist @ Name"
@@ -80,10 +85,11 @@ final class SongDrawerTests: XCTestCase {
     // Should not crash with special characters and should call dismiss
     model.openAppleMusic()
 
-    XCTAssertTrue(dismissCalled, "Should handle URL encoding and call onDismiss")
+    #expect(dismissCalled, "Should handle URL encoding and call onDismiss")
   }
 
-  func testShouldShowSpotify_TrueWhenSpotifyIdExists() {
+  @Test
+  func testShouldShowSpotifyTrueWhenSpotifyIdExists() {
     let audioBlock = AudioBlock.mockWith(spotifyId: "4iV5W9uYEdYUVa79Axb7Rh")
     let model = SongDrawerModel(
       audioBlock: audioBlock,
@@ -91,10 +97,11 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertTrue(model.shouldShowSpotify)
+    #expect(model.shouldShowSpotify)
   }
 
-  func testShouldShowSpotify_FalseWhenSpotifyIdIsNil() {
+  @Test
+  func testShouldShowSpotifyFalseWhenSpotifyIdIsNil() {
     let audioBlock = AudioBlock.mockWith(spotifyId: nil)
     let model = SongDrawerModel(
       audioBlock: audioBlock,
@@ -102,10 +109,11 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertFalse(model.shouldShowSpotify)
+    #expect(!model.shouldShowSpotify)
   }
 
-  func testShouldShowAppleMusic_TrueWhenTitleAndArtistExist() {
+  @Test
+  func testShouldShowAppleMusicTrueWhenTitleAndArtistExist() {
     let audioBlock = AudioBlock.mockWith(
       title: "Test Song",
       artist: "Test Artist"
@@ -116,10 +124,11 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertTrue(model.shouldShowAppleMusic)
+    #expect(model.shouldShowAppleMusic)
   }
 
-  func testShouldShowAppleMusic_FalseWhenTitleOrArtistEmpty() {
+  @Test
+  func testShouldShowAppleMusicFalseWhenTitleOrArtistEmpty() {
     let audioBlockEmptyTitle = AudioBlock.mockWith(
       title: "",
       artist: "Test Artist"
@@ -130,7 +139,7 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertFalse(modelEmptyTitle.shouldShowAppleMusic)
+    #expect(!modelEmptyTitle.shouldShowAppleMusic)
 
     let audioBlockEmptyArtist = AudioBlock.mockWith(
       title: "Test Song",
@@ -142,10 +151,11 @@ final class SongDrawerTests: XCTestCase {
       onDismiss: {}
     )
 
-    XCTAssertFalse(modelEmptyArtist.shouldShowAppleMusic)
+    #expect(!modelEmptyArtist.shouldShowAppleMusic)
   }
 
-  func testRemoveFromLikedSongs_UnlikesAndDismisses() async {
+  @Test
+  func testRemoveFromLikedSongsUnlikesAndDismisses() async {
     let audioBlock = AudioBlock.mock
     var dismissCalled = false
 
@@ -162,17 +172,18 @@ final class SongDrawerTests: XCTestCase {
       )
 
       // Verify it's liked initially
-      XCTAssertTrue(model.likesManager.isLiked(audioBlock.id))
+      #expect(model.likesManager.isLiked(audioBlock.id))
 
       model.removeFromLikedSongs()
 
       // Verify it's been unliked and dismiss was called
-      XCTAssertFalse(model.likesManager.isLiked(audioBlock.id))
-      XCTAssertTrue(dismissCalled)
+      #expect(!model.likesManager.isLiked(audioBlock.id))
+      #expect(dismissCalled)
     }
   }
 
-  func testRemoveFromLikedSongs_WithOnRemoveCallback() async {
+  @Test
+  func testRemoveFromLikedSongsWithOnRemoveCallback() async {
     let audioBlock = AudioBlock.mock
     var dismissCalled = false
     var onRemoveCalled = false
@@ -196,13 +207,13 @@ final class SongDrawerTests: XCTestCase {
       model.removeFromLikedSongs()
 
       // Verify the onRemove callback was called with correct audio block
-      XCTAssertTrue(onRemoveCalled, "Should call onRemove callback")
-      XCTAssertEqual(
-        removedAudioBlock?.id, audioBlock.id, "Should pass correct audioBlock to onRemove")
-      XCTAssertTrue(dismissCalled, "Should call onDismiss")
+      #expect(onRemoveCalled, "Should call onRemove callback")
+      #expect(
+        removedAudioBlock?.id == audioBlock.id, "Should pass correct audioBlock to onRemove")
+      #expect(dismissCalled, "Should call onDismiss")
 
       // Verify song is still liked (since onRemove callback handles the removal)
-      XCTAssertTrue(
+      #expect(
         model.likesManager.isLiked(audioBlock.id),
         "Song should still be liked when using onRemove callback"
       )

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
@@ -16,7 +16,7 @@ import Testing
 struct SongDrawerTests {
 
   @Test
-  func testOpenSpotifyWithSpotifyIdOpensCorrectURL() {
+  func testSpotifyTappedWithSpotifyIdOpensCorrectURL() {
     let audioBlock = AudioBlock.mockWith(spotifyId: "4iV5W9uYEdYUVa79Axb7Rh")
     var dismissCalled = false
 
@@ -28,13 +28,13 @@ struct SongDrawerTests {
 
     // Note: In a real test environment, UIApplication.shared.open won't actually open URLs
     // This test verifies the logic flow and that dismiss is called
-    model.openSpotify()
+    model.spotifyTapped()
 
     #expect(dismissCalled, "Should call onDismiss after attempting to open Spotify")
   }
 
   @Test
-  func testOpenSpotifyWithoutSpotifyIdJustDismisses() {
+  func testSpotifyTappedWithoutSpotifyIdJustDismisses() {
     let audioBlock = AudioBlock.mockWith(spotifyId: nil)
     var dismissCalled = false
 
@@ -44,13 +44,13 @@ struct SongDrawerTests {
       onDismiss: { dismissCalled = true }
     )
 
-    model.openSpotify()
+    model.spotifyTapped()
 
     #expect(dismissCalled, "Should call onDismiss when no Spotify ID is available")
   }
 
   @Test
-  func testOpenAppleMusicOpensSearchURL() {
+  func testAppleMusicTappedOpensSearchURL() {
     let audioBlock = AudioBlock.mockWith(
       title: "Test Song",
       artist: "Test Artist"
@@ -63,13 +63,13 @@ struct SongDrawerTests {
       onDismiss: { dismissCalled = true }
     )
 
-    model.openAppleMusic()
+    model.appleMusicTapped()
 
     #expect(dismissCalled, "Should call onDismiss after attempting to open Apple Music")
   }
 
   @Test
-  func testOpenAppleMusicHandlesSpecialCharacters() {
+  func testAppleMusicTappedHandlesSpecialCharacters() {
     let audioBlock = AudioBlock.mockWith(
       title: "Song & Title",
       artist: "Artist @ Name"
@@ -83,7 +83,7 @@ struct SongDrawerTests {
     )
 
     // Should not crash with special characters and should call dismiss
-    model.openAppleMusic()
+    model.appleMusicTapped()
 
     #expect(dismissCalled, "Should handle URL encoding and call onDismiss")
   }
@@ -155,7 +155,7 @@ struct SongDrawerTests {
   }
 
   @Test
-  func testRemoveFromLikedSongsUnlikesAndDismisses() async {
+  func testRemoveFromLikedSongsTappedUnlikesAndDismisses() async {
     let audioBlock = AudioBlock.mock
     var dismissCalled = false
 
@@ -174,7 +174,7 @@ struct SongDrawerTests {
       // Verify it's liked initially
       #expect(model.likesManager.isLiked(audioBlock.id))
 
-      model.removeFromLikedSongs()
+      model.removeFromLikedSongsTapped()
 
       // Verify it's been unliked and dismiss was called
       #expect(!model.likesManager.isLiked(audioBlock.id))
@@ -183,7 +183,7 @@ struct SongDrawerTests {
   }
 
   @Test
-  func testRemoveFromLikedSongsWithOnRemoveCallback() async {
+  func testRemoveFromLikedSongsTappedWithOnRemoveCallback() async {
     let audioBlock = AudioBlock.mock
     var dismissCalled = false
     var onRemoveCalled = false
@@ -204,7 +204,7 @@ struct SongDrawerTests {
         }
       )
 
-      model.removeFromLikedSongs()
+      model.removeFromLikedSongsTapped()
 
       // Verify the onRemove callback was called with correct audio block
       #expect(onRemoveCalled, "Should call onRemove callback")

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
@@ -68,7 +68,7 @@ struct SongDrawerView: View {
                   .resizable()
                   .frame(width: 32, height: 32)
 
-                Text("Listen on Apple Music")
+                Text(model.appleMusicButtonLabel)
                   .font(.custom(FontNames.Inter_400_Regular, size: 16))
                   .foregroundColor(.white)
 
@@ -93,7 +93,7 @@ struct SongDrawerView: View {
                   .resizable()
                   .frame(width: 32, height: 32)
 
-                Text("Listen on Spotify")
+                Text(model.spotifyButtonLabel)
                   .font(.custom(FontNames.Inter_400_Regular, size: 16))
                   .foregroundColor(.white)
 
@@ -117,7 +117,7 @@ struct SongDrawerView: View {
                 .frame(width: 24, height: 24)
                 .foregroundColor(.white)
 
-              Text("Remove from Liked Songs")
+              Text(model.removeFromLikedSongsButtonLabel)
                 .font(.custom(FontNames.Inter_400_Regular, size: 16))
                 .foregroundColor(.white)
 

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
@@ -60,7 +60,7 @@ struct SongDrawerView: View {
         // Apple Music
         if model.shouldShowAppleMusic {
           Button(
-            action: { model.openAppleMusic() },
+            action: { model.appleMusicTapped() },
             label: {
               HStack(spacing: 16) {
                 // Replace with your branded asset if you have it
@@ -85,7 +85,7 @@ struct SongDrawerView: View {
         // Spotify
         if model.shouldShowSpotify {
           Button(
-            action: { model.openSpotify() },
+            action: { model.spotifyTapped() },
             label: {
               HStack(spacing: 16) {
                 // Replace with a Spotify glyph asset for perfect branding
@@ -109,7 +109,7 @@ struct SongDrawerView: View {
 
         // Remove from liked songs
         Button(
-          action: { model.removeFromLikedSongs() },
+          action: { model.removeFromLikedSongsTapped() },
           label: {
             HStack(spacing: 16) {
               Image(systemName: "xmark")

--- a/PlayolaRadioTests/Mocks/StationPlayerMock.swift
+++ b/PlayolaRadioTests/Mocks/StationPlayerMock.swift
@@ -18,7 +18,7 @@ class StationPlayerMock: StationPlayer {
     super.init(urlStreamPlayer: URLStreamPlayerMock())
   }
 
-  override public func play(station: AnyStation) {
+  override public func play(station: AnyStation) async {
     callsToPlay.append(station)
   }
 

--- a/scripts/bump-build.sh
+++ b/scripts/bump-build.sh
@@ -28,7 +28,7 @@ git fetch origin --tags --quiet
 PBXPROJ="PlayolaRadio.xcodeproj/project.pbxproj"
 
 current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
-current_build=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+current_build=$(grep 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ' | sort -n | tail -1)
 
 if [ -z "$current_version" ]; then
   echo "Error: could not detect MARKETING_VERSION from $PBXPROJ" >&2

--- a/scripts/bump-build.sh
+++ b/scripts/bump-build.sh
@@ -25,8 +25,21 @@ fi
 git fetch origin main develop --quiet
 git fetch origin --tags --quiet
 
-current_version=$(agvtool what-marketing-version -terse1 | head -1)
-current_build=$(agvtool what-version -terse | sort -n | tail -1)
+PBXPROJ="PlayolaRadio.xcodeproj/project.pbxproj"
+
+current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+current_build=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+
+if [ -z "$current_version" ]; then
+  echo "Error: could not detect MARKETING_VERSION from $PBXPROJ" >&2
+  exit 1
+fi
+
+if ! [[ "$current_build" =~ ^[0-9]+$ ]]; then
+  echo "Error: could not detect a numeric CURRENT_PROJECT_VERSION from $PBXPROJ (got '$current_build')" >&2
+  exit 1
+fi
+
 new_build=$((current_build + 1))
 
 last_tag=$(git describe --tags --abbrev=0 origin/main 2>/dev/null || echo "")

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -59,8 +59,18 @@ esac
 PBXPROJ="PlayolaRadio.xcodeproj/project.pbxproj"
 
 # Get current version info
-current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed 's/.*= //' | sed 's/;.*//' | tr -d ' ')
-current_build=$(agvtool what-version -terse | sort -n | tail -1)
+current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+current_build=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+
+if [ -z "$current_version" ]; then
+  echo "Error: could not detect MARKETING_VERSION from $PBXPROJ" >&2
+  exit 1
+fi
+
+if ! [[ "$current_build" =~ ^[0-9]+$ ]]; then
+  echo "Error: could not detect a numeric CURRENT_PROJECT_VERSION from $PBXPROJ (got '$current_build')" >&2
+  exit 1
+fi
 
 # Calculate new version
 IFS='.' read -r major minor patch <<< "$current_version"

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -60,7 +60,7 @@ PBXPROJ="PlayolaRadio.xcodeproj/project.pbxproj"
 
 # Get current version info
 current_version=$(grep -m1 'MARKETING_VERSION' "$PBXPROJ" | sed -E 's/.*MARKETING_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
-current_build=$(grep -m1 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ')
+current_build=$(grep 'CURRENT_PROJECT_VERSION' "$PBXPROJ" | sed -E 's/.*CURRENT_PROJECT_VERSION = ([^;]+);.*/\1/' | tr -d ' ' | sort -n | tail -1)
 
 if [ -z "$current_version" ]; then
   echo "Error: could not detect MARKETING_VERSION from $PBXPROJ" >&2


### PR DESCRIPTION
## Swift Testing Conversion - Hang Fix

### Changes
- #287: Fix: hang reading @Shared(.unreadSupportCount) on main thread
- #286: Standardize SongDrawerModel naming and init
- #285: Inject audio playback services as Dependencies
- #284: Tighten lifecycle on long-lived Combine subscriptions
- #283: Convert ListenerQuestionDetailPageTests to swift-testing
- #282: Inject Date and UUID dependencies in Core services
- #281: Convert auth/profile/recording page tests to swift-testing
- #280: Convert browse/playback page tests to swift-testing
- #279: Convert misc/components tests to swift-testing
- #278: Convert XCTest suites to swift-testing (Core, Models, Formatters)
- #277: Apply Point-Free observable model patterns to view models
- #276: Sync main to develop
- #271: Fix bump-build.sh version detection (don't rely on agvtool/Info.plist)

### Version
`6.2.0` (build `86`)