### PR TITLE
Fix empty station artwork slots by using cached WebImage loader

### DIFF
--- a/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageView.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageView.swift
@@ -4,6 +4,7 @@
 //
 
 import PlayolaPlayer
+import SDWebImageSwiftUI
 import SwiftUI
 
 struct ChooseStationPageView: View {
@@ -35,7 +36,7 @@ private struct StationRow: View {
 
   var body: some View {
     HStack(spacing: 16) {
-      AsyncImage(url: station.imageUrl) { image in
+      WebImage(url: station.imageUrl) { image in
         image
           .resizable()
           .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
@@ -6,6 +6,7 @@
 //
 
 import IdentifiedCollections
+import SDWebImageSwiftUI
 import SwiftUI
 
 struct StationCardView: View {
@@ -21,7 +22,7 @@ struct StationCardView: View {
       label: {
         HStack(spacing: 2) {
           ZStack(alignment: .topLeading) {
-            AsyncImage(url: imageURL) { image in
+            WebImage(url: imageURL) { image in
               image
                 .resizable()
                 .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
@@ -1,4 +1,5 @@
 import PlayolaPlayer
+import SDWebImageSwiftUI
 import SwiftUI
 
 struct LikedSongsPage: View {
@@ -114,7 +115,7 @@ struct SongRow: View {
   var body: some View {
     HStack(spacing: 12) {
       // Album Art Placeholder
-      AsyncImage(url: audioBlock.imageUrl) { image in
+      WebImage(url: audioBlock.imageUrl) { image in
         image
           .resizable()
           .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 9/26/25.
 //
 
+import SDWebImageSwiftUI
 import SwiftUI
 
 struct StationListStationRowView: View {
@@ -18,7 +19,7 @@ struct StationListStationRowView: View {
     HStack(spacing: 0) {
       Button(action: action) {
         HStack(spacing: 16) {
-          AsyncImage(url: model.imageUrl) { image in
+          WebImage(url: model.imageUrl) { image in
             image
               .resizable()
               .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -8,6 +8,7 @@
 import Dependencies
 import Foundation
 import PlayolaPlayer
+import SDWebImageSwiftUI
 import Sharing
 import SwiftUI
 
@@ -55,15 +56,12 @@ struct SmallPlayer: View {
       // Player bar
       HStack(spacing: 16) {
         // Artwork
-        AsyncImage(url: artworkURL) { phase in
-          switch phase {
-          case .success(let image):
-            image
-              .resizable()
-              .scaledToFill()
-          default:
-            Color.gray.opacity(0.3)
-          }
+        WebImage(url: artworkURL) { image in
+          image
+            .resizable()
+            .scaledToFill()
+        } placeholder: {
+          Color.gray.opacity(0.3)
         }
         .frame(width: 64, height: 64)
         .clipped()


### PR DESCRIPTION
## Problem
Artist-station rows on the Radio Stations page often showed empty gray image slots while the Presets carousel loaded fine. The same bug existed in other scrollable views.

## Cause
These views used SwiftUI's `AsyncImage`, which has no cache and cancels its in-flight request when a row is recycled during scroll, leaving rows stuck on the gray placeholder.

## Fix
Switch to SDWebImageSwiftUI's `WebImage` (already used by the Presets carousel, which never had this issue) across all affected views:
- `StationListStationRowView` (the originally reported page)
- `HomePageStationList`, `LikedSongsPage`, `ChooseStationPageView` (same scroll-recycling bug)
- `SmallPlayer` (uncached artwork; phase-based loader converted to the content/placeholder form)

Placeholders and layout are unchanged in every case.

## Verification
Build succeeds; HomePageTests, SmallPlayerTests, and StationListStationRowTests all pass (65 tests). Two Codex reviews of the diff found no issues.