### PR TITLE
Fix greptile review issues from PR #288

### DIFF
--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -321,7 +321,7 @@ class NowPlayingUpdater {
   private func setupSharedStateObservation() {
     @Dependency(\.urlStreamPlayer) var urlStreamPlayer
 
-    PlayolaStationPlayer.shared.$state
+    stationPlayer.playolaStationPlayer.$state
       .sink { [weak self] playolaState in
         self?.processPlayolaStationPlayerState(playolaState)
       }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -329,6 +329,10 @@ class MainContainerModel: ViewModel {
       }
     }
   }
+
+  deinit {
+    toastObservationTask?.cancel()
+  }
 }
 
 extension PlayolaAlert {


### PR DESCRIPTION
## Summary
- Add `deinit` to `MainContainerModel` cancelling `toastObservationTask` so the non-terminating `toast.stream()` doesn't outlive the model in tests.
- Route `NowPlayingUpdater`'s `PlayolaStationPlayer` observation through the injected `StationPlayer.playolaStationPlayer` instead of the hardcoded `.shared` singleton, matching the surrounding DI pattern.

## Test plan
- [ ] `xcodebuild build` succeeds
- [ ] Existing MainContainer / NowPlayingUpdater tests pass