### PR TITLE
Show In Development badge on suggested stations

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -235,7 +235,9 @@
 		D35EFC202F17D47F000F64A4 /* LiveStationsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC1E2F17D47F000F64A4 /* LiveStationsPoller.swift */; };
 		D35EFC212F17D47F000F64A4 /* LiveStationsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC1E2F17D47F000F64A4 /* LiveStationsPoller.swift */; };
 		D35EFC232F17D4CC000F64A4 /* LiveBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */; };
+		D3FACE010000000000000002 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
 		D35EFC242F17D4CC000F64A4 /* LiveBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */; };
+		D3FACE010000000000000003 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
 		D35EFC262F192AAF000F64A4 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC252F192AAF000F64A4 /* Conversation.swift */; };
 		D35EFC272F192AAF000F64A4 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC252F192AAF000F64A4 /* Conversation.swift */; };
 		D35EFC292F192AB9000F64A4 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC282F192AB9000F64A4 /* Message.swift */; };
@@ -342,6 +344,7 @@
 		D39728712F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */; };
 		D39728722F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */; };
 		D39728762F60E2A7008591E3 /* StationSuggestionPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39728732F60E29B008591E3 /* StationSuggestionPageTests.swift */; };
+		D3FACE010000000000000005 /* ArtistSuggestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000004 /* ArtistSuggestionTests.swift */; };
 		D3A08A2F2E4E2A35002468E0 /* AnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */; };
 		D3A08A312E4E2E2A002468E0 /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */; };
 		D3A08A352E4E6F66002468E0 /* NowPlayingUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A332E4E6F5D002468E0 /* NowPlayingUpdaterTests.swift */; };
@@ -543,6 +546,7 @@
 		D35EFC1B2F17D361000F64A4 /* LiveStationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStationInfo.swift; sourceTree = "<group>"; };
 		D35EFC1E2F17D47F000F64A4 /* LiveStationsPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStationsPoller.swift; sourceTree = "<group>"; };
 		D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveBadge.swift; sourceTree = "<group>"; };
+		D3FACE010000000000000001 /* InDevelopmentBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InDevelopmentBadge.swift; sourceTree = "<group>"; };
 		D35EFC252F192AAF000F64A4 /* Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conversation.swift; sourceTree = "<group>"; };
 		D35EFC282F192AB9000F64A4 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		D35EFC352F192C76000F64A4 /* SupportPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportPageModel.swift; sourceTree = "<group>"; };
@@ -612,6 +616,7 @@
 		D39728672F60CF59008591E3 /* StationSuggestionPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSuggestionPageView.swift; sourceTree = "<group>"; };
 		D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestion.swift; sourceTree = "<group>"; };
 		D39728732F60E29B008591E3 /* StationSuggestionPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSuggestionPageTests.swift; sourceTree = "<group>"; };
+		D3FACE010000000000000004 /* ArtistSuggestionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestionTests.swift; sourceTree = "<group>"; };
 		D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClient.swift; sourceTree = "<group>"; };
 		D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
 		D3A08A332E4E6F5D002468E0 /* NowPlayingUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingUpdaterTests.swift; sourceTree = "<group>"; };
@@ -819,6 +824,7 @@
 			children = (
 				D39728582F5F0427008591E3 /* AppVersionRequirements.swift */,
 				D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */,
+				D3FACE010000000000000004 /* ArtistSuggestionTests.swift */,
 				D35EFC252F192AAF000F64A4 /* Conversation.swift */,
 				D3137DD12D3ABB4F0070033A /* GenericNowPlaying.swift */,
 				D3B9C7A52F534CE0002D75C2 /* IntroPresignedURLResponse.swift */,
