### PR TITLE
Preserve transport errors in APIClient instead of collapsing to dataNotValid

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		D3137DC02D39818E0070033A /* MailServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBF2D3981880070033A /* MailServiceMock.swift */; };
 		D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DC12D39B4FC0070033A /* StationListPageTests.swift */; };
 		76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */; };
+		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */; };
 		BFF0E48BF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
 		BFF0E48CF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
@@ -467,6 +468,7 @@
 		D3137DBF2D3981880070033A /* MailServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailServiceMock.swift; sourceTree = "<group>"; };
 		D3137DC12D39B4FC0070033A /* StationListPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPageTests.swift; sourceTree = "<group>"; };
 		BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetTests.swift; sourceTree = "<group>"; };
+		FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetErrorReportingTests.swift; sourceTree = "<group>"; };
 		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
 		BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetStarButton.swift; sourceTree = "<group>"; };
 		BFF0E49DF7714364A04B11B3 /* PresetTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTile.swift; sourceTree = "<group>"; };
@@ -794,6 +796,7 @@
 				D339E5662BFD10AE00B9E35B /* StationListPage.swift */,
 				D3137DC12D39B4FC0070033A /* StationListPageTests.swift */,
 				BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */,
+				FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */,
 				A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */,
 				BFF0E48DF7714364A04B11B2 /* Presets */,
 			);
@@ -2089,6 +2092,7 @@
 				D3C7E5E32EF0A44D00EDD3ED /* SongSearchPageTests.swift in Sources */,
 				D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */,
 				76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */,
+				FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */,
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */,
 				D30F00BF2E87196A007BCC73 /* StationListStationRowTests.swift in Sources */,
 				D395912D2E3D1E1E00720CF8 /* EditProfilePageTests.swift in Sources */,

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -117,6 +117,16 @@ private func signInPost(
   }
 }
 
