### PR TITLE
Release 7.0.0: Hanging Issues and In Development Badge

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -235,7 +235,9 @@
 		D35EFC202F17D47F000F64A4 /* LiveStationsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC1E2F17D47F000F64A4 /* LiveStationsPoller.swift */; };
 		D35EFC212F17D47F000F64A4 /* LiveStationsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC1E2F17D47F000F64A4 /* LiveStationsPoller.swift */; };
 		D35EFC232F17D4CC000F64A4 /* LiveBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */; };
+		D3FACE010000000000000002 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
 		D35EFC242F17D4CC000F64A4 /* LiveBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */; };
+		D3FACE010000000000000003 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
 		D35EFC262F192AAF000F64A4 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC252F192AAF000F64A4 /* Conversation.swift */; };
 		D35EFC272F192AAF000F64A4 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC252F192AAF000F64A4 /* Conversation.swift */; };
 		D35EFC292F192AB9000F64A4 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC282F192AB9000F64A4 /* Message.swift */; };
@@ -342,6 +344,7 @@
 		D39728712F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */; };
 		D39728722F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */; };
 		D39728762F60E2A7008591E3 /* StationSuggestionPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39728732F60E29B008591E3 /* StationSuggestionPageTests.swift */; };
+		D3FACE010000000000000005 /* ArtistSuggestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000004 /* ArtistSuggestionTests.swift */; };
 		D3A08A2F2E4E2A35002468E0 /* AnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */; };
 		D3A08A312E4E2E2A002468E0 /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */; };
 		D3A08A352E4E6F66002468E0 /* NowPlayingUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A332E4E6F5D002468E0 /* NowPlayingUpdaterTests.swift */; };
@@ -543,6 +546,7 @@
 		D35EFC1B2F17D361000F64A4 /* LiveStationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStationInfo.swift; sourceTree = "<group>"; };
 		D35EFC1E2F17D47F000F64A4 /* LiveStationsPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStationsPoller.swift; sourceTree = "<group>"; };
 		D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveBadge.swift; sourceTree = "<group>"; };
+		D3FACE010000000000000001 /* InDevelopmentBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InDevelopmentBadge.swift; sourceTree = "<group>"; };
 		D35EFC252F192AAF000F64A4 /* Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conversation.swift; sourceTree = "<group>"; };
 		D35EFC282F192AB9000F64A4 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		D35EFC352F192C76000F64A4 /* SupportPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportPageModel.swift; sourceTree = "<group>"; };
@@ -612,6 +616,7 @@
 		D39728672F60CF59008591E3 /* StationSuggestionPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSuggestionPageView.swift; sourceTree = "<group>"; };
 		D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestion.swift; sourceTree = "<group>"; };
 		D39728732F60E29B008591E3 /* StationSuggestionPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSuggestionPageTests.swift; sourceTree = "<group>"; };
+		D3FACE010000000000000004 /* ArtistSuggestionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestionTests.swift; sourceTree = "<group>"; };
 		D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClient.swift; sourceTree = "<group>"; };
 		D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
 		D3A08A332E4E6F5D002468E0 /* NowPlayingUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingUpdaterTests.swift; sourceTree = "<group>"; };
@@ -819,6 +824,7 @@
 			children = (
 				D39728582F5F0427008591E3 /* AppVersionRequirements.swift */,
 				D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */,
+				D3FACE010000000000000004 /* ArtistSuggestionTests.swift */,
 				D35EFC252F192AAF000F64A4 /* Conversation.swift */,
 				D3137DD12D3ABB4F0070033A /* GenericNowPlaying.swift */,
 				D3B9C7A52F534CE0002D75C2 /* IntroPresignedURLResponse.swift */,
@@ -926,6 +932,7 @@
 			children = (
 				D3B744C62E3139860042A427 /* ListeningTimeTile */,
 				D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */,
+				D3FACE010000000000000001 /* InDevelopmentBadge.swift */,
 				D35EFBF42F1576EF000F64A4 /* NewFeatureTile */,
 				D3137DBA2D3976550070033A /* PlayolaAlert.swift */,
 				D3137DCE2D3AA1E10070033A /* PlayolaSheet.swift */,
@@ -1772,6 +1779,7 @@
 				D37769FA2F22B38700200ADF /* ChooseStationPageView.swift in Sources */,
 				D30F00532E8592F0007BCC73 /* ListeningTracker.swift in Sources */,
 				D35EFC242F17D4CC000F64A4 /* LiveBadge.swift in Sources */,
+				D3FACE010000000000000003 /* InDevelopmentBadge.swift in Sources */,
 				D30F00542E8592F0007BCC73 /* ViewModel.swift in Sources */,
 				D30F00552E8592F0007BCC73 /* SignInPageView.swift in Sources */,
 				D30F00562E8592F0007BCC73 /* UrlStation.swift in Sources */,
@@ -1932,6 +1940,7 @@
 				D37769FC2F22B38700200ADF /* ChooseStationPageView.swift in Sources */,
 				D3B744B72E2FED940042A427 /* ListeningTracker.swift in Sources */,
 				D35EFC232F17D4CC000F64A4 /* LiveBadge.swift in Sources */,
+				D3FACE010000000000000002 /* InDevelopmentBadge.swift in Sources */,
 				D31CD5232DFBA1F2009B9780 /* ViewModel.swift in Sources */,
 				D3B6626A2D40103C00975D2F /* SignInPageView.swift in Sources */,
 				D30AE8A72E75C92700D9FBCA /* UrlStation.swift in Sources */,
@@ -2102,6 +2111,7 @@
 				D342A0C72DFCB368002BAC30 /* HomePageTests.swift in Sources */,
 				D35EFBEE2F1092A7000F64A4 /* RRuleFormatterTests.swift in Sources */,
 				D39728762F60E2A7008591E3 /* StationSuggestionPageTests.swift in Sources */,
+				D3FACE010000000000000005 /* ArtistSuggestionTests.swift in Sources */,
 				D30257812E639FF200F4228B /* LikesManagerTests.swift in Sources */,
 				D35EFC592F1B0472000F64A4 /* AppRatingClientTests.swift in Sources */,
 				D3ABC1252F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift in Sources */,

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		D3137DC02D39818E0070033A /* MailServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBF2D3981880070033A /* MailServiceMock.swift */; };
 		D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DC12D39B4FC0070033A /* StationListPageTests.swift */; };
 		76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */; };
 		BFF0E48BF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
 		BFF0E48CF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
 		BFF0E49EF7714364A04B11B4 /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
@@ -466,6 +467,7 @@
 		D3137DBF2D3981880070033A /* MailServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailServiceMock.swift; sourceTree = "<group>"; };
 		D3137DC12D39B4FC0070033A /* StationListPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPageTests.swift; sourceTree = "<group>"; };
 		BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetTests.swift; sourceTree = "<group>"; };
+		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
 		BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetStarButton.swift; sourceTree = "<group>"; };
 		BFF0E49DF7714364A04B11B3 /* PresetTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTile.swift; sourceTree = "<group>"; };
 		BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsCarousel.swift; sourceTree = "<group>"; };
@@ -792,6 +794,7 @@
 				D339E5662BFD10AE00B9E35B /* StationListPage.swift */,
 				D3137DC12D39B4FC0070033A /* StationListPageTests.swift */,
 				BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */,
+				A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */,
 				BFF0E48DF7714364A04B11B2 /* Presets */,
 			);
 			path = StationListPage;
@@ -2086,6 +2089,7 @@
 				D3C7E5E32EF0A44D00EDD3ED /* SongSearchPageTests.swift in Sources */,
 				D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */,
 				76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */,
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */,
 				D30F00BF2E87196A007BCC73 /* StationListStationRowTests.swift in Sources */,
 				D395912D2E3D1E1E00720CF8 /* EditProfilePageTests.swift in Sources */,
 				D34D5C392D7106CD00148048 /* AuthServiceMock.swift in Sources */,

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2162,7 +2162,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2182,7 +2182,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.4.0;
+				MARKETING_VERSION = 7.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2206,7 +2206,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2226,7 +2226,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.4.0;
+				MARKETING_VERSION = 7.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2250,7 +2250,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2270,7 +2270,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.4.0;
+				MARKETING_VERSION = 7.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2415,7 +2415,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2437,7 +2437,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.4.0;
+				MARKETING_VERSION = 7.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2461,7 +2461,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2483,7 +2483,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.4.0;
+				MARKETING_VERSION = 7.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2502,7 +2502,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2521,7 +2521,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2609,7 +2609,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2631,7 +2631,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 6.4.0;
+				MARKETING_VERSION = 7.0.0;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2650,7 +2650,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 88;
+				CURRENT_PROJECT_VERSION = 89;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2725,7 +2725,7 @@
 			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.10.0;
+				minimumVersion = 0.19.0;
 			};
 		};
 		D30F003A2E8592F0007BCC73 /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {
@@ -2869,7 +2869,7 @@
 			repositoryURL = "https://github.com/briankeane/PlayolaPlayer";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.17.0;
+				minimumVersion = 0.19.0;
 			};
 		};
 		D3FF74D32FA7CA760052D500 /* XCRemoteSwiftPackageReference "swift-custom-dump" */ = {

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -7,6 +7,17 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1F6F57E01E254F5483BD939B /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
+		76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */; };
+		81599AD0B41E4A2496EEF25A /* PresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6613FD7A13B448187CB8595 /* PresetTests.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */; };
+		AA01000000000001AAAAAAAA /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
+		AA01000000000002AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
+		AA01000000000003AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
+		AA01000000000004AAAAAAAA /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
+		AA01000000000005AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
+		AA01000000000006AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
+		C8BA849E20B449EC91DBF5F2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
 		D302576B2E63423D00F4228B /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
 		D302576D2E63428800F4228B /* ToastClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576C2E63428700F4228B /* ToastClient.swift */; };
 		D30257762E6342C900F4228B /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257752E6342C600F4228B /* ToastView.swift */; };
@@ -131,25 +142,7 @@
 		D3137DBB2D3976580070033A /* PlayolaAlert.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBA2D3976550070033A /* PlayolaAlert.swift */; };
 		D3137DC02D39818E0070033A /* MailServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBF2D3981880070033A /* MailServiceMock.swift */; };
 		D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DC12D39B4FC0070033A /* StationListPageTests.swift */; };
-		76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */; };
-		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
-		A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */; };
-		BFF0E48BF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
-		BFF0E48CF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
-		BFF0E49EF7714364A04B11B4 /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
-		BFF0EA0EF7714364A04B11B6 /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
-		AA01000000000001AAAAAAAA /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
-		AA01000000000002AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
-		AA01000000000003AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
-		AA01000000000004AAAAAAAA /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
-		AA01000000000005AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
-		AA01000000000006AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
-		AA01000000000007AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
-		AA01000000000008AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
-
 		D3137DC62D39BEE00070033A /* URLStreamPlayerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DC52D39BEDD0070033A /* URLStreamPlayerMock.swift */; };
-		BFF0E49FF7714364A04B11B5 /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
-		BFF0EA1FF7714364A04B11B8 /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
 		D3137DCF2D3AA1E40070033A /* PlayolaSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DCE2D3AA1E10070033A /* PlayolaSheet.swift */; };
 		D3137DD22D3ABB520070033A /* GenericNowPlaying.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DD12D3ABB4F0070033A /* GenericNowPlaying.swift */; };
 		D3137DD42D3AC9BE0070033A /* EnumTypeEquatableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DD32D3AC9B40070033A /* EnumTypeEquatableProtocol.swift */; };
@@ -235,9 +228,7 @@
 		D35EFC202F17D47F000F64A4 /* LiveStationsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC1E2F17D47F000F64A4 /* LiveStationsPoller.swift */; };
 		D35EFC212F17D47F000F64A4 /* LiveStationsPoller.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC1E2F17D47F000F64A4 /* LiveStationsPoller.swift */; };
 		D35EFC232F17D4CC000F64A4 /* LiveBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */; };
-		D3FACE010000000000000002 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
 		D35EFC242F17D4CC000F64A4 /* LiveBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */; };
-		D3FACE010000000000000003 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
 		D35EFC262F192AAF000F64A4 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC252F192AAF000F64A4 /* Conversation.swift */; };
 		D35EFC272F192AAF000F64A4 /* Conversation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC252F192AAF000F64A4 /* Conversation.swift */; };
 		D35EFC292F192AB9000F64A4 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFC282F192AB9000F64A4 /* Message.swift */; };
@@ -344,7 +335,6 @@
 		D39728712F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */; };
 		D39728722F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */; };
 		D39728762F60E2A7008591E3 /* StationSuggestionPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39728732F60E29B008591E3 /* StationSuggestionPageTests.swift */; };
-		D3FACE010000000000000005 /* ArtistSuggestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000004 /* ArtistSuggestionTests.swift */; };
 		D3A08A2F2E4E2A35002468E0 /* AnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */; };
 		D3A08A312E4E2E2A002468E0 /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */; };
 		D3A08A352E4E6F66002468E0 /* NowPlayingUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A332E4E6F5D002468E0 /* NowPlayingUpdaterTests.swift */; };
@@ -392,9 +382,6 @@
 		D3C7E5E92EF0C56200EDD3ED /* StagingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C7E5E82EF0C56000EDD3ED /* StagingItem.swift */; };
 		D3C7E5EA2EF0C56200EDD3ED /* StagingItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C7E5E82EF0C56000EDD3ED /* StagingItem.swift */; };
 		D3C7E5EF2EF0C58900EDD3ED /* StagingItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C7E5EC2EF0C57E00EDD3ED /* StagingItemTests.swift */; };
-		C8BA849E20B449EC91DBF5F2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
-		1F6F57E01E254F5483BD939B /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
-		81599AD0B41E4A2496EEF25A /* PresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6613FD7A13B448187CB8595 /* PresetTests.swift */; };
 		D3C7E5F62EF0D12A00EDD3ED /* SongSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C7E5F32EF0D12A00EDD3ED /* SongSeed.swift */; };
 		D3C7E5F82EF0D12A00EDD3ED /* SongSeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C7E5F32EF0D12A00EDD3ED /* SongSeed.swift */; };
 		D3C7E5FA2EF0D13800EDD3ED /* SongSeedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3C7E5F42EF0D12A00EDD3ED /* SongSeedTests.swift */; };
@@ -419,6 +406,9 @@
 		D3F493D32EEE58CF008ED463 /* VoicetrackUploadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F493D22EEE58CF008ED463 /* VoicetrackUploadService.swift */; };
 		D3F493D42EEE58CF008ED463 /* VoicetrackUploadService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F493D22EEE58CF008ED463 /* VoicetrackUploadService.swift */; };
 		D3FA612A2E00584200E9DF49 /* PlayerPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FA61292E00583F00E9DF49 /* PlayerPageModel.swift */; };
+		D3FACE010000000000000002 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
+		D3FACE010000000000000003 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
+		D3FACE010000000000000005 /* ArtistSuggestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000004 /* ArtistSuggestionTests.swift */; };
 		D3FE88842E37EF29009AE7B7 /* PrizeTier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FE88832E37EF24009AE7B7 /* PrizeTier.swift */; };
 		D3FEC8082EDF646A00A33AE8 /* ChooseStationToBroadcastPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */; };
 		D3FEC8092EDF646A00A33AE8 /* ChooseStationToBroadcastPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */; };
