### PR TITLE
Fix unused withLock result warning in StationListModel

### DIFF
--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -482,7 +482,7 @@ class StationListModel: ViewModel {
     let positionsSnapshot: [String: Int] = Dictionary(
       uniqueKeysWithValues: presets.map { ($0.id, $0.position) })
 
-    $pendingPresetRemovalStationIds.withLock { $0.insert(stationId) }
+    $pendingPresetRemovalStationIds.withLock { _ = $0.insert(stationId) }
     $presets.withLock { collection in
       collection.remove(id: presetId)
       for var existing in collection where existing.position > presetSnapshot.position {

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -449,7 +449,7 @@ class StationListModel: ViewModel {
     let stationInfo = StationInfo(from: item.anyStation)
     let isPlayola = item.station != nil
 
-    $pendingPresetStationIds.withLock { $0.insert(stationId) }
+    $pendingPresetStationIds.withLock { _ = $0.insert(stationId) }
 
     do {
       let created = try await api.createPreset(


### PR DESCRIPTION
Fixes the `Result of call to 'withLock' is unused` warning in `StationListModel.addPreset`. `Set.insert` returns an `(inserted:memberAfterInsert:)` tuple, so the `withLock` closure had a non-`Void` result that went unused; discarding it with `_ =` makes the closure return `Void`.