### PR TITLE
Update PlayolaPlayer to 0.19.0 and handle new terminal .error state

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2725,7 +2725,7 @@
 			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.10.0;
+				minimumVersion = 0.19.0;
 			};
 		};
 		D30F003A2E8592F0007BCC73 /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {
@@ -2869,7 +2869,7 @@
 			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.17.0;
+				minimumVersion = 0.19.0;
 			};
 		};
 		D3FF74D32FA7CA760052D500 /* XCRemoteSwiftPackageReference "swift-custom-dump" */ = {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -405,7 +405,11 @@ class NowPlayingUpdater {
           )
         }
       }
-    case .none:
+    // `.error` is PlayolaPlayer 0.19.0's terminal failure (e.g. the schedule
+    // fetch exhausted its retries); `.none` is an unexpected empty state. Both
+    // publish the recoverable `.error` status so the lock screen shows the
+    // error and the user can tap play again to retry.
+    case .error, .none:
       $nowPlaying.withLock {
         $0 = NowPlaying(
           artistPlaying: nil,

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -9,6 +9,7 @@ import Dependencies
 import Foundation
 import MediaPlayer
 import PlayolaPlayer
+import Sharing
 import Testing
 
 @testable import PlayolaRadio
@@ -53,6 +54,25 @@ struct NowPlayingUpdaterTests {
     let merged = updater.preservingExistingArtwork(in: [MPMediaItemPropertyTitle: "new title"])
 
     #expect(merged[MPMediaItemPropertyArtwork] == nil)
+  }
+
+  // MARK: - Playola State Processing Tests
+
+  @Test
+  func testProcessPlayolaErrorStatePublishesRecoverableErrorStatus() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .loading(.mock))
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      NowPlayingUpdater()
+    }
+
+    // PlayolaPlayer 0.19.0's terminal `.error` must publish the recoverable
+    // `.error` status into shared state, not leave the UI stuck on .loading.
+    updater.processPlayolaStationPlayerState(.error(.networkError("boom")))
+
+    #expect(nowPlaying?.playbackStatus == .error)
   }
 
   @Test

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -233,7 +233,11 @@ class StationPlayer: ObservableObject {
         )
       }
 
-    case .none:
+    // `.error` is PlayolaPlayer 0.19.0's terminal failure (e.g. the schedule
+    // fetch exhausted its retries); `.none` is an unexpected empty state. Both
+    // surface the recoverable `.error` state so the user sees the error and can
+    // tap play again to retry.
+    case .error, .none:
       state = .init(
         playbackStatus: .error,
         artistPlaying: nil,

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -59,6 +59,10 @@ struct StationPlayerTests {
     stationPlayer.processPlayolaStationPlayerState(.error(.networkError("boom")))
 
     expectNoDifference(stationPlayer.state.playbackStatus, .error)
+    // StationPlayer.processPlayolaStationPlayerState drives only `state`; the
+    // shared `nowPlaying` is NowPlayingUpdater's responsibility and must be
+    // left untouched here.
+    expectNoDifference(nowPlaying?.playbackStatus, .loading(.mock))
   }
 
   // MARK: - seekNext Tests

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -46,6 +46,21 @@ struct StationPlayerTests {
     expectNoDifference(nowPlaying?.playbackStatus, .loading(.mock))
   }
 
+  // MARK: - Playola State Processing Tests
+
+  @Test
+  func testProcessPlayolaErrorStateSetsRecoverableErrorState() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .loading(.mock))
+    let stationPlayer = StationPlayer()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .loading(.mock))
+
+    // PlayolaPlayer 0.19.0's terminal `.error` must surface as the app's
+    // recoverable `.error` state, not leave the player stuck on .loading.
+    stationPlayer.processPlayolaStationPlayerState(.error(.networkError("boom")))
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .error)
+  }
+
   // MARK: - seekNext Tests
 
   @Test


### PR DESCRIPTION
## What

Updates the PlayolaPlayer SPM dependency to **0.19.0** and fixes the resulting source-breaking change.

PlayolaPlayer 0.19.0 adds a terminal `PlayolaStationPlayer.State.error(StationPlayerError)` case (emitted when a play attempt fails terminally — e.g. the schedule fetch exhausts its bounded retries). This makes any exhaustive `switch` over `State` non-exhaustive → compile error.

## Changes

- **SPM bump:** both PlayolaPlayer `XCRemoteSwiftPackageReference` entries (`PlayolaRadio` target at 0.17.0 and `PlayolaRadio Staging` target at 0.10.0) → **0.19.0** (`upToNextMinorVersion`). `Package.resolved` resolves to `PlayolaPlayer @ 0.19.0`.
- **`StationPlayer.processPlayolaStationPlayerState`** and **`NowPlayingUpdater.processPlayolaStationPlayerState`**: handle the new `.error` case by routing it to the app's existing recoverable `.error` playback status, combined with the existing `.none` arm (identical body). This mirrors how the app already handles transient playback failures (`handlePlayFailure(_:)`): the user sees the error state (`PlayerPageModel` → "Error Playing Station") and can tap play to retry — it is **not** treated as a fatal crash.
- **Regression tests** added in both files asserting `.error(...)` → recoverable `.error` status.

### Not affected
- `playNow(from:to:)` / `schedulePlay(at:)` became `async` in 0.19.0, but those are on `SpinPlayer`, which the app does not call. No `await` sites changed.

## Verification
- ✅ Builds (`PlayolaRadio` scheme, iOS Simulator).
- ✅ Full test suite: **992 passed, 0 failed**.
- ✅ `make format` / `make lint` clean.
- ✅ Codex adversarial review: **GATE PASS** (no critical findings).

## Known limitation (pre-existing, not a regression)
Codex flagged a [P2]: because `PlaybackStatus.error` carries no station, `currentStation` returns `nil` for `.error`, so the lock-screen path (`NowPlayingUpdater.updateNowPlaying`) clears Now Playing info rather than showing "Connection Error" for the failed station. This is **existing behavior** shared by `handlePlayFailure` and the prior `.none` arm — this PR routes the new SDK `.error` through that same established path. Surfacing the failed station on the lock screen would require changing `PlaybackStatus.error` to carry a station (broad ripple), out of scope for this dependency bump. The error is still surfaced in-app and remains retryable. Tracked as a potential follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)