@@ -427,6 +417,7 @@
 		D3FEC80D2EDF689F00A33AE8 /* ChooseStationToBroadcastPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */; };
 		D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = D3FF74D42FA7CA760052D500 /* CustomDump */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
+		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -440,6 +431,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		9E8719F70AFA4992B9037775 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
+		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
+		A6613FD7A13B448187CB8595 /* PresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTests.swift; sourceTree = "<group>"; };
+		BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetTests.swift; sourceTree = "<group>"; };
+		BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetStarButton.swift; sourceTree = "<group>"; };
+		BFF0E49DF7714364A04B11B3 /* PresetTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTile.swift; sourceTree = "<group>"; };
+		BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsCarousel.swift; sourceTree = "<group>"; };
 		D302576A2E63423B00F4228B /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		D302576C2E63428700F4228B /* ToastClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastClient.swift; sourceTree = "<group>"; };
 		D30257752E6342C600F4228B /* ToastView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastView.swift; sourceTree = "<group>"; };
@@ -470,13 +468,6 @@
 		D3137DBA2D3976550070033A /* PlayolaAlert.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaAlert.swift; sourceTree = "<group>"; };
 		D3137DBF2D3981880070033A /* MailServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailServiceMock.swift; sourceTree = "<group>"; };
 		D3137DC12D39B4FC0070033A /* StationListPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPageTests.swift; sourceTree = "<group>"; };
-		BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetTests.swift; sourceTree = "<group>"; };
-		FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetErrorReportingTests.swift; sourceTree = "<group>"; };
-		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
-		BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetStarButton.swift; sourceTree = "<group>"; };
-		BFF0E49DF7714364A04B11B3 /* PresetTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTile.swift; sourceTree = "<group>"; };
-		BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsCarousel.swift; sourceTree = "<group>"; };
-
 		D3137DC52D39BEDD0070033A /* URLStreamPlayerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLStreamPlayerMock.swift; sourceTree = "<group>"; };
 		D3137DCE2D3AA1E10070033A /* PlayolaSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaSheet.swift; sourceTree = "<group>"; };
 		D3137DD12D3ABB4F0070033A /* GenericNowPlaying.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GenericNowPlaying.swift; sourceTree = "<group>"; };
@@ -546,7 +537,6 @@
 		D35EFC1B2F17D361000F64A4 /* LiveStationInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStationInfo.swift; sourceTree = "<group>"; };
 		D35EFC1E2F17D47F000F64A4 /* LiveStationsPoller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveStationsPoller.swift; sourceTree = "<group>"; };
 		D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveBadge.swift; sourceTree = "<group>"; };
-		D3FACE010000000000000001 /* InDevelopmentBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InDevelopmentBadge.swift; sourceTree = "<group>"; };
 		D35EFC252F192AAF000F64A4 /* Conversation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Conversation.swift; sourceTree = "<group>"; };
 		D35EFC282F192AB9000F64A4 /* Message.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Message.swift; sourceTree = "<group>"; };
 		D35EFC352F192C76000F64A4 /* SupportPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SupportPageModel.swift; sourceTree = "<group>"; };
@@ -616,7 +606,6 @@
 		D39728672F60CF59008591E3 /* StationSuggestionPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSuggestionPageView.swift; sourceTree = "<group>"; };
 		D39728702F60DCCC008591E3 /* ArtistSuggestion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestion.swift; sourceTree = "<group>"; };
 		D39728732F60E29B008591E3 /* StationSuggestionPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationSuggestionPageTests.swift; sourceTree = "<group>"; };
-		D3FACE010000000000000004 /* ArtistSuggestionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestionTests.swift; sourceTree = "<group>"; };
 		D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClient.swift; sourceTree = "<group>"; };
 		D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
 		D3A08A332E4E6F5D002468E0 /* NowPlayingUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingUpdaterTests.swift; sourceTree = "<group>"; };
@@ -653,8 +642,6 @@
 		D3C7E5E02EF0A43E00EDD3ED /* SongSearchPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongSearchPageView.swift; sourceTree = "<group>"; };
 		D3C7E5E82EF0C56000EDD3ED /* StagingItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagingItem.swift; sourceTree = "<group>"; };
 		D3C7E5EC2EF0C57E00EDD3ED /* StagingItemTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StagingItemTests.swift; sourceTree = "<group>"; };
-		9E8719F70AFA4992B9037775 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
-		A6613FD7A13B448187CB8595 /* PresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTests.swift; sourceTree = "<group>"; };
 		D3C7E5F32EF0D12A00EDD3ED /* SongSeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongSeed.swift; sourceTree = "<group>"; };
 		D3C7E5F42EF0D12A00EDD3ED /* SongSeedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongSeedTests.swift; sourceTree = "<group>"; };
 		D3CE19042D3CA6150091B888 /* SharedUserDefaults.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedUserDefaults.swift; sourceTree = "<group>"; };
@@ -670,10 +657,13 @@
 		D3F493CF2EEE52F4008ED463 /* PresignedURLResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresignedURLResponse.swift; sourceTree = "<group>"; };
 		D3F493D22EEE58CF008ED463 /* VoicetrackUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicetrackUploadService.swift; sourceTree = "<group>"; };
 		D3FA61292E00583F00E9DF49 /* PlayerPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPageModel.swift; sourceTree = "<group>"; };
+		D3FACE010000000000000001 /* InDevelopmentBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InDevelopmentBadge.swift; sourceTree = "<group>"; };
+		D3FACE010000000000000004 /* ArtistSuggestionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestionTests.swift; sourceTree = "<group>"; };
 		D3FE88832E37EF24009AE7B7 /* PrizeTier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrizeTier.swift; sourceTree = "<group>"; };
 		D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageTests.swift; sourceTree = "<group>"; };
 		D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageView.swift; sourceTree = "<group>"; };
 		D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageModel.swift; sourceTree = "<group>"; };
+		FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetErrorReportingTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -731,6 +721,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5C5534927BB84EF0BB547E65 /* Preset */ = {
+			isa = PBXGroup;
+			children = (
+				9E8719F70AFA4992B9037775 /* Preset.swift */,
+				A6613FD7A13B448187CB8595 /* PresetTests.swift */,
+			);
+			path = Preset;
+			sourceTree = "<group>";
+		};
+		BFF0E48DF7714364A04B11B2 /* Presets */ = {
+			isa = PBXGroup;
+			children = (
+				BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */,
+				BFF0E49DF7714364A04B11B3 /* PresetTile.swift */,
+				BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */,
+			);
+			path = Presets;
+			sourceTree = "<group>";
+		};
 		D302576E2E63429000F4228B /* Toast */ = {
 			isa = PBXGroup;
 			children = (
@@ -806,17 +815,6 @@
 				BFF0E48DF7714364A04B11B2 /* Presets */,
 			);
 			path = StationListPage;
-			sourceTree = "<group>";
-		};
-		BFF0E48DF7714364A04B11B2 /* Presets */ = {
-			isa = PBXGroup;
-			children = (
-				BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */,
-			
-				BFF0E49DF7714364A04B11B3 /* PresetTile.swift */,
-				BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */,
-			);
-			path = Presets;
 			sourceTree = "<group>";
 		};
 		D3137DD02D3ABB490070033A /* Models */ = {
@@ -1485,15 +1483,6 @@
 				D3C7E5EC2EF0C57E00EDD3ED /* StagingItemTests.swift */,
 			);
 			path = StagingItem;
-			sourceTree = "<group>";
-		};
-		5C5534927BB84EF0BB547E65 /* Preset */ = {
-			isa = PBXGroup;
-			children = (
-				9E8719F70AFA4992B9037775 /* Preset.swift */,
-				A6613FD7A13B448187CB8595 /* PresetTests.swift */,
-			);
-			path = Preset;
 			sourceTree = "<group>";
 		};
 		D3C7E5F52EF0D12A00EDD3ED /* SongSeed */ = {
@@ -2418,7 +2407,7 @@
 				CURRENT_PROJECT_VERSION = 89;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
-				DEVELOPMENT_TEAM = FSRSPV9N9Q;
+				DEVELOPMENT_TEAM = CTFSB7Y8TD;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -2612,7 +2601,7 @@
 				CURRENT_PROJECT_VERSION = 89;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
-				DEVELOPMENT_TEAM = FSRSPV9N9Q;
+				DEVELOPMENT_TEAM = CTFSB7Y8TD;
 				ENABLE_PREVIEWS = YES;
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -132,6 +132,7 @@
 		D3137DC02D39818E0070033A /* MailServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DBF2D3981880070033A /* MailServiceMock.swift */; };
 		D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DC12D39B4FC0070033A /* StationListPageTests.swift */; };
 		76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */; };
+		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */; };
 		BFF0E48BF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
 		BFF0E48CF7714364A04B11B2 /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
@@ -467,6 +468,7 @@
 		D3137DBF2D3981880070033A /* MailServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MailServiceMock.swift; sourceTree = "<group>"; };
 		D3137DC12D39B4FC0070033A /* StationListPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPageTests.swift; sourceTree = "<group>"; };
 		BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetTests.swift; sourceTree = "<group>"; };
+		FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetErrorReportingTests.swift; sourceTree = "<group>"; };
 		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
 		BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetStarButton.swift; sourceTree = "<group>"; };
 		BFF0E49DF7714364A04B11B3 /* PresetTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTile.swift; sourceTree = "<group>"; };
@@ -794,6 +796,7 @@
 				D339E5662BFD10AE00B9E35B /* StationListPage.swift */,
 				D3137DC12D39B4FC0070033A /* StationListPageTests.swift */,
 				BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */,
+				FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */,
 				A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */,
 				BFF0E48DF7714364A04B11B2 /* Presets */,
 			);
@@ -2089,6 +2092,7 @@
 				D3C7E5E32EF0A44D00EDD3ED /* SongSearchPageTests.swift in Sources */,
 				D3137DC22D39B5070070033A /* StationListPageTests.swift in Sources */,
 				76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */,
+				FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */,
 				A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */,
 				D30F00BF2E87196A007BCC73 /* StationListStationRowTests.swift in Sources */,
 				D395912D2E3D1E1E00720CF8 /* EditProfilePageTests.swift in Sources */,

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -117,6 +117,16 @@ private func signInPost(
   }
 }
 
