### PR TITLE
Swap sign-in button order (Google on top) and match font size

### DIFF
--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -33,6 +33,8 @@ class SignInPageModel: ViewModel {
   // MARK: - Properties
   var presentedAlert: PlayolaAlert?
 
+  var googleSignInButtonTitle: String { "Sign in with Google" }
+
   @ObservationIgnored
   var keyWindowProvider: @MainActor () -> UIViewController? = {
     UIApplication.shared.keyWindowPresentedController

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -58,6 +58,13 @@ struct SignInPage: View {
 
           // Auth buttons
           VStack(spacing: 16) {
+            CustomGoogleSignInButton {
+              Task {
+                await model.signInWithGoogleButtonTapped()
+              }
+            }
+            .padding(.horizontal, 30)
+
             SignInWithAppleButton(.signIn) { request in
               model.signInWithAppleButtonTapped(request: request)
             } onCompletion: { result in
@@ -66,13 +73,6 @@ struct SignInPage: View {
             .signInWithAppleButtonStyle(.white)
             .frame(height: 56)
             .cornerRadius(12)
-            .padding(.horizontal, 30)
-
-            CustomGoogleSignInButton {
-              Task {
-                await model.signInWithGoogleButtonTapped()
-              }
-            }
             .padding(.horizontal, 30)
           }
 
@@ -123,7 +123,7 @@ struct CustomGoogleSignInButton: View {
           .frame(width: 24, height: 24)
 
         Text("Sign in with Google")
-          .fontWeight(.semibold)
+          .font(.system(size: 21, weight: .medium))
           .foregroundColor(.black)
       }
       .frame(maxWidth: .infinity)

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -58,7 +58,7 @@ struct SignInPage: View {
 
           // Auth buttons
           VStack(spacing: 16) {
-            CustomGoogleSignInButton {
+            CustomGoogleSignInButton(title: model.googleSignInButtonTitle) {
               Task {
                 await model.signInWithGoogleButtonTapped()
               }
@@ -112,6 +112,7 @@ struct SignInPage: View {
 }
 
 struct CustomGoogleSignInButton: View {
+  let title: String
   let action: () -> Void
 
   var body: some View {
@@ -122,7 +123,7 @@ struct CustomGoogleSignInButton: View {
           .scaledToFit()
           .frame(width: 24, height: 24)
 
-        Text("Sign in with Google")
+        Text(title)
           .font(.system(size: 21, weight: .medium))
           .foregroundColor(.black)
       }


### PR DESCRIPTION
## Summary
- Reorder the sign-in buttons so Google sits above Apple in the auth button stack
- Size the Google button label at 21pt medium so it matches the Apple button's text size

## Test plan
- [ ] Sign-in screen shows Google button on top, Apple below
- [ ] Google and Apple button labels appear the same size

🤖 Generated with [Claude Code](https://claude.com/claude-code)