@@ -926,6 +932,7 @@
 			children = (
 				D3B744C62E3139860042A427 /* ListeningTimeTile */,
 				D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */,
+				D3FACE010000000000000001 /* InDevelopmentBadge.swift */,
 				D35EFBF42F1576EF000F64A4 /* NewFeatureTile */,
 				D3137DBA2D3976550070033A /* PlayolaAlert.swift */,
 				D3137DCE2D3AA1E10070033A /* PlayolaSheet.swift */,
@@ -1772,6 +1779,7 @@
 				D37769FA2F22B38700200ADF /* ChooseStationPageView.swift in Sources */,
 				D30F00532E8592F0007BCC73 /* ListeningTracker.swift in Sources */,
 				D35EFC242F17D4CC000F64A4 /* LiveBadge.swift in Sources */,
+				D3FACE010000000000000003 /* InDevelopmentBadge.swift in Sources */,
 				D30F00542E8592F0007BCC73 /* ViewModel.swift in Sources */,
 				D30F00552E8592F0007BCC73 /* SignInPageView.swift in Sources */,
 				D30F00562E8592F0007BCC73 /* UrlStation.swift in Sources */,
@@ -1932,6 +1940,7 @@
 				D37769FC2F22B38700200ADF /* ChooseStationPageView.swift in Sources */,
 				D3B744B72E2FED940042A427 /* ListeningTracker.swift in Sources */,
 				D35EFC232F17D4CC000F64A4 /* LiveBadge.swift in Sources */,
+				D3FACE010000000000000002 /* InDevelopmentBadge.swift in Sources */,
 				D31CD5232DFBA1F2009B9780 /* ViewModel.swift in Sources */,
 				D3B6626A2D40103C00975D2F /* SignInPageView.swift in Sources */,
 				D30AE8A72E75C92700D9FBCA /* UrlStation.swift in Sources */,
@@ -2102,6 +2111,7 @@
 				D342A0C72DFCB368002BAC30 /* HomePageTests.swift in Sources */,
 				D35EFBEE2F1092A7000F64A4 /* RRuleFormatterTests.swift in Sources */,
 				D39728762F60E2A7008591E3 /* StationSuggestionPageTests.swift in Sources */,
+				D3FACE010000000000000005 /* ArtistSuggestionTests.swift in Sources */,
 				D30257812E639FF200F4228B /* LikesManagerTests.swift in Sources */,
 				D35EFC592F1B0472000F64A4 /* AppRatingClientTests.swift in Sources */,
 				D3ABC1252F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift in Sources */,

--- a/PlayolaRadio/Core/API/APIClient.swift
+++ b/PlayolaRadio/Core/API/APIClient.swift
@@ -738,7 +738,7 @@ struct APIClient: Sendable {
       _, _ in
       ArtistSuggestion(
         id: "", artistName: "", createdByUserId: "", voteCount: 0, hasVoted: false,
-        createdAt: Date(), updatedAt: Date())
+        status: .suggested, createdAt: Date(), updatedAt: Date())
     }
 
   /// Votes for an artist suggestion

--- a/PlayolaRadio/Models/ArtistSuggestion.swift
+++ b/PlayolaRadio/Models/ArtistSuggestion.swift
@@ -27,3 +27,18 @@ struct ArtistSuggestion: Codable, Identifiable, Equatable, Sendable {
   let createdAt: Date
   let updatedAt: Date
 }
+
+extension ArtistSuggestion {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    artistName = try container.decode(String.self, forKey: .artistName)
+    createdByUserId = try container.decode(String.self, forKey: .createdByUserId)
+    voteCount = try container.decode(Int.self, forKey: .voteCount)
+    hasVoted = try container.decode(Bool.self, forKey: .hasVoted)
+    status =
+      try container.decodeIfPresent(ArtistSuggestionStatus.self, forKey: .status) ?? .suggested
+    createdAt = try container.decode(Date.self, forKey: .createdAt)
+    updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+  }
+}

--- a/PlayolaRadio/Models/ArtistSuggestion.swift
+++ b/PlayolaRadio/Models/ArtistSuggestion.swift
@@ -5,12 +5,25 @@
 
 import Foundation
 
+enum ArtistSuggestionStatus: String, Codable, Equatable, Sendable {
+  case suggested
+  case inDevelopment = "in_development"
+  case streaming
+  case unknown
+
+  init(from decoder: Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = ArtistSuggestionStatus(rawValue: raw) ?? .unknown
+  }
+}
+
 struct ArtistSuggestion: Codable, Identifiable, Equatable, Sendable {
   let id: String
   let artistName: String
   let createdByUserId: String
   let voteCount: Int
   let hasVoted: Bool
+  let status: ArtistSuggestionStatus
   let createdAt: Date
   let updatedAt: Date
 }

