### PR TITLE
Fix main-thread App Hang from MPNowPlayingInfoCenter getter (APPLE-IOS-1C)

### DIFF
--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -72,6 +72,13 @@ class NowPlayingUpdater {
   var lastPlayedStation: AnyStation?
   private var currentArtworkURL: String?
 
+  // Local source of truth for the now-playing dictionary. We never read
+  // MPNowPlayingInfoCenter.default().nowPlayingInfo: that getter performs a
+  // synchronous cross-process wait that can block the main thread for seconds
+  // (Sentry APPLE-IOS-1C). We are the only writer, so we keep our own copy and
+  // read from it instead.
+  private(set) var currentNowPlayingInfo: [String: Any] = [:]
+
   // Analytics tracking
   private var sessionStartTime: Date?
   private var lastPlaybackStatus: StationPlayer.PlaybackStatus = .stopped
@@ -99,35 +106,46 @@ class NowPlayingUpdater {
     switch stationPlayerState.playbackStatus {
     case .loading, .stopped:
       // For loading/stopped states, preserve existing artwork if available, otherwise load new
-      if let existingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo,
-        let existingArtwork = existingInfo[MPMediaItemPropertyArtwork]
-      {
-        nowPlayingInfo[MPMediaItemPropertyArtwork] = existingArtwork
-      } else {
+      if currentNowPlayingInfo[MPMediaItemPropertyArtwork] != nil {
+        nowPlayingInfo = preservingExistingArtwork(in: nowPlayingInfo)
+      } else if currentArtworkURL != currentStation.imageUrl?.absoluteString {
         // Only load if we don't already have this station's artwork
-        if currentArtworkURL != currentStation.imageUrl?.absoluteString {
-          loadStationArtwork(from: stationPlayerState, station: currentStation)
-        }
+        loadStationArtwork(from: stationPlayerState, station: currentStation)
       }
     case .playing:
       // Preserve existing artwork
-      if let existingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo,
-        let existingArtwork = existingInfo[MPMediaItemPropertyArtwork]
-      {
-        nowPlayingInfo[MPMediaItemPropertyArtwork] = existingArtwork
-      }
+      nowPlayingInfo = preservingExistingArtwork(in: nowPlayingInfo)
     default:
       break
     }
 
-    MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    setNowPlayingInfo(nowPlayingInfo)
   }
 
   private func clearNowPlayingInfo() {
     print("🧹 Clearing now playing info")
     MPNowPlayingInfoCenter.default().playbackState = .stopped
+    currentNowPlayingInfo = [:]
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     currentArtworkURL = nil
+  }
+
+  /// Assigns the now-playing dictionary, keeping our local copy in sync with the
+  /// system center. This is the only place that writes `nowPlayingInfo`.
+  func setNowPlayingInfo(_ info: [String: Any]) {
+    currentNowPlayingInfo = info
+    MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+  }
+
+  /// Carries the artwork from our local copy into `info`, if present. Reads from
+  /// `currentNowPlayingInfo`, never from `MPNowPlayingInfoCenter`'s getter.
+  func preservingExistingArtwork(in info: [String: Any]) -> [String: Any] {
+    guard let existingArtwork = currentNowPlayingInfo[MPMediaItemPropertyArtwork] else {
+      return info
+    }
+    var info = info
+    info[MPMediaItemPropertyArtwork] = existingArtwork
+    return info
   }
 
   private func buildNowPlayingInfo(
@@ -282,21 +300,23 @@ class NowPlayingUpdater {
     // For CarPlay/Lock Screen: always use station image, ignore album artwork
     Task {
       let image = await station.getImage()
+      // Artwork loads asynchronously; a fast station switch can resolve a stale
+      // image. Only apply it if this station is still the current one.
+      guard stationPlayer.currentStation?.id == station.id else { return }
       self.updateNowPlayingImage(image)
       self.currentArtworkURL = station.imageUrl?.absoluteString
     }
   }
 
   private func updateNowPlayingImage(_ image: UIImage) {
-    var nowPlayingInfo: [String: Any] =
-      MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
+    var nowPlayingInfo = currentNowPlayingInfo
     nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(
       boundsSize: image.size,
       requestHandler: { _ in
         return image
       }
     )
-    MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    setNowPlayingInfo(nowPlayingInfo)
   }
 
   // The Combine subscriptions below capture `self` weakly so the cancellable
@@ -508,6 +528,7 @@ class NowPlayingUpdater {
     commandCenter.previousTrackCommand.removeTarget(nil)
 
     // Clear now playing info
+    currentNowPlayingInfo = [:]
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     MPNowPlayingInfoCenter.default().playbackState = .stopped
 

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -132,6 +132,7 @@ class NowPlayingUpdater {
 
   /// Assigns the now-playing dictionary, keeping our local copy in sync with the
   /// system center. This is the only place that writes `nowPlayingInfo`.
+  // internal for testability
   func setNowPlayingInfo(_ info: [String: Any]) {
     currentNowPlayingInfo = info
     MPNowPlayingInfoCenter.default().nowPlayingInfo = info
@@ -139,6 +140,7 @@ class NowPlayingUpdater {
 
   /// Carries the artwork from our local copy into `info`, if present. Reads from
   /// `currentNowPlayingInfo`, never from `MPNowPlayingInfoCenter`'s getter.
+  // internal for testability
   func preservingExistingArtwork(in info: [String: Any]) -> [String: Any] {
     guard let existingArtwork = currentNowPlayingInfo[MPMediaItemPropertyArtwork] else {
       return info
@@ -302,10 +304,17 @@ class NowPlayingUpdater {
       let image = await station.getImage()
       // Artwork loads asynchronously; a fast station switch can resolve a stale
       // image. Only apply it if this station is still the current one.
-      guard stationPlayer.currentStation?.id == station.id else { return }
+      guard self.isStillCurrent(station) else { return }
       self.updateNowPlayingImage(image)
       self.currentArtworkURL = station.imageUrl?.absoluteString
     }
+  }
+
+  /// Whether `station` is still the one being played. Used to drop artwork that
+  /// finished loading after a fast station switch superseded the request.
+  // internal for testability
+  func isStillCurrent(_ station: AnyStation) -> Bool {
+    stationPlayer.currentStation?.id == station.id
   }
 
   private func updateNowPlayingImage(_ image: UIImage) {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -130,17 +130,17 @@ class NowPlayingUpdater {
     currentArtworkURL = nil
   }
 
+  // internal for testability
   /// Assigns the now-playing dictionary, keeping our local copy in sync with the
   /// system center. This is the only place that writes `nowPlayingInfo`.
-  // internal for testability
   func setNowPlayingInfo(_ info: [String: Any]) {
     currentNowPlayingInfo = info
     MPNowPlayingInfoCenter.default().nowPlayingInfo = info
   }
 
+  // internal for testability
   /// Carries the artwork from our local copy into `info`, if present. Reads from
   /// `currentNowPlayingInfo`, never from `MPNowPlayingInfoCenter`'s getter.
-  // internal for testability
   func preservingExistingArtwork(in info: [String: Any]) -> [String: Any] {
     guard let existingArtwork = currentNowPlayingInfo[MPMediaItemPropertyArtwork] else {
       return info
@@ -310,9 +310,9 @@ class NowPlayingUpdater {
     }
   }
 
+  // internal for testability
   /// Whether `station` is still the one being played. Used to drop artwork that
   /// finished loading after a fast station switch superseded the request.
-  // internal for testability
   func isStillCurrent(_ station: AnyStation) -> Bool {
     stationPlayer.currentStation?.id == station.id
   }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -16,6 +16,45 @@ import Testing
 @MainActor
 struct NowPlayingUpdaterTests {
 
+  // MARK: - Now Playing Info Cache Tests
+
+  // Regression: the now-playing artwork merge must read from our local copy,
+  // never MPNowPlayingInfoCenter.default().nowPlayingInfo (Sentry APPLE-IOS-1C).
+
+  @Test
+  func testSetNowPlayingInfoUpdatesLocalCache() {
+    let updater = NowPlayingUpdater()
+
+    updater.setNowPlayingInfo([MPMediaItemPropertyTitle: "cached title"])
+
+    #expect(updater.currentNowPlayingInfo[MPMediaItemPropertyTitle] as? String == "cached title")
+  }
+
+  @Test
+  func testPreservingExistingArtworkCarriesArtworkFromLocalCache() {
+    let updater = NowPlayingUpdater()
+    let artwork = MPMediaItemArtwork(boundsSize: CGSize(width: 10, height: 10)) { _ in UIImage() }
+    updater.setNowPlayingInfo([
+      MPMediaItemPropertyArtwork: artwork,
+      MPMediaItemPropertyTitle: "old title",
+    ])
+
+    let merged = updater.preservingExistingArtwork(in: [MPMediaItemPropertyTitle: "new title"])
+
+    #expect(merged[MPMediaItemPropertyTitle] as? String == "new title")
+    #expect(merged[MPMediaItemPropertyArtwork] != nil)
+  }
+
+  @Test
+  func testPreservingExistingArtworkNoOpWhenNoArtworkCached() {
+    let updater = NowPlayingUpdater()
+    updater.setNowPlayingInfo([MPMediaItemPropertyTitle: "title"])
+
+    let merged = updater.preservingExistingArtwork(in: [MPMediaItemPropertyTitle: "new title"])
+
+    #expect(merged[MPMediaItemPropertyArtwork] == nil)
+  }
+
   // MARK: - Analytics Tests
 
   @Test

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -55,6 +55,23 @@ struct NowPlayingUpdaterTests {
     #expect(merged[MPMediaItemPropertyArtwork] == nil)
   }
 
+  @Test
+  func testIsStillCurrentTrueForPlayingStationFalseAfterSwitch() {
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer()
+      stationPlayer.state = StationPlayer.State(playbackStatus: .playing(.mock))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    // Artwork that resolves for the current station applies; artwork for a
+    // station we've since switched away from is dropped (stale-artwork guard).
+    #expect(updater.isStillCurrent(.mock))
+    #expect(!updater.isStillCurrent(makeTestStation2()))
+  }
+
   // MARK: - Analytics Tests
 
   @Test

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -20,6 +20,7 @@ class StationPlayer: ObservableObject {
 
   @ObservationIgnored @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList>
   @ObservationIgnored @Shared(.showSecretStations) var showSecretStations: Bool
+  @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
 
   enum PlaybackStatus: Codable, Equatable {
     case startingNewStation(AnyStation)
@@ -122,11 +123,20 @@ class StationPlayer: ObservableObject {
   /// a swallowed failure (e.g. the schedule endpoint returning 500 during an
   /// outage) leaves the player stuck on `.loading` forever, with no error shown
   /// and no recovery — which pushes users into a manual retry storm.
+  ///
+  /// Both representations of playback state are updated: `state` (which drives
+  /// the lock screen via `NowPlayingUpdater`) and `@Shared(.nowPlaying)` (the
+  /// app-wide source of truth the in-app UI reads). The shared state would
+  /// otherwise stay `.loading`, because it is only driven by
+  /// `playolaStationPlayer.$state`, which does not emit when `play()` throws.
+  ///
   /// `CancellationError` is ignored: it means a newer `play()`/`stop()` already
   /// superseded this attempt and owns the current state.
+  // internal for testability
   func handlePlayFailure(_ error: Error) {
     if error is CancellationError { return }
     state = State(playbackStatus: .error)
+    $nowPlaying.withLock { $0 = NowPlaying(playbackStatus: .error) }
   }
 
   /// Stops the currently playing station

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -119,6 +119,7 @@ class StationPlayer: ObservableObject {
     }
   }
 
+  // internal for testability
   /// Surfaces a failed station start as a recoverable error state. Without this,
   /// a swallowed failure (e.g. the schedule endpoint returning 500 during an
   /// outage) leaves the player stuck on `.loading` forever, with no error shown
@@ -132,7 +133,6 @@ class StationPlayer: ObservableObject {
   ///
   /// `CancellationError` is ignored: it means a newer `play()`/`stop()` already
   /// superseded this attempt and owns the current state.
-  // internal for testability
   func handlePlayFailure(_ error: Error) {
     if error is CancellationError { return }
     state = State(playbackStatus: .error)

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -110,8 +110,23 @@ class StationPlayer: ObservableObject {
       urlStreamPlayer.set(station: urlStation)
     case .playola(let playolaStation):
       urlStreamPlayer.reset()
-      try? await playolaStationPlayer.play(stationId: playolaStation.id)
+      do {
+        try await playolaStationPlayer.play(stationId: playolaStation.id)
+      } catch {
+        handlePlayFailure(error)
+      }
     }
+  }
+
+  /// Surfaces a failed station start as a recoverable error state. Without this,
+  /// a swallowed failure (e.g. the schedule endpoint returning 500 during an
+  /// outage) leaves the player stuck on `.loading` forever, with no error shown
+  /// and no recovery — which pushes users into a manual retry storm.
+  /// `CancellationError` is ignored: it means a newer `play()`/`stop()` already
+  /// superseded this attempt and owns the current state.
+  func handlePlayFailure(_ error: Error) {
+    if error is CancellationError { return }
+    state = State(playbackStatus: .error)
   }
 
   /// Stops the currently playing station

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -23,21 +23,27 @@ struct StationPlayerTests {
 
   @Test
   func testHandlePlayFailureSetsErrorState() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .loading(.mock))
     let stationPlayer = StationPlayer()
 
     stationPlayer.handlePlayFailure(PlayFailureTestError())
 
+    // Both the lock-screen-facing state and the app-wide shared state must move
+    // to .error, otherwise in-app UI stays stuck on .loading.
     expectNoDifference(stationPlayer.state.playbackStatus, .error)
+    expectNoDifference(nowPlaying?.playbackStatus, .error)
   }
 
   @Test
   func testHandlePlayFailureIgnoresCancellation() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .loading(.mock))
     let stationPlayer = StationPlayer()
     stationPlayer.state = StationPlayer.State(playbackStatus: .loading(.mock))
 
     stationPlayer.handlePlayFailure(CancellationError())
 
     expectNoDifference(stationPlayer.state.playbackStatus, .loading(.mock))
+    expectNoDifference(nowPlaying?.playbackStatus, .loading(.mock))
   }
 
   // MARK: - seekNext Tests

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -5,6 +5,7 @@
 //  Created by Claude on 1/8/26.
 //
 
+import CustomDump
 import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
@@ -13,8 +14,31 @@ import Testing
 
 @testable import PlayolaRadio
 
+private struct PlayFailureTestError: Error {}
+
 @MainActor
 struct StationPlayerTests {
+
+  // MARK: - Play Failure Tests
+
+  @Test
+  func testHandlePlayFailureSetsErrorState() {
+    let stationPlayer = StationPlayer()
+
+    stationPlayer.handlePlayFailure(PlayFailureTestError())
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .error)
+  }
+
+  @Test
+  func testHandlePlayFailureIgnoresCancellation() {
+    let stationPlayer = StationPlayer()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .loading(.mock))
+
+    stationPlayer.handlePlayFailure(CancellationError())
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .loading(.mock))
+  }
 
   // MARK: - seekNext Tests
 


### PR DESCRIPTION
Reading `MPNowPlayingInfoCenter.default().nowPlayingInfo` on the main thread does a synchronous cross-process wait that blocked the main thread for 4.4–5.2s (Sentry APPLE-IOS-1C); `NowPlayingUpdater` now keeps a local source-of-truth dictionary and reads artwork from it instead of the system getter. `StationPlayer` no longer swallows a failed playola station start — it surfaces a recoverable `.error` state instead of getting stuck on `.loading` forever, which is what drove the retry storm that exposed the hang during the schedule-endpoint outage (`CancellationError` is ignored so a superseding play/stop keeps state). Also adds a stale-artwork guard so a fast station switch can't paint the previous station's image. Covered by 5 new regression tests; the full StationPlayer and NowPlayingUpdater suites pass (37 tests) on iPhone 17 Pro / iOS 26.5.