### PR TITLE
Address PR #295 review: inline preset loading/error states + race + view-logic + orphan analytics

### DIFF
--- a/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
@@ -69,7 +69,6 @@ struct PresetTile: View {
       startOrStopWiggle(active: isEditing)
     }
     .onLongPressGesture(minimumDuration: 0.5) {
-      guard !display.isPending else { return }
       onLongPress()
     }
     .onTapGesture {

--- a/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetsCarousel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetsCarousel.swift
@@ -12,11 +12,16 @@ struct PresetsCarousel: View {
   let emptyStateText: String
   let doneButtonText: String
   let isEditing: Bool
+  let isLoading: Bool
+  let hasLoadError: Bool
+  let loadErrorText: String
+  let retryButtonText: String
   let onTilePlay: (PresetDisplayItem) async -> Void
   let onTileLongPress: (PresetDisplayItem) -> Void
   let onTileRemove: (PresetDisplayItem) async -> Void
-  let onMove: (Int, Int) async -> Void
+  let onMove: (String, Int) async -> Void
   let onEditDoneTapped: () -> Void
+  let onRetryTapped: () async -> Void
 
   @State private var dragState: PresetDragState?
   @State private var tileFrames: [String: CGRect] = [:]
@@ -52,12 +57,62 @@ struct PresetsCarousel: View {
       }
       .padding(.horizontal, 16)
 
-      if displays.isEmpty {
+      if isLoading {
+        loadingState
+      } else if hasLoadError {
+        errorState
+      } else if displays.isEmpty {
         emptyState
       } else {
         tiles
       }
     }
+  }
+
+  private var loadingState: some View {
+    HStack {
+      Spacer()
+      ProgressView()
+        .progressViewStyle(.circular)
+        .tint(.white)
+      Spacer()
+    }
+    .frame(height: 92)
+    .padding(.horizontal, 16)
+  }
+
+  private var errorState: some View {
+    HStack(spacing: 16) {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .font(.system(size: 24))
+        .foregroundColor(Color(hex: "#EF6962"))
+      Text(loadErrorText)
+        .font(.custom(FontNames.Inter_400_Regular, size: 13))
+        .foregroundColor(Color(hex: "#AAAAAA"))
+        .lineLimit(2)
+      Spacer(minLength: 0)
+      Button {
+        Task { await onRetryTapped() }
+      } label: {
+        Text(retryButtonText)
+          .font(.custom(FontNames.Inter_500_Medium, size: 14))
+          .foregroundColor(.white)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 8)
+          .background(Color.playolaRed)
+          .cornerRadius(16)
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(16)
+    .overlay(
+      RoundedRectangle(cornerRadius: 10)
+        .strokeBorder(
+          Color(hex: "#333333"),
+          style: StrokeStyle(lineWidth: 1, dash: [4])
+        )
+    )
+    .padding(.horizontal, 16)
   }
 
   private var emptyState: some View {
@@ -336,7 +391,7 @@ struct PresetsCarousel: View {
     guard state.sourceIndex != state.destinationIndex else { return }
 
     Task {
-      await onMove(state.sourceIndex, state.destinationIndex)
+      await onMove(state.sourceId, state.destinationIndex)
     }
   }
 
@@ -542,11 +597,16 @@ private struct PresetTileFramePreferenceKey: PreferenceKey {
     emptyStateText: "Tap the ★ on any station to save it here.",
     doneButtonText: "Done",
     isEditing: false,
+    isLoading: false,
+    hasLoadError: false,
+    loadErrorText: "Couldn't load presets.",
+    retryButtonText: "Retry",
     onTilePlay: { _ in },
     onTileLongPress: { _ in },
     onTileRemove: { _ in },
     onMove: { _, _ in },
-    onEditDoneTapped: {}
+    onEditDoneTapped: {},
+    onRetryTapped: {}
   )
   .padding(.vertical)
   .background(Color.black)
@@ -560,11 +620,62 @@ private struct PresetTileFramePreferenceKey: PreferenceKey {
     emptyStateText: "Tap the ★ on any station to save it here.",
     doneButtonText: "Done",
     isEditing: false,
+    isLoading: false,
+    hasLoadError: false,
+    loadErrorText: "Couldn't load presets.",
+    retryButtonText: "Retry",
     onTilePlay: { _ in },
     onTileLongPress: { _ in },
     onTileRemove: { _ in },
     onMove: { _, _ in },
-    onEditDoneTapped: {}
+    onEditDoneTapped: {},
+    onRetryTapped: {}
+  )
+  .padding(.vertical)
+  .background(Color.black)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("Loading") {
+  PresetsCarousel(
+    displays: [],
+    sectionTitle: "Presets",
+    emptyStateText: "Tap the ★ on any station to save it here.",
+    doneButtonText: "Done",
+    isEditing: false,
+    isLoading: true,
+    hasLoadError: false,
+    loadErrorText: "Couldn't load presets.",
+    retryButtonText: "Retry",
+    onTilePlay: { _ in },
+    onTileLongPress: { _ in },
+    onTileRemove: { _ in },
+    onMove: { _, _ in },
+    onEditDoneTapped: {},
+    onRetryTapped: {}
+  )
+  .padding(.vertical)
+  .background(Color.black)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("Load Error") {
+  PresetsCarousel(
+    displays: [],
+    sectionTitle: "Presets",
+    emptyStateText: "Tap the ★ on any station to save it here.",
+    doneButtonText: "Done",
+    isEditing: false,
+    isLoading: false,
+    hasLoadError: true,
+    loadErrorText: "Couldn't load presets.",
+    retryButtonText: "Retry",
+    onTilePlay: { _ in },
+    onTileLongPress: { _ in },
+    onTileRemove: { _ in },
+    onMove: { _, _ in },
+    onEditDoneTapped: {},
+    onRetryTapped: {}
   )
   .padding(.vertical)
   .background(Color.black)

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -89,6 +89,8 @@ class StationListModel: ViewModel {
   var searchText = ""
   var presentedAlert: PlayolaAlert?
   var presetListState: PresetListState = .normal
+  var isLoadingPresets: Bool = false
+  var presetsLoadFailed: Bool = false
   let navigationTitle = "Radio Stations"
   let suggestArtistButtonText = "Suggest Station"
   let searchBarPlaceholder = "Search stations"
@@ -99,6 +101,8 @@ class StationListModel: ViewModel {
   let presetsSectionTitle = "Presets"
   let presetsEmptyStateText = "Tap the ★ on any station to save it here."
   let presetsEditDoneButtonText = "Done"
+  let presetsLoadErrorText = "Couldn't load presets."
+  let presetsRetryButtonText = "Retry"
 
   // MARK: - User Actions
 
@@ -191,25 +195,23 @@ class StationListModel: ViewModel {
   }
 
   // swiftlint:disable:next cyclomatic_complexity
-  func presetMoved(from: Int, to: Int) async {
+  func presetMoved(presetId: String, to: Int) async {
     guard presetListState == .editing else { return }
-    guard from != to else { return }
     guard let token = auth.jwt else { return }
+    guard presets[id: presetId] != nil else { return }
+
+    let displayIds = displayPresets.map(\.id)
+    guard let fromIndex = displayIds.firstIndex(of: presetId) else { return }
+    guard fromIndex != to else { return }
 
     let snapshot: [String: Int] = Dictionary(
       uniqueKeysWithValues: presets.map { ($0.id, $0.position) })
 
-    let displayIds = displayPresets.map(\.id)
-    guard from >= 0, from < displayIds.count, to >= 0, to < displayIds.count
-    else { return }
-    let movedId = displayIds[from]
-    guard presets[id: movedId] != nil else { return }
-
     var orderedIds = displayIds.filter { presets[id: $0] != nil }
-    guard let oldIndex = orderedIds.firstIndex(of: movedId) else { return }
+    guard let oldIndex = orderedIds.firstIndex(of: presetId) else { return }
     orderedIds.remove(at: oldIndex)
     let clampedTo = min(max(0, to), orderedIds.count)
-    orderedIds.insert(movedId, at: clampedTo)
+    orderedIds.insert(presetId, at: clampedTo)
 
     $presets.withLock { collection in
       for (index, id) in orderedIds.enumerated() {
@@ -221,15 +223,16 @@ class StationListModel: ViewModel {
     }
 
     let movedStationInfo: StationInfo? = {
-      guard let item = displayPresets.first(where: { $0.id == movedId })?.stationItem
+      guard let item = displayPresets.first(where: { $0.id == presetId })?.stationItem
       else { return nil }
       return StationInfo(from: item.anyStation)
     }()
 
     do {
-      _ = try await api.movePreset(token, movedId, clampedTo)
+      _ = try await api.movePreset(token, presetId, clampedTo)
       if let info = movedStationInfo {
-        await analytics.track(.presetMoved(station: info, fromIndex: from, toIndex: clampedTo))
+        await analytics.track(
+          .presetMoved(station: info, fromIndex: fromIndex, toIndex: clampedTo))
       }
     } catch {
       $presets.withLock { collection in
@@ -242,8 +245,8 @@ class StationListModel: ViewModel {
       }
       await reportPresetError(
         error,
-        endpoint: "PUT /v1/presets/\(movedId)",
-        extraTags: ["preset_id": movedId])
+        endpoint: "PUT /v1/presets/\(presetId)",
+        extraTags: ["preset_id": presetId])
       presentedAlert = .errorMovingPreset
     }
   }
@@ -270,12 +273,10 @@ class StationListModel: ViewModel {
     else { return }
 
     let allItems = stationLists.flatMap { $0.stationItems(includeHidden: showSecretStations) }
-    let stationInfo: StationInfo
-    if let item = allItems.first(where: { $0.anyStation.id == preset.embeddedStationId }) {
-      stationInfo = StationInfo(from: item.anyStation)
-    } else {
-      stationInfo = StationInfo(from: .playola(Station.mockWith(id: preset.embeddedStationId)))
-    }
+    let stationInfo: StationInfo? =
+      allItems
+      .first(where: { $0.anyStation.id == preset.embeddedStationId })
+      .map { StationInfo(from: $0.anyStation) }
 
     await removePreset(presetId: preset.id, stationInfo: stationInfo)
   }
@@ -461,12 +462,12 @@ class StationListModel: ViewModel {
     }
   }
 
-  private func removePreset(presetId: String, stationInfo: StationInfo) async {
+  private func removePreset(presetId: String, stationInfo: StationInfo?) async {
     guard let token = auth.jwt else { return }
-    let stationId = stationInfo.id
+    guard let presetSnapshot = presets[id: presetId] else { return }
+    let stationId = presetSnapshot.embeddedStationId
     if pendingPresetRemovalStationIds.contains(stationId) { return }
 
-    guard let presetSnapshot = presets[id: presetId] else { return }
     let positionsSnapshot: [String: Int] = Dictionary(
       uniqueKeysWithValues: presets.map { ($0.id, $0.position) })
 
@@ -482,7 +483,9 @@ class StationListModel: ViewModel {
     do {
       try await api.deletePreset(token, presetId)
       $pendingPresetRemovalStationIds.withLock { $0.remove(stationId) }
-      await analytics.track(.presetRemoved(station: stationInfo))
+      if let stationInfo {
+        await analytics.track(.presetRemoved(station: stationInfo))
+      }
     } catch {
       $pendingPresetRemovalStationIds.withLock { $0.remove(stationId) }
       $presets.withLock { collection in
@@ -502,14 +505,21 @@ class StationListModel: ViewModel {
     }
   }
 
+  func retryLoadPresetsTapped() async {
+    await loadPresets()
+  }
+
   private func loadPresets() async {
     guard let token = auth.jwt else { return }
+    isLoadingPresets = true
+    defer { isLoadingPresets = false }
     do {
       let fetched = try await api.getPresets(token)
       $presets.withLock { $0 = IdentifiedArray(uniqueElements: fetched) }
+      presetsLoadFailed = false
     } catch {
+      presetsLoadFailed = true
       await reportPresetError(error, endpoint: "GET /v1/presets")
-      presentedAlert = .errorLoadingPresets
     }
   }
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -289,6 +289,10 @@ class StationListModel: ViewModel {
     if presetListState == .editing { presetListState = .normal }
   }
 
+  func retryLoadPresetsTapped() async {
+    await loadPresets()
+  }
+
   func stationSelected(_ item: APIStationItem) async {
     if item.visibility == .comingSoon && showSecretStations == false {
       return
@@ -503,10 +507,6 @@ class StationListModel: ViewModel {
         extraTags: ["preset_id": presetId])
       presentedAlert = .errorRemovingPreset
     }
-  }
-
-  func retryLoadPresetsTapped() async {
-    await loadPresets()
   }
 
   private func loadPresets() async {

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -106,11 +106,16 @@ struct StationListPage: View {
                 emptyStateText: model.presetsEmptyStateText,
                 doneButtonText: model.presetsEditDoneButtonText,
                 isEditing: model.isEditingPresets,
+                isLoading: model.isLoadingPresets,
+                hasLoadError: model.presetsLoadFailed,
+                loadErrorText: model.presetsLoadErrorText,
+                retryButtonText: model.presetsRetryButtonText,
                 onTilePlay: { display in await model.presetTileTapped(display) },
                 onTileLongPress: { display in model.presetTileLongPressed(display) },
                 onTileRemove: { display in await model.presetRemoveTapped(display) },
-                onMove: { from, to in await model.presetMoved(from: from, to: to) },
-                onEditDoneTapped: { model.presetsEditDoneTapped() }
+                onMove: { presetId, to in await model.presetMoved(presetId: presetId, to: to) },
+                onEditDoneTapped: { model.presetsEditDoneTapped() },
+                onRetryTapped: { await model.retryLoadPresetsTapped() }
               )
             }
             ForEach(model.stationListsForDisplay) { list in

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
@@ -88,14 +88,7 @@ struct StationListPresetTests {
   @Test
   func testDisplayPresetsOrdersByPosition() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station1 = Station.mockWith(id: "s1", name: "S1")
-    let station2 = Station.mockWith(id: "s2", name: "S2")
-    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(sortOrder: 0, visibility: .visible, station: station1, urlStation: nil),
-        APIStationItem(sortOrder: 1, visibility: .visible, station: station2, urlStation: nil),
-      ])
-    ]
+    @Shared(.stationLists) var stationLists = presetStationLists("s1", "s2")
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
       Preset.mockPlayola(id: "p2", stationId: "s2", position: 1),
       Preset.mockPlayola(id: "p1", stationId: "s1", position: 0),
@@ -111,12 +104,7 @@ struct StationListPresetTests {
   @Test
   func testDisplayPresetsFiltersOrphans() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station1 = Station.mockWith(id: "s1", name: "S1")
-    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(sortOrder: 0, visibility: .visible, station: station1, urlStation: nil)
-      ])
-    ]
+    @Shared(.stationLists) var stationLists = presetStationLists("s1")
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
       Preset.mockPlayola(id: "p1", stationId: "s1", position: 0),
       Preset.mockPlayola(id: "p-orphan", stationId: "gone", position: 1),
@@ -286,14 +274,7 @@ struct StationListPresetTests {
   @Test
   func testDisplayPresetsAppendsPendingAddAsGhostTile() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station1 = Station.mockWith(id: "s1", name: "S1")
-    let station2 = Station.mockWith(id: "s2", name: "S2")
-    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(sortOrder: 0, visibility: .visible, station: station1, urlStation: nil),
-        APIStationItem(sortOrder: 1, visibility: .visible, station: station2, urlStation: nil),
-      ])
-    ]
+    @Shared(.stationLists) var stationLists = presetStationLists("s1", "s2")
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
       Preset.mockPlayola(id: "p1", stationId: "s1", position: 0)
     ]
@@ -433,17 +414,7 @@ struct StationListPresetTests {
     let p3 = Preset.mockPlayola(id: "p3", stationId: "s3", position: 2)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [p1, p2, p3]
 
-    let stationLists = IdentifiedArrayOf<StationList>(uniqueElements: [
-      makePresetTestList(with: [
-        APIStationItem(
-          sortOrder: 0, visibility: .visible, station: Station.mockWith(id: "s1"), urlStation: nil),
-        APIStationItem(
-          sortOrder: 1, visibility: .visible, station: Station.mockWith(id: "s2"), urlStation: nil),
-        APIStationItem(
-          sortOrder: 2, visibility: .visible, station: Station.mockWith(id: "s3"), urlStation: nil),
-      ])
-    ])
-    @Shared(.stationLists) var sharedLists = stationLists
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1", "s2", "s3")
 
     let capturedToken = LockIsolated<String?>(nil)
     let capturedPresetId = LockIsolated<String?>(nil)
@@ -460,7 +431,7 @@ struct StationListPresetTests {
     }
     model.presetListState = .editing
 
-    await model.presetMoved(from: 0, to: 2)
+    await model.presetMoved(presetId: "p1", to: 2)
 
     let ordered = presets.sorted { $0.position < $1.position }
     expectNoDifference(
@@ -490,8 +461,9 @@ struct StationListPresetTests {
     } operation: {
       StationListModel()
     }
+    model.presetListState = .editing
 
-    await model.presetMoved(from: 0, to: 0)
+    await model.presetMoved(presetId: "p1", to: 0)
 
     #expect(callCount.value == 0)
   }
@@ -503,15 +475,7 @@ struct StationListPresetTests {
     let p2 = Preset.mockPlayola(id: "p2", stationId: "s2", position: 1)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [p1, p2]
 
-    let stationLists = IdentifiedArrayOf<StationList>(uniqueElements: [
-      makePresetTestList(with: [
-        APIStationItem(
-          sortOrder: 0, visibility: .visible, station: Station.mockWith(id: "s1"), urlStation: nil),
-        APIStationItem(
-          sortOrder: 1, visibility: .visible, station: Station.mockWith(id: "s2"), urlStation: nil),
-      ])
-    ])
-    @Shared(.stationLists) var sharedLists = stationLists
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1", "s2")
 
     let model = withDependencies {
       $0.api.movePreset = { _, _, _ in throw APIError.validationError("nope") }
@@ -522,7 +486,7 @@ struct StationListPresetTests {
     }
     model.presetListState = .editing
 
-    await model.presetMoved(from: 0, to: 1)
+    await model.presetMoved(presetId: "p1", to: 1)
 
     let ordered = presets.sorted { $0.position < $1.position }
     expectNoDifference(ordered, [p1, p2])
@@ -534,13 +498,8 @@ struct StationListPresetTests {
   @Test
   func testPresetTileTappedPlaysStation() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station = Station.mockWith(id: "s1", name: "S1")
-    let item = APIStationItem(
-      sortOrder: 0, visibility: .visible, station: station, urlStation: nil)
-    let stationLists = IdentifiedArrayOf<StationList>(uniqueElements: [
-      makePresetTestList(with: [item])
-    ])
-    @Shared(.stationLists) var sharedLists = stationLists
+    let item = presetItem("s1")
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1")
 
     let display = PresetDisplayItem(id: "p1", stationItem: item, isPending: false)
 
@@ -553,7 +512,7 @@ struct StationListPresetTests {
     } operation: {
       StationListModel()
     }
-    model.stationListsForDisplay = stationLists
+    model.stationListsForDisplay = sharedLists
 
     await model.presetTileTapped(display)
 
@@ -628,13 +587,8 @@ struct StationListPresetTests {
   @Test
   func testPresetTileTappedNoOpInEditMode() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station = Station.mockWith(id: "s1", name: "S1")
-    let item = APIStationItem(
-      sortOrder: 0, visibility: .visible, station: station, urlStation: nil)
-    let stationLists = IdentifiedArrayOf<StationList>(uniqueElements: [
-      makePresetTestList(with: [item])
-    ])
-    @Shared(.stationLists) var sharedLists = stationLists
+    let item = presetItem("s1")
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1")
 
     let display = PresetDisplayItem(id: "p1", stationItem: item, isPending: false)
 
@@ -715,7 +669,7 @@ struct StationListPresetTests {
     }
 
     #expect(model.presetListState == .normal)
-    await model.presetMoved(from: 0, to: 1)
+    await model.presetMoved(presetId: "p1", to: 1)
 
     #expect(callCount.value == 0)
   }
@@ -831,7 +785,7 @@ struct StationListPresetTests {
   }
 
   @Test
-  func testLoadPresetsFailureReportsErrorWithoutMutatingPresets() async {
+  func testLoadPresetsFailureReportsErrorAndSetsLoadFailedWithoutAlert() async {
     @Shared(.auth) var auth = signedInAuth()
     let existing = Preset.mockPlayola(id: "p1", stationId: "s1", position: 0)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [existing]
@@ -849,6 +803,79 @@ struct StationListPresetTests {
 
     expectNoDifference(Array(presets), [existing])
     #expect(reportedTags.value["endpoint"] == "GET /v1/presets")
+    #expect(model.presetsLoadFailed)
+    #expect(!model.isLoadingPresets)
+    #expect(model.presentedAlert?.title != "Couldn't Load Presets")
+  }
+
+  @Test
+  func testLoadPresetsSuccessClearsLoadFailedFlag() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+
+    let model = withDependencies {
+      $0.api.getPresets = { _ in [Preset.mockPlayola(id: "p1")] }
+    } operation: {
+      StationListModel()
+    }
+    model.presetsLoadFailed = true
+
+    await model.retryLoadPresetsTapped()
+
+    #expect(!model.presetsLoadFailed)
+    #expect(!model.isLoadingPresets)
+    expectNoDifference(Array(presets), [Preset.mockPlayola(id: "p1")])
+  }
+
+  @Test
+  func testRetryLoadPresetsTappedCallsApi() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+
+    let callCount = LockIsolated(0)
+    let model = withDependencies {
+      $0.api.getPresets = { _ in
+        callCount.setValue(callCount.value + 1)
+        return []
+      }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.retryLoadPresetsTapped()
+
+    #expect(callCount.value == 1)
+  }
+
+  @Test
+  func testIsLoadingPresetsTrueWhileFetchInFlight() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+
+    let releaser = LockIsolated<CheckedContinuation<Void, Never>?>(nil)
+    let started = LockIsolated(false)
+
+    let model = withDependencies {
+      $0.api.getPresets = { _ in
+        await withCheckedContinuation { cont in
+          releaser.setValue(cont)
+          started.setValue(true)
+        }
+        return []
+      }
+    } operation: {
+      StationListModel()
+    }
+
+    let task = Task { await model.retryLoadPresetsTapped() }
+
+    while !started.value { await Task.yield() }
+    #expect(model.isLoadingPresets)
+
+    releaser.value?.resume()
+    await task.value
+
+    #expect(!model.isLoadingPresets)
   }
 
   // MARK: - presetMoved Analytics
@@ -860,14 +887,7 @@ struct StationListPresetTests {
     let p2 = Preset.mockPlayola(id: "p2", stationId: "s2", position: 1)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [p1, p2]
 
-    @Shared(.stationLists) var sharedLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(
-          sortOrder: 0, visibility: .visible, station: Station.mockWith(id: "s1"), urlStation: nil),
-        APIStationItem(
-          sortOrder: 1, visibility: .visible, station: Station.mockWith(id: "s2"), urlStation: nil),
-      ])
-    ]
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1", "s2")
 
     let captured = LockIsolated<[AnalyticsEvent]>([])
     let model = withDependencies {
@@ -880,7 +900,7 @@ struct StationListPresetTests {
     }
     model.presetListState = .editing
 
-    await model.presetMoved(from: 0, to: 1)
+    await model.presetMoved(presetId: "p1", to: 1)
 
     let moved = captured.value.contains {
       if case .presetMoved(_, let fromIndex, let toIndex) = $0, fromIndex == 0, toIndex == 1 {
@@ -896,12 +916,7 @@ struct StationListPresetTests {
   @Test
   func testDisplayPresetsFiltersPendingThatAlreadyExistsAsRealPreset() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station1 = Station.mockWith(id: "s1", name: "S1")
-    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(sortOrder: 0, visibility: .visible, station: station1, urlStation: nil)
-      ])
-    ]
+    @Shared(.stationLists) var stationLists = presetStationLists("s1")
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
       Preset.mockPlayola(id: "p1", stationId: "s1", position: 0)
     ]
@@ -912,26 +927,23 @@ struct StationListPresetTests {
     expectNoDifference(model.displayPresets.map(\.id), ["p1"])
   }
 
-  // MARK: - presetRemoveTapped Orphan Fallback
+  // MARK: - presetRemoveTapped Orphan Handling
 
   @Test
-  func testPresetRemoveTappedFallsBackForOrphanStation() async {
+  func testPresetRemoveTappedDeletesOrphanPresetWithoutFiringRemovedAnalytics() async {
     @Shared(.auth) var auth = signedInAuth()
     let orphanPreset = Preset.mockPlayola(id: "p1", stationId: "missing-s", position: 0)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [orphanPreset]
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
 
-    let orphanItem = APIStationItem(
-      sortOrder: 0,
-      visibility: .visible,
-      station: Station.mockWith(id: "missing-s"),
-      urlStation: nil)
-    let display = PresetDisplayItem(id: "p1", stationItem: orphanItem, isPending: false)
+    let display = PresetDisplayItem(
+      id: "p1", stationItem: presetItem("missing-s"), isPending: false)
 
     let capturedPresetId = LockIsolated<String?>(nil)
+    let trackedEvents = LockIsolated<[AnalyticsEvent]>([])
     let model = withDependencies {
       $0.api.deletePreset = { _, presetId in capturedPresetId.setValue(presetId) }
-      $0.analytics.track = { _ in }
+      $0.analytics.track = { event in trackedEvents.withValue { $0.append(event) } }
     } operation: {
       StationListModel()
     }
@@ -940,6 +952,11 @@ struct StationListPresetTests {
 
     #expect(capturedPresetId.value == "p1")
     #expect(presets.isEmpty)
+    let firedRemoved = trackedEvents.value.contains {
+      if case .presetRemoved = $0 { return true }
+      return false
+    }
+    #expect(!firedRemoved)
   }
 }
 
@@ -951,29 +968,31 @@ private func signedInAuth() -> Auth {
     jwt: "t")
 }
 
+private func presetItem(_ stationId: String, sortOrder: Int = 0) -> APIStationItem {
+  APIStationItem(
+    sortOrder: sortOrder, visibility: .visible,
+    station: Station.mockWith(id: stationId), urlStation: nil)
+}
+
+private func presetStationLists(_ stationIds: String...) -> IdentifiedArrayOf<StationList> {
+  IdentifiedArrayOf(uniqueElements: [
+    makePresetTestList(with: stationIds.enumerated().map { presetItem($1, sortOrder: $0) })
+  ])
+}
+
 private func makePresetTestList(with items: [APIStationItem], date: Date = Date()) -> StationList {
   StationList(
-    id: "preset-test-list",
-    name: "Test List",
-    slug: "preset-test-list",
-    hidden: false,
-    sortOrder: 0,
-    createdAt: date,
-    updatedAt: date,
-    items: items
-  )
+    id: "preset-test-list", name: "Test List", slug: "preset-test-list",
+    hidden: false, sortOrder: 0, createdAt: date, updatedAt: date, items: items)
 }
 
 private func makePresetVisibleItem(date: Date = Date()) -> APIStationItem {
-  let station = PlayolaPlayer.Station(
-    id: "playable-station",
-    name: "Moondog Radio",
-    curatorName: "Jacob Stelly",
-    imageUrl: URL(string: "https://example.com/moondog.png"),
-    description: "A playable station",
-    active: true,
-    createdAt: date,
-    updatedAt: date
-  )
-  return APIStationItem(sortOrder: 0, visibility: .visible, station: station, urlStation: nil)
+  APIStationItem(
+    sortOrder: 0,
+    visibility: .visible,
+    station: PlayolaPlayer.Station(
+      id: "playable-station", name: "Moondog Radio", curatorName: "Jacob Stelly",
+      imageUrl: URL(string: "https://example.com/moondog.png"),
+      description: "A playable station", active: true, createdAt: date, updatedAt: date),
+    urlStation: nil)
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
@@ -849,33 +849,31 @@ struct StationListPresetTests {
 
   @Test
   func testIsLoadingPresetsTrueWhileFetchInFlight() async {
-    @Shared(.auth) var auth = signedInAuth()
-    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = signedInAuth()
+      @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
 
-    let releaser = LockIsolated<CheckedContinuation<Void, Never>?>(nil)
-    let started = LockIsolated(false)
+      let releaser = LockIsolated<CheckedContinuation<Void, Never>?>(nil)
 
-    let model = withDependencies {
-      $0.api.getPresets = { _ in
-        await withCheckedContinuation { cont in
-          releaser.setValue(cont)
-          started.setValue(true)
+      let model = withDependencies {
+        $0.api.getPresets = { _ in
+          await withCheckedContinuation { releaser.setValue($0) }
+          return []
         }
-        return []
+      } operation: {
+        StationListModel()
       }
-    } operation: {
-      StationListModel()
+
+      let task = Task { await model.retryLoadPresetsTapped() }
+      await Task.yield()
+
+      #expect(model.isLoadingPresets)
+
+      releaser.value?.resume()
+      await task.value
+
+      #expect(!model.isLoadingPresets)
     }
-
-    let task = Task { await model.retryLoadPresetsTapped() }
-
-    while !started.value { await Task.yield() }
-    #expect(model.isLoadingPresets)
-
-    releaser.value?.resume()
-    await task.value
-
-    #expect(!model.isLoadingPresets)
   }
 
   // MARK: - presetMoved Analytics

--- a/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
@@ -255,13 +255,6 @@ extension PlayolaAlert {
       dismissButton: .cancel(Text("OK")))
   }
 
-  static var errorLoadingPresets: PlayolaAlert {
-    PlayolaAlert(
-      title: "Couldn't Load Presets",
-      message: "Pull to refresh or try again later.",
-      dismissButton: .cancel(Text("OK")))
-  }
-
   static func errorSavingPreset(_ serverMessage: String? = nil) -> PlayolaAlert {
     let message: String
     if let serverMessage, !serverMessage.isEmpty {


### PR DESCRIPTION
Addresses the four issues raised in [#295](https://github.com/playola-radio/playola-radio-ios/pull/295).

## Summary

- **Loading + error UX for `loadPresets`** — replaces the screen-blocking `.errorLoadingPresets` alert with inline states in `PresetsCarousel`: a `ProgressView` while loading, and a "Couldn't load presets." card with a Retry button on failure. Sentry/analytics reporting via `reportPresetError` is preserved on every failure path.
- **`presetMoved` race fix** — function now takes `presetId: String` rather than a display-index `from`. The previous version could resolve the wrong preset if a `loadPresets` response reordered `displayPresets` between drag-end (where indices were captured) and the start of `presetMoved`. The `from` for analytics is now derived from the preset's current display position at call time.
- **No view logic in `PresetTile`** — removes the duplicate `guard !display.isPending` from `.onLongPressGesture`; the model's `presetTileLongPressed` already enforces it.
- **Orphan-preset analytics** — `presetRemoveTapped` no longer falls back to `Station.mockWith(id:)` when the station has been removed from `stationLists`. Instead it passes `nil` `StationInfo` to `removePreset`, which skips the `.presetRemoved` event entirely so analytics aren't polluted with synthetic station names/curators. The DELETE still runs.

## Notes

- DRYed up `StationListPresetTests.swift` with two helpers (`presetItem`, `presetStationLists`) to stay under the 1000-line SwiftLint cap after adding the new loading/error/retry coverage.
- The new `PresetsCarousel` API picks up `isLoading`, `hasLoadError`, `loadErrorText`, `retryButtonText`, and `onRetryTapped`; previews updated for all three states.

## Test plan

- [x] `xcodebuild test` for `StationListPresetTests` (44 tests, all pass)
- [x] `xcodebuild test` for `StationListPageTests` and `StationListStationRowTests` (all pass)
- [x] `make lint` (0 violations)
- [x] swift-format check (0 violations; pre-commit hook ran on commit)
- [ ] Manual: cold-launch shows spinner instead of empty-state flash
- [ ] Manual: airplane-mode → app shows inline error with Retry; Retry succeeds when re-enabled
- [ ] Manual: long-press → drag-reorder still works and reports to server