+// When a manual `serializingData`/`serializingDecodable` request completes without a usable
+// HTTP response, prefer the underlying transport error (e.g. NSURLErrorSecureConnectionFailed
+// -1200 from the iOS 26 TLS middlebox issue) over a generic `dataNotValid`. The real
+// `NSURLError` code is what `NetworkErrorClassifier` needs to recognize the network failure and
+// keep it out of Sentry — and to surface the real code when it is reported.
+private func transportFailure(_ underlying: AFError?) -> Error {
+  if let underlying { return underlying }
+  return APIError.dataNotValid
+}
+
 private func authenticatedGet<T: Decodable & Sendable>(
   path: String,
   token: String,
@@ -324,7 +334,7 @@ extension APIClient: DependencyKey {
         guard
           let body = dataResponse.value
         else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         let newToken = dataResponse.response?.headers["X-New-Access-Token"] ?? jwtToken
@@ -409,7 +419,7 @@ extension APIClient: DependencyKey {
         .response
 
         guard let statusCode = dataResponse.response?.statusCode else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         guard let data = dataResponse.value else {
@@ -444,7 +454,7 @@ extension APIClient: DependencyKey {
         .response
 
         guard let statusCode = dataResponse.response?.statusCode else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         guard let data = dataResponse.value else {
@@ -487,7 +497,7 @@ extension APIClient: DependencyKey {
         .response
 
         guard let statusCode = dataResponse.response?.statusCode else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         guard let data = dataResponse.value else {
@@ -547,7 +557,7 @@ extension APIClient: DependencyKey {
         .response
 
         guard let statusCode = dataResponse.response?.statusCode else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         guard let data = dataResponse.value else {
@@ -601,7 +611,7 @@ extension APIClient: DependencyKey {
 
         guard let statusCode = dataResponse.response?.statusCode,
           let data = dataResponse.value
-        else { throw APIError.dataNotValid }
+        else { throw transportFailure(dataResponse.error) }
 
         if (200..<300).contains(statusCode) {
           return try sharedIsoDecoder.decode(Preset.self, from: data)

--- a/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
+++ b/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
@@ -127,6 +127,17 @@ enum NetworkErrorClassifier {
     nsURLErrorCodes(in: error).contains(NSURLErrorSecureConnectionFailed)
   }
 
+  /// Domain/code tags for the most relevant error in the chain, preferring an
+  /// `NSURLError` so transport failures surface their real code (e.g. -1200) in Sentry
+  /// rather than an opaque wrapper like `APIError.dataNotValid`.
+  static func errorTags(for error: Error) -> [String: String] {
+    let nsError = walkErrors(error).first { $0.domain == NSURLErrorDomain } ?? error as NSError
+    return [
+      "error_domain": nsError.domain,
+      "error_code": "\(nsError.code)",
+    ]
+  }
+
   private static func nsURLErrorCodes(in error: Error) -> [Int] {
     walkErrors(error).compactMap { $0.domain == NSURLErrorDomain ? $0.code : nil }
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -433,6 +433,7 @@ class StationListModel: ViewModel {
     if !NetworkErrorClassifier.isNetworkError(error) {
       var tags = extraTags
       tags["endpoint"] = endpoint
+      tags.merge(NetworkErrorClassifier.errorTags(for: error)) { current, _ in current }
       await errorReporting.reportError(error, tags)
     }
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -433,7 +433,7 @@ class StationListModel: ViewModel {
     if !NetworkErrorClassifier.isNetworkError(error) {
       var tags = extraTags
       tags["endpoint"] = endpoint
-      tags.merge(NetworkErrorClassifier.errorTags(for: error)) { current, _ in current }
+      tags.merge(NetworkErrorClassifier.errorTags(for: error)) { _, new in new }
       await errorReporting.reportError(error, tags)
     }
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetErrorReportingTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetErrorReportingTests.swift
@@ -1,0 +1,73 @@
+//
+//  StationListPresetErrorReportingTests.swift
+//  PlayolaRadio
+//
+
+import ConcurrencyExtras
+import CustomDump
+import Dependencies
+import Foundation
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct StationListPresetErrorReportingTests {
+
+  @Test
+  func testStarTappedAddNetworkErrorIsNotReportedToSentry() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
+
+    let item = makePresetVisibleItem()
+    let reportCount = LockIsolated(0)
+
+    let model = withDependencies {
+      $0.api.createPreset = { _, _, _ in
+        throw NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
+      }
+      $0.analytics.track = { _ in }
+      $0.errorReporting.reportError = { _, _ in reportCount.setValue(reportCount.value + 1) }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.starTapped(for: item)
+
+    #expect(reportCount.value == 0)
+    #expect(pending.isEmpty)
+    #expect(presets.isEmpty)
+    #expect(model.presentedAlert == .errorSavingPreset(nil))
+  }
+
+  @Test
+  func testStarTappedAddTagsReportedErrorWithDomainAndCode() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
+
+    let item = makePresetVisibleItem()
+    let reportedTags = LockIsolated<[String: String]>([:])
+
+    let model = withDependencies {
+      $0.api.createPreset = { _, _, _ in
+        throw NSError(domain: "TestDomain", code: 42)
+      }
+      $0.analytics.track = { _ in }
+      $0.errorReporting.reportError = { _, tags in reportedTags.setValue(tags) }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.starTapped(for: item)
+
+    #expect(reportedTags.value["endpoint"] == "POST /v1/presets")
+    #expect(reportedTags.value["error_domain"] == "TestDomain")
+    #expect(reportedTags.value["error_code"] == "42")
+    #expect(reportedTags.value["station_id"] == item.anyStation.id)
+  }
+}

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
@@ -221,6 +221,60 @@ struct StationListPresetTests {
   }
 
   @Test
+  func testStarTappedAddNetworkErrorIsNotReportedToSentry() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
+
+    let item = makePresetVisibleItem()
+    let reportCount = LockIsolated(0)
+
+    let model = withDependencies {
+      $0.api.createPreset = { _, _, _ in
+        throw NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
+      }
+      $0.analytics.track = { _ in }
+      $0.errorReporting.reportError = { _, _ in reportCount.setValue(reportCount.value + 1) }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.starTapped(for: item)
+
+    #expect(reportCount.value == 0)
+    #expect(pending.isEmpty)
+    #expect(presets.isEmpty)
+    #expect(model.presentedAlert == .errorSavingPreset(nil))
+  }
+
+  @Test
+  func testStarTappedAddTagsReportedErrorWithDomainAndCode() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
+
+    let item = makePresetVisibleItem()
+    let reportedTags = LockIsolated<[String: String]>([:])
+
+    let model = withDependencies {
+      $0.api.createPreset = { _, _, _ in
+        throw NSError(domain: "TestDomain", code: 42)
+      }
+      $0.analytics.track = { _ in }
+      $0.errorReporting.reportError = { _, tags in reportedTags.setValue(tags) }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.starTapped(for: item)
+
+    #expect(reportedTags.value["endpoint"] == "POST /v1/presets")
+    #expect(reportedTags.value["error_domain"] == "TestDomain")
+    #expect(reportedTags.value["error_code"] == "42")
+    #expect(reportedTags.value["station_id"] == item.anyStation.id)
+  }
+
+  @Test
   func testStarTappedIgnoredWhilePendingAdd() async {
     @Shared(.auth) var auth = signedInAuth()
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
@@ -221,60 +221,6 @@ struct StationListPresetTests {
   }
 
   @Test
-  func testStarTappedAddNetworkErrorIsNotReportedToSentry() async {
-    @Shared(.auth) var auth = signedInAuth()
-    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
-    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
-
-    let item = makePresetVisibleItem()
-    let reportCount = LockIsolated(0)
-
-    let model = withDependencies {
-      $0.api.createPreset = { _, _, _ in
-        throw NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
-      }
-      $0.analytics.track = { _ in }
-      $0.errorReporting.reportError = { _, _ in reportCount.setValue(reportCount.value + 1) }
-    } operation: {
-      StationListModel()
-    }
-
-    await model.starTapped(for: item)
-
-    #expect(reportCount.value == 0)
-    #expect(pending.isEmpty)
-    #expect(presets.isEmpty)
-    #expect(model.presentedAlert == .errorSavingPreset(nil))
-  }
-
-  @Test
-  func testStarTappedAddTagsReportedErrorWithDomainAndCode() async {
-    @Shared(.auth) var auth = signedInAuth()
-    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
-    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
-
-    let item = makePresetVisibleItem()
-    let reportedTags = LockIsolated<[String: String]>([:])
-
-    let model = withDependencies {
-      $0.api.createPreset = { _, _, _ in
-        throw NSError(domain: "TestDomain", code: 42)
-      }
-      $0.analytics.track = { _ in }
-      $0.errorReporting.reportError = { _, tags in reportedTags.setValue(tags) }
-    } operation: {
-      StationListModel()
-    }
-
-    await model.starTapped(for: item)
-
-    #expect(reportedTags.value["endpoint"] == "POST /v1/presets")
-    #expect(reportedTags.value["error_domain"] == "TestDomain")
-    #expect(reportedTags.value["error_code"] == "42")
-    #expect(reportedTags.value["station_id"] == item.anyStation.id)
-  }
-
-  @Test
   func testStarTappedIgnoredWhilePendingAdd() async {
     @Shared(.auth) var auth = signedInAuth()
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
@@ -1012,7 +958,7 @@ struct StationListPresetTests {
   }
 }
 
-private func signedInAuth() -> Auth {
+func signedInAuth() -> Auth {
   Auth(
     currentUser: LoggedInUser(
       id: "u1", firstName: "B", lastName: nil, email: "b@x.com",
@@ -1038,7 +984,7 @@ private func makePresetTestList(with items: [APIStationItem], date: Date = Date(
     hidden: false, sortOrder: 0, createdAt: date, updatedAt: date, items: items)
 }
 
-private func makePresetVisibleItem(date: Date = Date()) -> APIStationItem {
+func makePresetVisibleItem(date: Date = Date()) -> APIStationItem {
   APIStationItem(
     sortOrder: 0,
     visibility: .visible,


### PR DESCRIPTION
## Why

A production Sentry event (`APIError.dataNotValid` on `POST /v1/presets`) traced to a single device on iOS 26.5 that could not reach `admin-api.playola.fm` at all (every Playola endpoint failed with no response while S3/Mixpanel/example.com succeeded — the known iOS 26 TLS-1.3 middlebox issue, not fixed by the TLS 1.2 cap for that network). The DB confirmed the device left no server footprint. The reason it surfaced as Sentry noise: the manual request paths collapsed the real `NSURLError` (e.g. `-1200`) into `APIError.dataNotValid`, which defeated `NetworkErrorClassifier`'s intentional suppression of network errors and discarded the diagnostic code.

## What

The manual `serializingData`/`serializingDecodable` guards now rethrow the underlying transport error when a request completes with no usable HTTP response (via a shared `transportFailure` helper) across `createPreset`, `updateUser`, `deleteSpin`, `moveSpin`, `insertSpin`, and `createVoicetrack`; genuine empty-body responses still throw `dataNotValid`. Preset error reports are also tagged with `error_domain`/`error_code` via a new `NetworkErrorClassifier.errorTags` helper. Adds two `StationListPresetTests` covering network-error suppression and the new domain/code tags.

> Note: tests run in Xcode and have not been run yet.