### PR TITLE
Fix preset Coming Soon label to respect showSecretStations

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		D3137DC02D39818E0070033A /* MailServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBF2D3981880070033A /* MailServiceMock.swift */; };
 		D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DC12D39B4FC0070033A /* StationListPageTests.swift */; };
 		76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */; };
 		BFF0E48BF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
 		BFF0E48CF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
 		BFF0E49EF7714364A04B11B4 /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
@@ -466,6 +467,7 @@
 		D3137DBF2D3981880070033A /* MailServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailServiceMock.swift; sourceTree = "<group>"; };
 		D3137DC12D39B4FC0070033A /* StationListPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPageTests.swift; sourceTree = "<group>"; };
 		BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetTests.swift; sourceTree = "<group>"; };
+		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
 		BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetStarButton.swift; sourceTree = "<group>"; };
 		BFF0E49DF7714364A04B11B3 /* PresetTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTile.swift; sourceTree = "<group>"; };
 		BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsCarousel.swift; sourceTree = "<group>"; };
@@ -792,6 +794,7 @@
 				D339E5662BFD10AE00B9E35B /* StationListPage.swift */,
 				D3137DC12D39B4FC0070033A /* StationListPageTests.swift */,
 				BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */,
+				A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */,
 				BFF0E48DF7714364A04B11B2 /* Presets */,
 			);
 			path = StationListPage;
@@ -2086,6 +2089,7 @@
 				D3C7E5E32EF0A44D00EDD3ED /* SongSearchPageTests.swift in Sources */,
 				D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */,
 				76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */,
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */,
 				D30F00BF2E87196A007BCC73 /* StationListStationRowTests.swift in Sources */,
 				D395912D2E3D1E1E00720CF8 /* EditProfilePageTests.swift in Sources */,
 				D34D5C392D7106CD00148048 /* AuthServiceMock.swift in Sources */,

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -23,7 +23,9 @@ struct PresetDisplayItem: Identifiable {
   let accessibilityLabel: String
   let removeAccessibilityLabel: String
 
-  init(id: String, stationItem: APIStationItem, isPending: Bool) {
+  init(
+    id: String, stationItem: APIStationItem, isPending: Bool, showSecretStations: Bool = false
+  ) {
     self.id = id
     self.stationItem = stationItem
     self.isPending = isPending
@@ -35,8 +37,9 @@ struct PresetDisplayItem: Identifiable {
     self.accessibilityLabel = "Preset: \(title)"
     self.removeAccessibilityLabel = "Remove \(title) from presets"
 
-    let isComingSoon = stationItem.visibility == .comingSoon || !station.active
-    if isComingSoon {
+    let isInactive = !station.active
+    let isComingSoonAndHidden = stationItem.visibility == .comingSoon && !showSecretStations
+    if isInactive || isComingSoonAndHidden {
       self.subtitleText = "Coming Soon"
       self.subtitleColor = Color.playolaRed
     } else {
@@ -350,7 +353,9 @@ class StationListModel: ViewModel {
       .compactMap { preset in
         guard let item = allItems.first(where: { $0.anyStation.id == preset.embeddedStationId })
         else { return nil }
-        return PresetDisplayItem(id: preset.id, stationItem: item, isPending: false)
+        return PresetDisplayItem(
+          id: preset.id, stationItem: item, isPending: false,
+          showSecretStations: showSecretStations)
       }
 
     let realStationIds = Set(presets.map { $0.embeddedStationId })
@@ -363,7 +368,8 @@ class StationListModel: ViewModel {
         return PresetDisplayItem(
           id: "pending-\(stationId)",
           stationItem: item,
-          isPending: true
+          isPending: true,
+          showSecretStations: showSecretStations
         )
       }
       .sorted { $0.id < $1.id }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetComingSoonTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetComingSoonTests.swift
@@ -1,0 +1,55 @@
+//
+//  StationListPresetComingSoonTests.swift
+//  PlayolaRadio
+//
+
+import Foundation
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct StationListPresetComingSoonTests {
+
+  @Test
+  func testDisplayPresetsHidesComingSoonWhenSecretStationsUnlocked() async {
+    @Shared(.showSecretStations) var showSecretStations = true
+    let item = APIStationItem(
+      sortOrder: 0, visibility: .comingSoon,
+      station: Station.mockWith(id: "s1"), urlStation: nil)
+    #expect(presetSubtitle(for: item) == nil)
+  }
+
+  @Test
+  func testDisplayPresetsShowsComingSoonWhenSecretStationsHidden() async {
+    @Shared(.showSecretStations) var showSecretStations = false
+    let item = APIStationItem(
+      sortOrder: 0, visibility: .comingSoon,
+      station: Station.mockWith(id: "s1"), urlStation: nil)
+    #expect(presetSubtitle(for: item) == "Coming Soon")
+  }
+
+  @Test
+  func testDisplayPresetsShowsComingSoonForInactiveStationEvenWhenSecretStationsUnlocked() async {
+    @Shared(.showSecretStations) var showSecretStations = true
+    let item = APIStationItem(
+      sortOrder: 0, visibility: .visible,
+      station: Station.mockWith(id: "s1", active: false), urlStation: nil)
+    #expect(presetSubtitle(for: item) == "Coming Soon")
+  }
+
+  private func presetSubtitle(for item: APIStationItem) -> String? {
+    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
+      StationList(
+        id: "preset-test-list", name: "Test List", slug: "preset-test-list",
+        hidden: false, sortOrder: 0, createdAt: Date(), updatedAt: Date(), items: [item])
+    ]
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
+      Preset.mockPlayola(id: "p1", stationId: item.anyStation.id, position: 0)
+    ]
+    return StationListModel().displayPresets.first?.subtitleText
+  }
+}


### PR DESCRIPTION
## Summary
`PresetDisplayItem` was showing "Coming Soon" any time a station's visibility was `.comingSoon`, even when the user had secret stations unlocked — diverging from the rest of the station list which uses `.comingSoon && !showSecretStations`. This change mirrors `StationListStationRowModel`'s gating logic so presets behave the same. Inactive stations still always show "Coming Soon".

## Test plan
- [ ] Run `StationListPresetComingSoonTests` in Xcode
- [ ] Toggle secret stations on/off in the app and confirm the Coming Soon label hides/shows on preset tiles to match the station list rows