+// When a manual `serializingData`/`serializingDecodable` request completes without a usable
+// HTTP response, prefer the underlying transport error (e.g. NSURLErrorSecureConnectionFailed
+// -1200 from the iOS 26 TLS middlebox issue) over a generic `dataNotValid`. The real
+// `NSURLError` code is what `NetworkErrorClassifier` needs to recognize the network failure and
+// keep it out of Sentry — and to surface the real code when it is reported.
+private func transportFailure(_ underlying: AFError?) -> Error {
+  if let underlying { return underlying }
+  return APIError.dataNotValid
+}
+
 private func authenticatedGet<T: Decodable & Sendable>(
   path: String,
   token: String,
@@ -324,7 +334,7 @@ extension APIClient: DependencyKey {
         guard
           let body = dataResponse.value
         else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         let newToken = dataResponse.response?.headers["X-New-Access-Token"] ?? jwtToken
@@ -409,7 +419,7 @@ extension APIClient: DependencyKey {
         .response
 
         guard let statusCode = dataResponse.response?.statusCode else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         guard let data = dataResponse.value else {
@@ -444,7 +454,7 @@ extension APIClient: DependencyKey {
         .response
 
         guard let statusCode = dataResponse.response?.statusCode else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         guard let data = dataResponse.value else {
@@ -487,7 +497,7 @@ extension APIClient: DependencyKey {
         .response
 
         guard let statusCode = dataResponse.response?.statusCode else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         guard let data = dataResponse.value else {
@@ -547,7 +557,7 @@ extension APIClient: DependencyKey {
         .response
 
         guard let statusCode = dataResponse.response?.statusCode else {
-          throw APIError.dataNotValid
+          throw transportFailure(dataResponse.error)
         }
 
         guard let data = dataResponse.value else {
@@ -601,7 +611,7 @@ extension APIClient: DependencyKey {
 
         guard let statusCode = dataResponse.response?.statusCode,
           let data = dataResponse.value
-        else { throw APIError.dataNotValid }
+        else { throw transportFailure(dataResponse.error) }
 
         if (200..<300).contains(statusCode) {
           return try sharedIsoDecoder.decode(Preset.self, from: data)

--- a/PlayolaRadio/Core/API/APIClient.swift
+++ b/PlayolaRadio/Core/API/APIClient.swift
@@ -738,7 +738,7 @@ struct APIClient: Sendable {
       _, _ in
       ArtistSuggestion(
         id: "", artistName: "", createdByUserId: "", voteCount: 0, hasVoted: false,
-        createdAt: Date(), updatedAt: Date())
+        status: .suggested, createdAt: Date(), updatedAt: Date())
     }
 
   /// Votes for an artist suggestion

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -72,6 +72,13 @@ class NowPlayingUpdater {
   var lastPlayedStation: AnyStation?
   private var currentArtworkURL: String?
 
+  // Local source of truth for the now-playing dictionary. We never read
+  // MPNowPlayingInfoCenter.default().nowPlayingInfo: that getter performs a
+  // synchronous cross-process wait that can block the main thread for seconds
+  // (Sentry APPLE-IOS-1C). We are the only writer, so we keep our own copy and
+  // read from it instead.
+  private(set) var currentNowPlayingInfo: [String: Any] = [:]
+
   // Analytics tracking
   private var sessionStartTime: Date?
   private var lastPlaybackStatus: StationPlayer.PlaybackStatus = .stopped
@@ -99,35 +106,46 @@ class NowPlayingUpdater {
     switch stationPlayerState.playbackStatus {
     case .loading, .stopped:
       // For loading/stopped states, preserve existing artwork if available, otherwise load new
-      if let existingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo,
-        let existingArtwork = existingInfo[MPMediaItemPropertyArtwork]
-      {
-        nowPlayingInfo[MPMediaItemPropertyArtwork] = existingArtwork
-      } else {
+      if currentNowPlayingInfo[MPMediaItemPropertyArtwork] != nil {
+        nowPlayingInfo = preservingExistingArtwork(in: nowPlayingInfo)
+      } else if currentArtworkURL != currentStation.imageUrl?.absoluteString {
         // Only load if we don't already have this station's artwork
-        if currentArtworkURL != currentStation.imageUrl?.absoluteString {
-          loadStationArtwork(from: stationPlayerState, station: currentStation)
-        }
+        loadStationArtwork(from: stationPlayerState, station: currentStation)
       }
     case .playing:
       // Preserve existing artwork
-      if let existingInfo = MPNowPlayingInfoCenter.default().nowPlayingInfo,
-        let existingArtwork = existingInfo[MPMediaItemPropertyArtwork]
-      {
-        nowPlayingInfo[MPMediaItemPropertyArtwork] = existingArtwork
-      }
+      nowPlayingInfo = preservingExistingArtwork(in: nowPlayingInfo)
     default:
       break
     }
 
-    MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    setNowPlayingInfo(nowPlayingInfo)
   }
 
   private func clearNowPlayingInfo() {
     print("🧹 Clearing now playing info")
     MPNowPlayingInfoCenter.default().playbackState = .stopped
+    currentNowPlayingInfo = [:]
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     currentArtworkURL = nil
+  }
+
+  /// Assigns the now-playing dictionary, keeping our local copy in sync with the
+  /// system center. This is the only place that writes `nowPlayingInfo`.
+  func setNowPlayingInfo(_ info: [String: Any]) {
+    currentNowPlayingInfo = info
+    MPNowPlayingInfoCenter.default().nowPlayingInfo = info
+  }
+
+  /// Carries the artwork from our local copy into `info`, if present. Reads from
+  /// `currentNowPlayingInfo`, never from `MPNowPlayingInfoCenter`'s getter.
+  func preservingExistingArtwork(in info: [String: Any]) -> [String: Any] {
+    guard let existingArtwork = currentNowPlayingInfo[MPMediaItemPropertyArtwork] else {
+      return info
+    }
+    var info = info
+    info[MPMediaItemPropertyArtwork] = existingArtwork
+    return info
   }
 
   private func buildNowPlayingInfo(
@@ -282,21 +300,23 @@ class NowPlayingUpdater {
     // For CarPlay/Lock Screen: always use station image, ignore album artwork
     Task {
       let image = await station.getImage()
+      // Artwork loads asynchronously; a fast station switch can resolve a stale
+      // image. Only apply it if this station is still the current one.
+      guard stationPlayer.currentStation?.id == station.id else { return }
       self.updateNowPlayingImage(image)
       self.currentArtworkURL = station.imageUrl?.absoluteString
     }
   }
 
   private func updateNowPlayingImage(_ image: UIImage) {
-    var nowPlayingInfo: [String: Any] =
-      MPNowPlayingInfoCenter.default().nowPlayingInfo ?? [String: Any]()
+    var nowPlayingInfo = currentNowPlayingInfo
     nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(
       boundsSize: image.size,
       requestHandler: { _ in
         return image
       }
     )
-    MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
+    setNowPlayingInfo(nowPlayingInfo)
   }
 
   // The Combine subscriptions below capture `self` weakly so the cancellable
@@ -508,6 +528,7 @@ class NowPlayingUpdater {
     commandCenter.previousTrackCommand.removeTarget(nil)
 
     // Clear now playing info
+    currentNowPlayingInfo = [:]
     MPNowPlayingInfoCenter.default().nowPlayingInfo = nil
     MPNowPlayingInfoCenter.default().playbackState = .stopped
 

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -132,6 +132,7 @@ class NowPlayingUpdater {
 
   /// Assigns the now-playing dictionary, keeping our local copy in sync with the
   /// system center. This is the only place that writes `nowPlayingInfo`.
+  // internal for testability
   func setNowPlayingInfo(_ info: [String: Any]) {
     currentNowPlayingInfo = info
     MPNowPlayingInfoCenter.default().nowPlayingInfo = info
@@ -139,6 +140,7 @@ class NowPlayingUpdater {
 
   /// Carries the artwork from our local copy into `info`, if present. Reads from
   /// `currentNowPlayingInfo`, never from `MPNowPlayingInfoCenter`'s getter.
+  // internal for testability
   func preservingExistingArtwork(in info: [String: Any]) -> [String: Any] {
     guard let existingArtwork = currentNowPlayingInfo[MPMediaItemPropertyArtwork] else {
       return info
@@ -302,10 +304,17 @@ class NowPlayingUpdater {
       let image = await station.getImage()
       // Artwork loads asynchronously; a fast station switch can resolve a stale
       // image. Only apply it if this station is still the current one.
-      guard stationPlayer.currentStation?.id == station.id else { return }
+      guard self.isStillCurrent(station) else { return }
       self.updateNowPlayingImage(image)
       self.currentArtworkURL = station.imageUrl?.absoluteString
     }
+  }
+
+  /// Whether `station` is still the one being played. Used to drop artwork that
+  /// finished loading after a fast station switch superseded the request.
+  // internal for testability
+  func isStillCurrent(_ station: AnyStation) -> Bool {
+    stationPlayer.currentStation?.id == station.id
   }
 
   private func updateNowPlayingImage(_ image: UIImage) {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -130,17 +130,17 @@ class NowPlayingUpdater {
     currentArtworkURL = nil
   }
 
+  // internal for testability
   /// Assigns the now-playing dictionary, keeping our local copy in sync with the
   /// system center. This is the only place that writes `nowPlayingInfo`.
-  // internal for testability
   func setNowPlayingInfo(_ info: [String: Any]) {
     currentNowPlayingInfo = info
     MPNowPlayingInfoCenter.default().nowPlayingInfo = info
   }
 
+  // internal for testability
   /// Carries the artwork from our local copy into `info`, if present. Reads from
   /// `currentNowPlayingInfo`, never from `MPNowPlayingInfoCenter`'s getter.
-  // internal for testability
   func preservingExistingArtwork(in info: [String: Any]) -> [String: Any] {
     guard let existingArtwork = currentNowPlayingInfo[MPMediaItemPropertyArtwork] else {
       return info
@@ -310,9 +310,9 @@ class NowPlayingUpdater {
     }
   }
 
+  // internal for testability
   /// Whether `station` is still the one being played. Used to drop artwork that
   /// finished loading after a fast station switch superseded the request.
-  // internal for testability
   func isStillCurrent(_ station: AnyStation) -> Bool {
     stationPlayer.currentStation?.id == station.id
   }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -405,7 +405,11 @@ class NowPlayingUpdater {
           )
         }
       }
-    case .none:
+    // `.error` is PlayolaPlayer 0.19.0's terminal failure (e.g. the schedule
+    // fetch exhausted its retries); `.none` is an unexpected empty state. Both
+    // publish the recoverable `.error` status so the lock screen shows the
+    // error and the user can tap play again to retry.
+    case .error, .none:
       $nowPlaying.withLock {
         $0 = NowPlaying(
           artistPlaying: nil,

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -16,6 +16,45 @@ import Testing
 @MainActor
 struct NowPlayingUpdaterTests {
 
+  // MARK: - Now Playing Info Cache Tests
+
+  // Regression: the now-playing artwork merge must read from our local copy,
+  // never MPNowPlayingInfoCenter.default().nowPlayingInfo (Sentry APPLE-IOS-1C).
+
+  @Test
+  func testSetNowPlayingInfoUpdatesLocalCache() {
+    let updater = NowPlayingUpdater()
+
+    updater.setNowPlayingInfo([MPMediaItemPropertyTitle: "cached title"])
+
+    #expect(updater.currentNowPlayingInfo[MPMediaItemPropertyTitle] as? String == "cached title")
+  }
+
+  @Test
+  func testPreservingExistingArtworkCarriesArtworkFromLocalCache() {
+    let updater = NowPlayingUpdater()
+    let artwork = MPMediaItemArtwork(boundsSize: CGSize(width: 10, height: 10)) { _ in UIImage() }
+    updater.setNowPlayingInfo([
+      MPMediaItemPropertyArtwork: artwork,
+      MPMediaItemPropertyTitle: "old title",
+    ])
+
+    let merged = updater.preservingExistingArtwork(in: [MPMediaItemPropertyTitle: "new title"])
+
+    #expect(merged[MPMediaItemPropertyTitle] as? String == "new title")
+    #expect(merged[MPMediaItemPropertyArtwork] != nil)
+  }
+
+  @Test
+  func testPreservingExistingArtworkNoOpWhenNoArtworkCached() {
+    let updater = NowPlayingUpdater()
+    updater.setNowPlayingInfo([MPMediaItemPropertyTitle: "title"])
+
+    let merged = updater.preservingExistingArtwork(in: [MPMediaItemPropertyTitle: "new title"])
+
+    #expect(merged[MPMediaItemPropertyArtwork] == nil)
+  }
+
   // MARK: - Analytics Tests
 
   @Test

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -55,6 +55,23 @@ struct NowPlayingUpdaterTests {
     #expect(merged[MPMediaItemPropertyArtwork] == nil)
   }
 
+  @Test
+  func testIsStillCurrentTrueForPlayingStationFalseAfterSwitch() {
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer()
+      stationPlayer.state = StationPlayer.State(playbackStatus: .playing(.mock))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    // Artwork that resolves for the current station applies; artwork for a
+    // station we've since switched away from is dropped (stale-artwork guard).
+    #expect(updater.isStillCurrent(.mock))
+    #expect(!updater.isStillCurrent(makeTestStation2()))
+  }
+
   // MARK: - Analytics Tests
 
   @Test

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -9,6 +9,7 @@ import Dependencies
 import Foundation
 import MediaPlayer
 import PlayolaPlayer
+import Sharing
 import Testing
 
 @testable import PlayolaRadio
@@ -53,6 +54,25 @@ struct NowPlayingUpdaterTests {
     let merged = updater.preservingExistingArtwork(in: [MPMediaItemPropertyTitle: "new title"])
 
     #expect(merged[MPMediaItemPropertyArtwork] == nil)
+  }
+
+  // MARK: - Playola State Processing Tests
+
+  @Test
+  func testProcessPlayolaErrorStatePublishesRecoverableErrorStatus() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .loading(.mock))
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      NowPlayingUpdater()
+    }
+
+    // PlayolaPlayer 0.19.0's terminal `.error` must publish the recoverable
+    // `.error` status into shared state, not leave the UI stuck on .loading.
+    updater.processPlayolaStationPlayerState(.error(.networkError("boom")))
+
+    #expect(nowPlaying?.playbackStatus == .error)
   }
 
   @Test

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -20,6 +20,7 @@ class StationPlayer: ObservableObject {
 
   @ObservationIgnored @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList>
   @ObservationIgnored @Shared(.showSecretStations) var showSecretStations: Bool
+  @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
 
   enum PlaybackStatus: Codable, Equatable {
     case startingNewStation(AnyStation)
@@ -122,11 +123,20 @@ class StationPlayer: ObservableObject {
   /// a swallowed failure (e.g. the schedule endpoint returning 500 during an
   /// outage) leaves the player stuck on `.loading` forever, with no error shown
   /// and no recovery — which pushes users into a manual retry storm.
+  ///
+  /// Both representations of playback state are updated: `state` (which drives
+  /// the lock screen via `NowPlayingUpdater`) and `@Shared(.nowPlaying)` (the
+  /// app-wide source of truth the in-app UI reads). The shared state would
+  /// otherwise stay `.loading`, because it is only driven by
+  /// `playolaStationPlayer.$state`, which does not emit when `play()` throws.
+  ///
   /// `CancellationError` is ignored: it means a newer `play()`/`stop()` already
   /// superseded this attempt and owns the current state.
+  // internal for testability
   func handlePlayFailure(_ error: Error) {
     if error is CancellationError { return }
     state = State(playbackStatus: .error)
+    $nowPlaying.withLock { $0 = NowPlaying(playbackStatus: .error) }
   }
 
   /// Stops the currently playing station

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -119,6 +119,7 @@ class StationPlayer: ObservableObject {
     }
   }
 
+  // internal for testability
   /// Surfaces a failed station start as a recoverable error state. Without this,
   /// a swallowed failure (e.g. the schedule endpoint returning 500 during an
   /// outage) leaves the player stuck on `.loading` forever, with no error shown
@@ -132,7 +133,6 @@ class StationPlayer: ObservableObject {
   ///
   /// `CancellationError` is ignored: it means a newer `play()`/`stop()` already
   /// superseded this attempt and owns the current state.
-  // internal for testability
   func handlePlayFailure(_ error: Error) {
     if error is CancellationError { return }
     state = State(playbackStatus: .error)

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -233,7 +233,11 @@ class StationPlayer: ObservableObject {
         )
       }
 
-    case .none:
+    // `.error` is PlayolaPlayer 0.19.0's terminal failure (e.g. the schedule
+    // fetch exhausted its retries); `.none` is an unexpected empty state. Both
+    // surface the recoverable `.error` state so the user sees the error and can
+    // tap play again to retry.
+    case .error, .none:
       state = .init(
         playbackStatus: .error,
         artistPlaying: nil,

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -110,8 +110,23 @@ class StationPlayer: ObservableObject {
       urlStreamPlayer.set(station: urlStation)
     case .playola(let playolaStation):
       urlStreamPlayer.reset()
-      try? await playolaStationPlayer.play(stationId: playolaStation.id)
+      do {
+        try await playolaStationPlayer.play(stationId: playolaStation.id)
+      } catch {
+        handlePlayFailure(error)
+      }
     }
+  }
+
+  /// Surfaces a failed station start as a recoverable error state. Without this,
+  /// a swallowed failure (e.g. the schedule endpoint returning 500 during an
+  /// outage) leaves the player stuck on `.loading` forever, with no error shown
+  /// and no recovery — which pushes users into a manual retry storm.
+  /// `CancellationError` is ignored: it means a newer `play()`/`stop()` already
+  /// superseded this attempt and owns the current state.
+  func handlePlayFailure(_ error: Error) {
+    if error is CancellationError { return }
+    state = State(playbackStatus: .error)
   }
 
   /// Stops the currently playing station

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -59,6 +59,10 @@ struct StationPlayerTests {
     stationPlayer.processPlayolaStationPlayerState(.error(.networkError("boom")))
 
     expectNoDifference(stationPlayer.state.playbackStatus, .error)
+    // StationPlayer.processPlayolaStationPlayerState drives only `state`; the
+    // shared `nowPlaying` is NowPlayingUpdater's responsibility and must be
+    // left untouched here.
+    expectNoDifference(nowPlaying?.playbackStatus, .loading(.mock))
   }
 
   // MARK: - seekNext Tests

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -23,21 +23,27 @@ struct StationPlayerTests {
 
   @Test
   func testHandlePlayFailureSetsErrorState() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .loading(.mock))
     let stationPlayer = StationPlayer()
 
     stationPlayer.handlePlayFailure(PlayFailureTestError())
 
+    // Both the lock-screen-facing state and the app-wide shared state must move
+    // to .error, otherwise in-app UI stays stuck on .loading.
     expectNoDifference(stationPlayer.state.playbackStatus, .error)
+    expectNoDifference(nowPlaying?.playbackStatus, .error)
   }
 
   @Test
   func testHandlePlayFailureIgnoresCancellation() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .loading(.mock))
     let stationPlayer = StationPlayer()
     stationPlayer.state = StationPlayer.State(playbackStatus: .loading(.mock))
 
     stationPlayer.handlePlayFailure(CancellationError())
 
     expectNoDifference(stationPlayer.state.playbackStatus, .loading(.mock))
+    expectNoDifference(nowPlaying?.playbackStatus, .loading(.mock))
   }
 
   // MARK: - seekNext Tests

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -5,6 +5,7 @@
 //  Created by Claude on 1/8/26.
 //
 
+import CustomDump
 import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
@@ -13,8 +14,31 @@ import Testing
 
 @testable import PlayolaRadio
 
+private struct PlayFailureTestError: Error {}
+
 @MainActor
 struct StationPlayerTests {
+
+  // MARK: - Play Failure Tests
+
+  @Test
+  func testHandlePlayFailureSetsErrorState() {
+    let stationPlayer = StationPlayer()
+
+    stationPlayer.handlePlayFailure(PlayFailureTestError())
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .error)
+  }
+
+  @Test
+  func testHandlePlayFailureIgnoresCancellation() {
+    let stationPlayer = StationPlayer()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .loading(.mock))
+
+    stationPlayer.handlePlayFailure(CancellationError())
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .loading(.mock))
+  }
 
   // MARK: - seekNext Tests
 

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -46,6 +46,21 @@ struct StationPlayerTests {
     expectNoDifference(nowPlaying?.playbackStatus, .loading(.mock))
   }
 
+  // MARK: - Playola State Processing Tests
+
+  @Test
+  func testProcessPlayolaErrorStateSetsRecoverableErrorState() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .loading(.mock))
+    let stationPlayer = StationPlayer()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .loading(.mock))
+
+    // PlayolaPlayer 0.19.0's terminal `.error` must surface as the app's
+    // recoverable `.error` state, not leave the player stuck on .loading.
+    stationPlayer.processPlayolaStationPlayerState(.error(.networkError("boom")))
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .error)
+  }
+
   // MARK: - seekNext Tests
 
   @Test

--- a/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
+++ b/PlayolaRadio/Core/ErrorReporting/ErrorReportingClient.swift
@@ -127,6 +127,17 @@ enum NetworkErrorClassifier {
     nsURLErrorCodes(in: error).contains(NSURLErrorSecureConnectionFailed)
   }
 
+  /// Domain/code tags for the most relevant error in the chain, preferring an
+  /// `NSURLError` so transport failures surface their real code (e.g. -1200) in Sentry
+  /// rather than an opaque wrapper like `APIError.dataNotValid`.
+  static func errorTags(for error: Error) -> [String: String] {
+    let nsError = walkErrors(error).first { $0.domain == NSURLErrorDomain } ?? error as NSError
+    return [
+      "error_domain": nsError.domain,
+      "error_code": "\(nsError.code)",
+    ]
+  }
+
   private static func nsURLErrorCodes(in error: Error) -> [Int] {
     walkErrors(error).compactMap { $0.domain == NSURLErrorDomain ? $0.code : nil }
   }

--- a/PlayolaRadio/Models/ArtistSuggestion.swift
+++ b/PlayolaRadio/Models/ArtistSuggestion.swift
@@ -27,3 +27,18 @@ struct ArtistSuggestion: Codable, Identifiable, Equatable, Sendable {
   let createdAt: Date
   let updatedAt: Date
 }
+
+extension ArtistSuggestion {
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    artistName = try container.decode(String.self, forKey: .artistName)
+    createdByUserId = try container.decode(String.self, forKey: .createdByUserId)
+    voteCount = try container.decode(Int.self, forKey: .voteCount)
+    hasVoted = try container.decode(Bool.self, forKey: .hasVoted)
+    status =
+      try container.decodeIfPresent(ArtistSuggestionStatus.self, forKey: .status) ?? .suggested
+    createdAt = try container.decode(Date.self, forKey: .createdAt)
+    updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+  }
+}

--- a/PlayolaRadio/Models/ArtistSuggestion.swift
+++ b/PlayolaRadio/Models/ArtistSuggestion.swift
@@ -5,12 +5,25 @@
 
 import Foundation
 
+enum ArtistSuggestionStatus: String, Codable, Equatable, Sendable {
+  case suggested
+  case inDevelopment = "in_development"
+  case streaming
+  case unknown
+
+  init(from decoder: Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = ArtistSuggestionStatus(rawValue: raw) ?? .unknown
+  }
+}
+
 struct ArtistSuggestion: Codable, Identifiable, Equatable, Sendable {
   let id: String
   let artistName: String
   let createdByUserId: String
   let voteCount: Int
   let hasVoted: Bool
+  let status: ArtistSuggestionStatus
   let createdAt: Date
   let updatedAt: Date
 }

--- a/PlayolaRadio/Models/ArtistSuggestionTests.swift
+++ b/PlayolaRadio/Models/ArtistSuggestionTests.swift
@@ -1,0 +1,31 @@
+//
+//  ArtistSuggestionTests.swift
+//  PlayolaRadio
+//
+
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+struct ArtistSuggestionStatusTests {
+
+  @Test
+  func decodesKnownStatuses() throws {
+    let json = Data(#"["suggested", "in_development", "streaming"]"#.utf8)
+
+    let statuses = try JSONDecoder().decode([ArtistSuggestionStatus].self, from: json)
+
+    expectNoDifference(statuses, [.suggested, .inDevelopment, .streaming])
+  }
+
+  @Test
+  func decodesUnrecognizedStatusAsUnknown() throws {
+    let json = Data(#"["archived"]"#.utf8)
+
+    let statuses = try JSONDecoder().decode([ArtistSuggestionStatus].self, from: json)
+
+    expectNoDifference(statuses, [.unknown])
+  }
+}

--- a/PlayolaRadio/Models/ArtistSuggestionTests.swift
+++ b/PlayolaRadio/Models/ArtistSuggestionTests.swift
@@ -28,4 +28,24 @@ struct ArtistSuggestionStatusTests {
 
     expectNoDifference(statuses, [.unknown])
   }
+
+  @Test
+  func decodesMissingStatusAsSuggested() throws {
+    let json = Data(
+      #"""
+      {
+        "id": "s1",
+        "artistName": "Bri Bagwell",
+        "createdByUserId": "u1",
+        "voteCount": 3,
+        "hasVoted": false,
+        "createdAt": 0,
+        "updatedAt": 0
+      }
+      """#.utf8)
+
+    let suggestion = try JSONDecoder().decode(ArtistSuggestion.self, from: json)
+
+    expectNoDifference(suggestion.status, .suggested)
+  }
 }

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -46,6 +46,23 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
             $0.lifecycle = .trace
           }
           options.enableLogs = true
+
+          // App Hang Tracking: capture the real main-thread blocking stack so
+          // hangs resolve to named functions instead of collapsing into the
+          // generic `$main` bucket (Sentry APPLE-IOS-V / 7460768272).
+          //
+          // App Hang Tracking V2 captures the stack at hang onset and is the
+          // default on iOS/tvOS as of sentry-cocoa 9.x — the old
+          // `enableAppHangTrackingV2` toggle was removed (#5615), so no flag is
+          // needed to turn it on.
+          //
+          // 2.0s is the SDK default; set explicitly as the tuning knob if these
+          // turn out noisy.
+          options.appHangTimeoutInterval = 2.0
+          // Ignore non-fully-blocking hangs (app stutters but still renders a
+          // few frames): their stacks don't pinpoint the blocking location, so
+          // they add noise without being actionable.
+          options.enableReportNonFullyBlockingAppHangs = false
         }
       }
     #endif

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -33,6 +33,8 @@ class SignInPageModel: ViewModel {
   // MARK: - Properties
   var presentedAlert: PlayolaAlert?
 
+  var googleSignInButtonTitle: String { "Sign in with Google" }
+
   @ObservationIgnored
   var keyWindowProvider: @MainActor () -> UIViewController? = {
     UIApplication.shared.keyWindowPresentedController

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -58,6 +58,13 @@ struct SignInPage: View {
 
           // Auth buttons
           VStack(spacing: 16) {
+            CustomGoogleSignInButton {
+              Task {
+                await model.signInWithGoogleButtonTapped()
+              }
+            }
+            .padding(.horizontal, 30)
+
             SignInWithAppleButton(.signIn) { request in
               model.signInWithAppleButtonTapped(request: request)
             } onCompletion: { result in
@@ -66,13 +73,6 @@ struct SignInPage: View {
             .signInWithAppleButtonStyle(.white)
             .frame(height: 56)
             .cornerRadius(12)
-            .padding(.horizontal, 30)
-
-            CustomGoogleSignInButton {
-              Task {
-                await model.signInWithGoogleButtonTapped()
-              }
-            }
             .padding(.horizontal, 30)
           }
 
@@ -123,7 +123,7 @@ struct CustomGoogleSignInButton: View {
           .frame(width: 24, height: 24)
 
         Text("Sign in with Google")
-          .fontWeight(.semibold)
+          .font(.system(size: 21, weight: .medium))
           .foregroundColor(.black)
       }
       .frame(maxWidth: .infinity)

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -58,7 +58,7 @@ struct SignInPage: View {
 
           // Auth buttons
           VStack(spacing: 16) {
-            CustomGoogleSignInButton {
+            CustomGoogleSignInButton(title: model.googleSignInButtonTitle) {
               Task {
                 await model.signInWithGoogleButtonTapped()
               }
@@ -112,6 +112,7 @@ struct SignInPage: View {
 }
 
 struct CustomGoogleSignInButton: View {
+  let title: String
   let action: () -> Void
 
   var body: some View {
@@ -122,7 +123,7 @@ struct CustomGoogleSignInButton: View {
           .scaledToFit()
           .frame(width: 24, height: 24)
 
-        Text("Sign in with Google")
+        Text(title)
           .font(.system(size: 21, weight: .medium))
           .foregroundColor(.black)
       }

--- a/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
@@ -69,7 +69,6 @@ struct PresetTile: View {
       startOrStopWiggle(active: isEditing)
     }
     .onLongPressGesture(minimumDuration: 0.5) {
-      guard !display.isPending else { return }
       onLongPress()
     }
     .onTapGesture {

--- a/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetsCarousel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetsCarousel.swift
@@ -12,11 +12,16 @@ struct PresetsCarousel: View {
   let emptyStateText: String
   let doneButtonText: String
   let isEditing: Bool
+  let isLoading: Bool
+  let hasLoadError: Bool
+  let loadErrorText: String
+  let retryButtonText: String
   let onTilePlay: (PresetDisplayItem) async -> Void
   let onTileLongPress: (PresetDisplayItem) -> Void
   let onTileRemove: (PresetDisplayItem) async -> Void
-  let onMove: (Int, Int) async -> Void
+  let onMove: (String, Int) async -> Void
   let onEditDoneTapped: () -> Void
+  let onRetryTapped: () async -> Void
 
   @State private var dragState: PresetDragState?
   @State private var tileFrames: [String: CGRect] = [:]
@@ -52,12 +57,62 @@ struct PresetsCarousel: View {
       }
       .padding(.horizontal, 16)
 
-      if displays.isEmpty {
+      if isLoading {
+        loadingState
+      } else if hasLoadError {
+        errorState
+      } else if displays.isEmpty {
         emptyState
       } else {
         tiles
       }
     }
+  }
+
+  private var loadingState: some View {
+    HStack {
+      Spacer()
+      ProgressView()
+        .progressViewStyle(.circular)
+        .tint(.white)
+      Spacer()
+    }
+    .frame(height: 92)
+    .padding(.horizontal, 16)
+  }
+
+  private var errorState: some View {
+    HStack(spacing: 16) {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .font(.system(size: 24))
+        .foregroundColor(Color(hex: "#EF6962"))
+      Text(loadErrorText)
+        .font(.custom(FontNames.Inter_400_Regular, size: 13))
+        .foregroundColor(Color(hex: "#AAAAAA"))
+        .lineLimit(2)
+      Spacer(minLength: 0)
+      Button {
+        Task { await onRetryTapped() }
+      } label: {
+        Text(retryButtonText)
+          .font(.custom(FontNames.Inter_500_Medium, size: 14))
+          .foregroundColor(.white)
+          .padding(.horizontal, 14)
+          .padding(.vertical, 8)
+          .background(Color.playolaRed)
+          .cornerRadius(16)
+      }
+      .buttonStyle(.plain)
+    }
+    .padding(16)
+    .overlay(
+      RoundedRectangle(cornerRadius: 10)
+        .strokeBorder(
+          Color(hex: "#333333"),
+          style: StrokeStyle(lineWidth: 1, dash: [4])
+        )
+    )
+    .padding(.horizontal, 16)
   }
 
   private var emptyState: some View {
@@ -336,7 +391,7 @@ struct PresetsCarousel: View {
     guard state.sourceIndex != state.destinationIndex else { return }
 
     Task {
-      await onMove(state.sourceIndex, state.destinationIndex)
+      await onMove(state.sourceId, state.destinationIndex)
     }
   }
 
@@ -542,11 +597,16 @@ private struct PresetTileFramePreferenceKey: PreferenceKey {
     emptyStateText: "Tap the ★ on any station to save it here.",
     doneButtonText: "Done",
     isEditing: false,
+    isLoading: false,
+    hasLoadError: false,
+    loadErrorText: "Couldn't load presets.",
+    retryButtonText: "Retry",
     onTilePlay: { _ in },
     onTileLongPress: { _ in },
     onTileRemove: { _ in },
     onMove: { _, _ in },
-    onEditDoneTapped: {}
+    onEditDoneTapped: {},
+    onRetryTapped: {}
   )
   .padding(.vertical)
   .background(Color.black)
@@ -560,11 +620,62 @@ private struct PresetTileFramePreferenceKey: PreferenceKey {
     emptyStateText: "Tap the ★ on any station to save it here.",
     doneButtonText: "Done",
     isEditing: false,
+    isLoading: false,
+    hasLoadError: false,
+    loadErrorText: "Couldn't load presets.",
+    retryButtonText: "Retry",
     onTilePlay: { _ in },
     onTileLongPress: { _ in },
     onTileRemove: { _ in },
     onMove: { _, _ in },
-    onEditDoneTapped: {}
+    onEditDoneTapped: {},
+    onRetryTapped: {}
+  )
+  .padding(.vertical)
+  .background(Color.black)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("Loading") {
+  PresetsCarousel(
+    displays: [],
+    sectionTitle: "Presets",
+    emptyStateText: "Tap the ★ on any station to save it here.",
+    doneButtonText: "Done",
+    isEditing: false,
+    isLoading: true,
+    hasLoadError: false,
+    loadErrorText: "Couldn't load presets.",
+    retryButtonText: "Retry",
+    onTilePlay: { _ in },
+    onTileLongPress: { _ in },
+    onTileRemove: { _ in },
+    onMove: { _, _ in },
+    onEditDoneTapped: {},
+    onRetryTapped: {}
+  )
+  .padding(.vertical)
+  .background(Color.black)
+  .preferredColorScheme(.dark)
+}
+
+#Preview("Load Error") {
+  PresetsCarousel(
+    displays: [],
+    sectionTitle: "Presets",
+    emptyStateText: "Tap the ★ on any station to save it here.",
+    doneButtonText: "Done",
+    isEditing: false,
+    isLoading: false,
+    hasLoadError: true,
+    loadErrorText: "Couldn't load presets.",
+    retryButtonText: "Retry",
+    onTilePlay: { _ in },
+    onTileLongPress: { _ in },
+    onTileRemove: { _ in },
+    onMove: { _, _ in },
+    onEditDoneTapped: {},
+    onRetryTapped: {}
   )
   .padding(.vertical)
   .background(Color.black)

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -433,6 +433,7 @@ class StationListModel: ViewModel {
     if !NetworkErrorClassifier.isNetworkError(error) {
       var tags = extraTags
       tags["endpoint"] = endpoint
+      tags.merge(NetworkErrorClassifier.errorTags(for: error)) { current, _ in current }
       await errorReporting.reportError(error, tags)
     }
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -89,6 +89,8 @@ class StationListModel: ViewModel {
   var searchText = ""
   var presentedAlert: PlayolaAlert?
   var presetListState: PresetListState = .normal
+  var isLoadingPresets: Bool = false
+  var presetsLoadFailed: Bool = false
   let navigationTitle = "Radio Stations"
   let suggestArtistButtonText = "Suggest Station"
   let searchBarPlaceholder = "Search stations"
@@ -99,6 +101,8 @@ class StationListModel: ViewModel {
   let presetsSectionTitle = "Presets"
   let presetsEmptyStateText = "Tap the ★ on any station to save it here."
   let presetsEditDoneButtonText = "Done"
+  let presetsLoadErrorText = "Couldn't load presets."
+  let presetsRetryButtonText = "Retry"
 
   // MARK: - User Actions
 
@@ -191,25 +195,23 @@ class StationListModel: ViewModel {
   }
 
   // swiftlint:disable:next cyclomatic_complexity
-  func presetMoved(from: Int, to: Int) async {
+  func presetMoved(presetId: String, to: Int) async {
     guard presetListState == .editing else { return }
-    guard from != to else { return }
     guard let token = auth.jwt else { return }
+    guard presets[id: presetId] != nil else { return }
+
+    let displayIds = displayPresets.map(\.id)
+    guard let fromIndex = displayIds.firstIndex(of: presetId) else { return }
+    guard fromIndex != to else { return }
 
     let snapshot: [String: Int] = Dictionary(
       uniqueKeysWithValues: presets.map { ($0.id, $0.position) })
 
-    let displayIds = displayPresets.map(\.id)
-    guard from >= 0, from < displayIds.count, to >= 0, to < displayIds.count
-    else { return }
-    let movedId = displayIds[from]
-    guard presets[id: movedId] != nil else { return }
-
     var orderedIds = displayIds.filter { presets[id: $0] != nil }
-    guard let oldIndex = orderedIds.firstIndex(of: movedId) else { return }
+    guard let oldIndex = orderedIds.firstIndex(of: presetId) else { return }
     orderedIds.remove(at: oldIndex)
     let clampedTo = min(max(0, to), orderedIds.count)
-    orderedIds.insert(movedId, at: clampedTo)
+    orderedIds.insert(presetId, at: clampedTo)
 
     $presets.withLock { collection in
       for (index, id) in orderedIds.enumerated() {
@@ -221,15 +223,16 @@ class StationListModel: ViewModel {
     }
 
     let movedStationInfo: StationInfo? = {
-      guard let item = displayPresets.first(where: { $0.id == movedId })?.stationItem
+      guard let item = displayPresets.first(where: { $0.id == presetId })?.stationItem
       else { return nil }
       return StationInfo(from: item.anyStation)
     }()
 
     do {
-      _ = try await api.movePreset(token, movedId, clampedTo)
+      _ = try await api.movePreset(token, presetId, clampedTo)
       if let info = movedStationInfo {
-        await analytics.track(.presetMoved(station: info, fromIndex: from, toIndex: clampedTo))
+        await analytics.track(
+          .presetMoved(station: info, fromIndex: fromIndex, toIndex: clampedTo))
       }
     } catch {
       $presets.withLock { collection in
@@ -242,8 +245,8 @@ class StationListModel: ViewModel {
       }
       await reportPresetError(
         error,
-        endpoint: "PUT /v1/presets/\(movedId)",
-        extraTags: ["preset_id": movedId])
+        endpoint: "PUT /v1/presets/\(presetId)",
+        extraTags: ["preset_id": presetId])
       presentedAlert = .errorMovingPreset
     }
   }
@@ -270,12 +273,10 @@ class StationListModel: ViewModel {
     else { return }
 
     let allItems = stationLists.flatMap { $0.stationItems(includeHidden: showSecretStations) }
-    let stationInfo: StationInfo
-    if let item = allItems.first(where: { $0.anyStation.id == preset.embeddedStationId }) {
-      stationInfo = StationInfo(from: item.anyStation)
-    } else {
-      stationInfo = StationInfo(from: .playola(Station.mockWith(id: preset.embeddedStationId)))
-    }
+    let stationInfo: StationInfo? =
+      allItems
+      .first(where: { $0.anyStation.id == preset.embeddedStationId })
+      .map { StationInfo(from: $0.anyStation) }
 
     await removePreset(presetId: preset.id, stationInfo: stationInfo)
   }
@@ -461,12 +462,12 @@ class StationListModel: ViewModel {
     }
   }
 
-  private func removePreset(presetId: String, stationInfo: StationInfo) async {
+  private func removePreset(presetId: String, stationInfo: StationInfo?) async {
     guard let token = auth.jwt else { return }
-    let stationId = stationInfo.id
+    guard let presetSnapshot = presets[id: presetId] else { return }
+    let stationId = presetSnapshot.embeddedStationId
     if pendingPresetRemovalStationIds.contains(stationId) { return }
 
-    guard let presetSnapshot = presets[id: presetId] else { return }
     let positionsSnapshot: [String: Int] = Dictionary(
       uniqueKeysWithValues: presets.map { ($0.id, $0.position) })
 
@@ -482,7 +483,9 @@ class StationListModel: ViewModel {
     do {
       try await api.deletePreset(token, presetId)
       $pendingPresetRemovalStationIds.withLock { $0.remove(stationId) }
-      await analytics.track(.presetRemoved(station: stationInfo))
+      if let stationInfo {
+        await analytics.track(.presetRemoved(station: stationInfo))
+      }
     } catch {
       $pendingPresetRemovalStationIds.withLock { $0.remove(stationId) }
       $presets.withLock { collection in
@@ -502,14 +505,21 @@ class StationListModel: ViewModel {
     }
   }
 
+  func retryLoadPresetsTapped() async {
+    await loadPresets()
+  }
+
   private func loadPresets() async {
     guard let token = auth.jwt else { return }
+    isLoadingPresets = true
+    defer { isLoadingPresets = false }
     do {
       let fetched = try await api.getPresets(token)
       $presets.withLock { $0 = IdentifiedArray(uniqueElements: fetched) }
+      presetsLoadFailed = false
     } catch {
+      presetsLoadFailed = true
       await reportPresetError(error, endpoint: "GET /v1/presets")
-      presentedAlert = .errorLoadingPresets
     }
   }
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -433,7 +433,7 @@ class StationListModel: ViewModel {
     if !NetworkErrorClassifier.isNetworkError(error) {
       var tags = extraTags
       tags["endpoint"] = endpoint
-      tags.merge(NetworkErrorClassifier.errorTags(for: error)) { current, _ in current }
+      tags.merge(NetworkErrorClassifier.errorTags(for: error)) { _, new in new }
       await errorReporting.reportError(error, tags)
     }
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -289,6 +289,10 @@ class StationListModel: ViewModel {
     if presetListState == .editing { presetListState = .normal }
   }
 
+  func retryLoadPresetsTapped() async {
+    await loadPresets()
+  }
+
   func stationSelected(_ item: APIStationItem) async {
     if item.visibility == .comingSoon && showSecretStations == false {
       return
@@ -503,10 +507,6 @@ class StationListModel: ViewModel {
         extraTags: ["preset_id": presetId])
       presentedAlert = .errorRemovingPreset
     }
-  }
-
-  func retryLoadPresetsTapped() async {
-    await loadPresets()
   }
 
   private func loadPresets() async {

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -23,7 +23,9 @@ struct PresetDisplayItem: Identifiable {
   let accessibilityLabel: String
   let removeAccessibilityLabel: String
 
-  init(id: String, stationItem: APIStationItem, isPending: Bool) {
+  init(
+    id: String, stationItem: APIStationItem, isPending: Bool, showSecretStations: Bool = false
+  ) {
     self.id = id
     self.stationItem = stationItem
     self.isPending = isPending
@@ -35,8 +37,9 @@ struct PresetDisplayItem: Identifiable {
     self.accessibilityLabel = "Preset: \(title)"
     self.removeAccessibilityLabel = "Remove \(title) from presets"
 
-    let isComingSoon = stationItem.visibility == .comingSoon || !station.active
-    if isComingSoon {
+    let isInactive = !station.active
+    let isComingSoonAndHidden = stationItem.visibility == .comingSoon && !showSecretStations
+    if isInactive || isComingSoonAndHidden {
       self.subtitleText = "Coming Soon"
       self.subtitleColor = Color.playolaRed
     } else {
@@ -350,7 +353,9 @@ class StationListModel: ViewModel {
       .compactMap { preset in
         guard let item = allItems.first(where: { $0.anyStation.id == preset.embeddedStationId })
         else { return nil }
-        return PresetDisplayItem(id: preset.id, stationItem: item, isPending: false)
+        return PresetDisplayItem(
+          id: preset.id, stationItem: item, isPending: false,
+          showSecretStations: showSecretStations)
       }
 
     let realStationIds = Set(presets.map { $0.embeddedStationId })
@@ -363,7 +368,8 @@ class StationListModel: ViewModel {
         return PresetDisplayItem(
           id: "pending-\(stationId)",
           stationItem: item,
-          isPending: true
+          isPending: true,
+          showSecretStations: showSecretStations
         )
       }
       .sorted { $0.id < $1.id }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -106,11 +106,16 @@ struct StationListPage: View {
                 emptyStateText: model.presetsEmptyStateText,
                 doneButtonText: model.presetsEditDoneButtonText,
                 isEditing: model.isEditingPresets,
+                isLoading: model.isLoadingPresets,
+                hasLoadError: model.presetsLoadFailed,
+                loadErrorText: model.presetsLoadErrorText,
+                retryButtonText: model.presetsRetryButtonText,
                 onTilePlay: { display in await model.presetTileTapped(display) },
                 onTileLongPress: { display in model.presetTileLongPressed(display) },
                 onTileRemove: { display in await model.presetRemoveTapped(display) },
-                onMove: { from, to in await model.presetMoved(from: from, to: to) },
-                onEditDoneTapped: { model.presetsEditDoneTapped() }
+                onMove: { presetId, to in await model.presetMoved(presetId: presetId, to: to) },
+                onEditDoneTapped: { model.presetsEditDoneTapped() },
+                onRetryTapped: { await model.retryLoadPresetsTapped() }
               )
             }
             ForEach(model.stationListsForDisplay) { list in

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetComingSoonTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetComingSoonTests.swift
@@ -1,0 +1,55 @@
+//
+//  StationListPresetComingSoonTests.swift
+//  PlayolaRadio
+//
+
+import Foundation
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct StationListPresetComingSoonTests {
+
+  @Test
+  func testDisplayPresetsHidesComingSoonWhenSecretStationsUnlocked() async {
+    @Shared(.showSecretStations) var showSecretStations = true
+    let item = APIStationItem(
+      sortOrder: 0, visibility: .comingSoon,
+      station: Station.mockWith(id: "s1"), urlStation: nil)
+    #expect(presetSubtitle(for: item) == nil)
+  }
+
+  @Test
+  func testDisplayPresetsShowsComingSoonWhenSecretStationsHidden() async {
+    @Shared(.showSecretStations) var showSecretStations = false
+    let item = APIStationItem(
+      sortOrder: 0, visibility: .comingSoon,
+      station: Station.mockWith(id: "s1"), urlStation: nil)
+    #expect(presetSubtitle(for: item) == "Coming Soon")
+  }
+
+  @Test
+  func testDisplayPresetsShowsComingSoonForInactiveStationEvenWhenSecretStationsUnlocked() async {
+    @Shared(.showSecretStations) var showSecretStations = true
+    let item = APIStationItem(
+      sortOrder: 0, visibility: .visible,
+      station: Station.mockWith(id: "s1", active: false), urlStation: nil)
+    #expect(presetSubtitle(for: item) == "Coming Soon")
+  }
+
+  private func presetSubtitle(for item: APIStationItem) -> String? {
+    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
+      StationList(
+        id: "preset-test-list", name: "Test List", slug: "preset-test-list",
+        hidden: false, sortOrder: 0, createdAt: Date(), updatedAt: Date(), items: [item])
+    ]
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
+      Preset.mockPlayola(id: "p1", stationId: item.anyStation.id, position: 0)
+    ]
+    return StationListModel().displayPresets.first?.subtitleText
+  }
+}

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetErrorReportingTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetErrorReportingTests.swift
@@ -1,0 +1,73 @@
+//
+//  StationListPresetErrorReportingTests.swift
+//  PlayolaRadio
+//
+
+import ConcurrencyExtras
+import CustomDump
+import Dependencies
+import Foundation
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct StationListPresetErrorReportingTests {
+
+  @Test
+  func testStarTappedAddNetworkErrorIsNotReportedToSentry() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
+
+    let item = makePresetVisibleItem()
+    let reportCount = LockIsolated(0)
+
+    let model = withDependencies {
+      $0.api.createPreset = { _, _, _ in
+        throw NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
+      }
+      $0.analytics.track = { _ in }
+      $0.errorReporting.reportError = { _, _ in reportCount.setValue(reportCount.value + 1) }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.starTapped(for: item)
+
+    #expect(reportCount.value == 0)
+    #expect(pending.isEmpty)
+    #expect(presets.isEmpty)
+    #expect(model.presentedAlert == .errorSavingPreset(nil))
+  }
+
+  @Test
+  func testStarTappedAddTagsReportedErrorWithDomainAndCode() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
+
+    let item = makePresetVisibleItem()
+    let reportedTags = LockIsolated<[String: String]>([:])
+
+    let model = withDependencies {
+      $0.api.createPreset = { _, _, _ in
+        throw NSError(domain: "TestDomain", code: 42)
+      }
+      $0.analytics.track = { _ in }
+      $0.errorReporting.reportError = { _, tags in reportedTags.setValue(tags) }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.starTapped(for: item)
+
+    #expect(reportedTags.value["endpoint"] == "POST /v1/presets")
+    #expect(reportedTags.value["error_domain"] == "TestDomain")
+    #expect(reportedTags.value["error_code"] == "42")
+    #expect(reportedTags.value["station_id"] == item.anyStation.id)
+  }
+}

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
@@ -221,6 +221,60 @@ struct StationListPresetTests {
   }
 
   @Test
+  func testStarTappedAddNetworkErrorIsNotReportedToSentry() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
+
+    let item = makePresetVisibleItem()
+    let reportCount = LockIsolated(0)
+
+    let model = withDependencies {
+      $0.api.createPreset = { _, _, _ in
+        throw NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
+      }
+      $0.analytics.track = { _ in }
+      $0.errorReporting.reportError = { _, _ in reportCount.setValue(reportCount.value + 1) }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.starTapped(for: item)
+
+    #expect(reportCount.value == 0)
+    #expect(pending.isEmpty)
+    #expect(presets.isEmpty)
+    #expect(model.presentedAlert == .errorSavingPreset(nil))
+  }
+
+  @Test
+  func testStarTappedAddTagsReportedErrorWithDomainAndCode() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
+
+    let item = makePresetVisibleItem()
+    let reportedTags = LockIsolated<[String: String]>([:])
+
+    let model = withDependencies {
+      $0.api.createPreset = { _, _, _ in
+        throw NSError(domain: "TestDomain", code: 42)
+      }
+      $0.analytics.track = { _ in }
+      $0.errorReporting.reportError = { _, tags in reportedTags.setValue(tags) }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.starTapped(for: item)
+
+    #expect(reportedTags.value["endpoint"] == "POST /v1/presets")
+    #expect(reportedTags.value["error_domain"] == "TestDomain")
+    #expect(reportedTags.value["error_code"] == "42")
+    #expect(reportedTags.value["station_id"] == item.anyStation.id)
+  }
+
+  @Test
   func testStarTappedIgnoredWhilePendingAdd() async {
     @Shared(.auth) var auth = signedInAuth()
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
@@ -88,14 +88,7 @@ struct StationListPresetTests {
   @Test
   func testDisplayPresetsOrdersByPosition() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station1 = Station.mockWith(id: "s1", name: "S1")
-    let station2 = Station.mockWith(id: "s2", name: "S2")
-    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(sortOrder: 0, visibility: .visible, station: station1, urlStation: nil),
-        APIStationItem(sortOrder: 1, visibility: .visible, station: station2, urlStation: nil),
-      ])
-    ]
+    @Shared(.stationLists) var stationLists = presetStationLists("s1", "s2")
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
       Preset.mockPlayola(id: "p2", stationId: "s2", position: 1),
       Preset.mockPlayola(id: "p1", stationId: "s1", position: 0),
@@ -111,12 +104,7 @@ struct StationListPresetTests {
   @Test
   func testDisplayPresetsFiltersOrphans() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station1 = Station.mockWith(id: "s1", name: "S1")
-    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(sortOrder: 0, visibility: .visible, station: station1, urlStation: nil)
-      ])
-    ]
+    @Shared(.stationLists) var stationLists = presetStationLists("s1")
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
       Preset.mockPlayola(id: "p1", stationId: "s1", position: 0),
       Preset.mockPlayola(id: "p-orphan", stationId: "gone", position: 1),
@@ -286,14 +274,7 @@ struct StationListPresetTests {
   @Test
   func testDisplayPresetsAppendsPendingAddAsGhostTile() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station1 = Station.mockWith(id: "s1", name: "S1")
-    let station2 = Station.mockWith(id: "s2", name: "S2")
-    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(sortOrder: 0, visibility: .visible, station: station1, urlStation: nil),
-        APIStationItem(sortOrder: 1, visibility: .visible, station: station2, urlStation: nil),
-      ])
-    ]
+    @Shared(.stationLists) var stationLists = presetStationLists("s1", "s2")
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
       Preset.mockPlayola(id: "p1", stationId: "s1", position: 0)
     ]
@@ -433,17 +414,7 @@ struct StationListPresetTests {
     let p3 = Preset.mockPlayola(id: "p3", stationId: "s3", position: 2)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [p1, p2, p3]
 
-    let stationLists = IdentifiedArrayOf<StationList>(uniqueElements: [
-      makePresetTestList(with: [
-        APIStationItem(
-          sortOrder: 0, visibility: .visible, station: Station.mockWith(id: "s1"), urlStation: nil),
-        APIStationItem(
-          sortOrder: 1, visibility: .visible, station: Station.mockWith(id: "s2"), urlStation: nil),
-        APIStationItem(
-          sortOrder: 2, visibility: .visible, station: Station.mockWith(id: "s3"), urlStation: nil),
-      ])
-    ])
-    @Shared(.stationLists) var sharedLists = stationLists
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1", "s2", "s3")
 
     let capturedToken = LockIsolated<String?>(nil)
     let capturedPresetId = LockIsolated<String?>(nil)
@@ -460,7 +431,7 @@ struct StationListPresetTests {
     }
     model.presetListState = .editing
 
-    await model.presetMoved(from: 0, to: 2)
+    await model.presetMoved(presetId: "p1", to: 2)
 
     let ordered = presets.sorted { $0.position < $1.position }
     expectNoDifference(
@@ -490,8 +461,9 @@ struct StationListPresetTests {
     } operation: {
       StationListModel()
     }
+    model.presetListState = .editing
 
-    await model.presetMoved(from: 0, to: 0)
+    await model.presetMoved(presetId: "p1", to: 0)
 
     #expect(callCount.value == 0)
   }
@@ -503,15 +475,7 @@ struct StationListPresetTests {
     let p2 = Preset.mockPlayola(id: "p2", stationId: "s2", position: 1)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [p1, p2]
 
-    let stationLists = IdentifiedArrayOf<StationList>(uniqueElements: [
-      makePresetTestList(with: [
-        APIStationItem(
-          sortOrder: 0, visibility: .visible, station: Station.mockWith(id: "s1"), urlStation: nil),
-        APIStationItem(
-          sortOrder: 1, visibility: .visible, station: Station.mockWith(id: "s2"), urlStation: nil),
-      ])
-    ])
-    @Shared(.stationLists) var sharedLists = stationLists
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1", "s2")
 
     let model = withDependencies {
       $0.api.movePreset = { _, _, _ in throw APIError.validationError("nope") }
@@ -522,7 +486,7 @@ struct StationListPresetTests {
     }
     model.presetListState = .editing
 
-    await model.presetMoved(from: 0, to: 1)
+    await model.presetMoved(presetId: "p1", to: 1)
 
     let ordered = presets.sorted { $0.position < $1.position }
     expectNoDifference(ordered, [p1, p2])
@@ -534,13 +498,8 @@ struct StationListPresetTests {
   @Test
   func testPresetTileTappedPlaysStation() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station = Station.mockWith(id: "s1", name: "S1")
-    let item = APIStationItem(
-      sortOrder: 0, visibility: .visible, station: station, urlStation: nil)
-    let stationLists = IdentifiedArrayOf<StationList>(uniqueElements: [
-      makePresetTestList(with: [item])
-    ])
-    @Shared(.stationLists) var sharedLists = stationLists
+    let item = presetItem("s1")
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1")
 
     let display = PresetDisplayItem(id: "p1", stationItem: item, isPending: false)
 
@@ -553,7 +512,7 @@ struct StationListPresetTests {
     } operation: {
       StationListModel()
     }
-    model.stationListsForDisplay = stationLists
+    model.stationListsForDisplay = sharedLists
 
     await model.presetTileTapped(display)
 
@@ -628,13 +587,8 @@ struct StationListPresetTests {
   @Test
   func testPresetTileTappedNoOpInEditMode() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station = Station.mockWith(id: "s1", name: "S1")
-    let item = APIStationItem(
-      sortOrder: 0, visibility: .visible, station: station, urlStation: nil)
-    let stationLists = IdentifiedArrayOf<StationList>(uniqueElements: [
-      makePresetTestList(with: [item])
-    ])
-    @Shared(.stationLists) var sharedLists = stationLists
+    let item = presetItem("s1")
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1")
 
     let display = PresetDisplayItem(id: "p1", stationItem: item, isPending: false)
 
@@ -715,7 +669,7 @@ struct StationListPresetTests {
     }
 
     #expect(model.presetListState == .normal)
-    await model.presetMoved(from: 0, to: 1)
+    await model.presetMoved(presetId: "p1", to: 1)
 
     #expect(callCount.value == 0)
   }
@@ -831,7 +785,7 @@ struct StationListPresetTests {
   }
 
   @Test
-  func testLoadPresetsFailureReportsErrorWithoutMutatingPresets() async {
+  func testLoadPresetsFailureReportsErrorAndSetsLoadFailedWithoutAlert() async {
     @Shared(.auth) var auth = signedInAuth()
     let existing = Preset.mockPlayola(id: "p1", stationId: "s1", position: 0)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [existing]
@@ -849,6 +803,79 @@ struct StationListPresetTests {
 
     expectNoDifference(Array(presets), [existing])
     #expect(reportedTags.value["endpoint"] == "GET /v1/presets")
+    #expect(model.presetsLoadFailed)
+    #expect(!model.isLoadingPresets)
+    #expect(model.presentedAlert?.title != "Couldn't Load Presets")
+  }
+
+  @Test
+  func testLoadPresetsSuccessClearsLoadFailedFlag() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+
+    let model = withDependencies {
+      $0.api.getPresets = { _ in [Preset.mockPlayola(id: "p1")] }
+    } operation: {
+      StationListModel()
+    }
+    model.presetsLoadFailed = true
+
+    await model.retryLoadPresetsTapped()
+
+    #expect(!model.presetsLoadFailed)
+    #expect(!model.isLoadingPresets)
+    expectNoDifference(Array(presets), [Preset.mockPlayola(id: "p1")])
+  }
+
+  @Test
+  func testRetryLoadPresetsTappedCallsApi() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+
+    let callCount = LockIsolated(0)
+    let model = withDependencies {
+      $0.api.getPresets = { _ in
+        callCount.setValue(callCount.value + 1)
+        return []
+      }
+    } operation: {
+      StationListModel()
+    }
+
+    await model.retryLoadPresetsTapped()
+
+    #expect(callCount.value == 1)
+  }
+
+  @Test
+  func testIsLoadingPresetsTrueWhileFetchInFlight() async {
+    @Shared(.auth) var auth = signedInAuth()
+    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+
+    let releaser = LockIsolated<CheckedContinuation<Void, Never>?>(nil)
+    let started = LockIsolated(false)
+
+    let model = withDependencies {
+      $0.api.getPresets = { _ in
+        await withCheckedContinuation { cont in
+          releaser.setValue(cont)
+          started.setValue(true)
+        }
+        return []
+      }
+    } operation: {
+      StationListModel()
+    }
+
+    let task = Task { await model.retryLoadPresetsTapped() }
+
+    while !started.value { await Task.yield() }
+    #expect(model.isLoadingPresets)
+
+    releaser.value?.resume()
+    await task.value
+
+    #expect(!model.isLoadingPresets)
   }
 
   // MARK: - presetMoved Analytics
@@ -860,14 +887,7 @@ struct StationListPresetTests {
     let p2 = Preset.mockPlayola(id: "p2", stationId: "s2", position: 1)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [p1, p2]
 
-    @Shared(.stationLists) var sharedLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(
-          sortOrder: 0, visibility: .visible, station: Station.mockWith(id: "s1"), urlStation: nil),
-        APIStationItem(
-          sortOrder: 1, visibility: .visible, station: Station.mockWith(id: "s2"), urlStation: nil),
-      ])
-    ]
+    @Shared(.stationLists) var sharedLists = presetStationLists("s1", "s2")
 
     let captured = LockIsolated<[AnalyticsEvent]>([])
     let model = withDependencies {
@@ -880,7 +900,7 @@ struct StationListPresetTests {
     }
     model.presetListState = .editing
 
-    await model.presetMoved(from: 0, to: 1)
+    await model.presetMoved(presetId: "p1", to: 1)
 
     let moved = captured.value.contains {
       if case .presetMoved(_, let fromIndex, let toIndex) = $0, fromIndex == 0, toIndex == 1 {
@@ -896,12 +916,7 @@ struct StationListPresetTests {
   @Test
   func testDisplayPresetsFiltersPendingThatAlreadyExistsAsRealPreset() async {
     @Shared(.showSecretStations) var showSecretStations = false
-    let station1 = Station.mockWith(id: "s1", name: "S1")
-    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = [
-      makePresetTestList(with: [
-        APIStationItem(sortOrder: 0, visibility: .visible, station: station1, urlStation: nil)
-      ])
-    ]
+    @Shared(.stationLists) var stationLists = presetStationLists("s1")
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [
       Preset.mockPlayola(id: "p1", stationId: "s1", position: 0)
     ]
@@ -912,26 +927,23 @@ struct StationListPresetTests {
     expectNoDifference(model.displayPresets.map(\.id), ["p1"])
   }
 
-  // MARK: - presetRemoveTapped Orphan Fallback
+  // MARK: - presetRemoveTapped Orphan Handling
 
   @Test
-  func testPresetRemoveTappedFallsBackForOrphanStation() async {
+  func testPresetRemoveTappedDeletesOrphanPresetWithoutFiringRemovedAnalytics() async {
     @Shared(.auth) var auth = signedInAuth()
     let orphanPreset = Preset.mockPlayola(id: "p1", stationId: "missing-s", position: 0)
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = [orphanPreset]
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
 
-    let orphanItem = APIStationItem(
-      sortOrder: 0,
-      visibility: .visible,
-      station: Station.mockWith(id: "missing-s"),
-      urlStation: nil)
-    let display = PresetDisplayItem(id: "p1", stationItem: orphanItem, isPending: false)
+    let display = PresetDisplayItem(
+      id: "p1", stationItem: presetItem("missing-s"), isPending: false)
 
     let capturedPresetId = LockIsolated<String?>(nil)
+    let trackedEvents = LockIsolated<[AnalyticsEvent]>([])
     let model = withDependencies {
       $0.api.deletePreset = { _, presetId in capturedPresetId.setValue(presetId) }
-      $0.analytics.track = { _ in }
+      $0.analytics.track = { event in trackedEvents.withValue { $0.append(event) } }
     } operation: {
       StationListModel()
     }
@@ -940,6 +952,11 @@ struct StationListPresetTests {
 
     #expect(capturedPresetId.value == "p1")
     #expect(presets.isEmpty)
+    let firedRemoved = trackedEvents.value.contains {
+      if case .presetRemoved = $0 { return true }
+      return false
+    }
+    #expect(!firedRemoved)
   }
 }
 
@@ -951,29 +968,31 @@ private func signedInAuth() -> Auth {
     jwt: "t")
 }
 
+private func presetItem(_ stationId: String, sortOrder: Int = 0) -> APIStationItem {
+  APIStationItem(
+    sortOrder: sortOrder, visibility: .visible,
+    station: Station.mockWith(id: stationId), urlStation: nil)
+}
+
+private func presetStationLists(_ stationIds: String...) -> IdentifiedArrayOf<StationList> {
+  IdentifiedArrayOf(uniqueElements: [
+    makePresetTestList(with: stationIds.enumerated().map { presetItem($1, sortOrder: $0) })
+  ])
+}
+
 private func makePresetTestList(with items: [APIStationItem], date: Date = Date()) -> StationList {
   StationList(
-    id: "preset-test-list",
-    name: "Test List",
-    slug: "preset-test-list",
-    hidden: false,
-    sortOrder: 0,
-    createdAt: date,
-    updatedAt: date,
-    items: items
-  )
+    id: "preset-test-list", name: "Test List", slug: "preset-test-list",
+    hidden: false, sortOrder: 0, createdAt: date, updatedAt: date, items: items)
 }
 
 private func makePresetVisibleItem(date: Date = Date()) -> APIStationItem {
-  let station = PlayolaPlayer.Station(
-    id: "playable-station",
-    name: "Moondog Radio",
-    curatorName: "Jacob Stelly",
-    imageUrl: URL(string: "https://example.com/moondog.png"),
-    description: "A playable station",
-    active: true,
-    createdAt: date,
-    updatedAt: date
-  )
-  return APIStationItem(sortOrder: 0, visibility: .visible, station: station, urlStation: nil)
+  APIStationItem(
+    sortOrder: 0,
+    visibility: .visible,
+    station: PlayolaPlayer.Station(
+      id: "playable-station", name: "Moondog Radio", curatorName: "Jacob Stelly",
+      imageUrl: URL(string: "https://example.com/moondog.png"),
+      description: "A playable station", active: true, createdAt: date, updatedAt: date),
+    urlStation: nil)
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
@@ -221,60 +221,6 @@ struct StationListPresetTests {
   }
 
   @Test
-  func testStarTappedAddNetworkErrorIsNotReportedToSentry() async {
-    @Shared(.auth) var auth = signedInAuth()
-    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
-    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
-
-    let item = makePresetVisibleItem()
-    let reportCount = LockIsolated(0)
-
-    let model = withDependencies {
-      $0.api.createPreset = { _, _, _ in
-        throw NSError(domain: NSURLErrorDomain, code: NSURLErrorSecureConnectionFailed)
-      }
-      $0.analytics.track = { _ in }
-      $0.errorReporting.reportError = { _, _ in reportCount.setValue(reportCount.value + 1) }
-    } operation: {
-      StationListModel()
-    }
-
-    await model.starTapped(for: item)
-
-    #expect(reportCount.value == 0)
-    #expect(pending.isEmpty)
-    #expect(presets.isEmpty)
-    #expect(model.presentedAlert == .errorSavingPreset(nil))
-  }
-
-  @Test
-  func testStarTappedAddTagsReportedErrorWithDomainAndCode() async {
-    @Shared(.auth) var auth = signedInAuth()
-    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
-    @Shared(.pendingPresetStationIds) var pending: Set<String> = []
-
-    let item = makePresetVisibleItem()
-    let reportedTags = LockIsolated<[String: String]>([:])
-
-    let model = withDependencies {
-      $0.api.createPreset = { _, _, _ in
-        throw NSError(domain: "TestDomain", code: 42)
-      }
-      $0.analytics.track = { _ in }
-      $0.errorReporting.reportError = { _, tags in reportedTags.setValue(tags) }
-    } operation: {
-      StationListModel()
-    }
-
-    await model.starTapped(for: item)
-
-    #expect(reportedTags.value["endpoint"] == "POST /v1/presets")
-    #expect(reportedTags.value["error_domain"] == "TestDomain")
-    #expect(reportedTags.value["error_code"] == "42")
-    #expect(reportedTags.value["station_id"] == item.anyStation.id)
-  }
-
-  @Test
   func testStarTappedIgnoredWhilePendingAdd() async {
     @Shared(.auth) var auth = signedInAuth()
     @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
@@ -1012,7 +958,7 @@ struct StationListPresetTests {
   }
 }
 
-private func signedInAuth() -> Auth {
+func signedInAuth() -> Auth {
   Auth(
     currentUser: LoggedInUser(
       id: "u1", firstName: "B", lastName: nil, email: "b@x.com",
@@ -1038,7 +984,7 @@ private func makePresetTestList(with items: [APIStationItem], date: Date = Date(
     hidden: false, sortOrder: 0, createdAt: date, updatedAt: date, items: items)
 }
 
-private func makePresetVisibleItem(date: Date = Date()) -> APIStationItem {
+func makePresetVisibleItem(date: Date = Date()) -> APIStationItem {
   APIStationItem(
     sortOrder: 0,
     visibility: .visible,

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
@@ -849,33 +849,31 @@ struct StationListPresetTests {
 
   @Test
   func testIsLoadingPresetsTrueWhileFetchInFlight() async {
-    @Shared(.auth) var auth = signedInAuth()
-    @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = signedInAuth()
+      @Shared(.presets) var presets: IdentifiedArrayOf<Preset> = []
 
-    let releaser = LockIsolated<CheckedContinuation<Void, Never>?>(nil)
-    let started = LockIsolated(false)
+      let releaser = LockIsolated<CheckedContinuation<Void, Never>?>(nil)
 
-    let model = withDependencies {
-      $0.api.getPresets = { _ in
-        await withCheckedContinuation { cont in
-          releaser.setValue(cont)
-          started.setValue(true)
+      let model = withDependencies {
+        $0.api.getPresets = { _ in
+          await withCheckedContinuation { releaser.setValue($0) }
+          return []
         }
-        return []
+      } operation: {
+        StationListModel()
       }
-    } operation: {
-      StationListModel()
+
+      let task = Task { await model.retryLoadPresetsTapped() }
+      await Task.yield()
+
+      #expect(model.isLoadingPresets)
+
+      releaser.value?.resume()
+      await task.value
+
+      #expect(!model.isLoadingPresets)
     }
-
-    let task = Task { await model.retryLoadPresetsTapped() }
-
-    while !started.value { await Task.yield() }
-    #expect(model.isLoadingPresets)
-
-    releaser.value?.resume()
-    await task.value
-
-    #expect(!model.isLoadingPresets)
   }
 
   // MARK: - presetMoved Analytics

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift
@@ -124,6 +124,10 @@ class StationSuggestionPageModel: ViewModel {
     "\(suggestion.voteCount)"
   }
 
+  func inDevelopmentBadgeText(_ suggestion: ArtistSuggestion) -> String? {
+    suggestion.status == .inDevelopment ? "IN DEVELOPMENT" : nil
+  }
+
   // MARK: - Private Helpers
 
   private func fetchSuggestions() async {

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
@@ -436,6 +436,25 @@ struct StationSuggestionPageTests {
     #expect(model.voteCountText(suggestion) == "42")
   }
 
+  @Test
+  func inDevelopmentBadgeTextShownOnlyForInDevelopment() {
+    let model = makeModel()
+
+    let inDevelopment = ArtistSuggestion(
+      id: "a", artistName: "A", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .inDevelopment, createdAt: Date(), updatedAt: Date())
+    let suggested = ArtistSuggestion(
+      id: "b", artistName: "B", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .suggested, createdAt: Date(), updatedAt: Date())
+    let streaming = ArtistSuggestion(
+      id: "c", artistName: "C", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .streaming, createdAt: Date(), updatedAt: Date())
+
+    #expect(model.inDevelopmentBadgeText(inDevelopment) == "IN DEVELOPMENT")
+    #expect(model.inDevelopmentBadgeText(suggested) == nil)
+    #expect(model.inDevelopmentBadgeText(streaming) == nil)
+  }
+
   // MARK: - Double-Tap Guard Tests
 
   @Test

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
@@ -24,13 +24,13 @@ struct StationSuggestionPageTests {
     [
       ArtistSuggestion(
         id: "s1", artistName: "Bri Bagwell", createdByUserId: "u1",
-        voteCount: 10, hasVoted: true, createdAt: Date(), updatedAt: Date()),
+        voteCount: 10, hasVoted: true, status: .inDevelopment, createdAt: Date(), updatedAt: Date()),
       ArtistSuggestion(
         id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-        voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date()),
+        voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date()),
       ArtistSuggestion(
         id: "s3", artistName: "Colter Wall", createdByUserId: "u3",
-        voteCount: 3, hasVoted: false, createdAt: Date(), updatedAt: Date()),
+        voteCount: 3, hasVoted: false, status: .streaming, createdAt: Date(), updatedAt: Date()),
     ]
   }
 
@@ -50,7 +50,7 @@ struct StationSuggestionPageTests {
     let defaultCreate: @Sendable (String, String) async throws -> ArtistSuggestion = { _, name in
       ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     }
     let defaultVote: @Sendable (String, String) async throws -> Void = { _, _ in }
     let defaultRemoveVote: @Sendable (String, String) async throws -> Void = { _, _ in }
@@ -159,7 +159,7 @@ struct StationSuggestionPageTests {
     let capturedVoteIds = LockIsolated<[String]>([])
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onVote: { _, id in
       capturedVoteIds.withValue { $0.append(id) }
@@ -176,7 +176,7 @@ struct StationSuggestionPageTests {
     let capturedRemoveIds = LockIsolated<[String]>([])
     let votedSuggestion = ArtistSuggestion(
       id: "s1", artistName: "Bri Bagwell", createdByUserId: "u1",
-      voteCount: 10, hasVoted: true, createdAt: Date(), updatedAt: Date())
+      voteCount: 10, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onRemoveVote: { _, id in
       capturedRemoveIds.withValue { $0.append(id) }
@@ -193,7 +193,7 @@ struct StationSuggestionPageTests {
     let fetchCount = LockIsolated(0)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onGetSuggestions: { _, _ in
       fetchCount.withValue { $0 += 1 }
@@ -210,7 +210,7 @@ struct StationSuggestionPageTests {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onVote: { _, _ in
       throw APIError.validationError("Already voted")
@@ -228,7 +228,7 @@ struct StationSuggestionPageTests {
     let capturedVoteIds = LockIsolated<[String]>([])
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Bri Bagwell", createdByUserId: "u1",
-      voteCount: 10, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 10, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onVote: { _, id in
       capturedVoteIds.withValue { $0.append(id) }
@@ -249,7 +249,7 @@ struct StationSuggestionPageTests {
       capturedNames.withValue { $0.append(name) }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
 
     model.searchText = "Tyler Childers"
@@ -267,7 +267,7 @@ struct StationSuggestionPageTests {
       capturedNames.withValue { $0.append(name) }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
 
     model.searchText = "  Tyler Childers  "
@@ -284,7 +284,7 @@ struct StationSuggestionPageTests {
       capturedNames.withValue { $0.append(name) }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
 
     model.searchText = "   "
@@ -301,7 +301,7 @@ struct StationSuggestionPageTests {
       capturedNames.withValue { $0.append(name) }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
 
     model.searchText = "Tyler Childers"
@@ -411,7 +411,7 @@ struct StationSuggestionPageTests {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
-      voteCount: 5, hasVoted: true, createdAt: Date(), updatedAt: Date())
+      voteCount: 5, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     #expect(model.voteButtonText(suggestion) == "Voted")
   }
@@ -421,7 +421,7 @@ struct StationSuggestionPageTests {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
-      voteCount: 5, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 5, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     #expect(model.voteButtonText(suggestion) == "Vote")
   }
@@ -431,7 +431,7 @@ struct StationSuggestionPageTests {
     let model = makeModel()
     let suggestion = ArtistSuggestion(
       id: "s1", artistName: "Test", createdByUserId: "u1",
-      voteCount: 42, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 42, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     #expect(model.voteCountText(suggestion) == "42")
   }
@@ -444,7 +444,7 @@ struct StationSuggestionPageTests {
     let voteCount = LockIsolated(0)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
 
     let model = makeModel(onVote: { _, _ in
       voteCount.withValue { $0 += 1 }
@@ -464,7 +464,7 @@ struct StationSuggestionPageTests {
       createCount.withValue { $0 += 1 }
       return ArtistSuggestion(
         id: "new", artistName: name, createdByUserId: "u1",
-        voteCount: 1, hasVoted: true, createdAt: Date(), updatedAt: Date())
+        voteCount: 1, hasVoted: true, status: .suggested, createdAt: Date(), updatedAt: Date())
     })
     model.isSubmitting = true
     model.searchText = "Tyler Childers"
@@ -479,7 +479,7 @@ struct StationSuggestionPageTests {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
     let model = makeModel()
 
     await model.voteTapped(unvotedSuggestion)
@@ -492,7 +492,7 @@ struct StationSuggestionPageTests {
     @Shared(.auth) var auth = Auth(jwt: testJwt)
     let unvotedSuggestion = ArtistSuggestion(
       id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
-      voteCount: 7, hasVoted: false, createdAt: Date(), updatedAt: Date())
+      voteCount: 7, hasVoted: false, status: .suggested, createdAt: Date(), updatedAt: Date())
     let model = makeModel(onVote: { _, _ in
       throw APIError.validationError("fail")
     })

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -147,6 +147,7 @@ struct StationSuggestionPageView: View {
             .foregroundColor(.textPrimary)
 
           if let badgeText = model.inDevelopmentBadgeText(suggestion) {
+            Spacer(minLength: 8)
             InDevelopmentBadge(text: badgeText)
           }
         }

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -141,13 +141,12 @@ struct StationSuggestionPageView: View {
   private func suggestionRow(_ suggestion: ArtistSuggestion) -> some View {
     HStack(spacing: 16) {
       VStack(alignment: .leading, spacing: 2) {
-        HStack(spacing: 8) {
+        HStack(spacing: 12) {
           Text(suggestion.artistName)
             .font(.custom(FontNames.Inter_500_Medium, size: 18))
             .foregroundColor(.textPrimary)
 
           if let badgeText = model.inDevelopmentBadgeText(suggestion) {
-            Spacer(minLength: 8)
             InDevelopmentBadge(text: badgeText)
           }
         }

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -140,10 +140,14 @@ struct StationSuggestionPageView: View {
 
   private func suggestionRow(_ suggestion: ArtistSuggestion) -> some View {
     HStack(spacing: 16) {
-      VStack(alignment: .leading, spacing: 2) {
+      VStack(alignment: .leading, spacing: 4) {
         Text(suggestion.artistName)
           .font(.custom(FontNames.Inter_500_Medium, size: 18))
           .foregroundColor(.textPrimary)
+
+        if let badgeText = model.inDevelopmentBadgeText(suggestion) {
+          InDevelopmentBadge(text: badgeText)
+        }
 
         Text("\(model.voteCountText(suggestion)) votes")
           .font(.custom(FontNames.Inter_400_Regular, size: 13))

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -146,9 +146,7 @@ struct StationSuggestionPageView: View {
             .font(.custom(FontNames.Inter_500_Medium, size: 18))
             .foregroundColor(.textPrimary)
 
-          if let badgeText = model.inDevelopmentBadgeText(suggestion) {
-            InDevelopmentBadge(text: badgeText)
-          }
+          InDevelopmentBadge(text: model.inDevelopmentBadgeText(suggestion))
         }
 
         Text("\(model.voteCountText(suggestion)) votes")

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -140,13 +140,15 @@ struct StationSuggestionPageView: View {
 
   private func suggestionRow(_ suggestion: ArtistSuggestion) -> some View {
     HStack(spacing: 16) {
-      VStack(alignment: .leading, spacing: 4) {
-        Text(suggestion.artistName)
-          .font(.custom(FontNames.Inter_500_Medium, size: 18))
-          .foregroundColor(.textPrimary)
+      VStack(alignment: .leading, spacing: 2) {
+        HStack(spacing: 8) {
+          Text(suggestion.artistName)
+            .font(.custom(FontNames.Inter_500_Medium, size: 18))
+            .foregroundColor(.textPrimary)
 
-        if let badgeText = model.inDevelopmentBadgeText(suggestion) {
-          InDevelopmentBadge(text: badgeText)
+          if let badgeText = model.inDevelopmentBadgeText(suggestion) {
+            InDevelopmentBadge(text: badgeText)
+          }
         }
 
         Text("\(model.voteCountText(suggestion)) votes")

--- a/PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift
+++ b/PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift
@@ -1,0 +1,27 @@
+//
+//  InDevelopmentBadge.swift
+//  PlayolaRadio
+
+import SwiftUI
+
+struct InDevelopmentBadge: View {
+  let text: String
+
+  var body: some View {
+    Text(text)
+      .font(.custom(FontNames.Inter_700_Bold, size: 10))
+      .tracking(1.4)
+      .foregroundColor(.playolaRed)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
+      .overlay(
+        RoundedRectangle(cornerRadius: 4)
+          .stroke(Color.playolaRed, lineWidth: 1)
+      )
+  }
+}
+
+#Preview {
+  InDevelopmentBadge(text: "IN DEVELOPMENT")
+    .preferredColorScheme(.dark)
+}

--- a/PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift
+++ b/PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift
@@ -5,19 +5,21 @@
 import SwiftUI
 
 struct InDevelopmentBadge: View {
-  let text: String
+  let text: String?
 
   var body: some View {
-    Text(text)
-      .font(.custom(FontNames.Inter_700_Bold, size: 10))
-      .tracking(1.4)
-      .foregroundColor(.playolaRed)
-      .padding(.horizontal, 8)
-      .padding(.vertical, 3)
-      .overlay(
-        RoundedRectangle(cornerRadius: 4)
-          .stroke(Color.playolaRed, lineWidth: 1)
-      )
+    if let text {
+      Text(text)
+        .font(.custom(FontNames.Inter_700_Bold, size: 10))
+        .tracking(1.4)
+        .foregroundColor(.playolaRed)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .overlay(
+          RoundedRectangle(cornerRadius: 4)
+            .stroke(Color.playolaRed, lineWidth: 1)
+        )
+    }
   }
 }
 

--- a/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
@@ -255,13 +255,6 @@ extension PlayolaAlert {
       dismissButton: .cancel(Text("OK")))
   }
 
-  static var errorLoadingPresets: PlayolaAlert {
-    PlayolaAlert(
-      title: "Couldn't Load Presets",
-      message: "Pull to refresh or try again later.",
-      dismissButton: .cancel(Text("OK")))
-  }
-
   static func errorSavingPreset(_ serverMessage: String? = nil) -> PlayolaAlert {
     let message: String
     if let serverMessage, !serverMessage.isEmpty {

--- a/docs/superpowers/plans/2026-06-02-in-development-status.md
+++ b/docs/superpowers/plans/2026-06-02-in-development-status.md
@@ -1,0 +1,311 @@
+# In Development Status Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show an "IN DEVELOPMENT" badge on a suggested-station row when the server reports its status as `in_development`.
+
+**Architecture:** Add a `status` enum to the `ArtistSuggestion` model (with an `.unknown` fallback for forward-compat), expose the badge text from `StationSuggestionPageModel`, add a small reusable `InDevelopmentBadge` view, and render it in the suggestion row when the model returns text.
+
+**Tech Stack:** Swift, SwiftUI, swift-testing (`import Testing`), CustomDump (`expectNoDifference`). Point-Free skills in force: pfw-observable-models, pfw-modern-swiftui, pfw-testing, pfw-custom-dump. No comments in generated code; avoid `self` where not needed.
+
+---
+
+### Task 1: Add `status` to the `ArtistSuggestion` model
+
+**Files:**
+- Test: `PlayolaRadio/Models/ArtistSuggestionTests.swift` (create)
+- Modify: `PlayolaRadio/Models/ArtistSuggestion.swift`
+- Modify: `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift:23-34,50-53`
+- Modify: `PlayolaRadio/Core/API/APIClient.swift:739-742` (and the empty-stub default at `726-729` returns `[]`, so no change there)
+
+- [ ] **Step 1: Write the failing decoding test**
+
+Create `PlayolaRadio/Models/ArtistSuggestionTests.swift`:
+
+```swift
+//
+//  ArtistSuggestionTests.swift
+//  PlayolaRadio
+//
+
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+struct ArtistSuggestionStatusTests {
+
+  @Test
+  func decodesKnownStatuses() throws {
+    let json = Data(#"["suggested", "in_development", "streaming"]"#.utf8)
+
+    let statuses = try JSONDecoder().decode([ArtistSuggestionStatus].self, from: json)
+
+    expectNoDifference(statuses, [.suggested, .inDevelopment, .streaming])
+  }
+
+  @Test
+  func decodesUnrecognizedStatusAsUnknown() throws {
+    let json = Data(#"["archived"]"#.utf8)
+
+    let statuses = try JSONDecoder().decode([ArtistSuggestionStatus].self, from: json)
+
+    expectNoDifference(statuses, [.unknown])
+  }
+}
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run in Xcode (user runs tests). Expected: compile failure — `ArtistSuggestionStatus` is undefined.
+
+- [ ] **Step 3: Add the enum and field**
+
+Replace the contents of `PlayolaRadio/Models/ArtistSuggestion.swift` with:
+
+```swift
+//
+//  ArtistSuggestion.swift
+//  PlayolaRadio
+//
+
+import Foundation
+
+enum ArtistSuggestionStatus: String, Codable, Equatable, Sendable {
+  case suggested
+  case inDevelopment = "in_development"
+  case streaming
+  case unknown
+
+  init(from decoder: Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = ArtistSuggestionStatus(rawValue: raw) ?? .unknown
+  }
+}
+
+struct ArtistSuggestion: Codable, Identifiable, Equatable, Sendable {
+  let id: String
+  let artistName: String
+  let createdByUserId: String
+  let voteCount: Int
+  let hasVoted: Bool
+  let status: ArtistSuggestionStatus
+  let createdAt: Date
+  let updatedAt: Date
+}
+```
+
+- [ ] **Step 4: Update the memberwise-init call sites so the project compiles**
+
+In `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift`, update `mockSuggestions()` (lines 23-34) so the three suggestions carry distinct statuses for later use, and the create stub (lines 50-53):
+
+```swift
+  nonisolated private func mockSuggestions() -> [ArtistSuggestion] {
+    [
+      ArtistSuggestion(
+        id: "s1", artistName: "Bri Bagwell", createdByUserId: "u1",
+        voteCount: 10, hasVoted: true, status: .inDevelopment,
+        createdAt: Date(), updatedAt: Date()),
+      ArtistSuggestion(
+        id: "s2", artistName: "Charley Crockett", createdByUserId: "u2",
+        voteCount: 7, hasVoted: false, status: .suggested,
+        createdAt: Date(), updatedAt: Date()),
+      ArtistSuggestion(
+        id: "s3", artistName: "Colter Wall", createdByUserId: "u3",
+        voteCount: 3, hasVoted: false, status: .streaming,
+        createdAt: Date(), updatedAt: Date()),
+    ]
+  }
+```
+
+```swift
+    let defaultCreate: @Sendable (String, String) async throws -> ArtistSuggestion = { _, name in
+      ArtistSuggestion(
+        id: "new", artistName: name, createdByUserId: "u1",
+        voteCount: 1, hasVoted: true, status: .suggested,
+        createdAt: Date(), updatedAt: Date())
+    }
+```
+
+In `PlayolaRadio/Core/API/APIClient.swift`, update the `createArtistSuggestion` default stub (lines 739-742):
+
+```swift
+  var createArtistSuggestion:
+    @Sendable (_ jwtToken: String, _ artistName: String) async throws -> ArtistSuggestion = {
+      _, _ in
+      ArtistSuggestion(
+        id: "", artistName: "", createdByUserId: "", voteCount: 0, hasVoted: false,
+        status: .suggested, createdAt: Date(), updatedAt: Date())
+    }
+```
+
+Note: the `getArtistSuggestions` default (lines 726-729) returns `[]` and needs no change. If a search across the repo finds any other `ArtistSuggestion(` construction site, add `status: .suggested` there too.
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run in Xcode. Expected: `ArtistSuggestionStatusTests` passes; existing `StationSuggestionPageTests` still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add PlayolaRadio/Models/ArtistSuggestion.swift PlayolaRadio/Models/ArtistSuggestionTests.swift PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift PlayolaRadio/Core/API/APIClient.swift
+git commit -m "Add status field to ArtistSuggestion model"
+```
+
+---
+
+### Task 2: Expose badge text from the page model
+
+**Files:**
+- Test: `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift`
+- Modify: `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift:119-125`
+
+- [ ] **Step 1: Write the failing test**
+
+Add to `StationSuggestionPageTests.swift` (inside the `StationSuggestionPageTests` struct):
+
+```swift
+  @Test
+  func inDevelopmentBadgeTextShownOnlyForInDevelopment() {
+    let model = makeModel()
+
+    let inDevelopment = ArtistSuggestion(
+      id: "a", artistName: "A", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .inDevelopment, createdAt: Date(), updatedAt: Date())
+    let suggested = ArtistSuggestion(
+      id: "b", artistName: "B", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .suggested, createdAt: Date(), updatedAt: Date())
+    let streaming = ArtistSuggestion(
+      id: "c", artistName: "C", createdByUserId: "u", voteCount: 0, hasVoted: false,
+      status: .streaming, createdAt: Date(), updatedAt: Date())
+
+    #expect(model.inDevelopmentBadgeText(inDevelopment) == "IN DEVELOPMENT")
+    #expect(model.inDevelopmentBadgeText(suggested) == nil)
+    #expect(model.inDevelopmentBadgeText(streaming) == nil)
+  }
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run in Xcode. Expected: compile failure — `inDevelopmentBadgeText` is undefined.
+
+- [ ] **Step 3: Add the helper**
+
+In `StationSuggestionPageModel.swift`, in the `// MARK: - View Helpers` section, add after `voteCountText` (line 125):
+
+```swift
+  func inDevelopmentBadgeText(_ suggestion: ArtistSuggestion) -> String? {
+    suggestion.status == .inDevelopment ? "IN DEVELOPMENT" : nil
+  }
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run in Xcode. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+git commit -m "Add in-development badge text to StationSuggestionPageModel"
+```
+
+---
+
+### Task 3: Create the `InDevelopmentBadge` view
+
+**Files:**
+- Create: `PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift`
+
+- [ ] **Step 1: Create the view**
+
+Create `PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift`:
+
+```swift
+//
+//  InDevelopmentBadge.swift
+//  PlayolaRadio
+//
+
+import SwiftUI
+
+struct InDevelopmentBadge: View {
+  let text: String
+
+  var body: some View {
+    Text(text)
+      .font(.custom(FontNames.Inter_700_Bold, size: 10))
+      .tracking(1.4)
+      .foregroundColor(.playolaRed)
+      .padding(.horizontal, 8)
+      .padding(.vertical, 3)
+      .overlay(
+        RoundedRectangle(cornerRadius: 4)
+          .stroke(Color.playolaRed, lineWidth: 1)
+      )
+  }
+}
+
+#Preview {
+  InDevelopmentBadge(text: "IN DEVELOPMENT")
+    .preferredColorScheme(.dark)
+}
+```
+
+- [ ] **Step 2: Verify it builds**
+
+Build in Xcode. Expected: builds; the preview renders an outlined red pill.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add "PlayolaRadio/Views/Reusable Components/InDevelopmentBadge.swift"
+git commit -m "Add InDevelopmentBadge reusable view"
+```
+
+---
+
+### Task 4: Render the badge in the suggestion row
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift:141-177`
+
+- [ ] **Step 1: Wire the badge into the row**
+
+In `suggestionRow(_:)`, place the badge between the artist name and the vote-count line. Replace the `VStack(alignment: .leading, spacing: 2)` block (lines 143-151) with:
+
+```swift
+      VStack(alignment: .leading, spacing: 4) {
+        Text(suggestion.artistName)
+          .font(.custom(FontNames.Inter_500_Medium, size: 18))
+          .foregroundColor(.textPrimary)
+
+        if let badgeText = model.inDevelopmentBadgeText(suggestion) {
+          InDevelopmentBadge(text: badgeText)
+        }
+
+        Text("\(model.voteCountText(suggestion)) votes")
+          .font(.custom(FontNames.Inter_400_Regular, size: 13))
+          .foregroundColor(.textSecondary)
+      }
+```
+
+- [ ] **Step 2: Verify it builds and renders**
+
+Build in Xcode and open `StationSuggestionPageView`'s preview. Expected: the in-development mock suggestion ("Bri Bagwell") shows the "IN DEVELOPMENT" badge; the others do not.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+git commit -m "Show In Development badge on suggested station rows"
+```
+
+---
+
+## Notes for the implementer
+
+- Run `make format` before each commit; SwiftLint/swift-format run on commit via git hooks. Do not use `--no-verify`.
+- Tests run in Xcode (the user runs them). Do not add `Task.sleep` to any test.
+- `Color.playolaRed` and `FontNames.Inter_700_Bold` / `Inter_500_Medium` / `Inter_400_Regular` already exist in the app.

--- a/docs/superpowers/specs/2026-06-02-in-development-status-design.md
+++ b/docs/superpowers/specs/2026-06-02-in-development-status-design.md
@@ -1,0 +1,101 @@
+# Display "In Development" status on suggested stations
+
+**Date:** 2026-06-02
+**Status:** Approved
+
+## Problem
+
+The server's artist-suggestion model gained a `status` field. We want the iOS
+"Suggest a Station" page to surface when Playola is actively building a
+suggested artist's station, matching the design in the `lovable-ios` prototype.
+
+## Context
+
+- **Server** (`~/playola/playola/server`): the model is `ArtistSuggestion`. It
+  now returns a `status` string field — `allowNull: false`, default
+  `"suggested"`. Possible values: `"suggested"`, `"in_development"`,
+  `"streaming"`.
+- **Design** (`lovable-ios/src/components/stations/SuggestStationModal.tsx`):
+  an `IN DEVELOPMENT` badge rendered inline with the artist name — an outlined
+  red pill. Text + border `#EF6962` (Playola red), transparent fill, 1px
+  border, 4px corner radius, 10px extrabold all-caps, `0.14em` letter-spacing,
+  8px×3px padding. Voting stays enabled. The design handles only the
+  in-development case.
+- **iOS** (this repo): `ArtistSuggestion.swift` has no `status` field.
+  Suggestions render on `StationSuggestionPage`. The app already has a
+  `LiveBadge` (outlined-pill idiom: `Inter_600_SemiBold` size 10, red stroke)
+  and uses an `.unknown` enum fallback convention for resilient decoding
+  (`StationListItemVisibility`).
+
+## Scope
+
+**In scope:** Show an "IN DEVELOPMENT" badge on a suggestion row when its
+status is `in_development`.
+
+**Out of scope:** Any badge for `streaming` or `suggested`; changes to voting;
+admin status-editing UI. (A `streaming` badge can be added later when that
+state matters in the UI.)
+
+## Design
+
+### 1. Model — `Models/ArtistSuggestion.swift`
+
+Add a `status` field backed by a new enum mirroring the server's three values
+plus an `.unknown` fallback (matching the existing `StationListItemVisibility`
+convention so a future server status won't break decoding):
+
+```swift
+enum ArtistSuggestionStatus: String, Codable, Equatable, Sendable {
+  case suggested
+  case inDevelopment = "in_development"
+  case streaming
+  case unknown
+
+  init(from decoder: Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = ArtistSuggestionStatus(rawValue: raw) ?? .unknown
+  }
+}
+```
+
+Add `let status: ArtistSuggestionStatus` to the struct (non-optional — the
+server always sends it). Synthesized `Codable` on the struct is kept. The
+memberwise-init call sites get `status:` added, defaulting to `.suggested`:
+- `StationSuggestionPageTests.swift` (3 in `mockSuggestions`, 1 in the create mock)
+- `APIClient.swift` (2 default-closure stubs)
+
+### 2. Model text — `StationSuggestionPageModel.swift`
+
+The model owns the badge text. Add a view helper alongside `voteButtonText`:
+
+```swift
+func inDevelopmentBadgeText(_ suggestion: ArtistSuggestion) -> String? {
+  suggestion.status == .inDevelopment ? "IN DEVELOPMENT" : nil
+}
+```
+
+`nil` → no badge. Only `.inDevelopment` returns text; `suggested` / `streaming`
+/ `unknown` return `nil`.
+
+### 3. Badge view — `Views/Reusable Components/InDevelopmentBadge.swift`
+
+A small view styled to match the lovable design (outlined red pill), in the
+same spirit as `LiveBadge`. Takes the label string as a parameter (text comes
+from the model):
+- Playola red (`#EF6962`) text + 1px border, transparent fill
+- `cornerRadius` 4, padding 8 horizontal × 3 vertical
+- `Inter_700_Bold` size 10, `.tracking(~1.4)` for the `0.14em` letter-spacing
+
+### 4. Row wiring — `StationSuggestionPageView.swift`
+
+In `suggestionRow`, render `InDevelopmentBadge` after the artist name when
+`model.inDevelopmentBadgeText(suggestion)` is non-nil. Voting unchanged.
+
+## Testing (TDD — written first)
+
+- **`Models/ArtistSuggestionTests.swift`** (new): decode `"in_development"` →
+  `.inDevelopment`, `"streaming"` → `.streaming`, `"suggested"` →
+  `.suggested`, and an unrecognized string → `.unknown`. Use
+  `expectNoDifference`.
+- **`StationSuggestionPageTests.swift`**: `inDevelopmentBadgeText` returns
+  `"IN DEVELOPMENT"` for an in-development suggestion and `nil` for the others.


### PR DESCRIPTION
## Hanging Issues and In Development Badge

### Changes
- #304: Update PlayolaPlayer to 0.19.0 and handle new terminal .error state
- #303: Improve Sentry app-hang instrumentation (split out of $main bucket)
- #302: Fix main-thread App Hang from MPNowPlayingInfoCenter getter (APPLE-IOS-1C)
- #301: Show In Development badge on suggested stations
- #300: Swap sign-in button order (Google on top) and match font size
- #299: Preserve transport errors in APIClient instead of collapsing to dataNotValid
- #298: Fix preset Coming Soon label to respect showSecretStations
- #297: Sync main to develop
- #296: Address PR #295 review: inline preset loading/error states + race + view-logic + orphan analytics

### Version
`7.0.0` (build `89`)