### PR TITLE
Improve Sentry app-hang instrumentation (split out of $main bucket)

### DIFF
--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -46,6 +46,23 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
             $0.lifecycle = .trace
           }
           options.enableLogs = true
+
+          // App Hang Tracking: capture the real main-thread blocking stack so
+          // hangs resolve to named functions instead of collapsing into the
+          // generic `$main` bucket (Sentry APPLE-IOS-V / 7460768272).
+          //
+          // App Hang Tracking V2 captures the stack at hang onset and is the
+          // default on iOS/tvOS as of sentry-cocoa 9.x — the old
+          // `enableAppHangTrackingV2` toggle was removed (#5615), so no flag is
+          // needed to turn it on.
+          //
+          // 2.0s is the SDK default; set explicitly as the tuning knob if these
+          // turn out noisy.
+          options.appHangTimeoutInterval = 2.0
+          // Ignore non-fully-blocking hangs (app stutters but still renders a
+          // few frames): their stacks don't pinpoint the blocking location, so
+          // they add noise without being actionable.
+          options.enableReportNonFullyBlockingAppHangs = false
         }
       }
     #endif


### PR DESCRIPTION
## What

Tune the Sentry SDK options block so future **app hangs capture the real main-thread blocking stack** and resolve to named functions, instead of collapsing into the generic `$main` catch-all group (Sentry **APPLE-IOS-V / 7460768272** — 51+ users, 600+ events, culprit `PlayolaRadioApp.$main`).

This is the instrumentation half of the app-hang work. The symbolicated main-thread audio hangs were already fixed in the PlayolaPlayer package (blocking `AVAudioEngine`/`AVAudioPlayerNode` calls moved off the main thread). This PR improves how Sentry captures the *remaining* un-attributable hangs.

## Changes

In `AppDelegate`'s `SentrySDK.start { … }` block:

```swift
options.appHangTimeoutInterval = 2.0
options.enableReportNonFullyBlockingAppHangs = false
```

- **App Hang Tracking V2** (captures the main-thread stack at hang onset, and reduces suspended-app false positives) is **already the default on iOS/tvOS** as of sentry-cocoa 9.x. The `enableAppHangTrackingV2` toggle from the task description was **removed in the 9.0 breaking changes (#5615)** — setting it would not compile. No flag is needed to turn V2 on; it's already active.
- `appHangTimeoutInterval = 2.0` is the SDK default, set explicitly as the documented tuning knob (raise it if these turn out noisy).
- `enableReportNonFullyBlockingAppHangs = false` drops non-fully-blocking hangs (app stutters but still renders a few frames). Their stacks don't pinpoint the blocking location, so they add noise without being actionable.

Existing config (DSN, `tracesSampleRate`, profiling, `enableLogs`, PII) is untouched.

## SDK version

Installed: **sentry-cocoa 9.16.1** (pinned in `Package.resolved`; project requires `upToNextMajor` from 9.10.0). This comfortably supports the V2 behavior — **no SDK bump needed**. Every API symbol was verified against the installed SDK source (not from memory), including confirming that `enableAppHangTrackingV2` no longer exists and that V2 is wired up via `SentryANRTrackerV2` on iOS.

## dSYM upload

Verified intact — both the Xcode **"Upload Debug Symbols to Sentry"** build phase (sentry-cli, org `playola-radio` / project `apple-ios`, `--include-sources`) and the fastlane `sentry_debug_files_upload` lanes, with release configs using `dwarf-with-dsym`. V2 stacks will symbolicate like other issues.

## Tradeoff (intentional)

Disabling non-fully-blocking reports also means *fatal* non-fully-blocking hangs won't be derived later (the initial stored event is skipped). **Fully-blocking hangs — fatal and non-fatal, including watchdog terminations, which are the actionable ones with exact stacks — are unaffected.** This is the right call: it cuts the noisy, hard-to-action partial hangs while keeping everything we can actually fix.

## Verification

- Builds clean for the iOS simulator (`xcodebuild ... -scheme PlayolaRadio` → `** BUILD SUCCEEDED **`).
- Independent Codex review of the diff: **no P1/P2 findings**; all API claims verified against the 9.x SDK source.

## Forward-looking

The effect is **forward-looking** — only new events get the better onset stacks. Existing APPLE-IOS-V events keep their stackless grouping. We should **re-measure V's volume one release after this ships** to confirm new hangs are splitting into named, fixable groups and that suspended-app false positives have dropped.

Refs: Sentry issue **APPLE-IOS-V / 7460768272**.