--- a/PlayolaRadio/Models/ArtistSuggestionTests.swift
+++ b/PlayolaRadio/Models/ArtistSuggestionTests.swift
@@ -1,0 +1,31 @@
+//
+//  ArtistSuggestionTests.swift
+//  PlayolaRadio
+//
+
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+struct ArtistSuggestionStatusTests {
+
+  @Test
+  func decodesKnownStatuses() throws {
+    let json = Data(#"["suggested", "in_development", "streaming"]"#.utf8)
+
+    let statuses = try JSONDecoder().decode([ArtistSuggestionStatus].self, from: json)
+
+    expectNoDifference(statuses, [.suggested, .inDevelopment, .streaming])
+  }
+
+  @Test
+  func decodesUnrecognizedStatusAsUnknown() throws {
+    let json = Data(#"["archived"]"#.utf8)
+
+    let statuses = try JSONDecoder().decode([ArtistSuggestionStatus].self, from: json)
+
+    expectNoDifference(statuses, [.unknown])
+  }
+}

--- a/PlayolaRadio/Models/ArtistSuggestionTests.swift
+++ b/PlayolaRadio/Models/ArtistSuggestionTests.swift
@@ -28,4 +28,24 @@ struct ArtistSuggestionStatusTests {
 
     expectNoDifference(statuses, [.unknown])
   }
+
+  @Test
+  func decodesMissingStatusAsSuggested() throws {
+    let json = Data(
+      #"""
+      {
+        "id": "s1",
+        "artistName": "Bri Bagwell",
+        "createdByUserId": "u1",
+        "voteCount": 3,
+        "hasVoted": false,
+        "createdAt": 0,
+        "updatedAt": 0
+      }
+      """#.utf8)
+
+    let suggestion = try JSONDecoder().decode(ArtistSuggestion.self, from: json)
+
+    expectNoDifference(suggestion.status, .suggested)
+  }
 }

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift
@@ -124,6 +124,10 @@ class StationSuggestionPageModel: ViewModel {
     "\(suggestion.voteCount)"
   }
 
+  func inDevelopmentBadgeText(_ suggestion: ArtistSuggestion) -> String? {
+    suggestion.status == .inDevelopment ? "IN DEVELOPMENT" : nil
+  }
+
   // MARK: - Private Helpers
 
   private func fetchSuggestions() async {

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
@@ -436,6 +436,25 @@ struct StationSuggestionPageTests {
     #expect(model.voteCountText(suggestion) == "42")
   }
 
+  @Test
+  func inDevelopmentBadgeTextShownOnlyForInDevelopment() {
+    let model = makeModel()
+
+    let inDevelopment = ArtistSuggestion(
+      id: "a", artistName: "A", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .inDevelopment, createdAt: Date(), updatedAt: Date())
+    let suggested = ArtistSuggestion(
+      id: "b", artistName: "B", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .suggested, createdAt: Date(), updatedAt: Date())
+    let streaming = ArtistSuggestion(
+      id: "c", artistName: "C", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .streaming, createdAt: Date(), updatedAt: Date())
+
+    #expect(model.inDevelopmentBadgeText(inDevelopment) == "IN DEVELOPMENT")
+    #expect(model.inDevelopmentBadgeText(suggested) == nil)
+    #expect(model.inDevelopmentBadgeText(streaming) == nil)
+  }
+
   // MARK: - Double-Tap Guard Tests
 
   @Test

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
@@ -24,13 +24,13 @@ struct StationSuggestionPageTests {
     [
       ArtistSuggestion(
         id: "s1", artistName: "Bri Bagwell", createdByUserId: "u1",
-        voteCount: 10, hasVoted: true, createdAt: Date(), updatedAt: Date()),
+        voteCount: 10, hasVoted: true, status: .inDevelopment, createdAt: Date(), updatedAt: Date()),
       ArtistSuggestion(
         id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-        voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date()),
+        voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date()),
       ArtistSuggestion(
         id: "s3", artistName: "Colter Wall", createdByUserId: "u3",
-        voteCount: 3, hasVoted: false, createdAt: Date(), updatedAt: Date()),
+        voteCount: 3, hasVoted: false, status: .streaming, createdAt: Date(), updatedAt: Date()),
     ]
   }
 
@@ -50,7 +50,7 @@ struct StationSuggestionPageTests {
     let defaultCreate: @Sendable (String, String) async throws -> ArtistSuggestion = { _, name in
       ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     }
     let defaultVote: @Sendable (String, String) async throws -> Void = { _, _ in }
     let defaultRemoveVote: @Sendable (String, String) async throws -> Void = { _, _ in }
@@ -159,7 +159,7 @@ struct StationSuggestionPageTests {
     let capturedVoteIds = LockIsolated<[String]>([])
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onVote: { _, id in
       capturedVoteIds.withValue { $0.append(id) }
@@ -176,7 +176,7 @@ struct StationSuggestionPageTests {
     let capturedRemoveIds = LockIsolated<[String]>([])
     let votedSuggestion = ArtistSuggestion(
       id: "s1", artistName: "Bri Bagwell", createdByUserId: "u1",
-      voteCount: 10, hasVoted: true, createdAt: Date(), updatedAt: Date())
+      voteCount: 10, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onRemoveVote: { _, id in
       capturedRemoveIds.withValue { $0.append(id) }
@@ -193,7 +193,7 @@ struct StationSuggestionPageTests {
     let fetchCount = LockIsolated(0)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onGetSuggestions: { _, _ in
       fetchCount.withValue { $0 += 1 }
@@ -210,7 +210,7 @@ struct StationSuggestionPageTests {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onVote: { _, _ in
       throw APIError.validationError("Already voted")
@@ -228,7 +228,7 @@ struct StationSuggestionPageTests {
     let capturedVoteIds = LockIsolated<[String]>([])
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Bri Bagwell", createdByUserId: "u1",
-      voteCount: 10, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 10, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onVote: { _, id in
       capturedVoteIds.withValue { $0.append(id) }
@@ -249,7 +249,7 @@ struct StationSuggestionPageTests {
       capturedNames.withValue { $0.append(name) }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
 
     model.searchText = "Tyler Childers"
@@ -267,7 +267,7 @@ struct StationSuggestionPageTests {
       capturedNames.withValue { $0.append(name) }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
 
     model.searchText = "  Tyler Childers  "
@@ -284,7 +284,7 @@ struct StationSuggestionPageTests {
       capturedNames.withValue { $0.append(name) }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
 
     model.searchText = "   "
@@ -301,7 +301,7 @@ struct StationSuggestionPageTests {
       capturedNames.withValue { $0.append(name) }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
 
     model.searchText = "Tyler Childers"
@@ -411,7 +411,7 @@ struct StationSuggestionPageTests {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
-      voteCount: 5, hasVoted: true, createdAt: Date(), updatedAt: Date())
+      voteCount: 5, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     #expect(model.voteButtonText(suggestion) == "Voted")
   }
@@ -421,7 +421,7 @@ struct StationSuggestionPageTests {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
-      voteCount: 5, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 5, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     #expect(model.voteButtonText(suggestion) == "Vote")
   }
@@ -431,7 +431,7 @@ struct StationSuggestionPageTests {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
-      voteCount: 42, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 42, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     #expect(model.voteCountText(suggestion) == "42")
   }
@@ -444,7 +444,7 @@ struct StationSuggestionPageTests {
     let voteCount = LockIsolated(0)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onVote: { _, _ in
       voteCount.withValue { $0 += 1 }
@@ -464,7 +464,7 @@ struct StationSuggestionPageTests {
       createCount.withValue { $0 += 1 }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
     model.isSubmitting = true
     model.searchText = "Tyler Childers"
@@ -479,7 +479,7 @@ struct StationSuggestionPageTests {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
     let model = makeModel()
 
     await model.voteTapped(unvotedSuggestion)
@@ -492,7 +492,7 @@ struct StationSuggestionPageTests {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
     let model = makeModel(onVote: { _, _ in
       throw APIError.validationError("fail")
     })

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -147,6 +147,7 @@ struct StationSuggestionPageView: View {
             .foregroundColor(.textPrimary)
 
           if let badgeText = model.inDevelopmentBadgeText(suggestion) {
+            Spacer(minLength: 8)
             InDevelopmentBadge(text: badgeText)
           }
         }

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -141,13 +141,12 @@ struct StationSuggestionPageView: View {
   private func suggestionRow(_ suggestion: ArtistSuggestion) -> some View {
     HStack(spacing: 16) {
       VStack(alignment: .leading, spacing: 2) {
-        HStack(spacing: 8) {
+        HStack(spacing: 12) {
           Text(suggestion.artistName)
             .font(.custom(FontNames.Inter_500_Medium, size: 18))
             .foregroundColor(.textPrimary)
 
           if let badgeText = model.inDevelopmentBadgeText(suggestion) {
-            Spacer(minLength: 8)
             InDevelopmentBadge(text: badgeText)
           }
         }

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -140,10 +140,14 @@ struct StationSuggestionPageView: View {
 
   private func suggestionRow(_ suggestion: ArtistSuggestion) -> some View {
     HStack(spacing: 16) {
-      VStack(alignment: .leading, spacing: 2) {
+      VStack(alignment: .leading, spacing: 4) {
         Text(suggestion.artistName)
           .font(.custom(FontNames.Inter_500_Medium, size: 18))
           .foregroundColor(.textPrimary)
+
+        if let badgeText = model.inDevelopmentBadgeText(suggestion) {
+          InDevelopmentBadge(text: badgeText)
+        }
 
         Text("\(model.voteCountText(suggestion)) votes")
           .font(.custom(FontNames.Inter_400_Regular, size: 13))

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -146,9 +146,7 @@ struct StationSuggestionPageView: View {
             .font(.custom(FontNames.Inter_500_Medium, size: 18))
             .foregroundColor(.textPrimary)
 
-          if let badgeText = model.inDevelopmentBadgeText(suggestion) {
-            InDevelopmentBadge(text: badgeText)
-          }
+          InDevelopmentBadge(text: model.inDevelopmentBadgeText(suggestion))
         }
 
         Text("\(model.voteCountText(suggestion)) votes")

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -140,13 +140,15 @@ struct StationSuggestionPageView: View {
 
   private func suggestionRow(_ suggestion: ArtistSuggestion) -> some View {
     HStack(spacing: 16) {
-      VStack(alignment: .leading, spacing: 4) {
-        Text(suggestion.artistName)
-          .font(.custom(FontNames.Inter_500_Medium, size: 18))
-          .foregroundColor(.textPrimary)
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 8) {
+          Text(suggestion.artistName)
+            .font(.custom(FontNames.Inter_500_Medium, size: 18))
+            .foregroundColor(.textPrimary)
 
-        if let badgeText = model.inDevelopmentBadgeText(suggestion) {
-          InDevelopmentBadge(text: badgeText)
+          if let badgeText = model.inDevelopmentBadgeText(suggestion) {
+            InDevelopmentBadge(text: badgeText)
+          }
         }
 
         Text("\(model.voteCountText(suggestion)) votes")

--- a/PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift
+++ b/PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift
@@ -1,0 +1,27 @@
+//
+//  InDevelopmentBadge.swift
+//  PlayolaRadio
+
+import SwiftUI
+
+struct InDevelopmentBadge: View {
+  let text: String
+
+  var body: some View {
+    Text(text)
+      .font(.custom(FontNames.Inter_700_Bold, size: 10))
+      .tracking(1.4)
+      .foregroundColor(.playolaRed)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
+      .overlay(
+        RoundedRectangle(cornerRadius: 4)
+          .stroke(Color.playolaRed, lineWidth: 1)
+      )
+  }
+}
+
+#Preview {
+  InDevelopmentBadge(text: "IN DEVELOPMENT")
+    .preferredColorScheme(.dark)
+}

--- a/PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift
+++ b/PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift
@@ -5,19 +5,21 @@
 import SwiftUI
 
 struct InDevelopmentBadge: View {
-  let text: String
+  let text: String?
 
   var body: some View {
-    Text(text)
-      .font(.custom(FontNames.Inter_700_Bold, size: 10))
-      .tracking(1.4)
-      .foregroundColor(.playolaRed)
-      .padding(.horizontal, 8)
-      .padding(.vertical, 3)
-      .overlay(
-        RoundedRectangle(cornerRadius: 4)
-          .stroke(Color.playolaRed, lineWidth: 1)
-      )
+    if let text {
+      Text(text)
+        .font(.custom(FontNames.Inter_700_Bold, size: 10))
+        .tracking(1.4)
+        .foregroundColor(.playolaRed)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .overlay(
+          RoundedRectangle(cornerRadius: 4)
+            .stroke(Color.playolaRed, lineWidth: 1)
+        )
+    }
   }
 }
 

--- a/docs/superpowers/plans/2026-06-02-in-development-status.md
+++ b/docs/superpowers/plans/2026-06-02-in-development-status.md
@@ -1,0 +1,311 @@
+# In Development Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show an "IN DEVELOPMENT" badge on a suggested-station row when the server reports its status as `in_development`.
+
+**Architecture:** Add a `status` enum to the `ArtistSuggestion` model (with an `.unknown` fallback for forward-compat), expose the badge text from `StationSuggestionPageModel`, add a small reusable `InDevelopmentBadge` view, and render it in the suggestion row when the model returns text.
+
+**Tech Stack:** Swift, SwiftUI, swift-testing (`import Testing`), CustomDump (`expectNoDifference`). Point-Free skills in force: pfw-observable-models, pfw-modern-swiftui, pfw-testing, pfw-custom-dump. No comments in generated code; avoid `self` where not needed.
+
+---
+
+### Task 1: Add `status` to the `ArtistSuggestion` model
+
+**Files:**
+- Test: `PlayolaRadio/Models/ArtistSuggestionTests.swift` (create)
+- Modify: `PlayolaRadio/Models/ArtistSuggestion.swift`
+- Modify: `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift:23-34,50-53`
+- Modify: `PlayolaRadio/Core/API/APIClient.swift:739-742` (and the empty-stub default at `726-729` returns `[]`, so no change there)
+
+- [ ] **Step 1: Write the failing decoding test**
+
+Create `PlayolaRadio/Models/ArtistSuggestionTests.swift`:
+
+```swift
+//
+//  ArtistSuggestionTests.swift
+//  PlayolaRadio
+//
+
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+struct ArtistSuggestionStatusTests {
+
+  @Test
+  func decodesKnownStatuses() throws {
+    let json = Data(#"["suggested", "in_development", "streaming"]"#.utf8)
+
+    let statuses = try JSONDecoder().decode([ArtistSuggestionStatus].self, from: json)
+
+    expectNoDifference(statuses, [.suggested, .inDevelopment, .streaming])
+  }
+
+  @Test
+  func decodesUnrecognizedStatusAsUnknown() throws {
+    let json = Data(#"["archived"]"#.utf8)
+
+    let statuses = try JSONDecoder().decode([ArtistSuggestionStatus].self, from: json)
+
+    expectNoDifference(statuses, [.unknown])
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run in Xcode (user runs tests). Expected: compile failure — `ArtistSuggestionStatus` is undefined.
+
+- [ ] **Step 3: Add the enum and field**
+
+Replace the contents of `PlayolaRadio/Models/ArtistSuggestion.swift` with:
+
+```swift
+//
+//  ArtistSuggestion.swift
+//  PlayolaRadio
+//
+
+import Foundation
+
+enum ArtistSuggestionStatus: String, Codable, Equatable, Sendable {
+  case suggested
+  case inDevelopment = "in_development"
+  case streaming
+  case unknown
+
+  init(from decoder: Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = ArtistSuggestionStatus(rawValue: raw) ?? .unknown
+  }
+}
+
+struct ArtistSuggestion: Codable, Identifiable, Equatable, Sendable {
+  let id: String
+  let artistName: String
+  let createdByUserId: String
+  let voteCount: Int
+  let hasVoted: Bool
+  let status: ArtistSuggestionStatus
+  let createdAt: Date
+  let updatedAt: Date
+}
+```
+
+- [ ] **Step 4: Update the memberwise-init call sites so the project compiles**
+
+In `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift`, update `mockSuggestions()` (lines 23-34) so the three suggestions carry distinct statuses for later use, and the create stub (lines 50-53):
+
+```swift
+  nonisolated private func mockSuggestions() -> [ArtistSuggestion] {
+    [
+      ArtistSuggestion(
+        id: "s1", artistName: "Bri Bagwell", createdByUserId: "u1",
+        voteCount: 10, hasVoted: true, status: .inDevelopment,
+        createdAt: Date(), updatedAt: Date()),
+      ArtistSuggestion(
+        id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
+        voteCount: 7, hasVoted: false, status: .suggested,
+        createdAt: Date(), updatedAt: Date()),
+      ArtistSuggestion(
+        id: "s3", artistName: "Colter Wall", createdByUserId: "u3",
+        voteCount: 3, hasVoted: false, status: .streaming,
+        createdAt: Date(), updatedAt: Date()),
+    ]
+  }
+```
+
+```swift
+    let defaultCreate: @Sendable (String, String) async throws -> ArtistSuggestion = { _, name in
+      ArtistSuggestion(
+        id: "new", artistName: name, createdByUserId: "u1",
+        voteCount: 1, hasVoted: true, status: .suggested,
+        createdAt: Date(), updatedAt: Date())
+    }
+```
+
+In `PlayolaRadio/Core/API/APIClient.swift`, update the `createArtistSuggestion` default stub (lines 739-742):
+
+```swift
+  var createArtistSuggestion:
+    @Sendable (_ jwtToken: String, _ artistName: String) async throws -> ArtistSuggestion = {
+      _, _ in
+      ArtistSuggestion(
+        id: "", artistName: "", createdByUserId: "", voteCount: 0, hasVoted: false,
+        status: .suggested, createdAt: Date(), updatedAt: Date())
+    }
+```
+
+Note: the `getArtistSuggestions` default (lines 726-729) returns `[]` and needs no change. If a search across the repo finds any other `ArtistSuggestion(` construction site, add `status: .suggested` there too.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run in Xcode. Expected: `ArtistSuggestionStatusTests` passes; existing `StationSuggestionPageTests` still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add PlayolaRadio/Models/ArtistSuggestion.swift PlayolaRadio/Models/ArtistSuggestionTests.swift PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift PlayolaRadio/Core/API/APIClient.swift
+git commit -m "Add status field to ArtistSuggestion model"
+```
+
+---
+
+### Task 2: Expose badge text from the page model
+
+**Files:**
+- Test: `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift`
+- Modify: `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift:119-125`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `StationSuggestionPageTests.swift` (inside the `StationSuggestionPageTests` struct):
+
+```swift
+  @Test
+  func inDevelopmentBadgeTextShownOnlyForInDevelopment() {
+    let model = makeModel()
+
+    let inDevelopment = ArtistSuggestion(
+      id: "a", artistName: "A", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .inDevelopment, createdAt: Date(), updatedAt: Date())
+    let suggested = ArtistSuggestion(
+      id: "b", artistName: "B", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .suggested, createdAt: Date(), updatedAt: Date())
+    let streaming = ArtistSuggestion(
+      id: "c", artistName: "C", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .streaming, createdAt: Date(), updatedAt: Date())
+
+    #expect(model.inDevelopmentBadgeText(inDevelopment) == "IN DEVELOPMENT")
+    #expect(model.inDevelopmentBadgeText(suggested) == nil)
+    #expect(model.inDevelopmentBadgeText(streaming) == nil)
+  }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run in Xcode. Expected: compile failure — `inDevelopmentBadgeText` is undefined.
+
+- [ ] **Step 3: Add the helper**
+
+In `StationSuggestionPageModel.swift`, in the `// MARK: - View Helpers` section, add after `voteCountText` (line 125):
+
+```swift
+  func inDevelopmentBadgeText(_ suggestion: ArtistSuggestion) -> String? {
+    suggestion.status == .inDevelopment ? "IN DEVELOPMENT" : nil
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run in Xcode. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+git commit -m "Add in-development badge text to StationSuggestionPageModel"
+```
+
+---
+
+### Task 3: Create the `InDevelopmentBadge` view
+
+**Files:**
+- Create: `PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift`
+
+- [ ] **Step 1: Create the view**
+
+Create `PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift`:
+
+```swift
+//
+//  InDevelopmentBadge.swift
+//  PlayolaRadio
+//
+
+import SwiftUI
+
+struct InDevelopmentBadge: View {
+  let text: String
+
+  var body: some View {
+    Text(text)
+      .font(.custom(FontNames.Inter_700_Bold, size: 10))
+      .tracking(1.4)
+      .foregroundColor(.playolaRed)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
+      .overlay(
+        RoundedRectangle(cornerRadius: 4)
+          .stroke(Color.playolaRed, lineWidth: 1)
+      )
+  }
+}
+
+#Preview {
+  InDevelopmentBadge(text: "IN DEVELOPMENT")
+    .preferredColorScheme(.dark)
+}
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Build in Xcode. Expected: builds; the preview renders an outlined red pill.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift"
+git commit -m "Add InDevelopmentBadge reusable view"
+```
+
+---
+
+### Task 4: Render the badge in the suggestion row
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift:141-177`
+
+- [ ] **Step 1: Wire the badge into the row**
+
+In `suggestionRow(_:)`, place the badge between the artist name and the vote-count line. Replace the `VStack(alignment: .leading, spacing: 2)` block (lines 143-151) with:
+
+```swift
+      VStack(alignment: .leading, spacing: 4) {
+        Text(suggestion.artistName)
+          .font(.custom(FontNames.Inter_500_Medium, size: 18))
+          .foregroundColor(.textPrimary)
+
+        if let badgeText = model.inDevelopmentBadgeText(suggestion) {
+          InDevelopmentBadge(text: badgeText)
+        }
+
+        Text("\(model.voteCountText(suggestion)) votes")
+          .font(.custom(FontNames.Inter_400_Regular, size: 13))
+          .foregroundColor(.textSecondary)
+      }
+```
+
+- [ ] **Step 2: Verify it builds and renders**
+
+Build in Xcode and open `StationSuggestionPageView`'s preview. Expected: the in-development mock suggestion ("Bri Bagwell") shows the "IN DEVELOPMENT" badge; the others do not.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+git commit -m "Show In Development badge on suggested station rows"
+```
+
+---
+
+## Notes for the implementer
+
+- Run `make format` before each commit; SwiftLint/swift-format run on commit via git hooks. Do not use `--no-verify`.
+- Tests run in Xcode (the user runs them). Do not add `Task.sleep` to any test.
+- `Color.playolaRed` and `FontNames.Inter_700_Bold` / `Inter_500_Medium` / `Inter_400_Regular` already exist in the app.

--- a/docs/superpowers/specs/2026-06-02-in-development-status-design.md
+++ b/docs/superpowers/specs/2026-06-02-in-development-status-design.md
@@ -1,0 +1,101 @@
+# Display "In Development" status on suggested stations
+
+**Date:** 2026-06-02
+**Status:** Approved
+
+## Problem
+
+The server's artist-suggestion model gained a `status` field. We want the iOS
+"Suggest a Station" page to surface when Playola is actively building a
+suggested artist's station, matching the design in the `lovable-ios` prototype.
+
+## Context
+
+- **Server** (`~/playola/playola/server`): the model is `ArtistSuggestion`. It
+  now returns a `status` string field — `allowNull: false`, default
+  `"suggested"`. Possible values: `"suggested"`, `"in_development"`,
+  `"streaming"`.
+- **Design** (`lovable-ios/src/components/stations/SuggestStationModal.tsx`):
+  an `IN DEVELOPMENT` badge rendered inline with the artist name — an outlined
+  red pill. Text + border `#EF6962` (Playola red), transparent fill, 1px
+  border, 4px corner radius, 10px extrabold all-caps, `0.14em` letter-spacing,
+  8px×3px padding. Voting stays enabled. The design handles only the
+  in-development case.
+- **iOS** (this repo): `ArtistSuggestion.swift` has no `status` field.
+  Suggestions render on `StationSuggestionPage`. The app already has a
+  `LiveBadge` (outlined-pill idiom: `Inter_600_SemiBold` size 10, red stroke)
+  and uses an `.unknown` enum fallback convention for resilient decoding
+  (`StationListItemVisibility`).
+
+## Scope
+
+**In scope:** Show an "IN DEVELOPMENT" badge on a suggestion row when its
+status is `in_development`.
+
+**Out of scope:** Any badge for `streaming` or `suggested`; changes to voting;
+admin status-editing UI. (A `streaming` badge can be added later when that
+state matters in the UI.)
+
+## Design
+
+### 1. Model — `Models/ArtistSuggestion.swift`
+
+Add a `status` field backed by a new enum mirroring the server's three values
+plus an `.unknown` fallback (matching the existing `StationListItemVisibility`
+convention so a future server status won't break decoding):
+
+```swift
+enum ArtistSuggestionStatus: String, Codable, Equatable, Sendable {
+  case suggested
+  case inDevelopment = "in_development"
+  case streaming
+  case unknown
+
+  init(from decoder: Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = ArtistSuggestionStatus(rawValue: raw) ?? .unknown
+  }
+}
+```
+
+Add `let status: ArtistSuggestionStatus` to the struct (non-optional — the
+server always sends it). Synthesized `Codable` on the struct is kept. The
+memberwise-init call sites get `status:` added, defaulting to `.suggested`:
+- `StationSuggestionPageTests.swift` (3 in `mockSuggestions`, 1 in the create mock)
+- `APIClient.swift` (2 default-closure stubs)
+
+### 2. Model text — `StationSuggestionPageModel.swift`
+
+The model owns the badge text. Add a view helper alongside `voteButtonText`:
+
+```swift
+func inDevelopmentBadgeText(_ suggestion: ArtistSuggestion) -> String? {
+  suggestion.status == .inDevelopment ? "IN DEVELOPMENT" : nil
+}
+```
+
+`nil` → no badge. Only `.inDevelopment` returns text; `suggested` / `streaming`
+/ `unknown` return `nil`.
+
+### 3. Badge view — `Views/Reusable Components/InDevelopmentBadge.swift`
+
+A small view styled to match the lovable design (outlined red pill), in the
+same spirit as `LiveBadge`. Takes the label string as a parameter (text comes
+from the model):
+- Playola red (`#EF6962`) text + 1px border, transparent fill
+- `cornerRadius` 4, padding 8 horizontal × 3 vertical
+- `Inter_700_Bold` size 10, `.tracking(~1.4)` for the `0.14em` letter-spacing
+
+### 4. Row wiring — `StationSuggestionPageView.swift`
+
+In `suggestionRow`, render `InDevelopmentBadge` after the artist name when
+`model.inDevelopmentBadgeText(suggestion)` is non-nil. Voting unchanged.
+
+## Testing (TDD — written first)
+
+- **`Models/ArtistSuggestionTests.swift`** (new): decode `"in_development"` →
+  `.inDevelopment`, `"streaming"` → `.streaming`, `"suggested"` →
+  `.suggested`, and an unrecognized string → `.unknown`. Use
+  `expectNoDifference`.
+- **`StationSuggestionPageTests.swift`**: `inDevelopmentBadgeText` returns
+  `"IN DEVELOPMENT"` for an in-development suggestion and `nil` for the others.


### PR DESCRIPTION
Adds an "IN DEVELOPMENT" badge to the "Suggest a Station" rows, surfacing the new server-side `status` field on artist suggestions. The `ArtistSuggestion` model gains a `status: ArtistSuggestionStatus` enum (`suggested` / `inDevelopment` / `streaming`, with an `.unknown` fallback for forward-compatibility), and `StationSuggestionPageModel` exposes the badge text so the view stays logic-free. A reusable `InDevelopmentBadge` view renders the outlined red pill (matching the lovable-ios design) inline to the right of the artist name, shown only when status is `in_development`. Includes decoding tests for the new enum and a model test for the badge text, and registers the two new files in the Xcode project. Also commits the design spec and implementation plan under `docs/superpowers/`.