### PR TITLE
Add one-time Welcome Message for eligible listeners

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -54,6 +54,11 @@
 		D30F005D2E8592F0007BCC73 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673AF2D3DC54F00E4E926 /* CarPlaySceneDelegate.swift */; };
 		D30F005E2E8592F0007BCC73 /* CPListItem+InitWithRemoteUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C22D3E871800E4E926 /* CPListItem+InitWithRemoteUrl.swift */; };
 		D30F005F2E8592F0007BCC73 /* MainContainerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744AC2E2FCD8E0042A427 /* MainContainerModel.swift */; };
+		FE110A0000000000000000B2 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
+		FE110A0000000000000000B5 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
+		FE110A0000000000000000B3 /* WelcomeMessagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */; };
+		FE110A0000000000000000B6 /* WelcomeMessagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */; };
+		FE110A0000000000000000B4 /* WelcomeMessagePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */; };
 		D30F00602E8592F0007BCC73 /* ContactPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39591162E39932300720CF8 /* ContactPageModel.swift */; };
 		D30F00612E8592F0007BCC73 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
 		D30F00622E8592F0007BCC73 /* MailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E57D2BFD750700B9E35B /* MailService.swift */; };
@@ -164,6 +169,7 @@
 		D31C43D42D3C783B0021AAE4 /* PlayolaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D31C43D32D3C783B0021AAE4 /* PlayolaPlayer */; };
 		D31CD5232DFBA1F2009B9780 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CD5222DFBA1EC009B9780 /* ViewModel.swift */; };
 		D31CD5272DFBB4DF009B9780 /* MainContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CD5252DFBB47D009B9780 /* MainContainerTests.swift */; };
+		FE110AC0DE0000000000B1B1 /* WelcomeMessageEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */; };
 		D3219C172EDD22150008AFDA /* BroadcastPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3219C162EDD22100008AFDA /* BroadcastPageView.swift */; };
 		D3219C182EDD22150008AFDA /* BroadcastPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3219C162EDD22100008AFDA /* BroadcastPageView.swift */; };
 		D3219C1A2EDD22200008AFDA /* BroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3219C192EDD22180008AFDA /* BroadcastPageModel.swift */; };
@@ -489,6 +495,10 @@
 		D31C43A92D3C390C0021AAE4 /* StationPlayerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerMock.swift; sourceTree = "<group>"; };
 		D31CD5222DFBA1EC009B9780 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		D31CD5252DFBB47D009B9780 /* MainContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContainerTests.swift; sourceTree = "<group>"; };
+		FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessageEligibilityTests.swift; sourceTree = "<group>"; };
+		FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageModel.swift; sourceTree = "<group>"; };
+		FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageView.swift; sourceTree = "<group>"; };
+		FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageTests.swift; sourceTree = "<group>"; };
 		D3219C162EDD22100008AFDA /* BroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastPageView.swift; sourceTree = "<group>"; };
 		D3219C192EDD22180008AFDA /* BroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastPageModel.swift; sourceTree = "<group>"; };
 		D3219C1C2EDD22230008AFDA /* BroadcastPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastPageTests.swift; sourceTree = "<group>"; };
@@ -922,6 +932,7 @@
 				D3137DCC2D3A9FAA0070033A /* StationListPage */,
 				D39728682F60CF59008591E3 /* StationSuggestionPage */,
 				D35EFC382F192C76000F64A4 /* SupportPage */,
+				FE110A0000000000000000A0 /* WelcomeMessage */,
 				D3536A062BFA4F49006942D6 /* ContentView.swift */,
 			);
 			path = Pages;
@@ -1187,9 +1198,20 @@
 			children = (
 				D3B744AC2E2FCD8E0042A427 /* MainContainerModel.swift */,
 				D31CD5252DFBB47D009B9780 /* MainContainerTests.swift */,
+				FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */,
 				D37257C82DFA247A001BC6F9 /* MainContainer.swift */,
 			);
 			path = MainContainer;
+			sourceTree = "<group>";
+		};
+		FE110A0000000000000000A0 /* WelcomeMessage */ = {
+			isa = PBXGroup;
+			children = (
+				FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */,
+				FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */,
+				FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */,
+			);
+			path = WelcomeMessage;
 			sourceTree = "<group>";
 		};
 		D37257CE2DFB4358001BC6F9 /* PlayerPage */ = {
@@ -1800,6 +1822,8 @@
 				D317C0D22EF2027000DBC82E /* VoicetrackStatusResponse.swift in Sources */,
 				D30F005E2E8592F0007BCC73 /* CPListItem+InitWithRemoteUrl.swift in Sources */,
 				D30F005F2E8592F0007BCC73 /* MainContainerModel.swift in Sources */,
+				FE110A0000000000000000B2 /* WelcomeMessagePageModel.swift in Sources */,
+				FE110A0000000000000000B3 /* WelcomeMessagePageView.swift in Sources */,
 				D30C01C52F5C9C8400889E6D /* UserPrize.swift in Sources */,
 				D30F00602E8592F0007BCC73 /* ContactPageModel.swift in Sources */,
 				D3F493BB2EEDD2B3008ED463 /* RecordPageView.swift in Sources */,
@@ -1961,6 +1985,8 @@
 				D317C0D12EF2027000DBC82E /* VoicetrackStatusResponse.swift in Sources */,
 				D35673C32D3E872600E4E926 /* CPListItem+InitWithRemoteUrl.swift in Sources */,
 				D3B744AD2E2FCD930042A427 /* MainContainerModel.swift in Sources */,
+				FE110A0000000000000000B5 /* WelcomeMessagePageModel.swift in Sources */,
+				FE110A0000000000000000B6 /* WelcomeMessagePageView.swift in Sources */,
 				D30C01C62F5C9C8500889E6D /* UserPrize.swift in Sources */,
 				D39591172E39932600720CF8 /* ContactPageModel.swift in Sources */,
 				D3F493BC2EEDD2B3008ED463 /* RecordPageView.swift in Sources */,
@@ -2119,6 +2145,8 @@
 				D3776A332F2695BE00200ADF /* ListenerQuestionDetailPageTests.swift in Sources */,
 				D30257842E63A37400F4228B /* LikeOperationTests.swift in Sources */,
 				D31CD5272DFBB4DF009B9780 /* MainContainerTests.swift in Sources */,
+				FE110AC0DE0000000000B1B1 /* WelcomeMessageEligibilityTests.swift in Sources */,
+				FE110A0000000000000000B4 /* WelcomeMessagePageTests.swift in Sources */,
 				D3776A092F22BA2100200ADF /* AskQuestionPageTests.swift in Sources */,
 				D3B9C7AE2F534D57002D75C2 /* IntroUploadServiceTests.swift in Sources */,
 				D37769FE2F22B70600200ADF /* ChooseStationPageTests.swift in Sources */,

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -290,6 +290,18 @@ extension APIClient: DependencyKey {
       getRewardsProfile: { jwtToken in
         try await authenticatedGet(path: "/v1/rewards/users/me/profile", token: jwtToken)
       },
+      markWelcomeMessageSeen: { jwtToken, stationId in
+        try await authenticatedPostVoid(
+          path: "/v1/users/me/welcome-message-seen",
+          token: jwtToken,
+          parameters: ["stationId": stationId]
+        )
+      },
+      getStationWelcomeMessage: { jwtToken, stationId in
+        let response: StationWelcomeMessageResponse = try await authenticatedGet(
+          path: "/v1/stations/\(stationId)/welcome-message", token: jwtToken)
+        return response.welcomeMessage
+      },
       getPrizeTiers: {
         let url = "\(Config.shared.baseUrl.absoluteString)/v1/rewards/tiers"
 

--- a/PlayolaRadio/Core/API/APIClient.swift
+++ b/PlayolaRadio/Core/API/APIClient.swift
@@ -52,6 +52,26 @@ struct APIClient: Sendable {
     RewardsProfile(totalTimeListenedMS: 0, totalMSAvailableForRewards: 0, accurateAsOfTime: Date())
   }
 
+  /// Marks the welcome message as seen for the authenticated user (write-once, idempotent).
+  /// - Parameters:
+  ///   - jwtToken: The JWT token for authentication
+  ///   - stationId: The station that triggered the welcome (stored for attribution)
+  /// - Throws: APIError if the request fails
+  var markWelcomeMessageSeen:
+    @Sendable (_ jwtToken: String, _ stationId: String) async throws ->
+      Void = { _, _ in }
+
+  /// Fetches a station's welcome-message recording (AudioBlock with downloadUrl + durationMS).
+  /// - Parameters:
+  ///   - jwtToken: The JWT token for authentication
+  ///   - stationId: The station to fetch the welcome message for
+  /// - Returns: The welcome-message AudioBlock, or nil when the station has none
+  /// - Throws: APIError if the request fails
+  var getStationWelcomeMessage:
+    @Sendable (_ jwtToken: String, _ stationId: String) async throws -> AudioBlock? = { _, _ in
+      nil
+    }
+
   /// Fetches all available prize tiers from the rewards system
   /// - Returns: Array of PrizeTier objects containing tiers and their associated prizes
   var getPrizeTiers: @Sendable () async throws -> [PrizeTier] = { [] }
@@ -815,4 +835,8 @@ struct RegisteredDevice: Decodable, Equatable {
   let deviceToken: String
   let platform: String
   let isActive: Bool
+}
+
+struct StationWelcomeMessageResponse: Decodable {
+  let welcomeMessage: AudioBlock?
 }

--- a/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
+++ b/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
@@ -14,7 +14,7 @@ public class UrlStreamListeningSessionReporter {
   var deviceId: String? {
     return UIDevice.current.identifierForVendor?.uuidString
   }
-  var timer: Timer?
+  private var notificationTask: Task<Void, Never>?
   @ObservationIgnored @Shared(.auth) var auth
   var disposeBag = Set<AnyCancellable>()
   weak var urlStreamPlayer: URLStreamPlayer?
@@ -50,7 +50,7 @@ public class UrlStreamListeningSessionReporter {
   }
 
   deinit {
-    timer?.invalidate()
+    notificationTask?.cancel()
   }
 
   public func endListeningSession() {
@@ -118,22 +118,23 @@ public class UrlStreamListeningSessionReporter {
   }
 
   private func startPeriodicNotifications() {
-    self.timer = Timer.scheduledTimer(
-      withTimeInterval: 10.0, repeats: true,
-      block: { [weak self] _ in
-        Task { @MainActor in
-          guard let self else { return }
-          guard let stationUrl = self.urlStreamPlayer?.currentStation?.streamUrl else {
-            print("Error -- stationId should exist")
-            return
-          }
-          self.reportOrExtendListeningSession(stationUrl)
+    notificationTask?.cancel()
+    notificationTask = Task { [weak self] in
+      while !Task.isCancelled {
+        try? await Task.sleep(for: .seconds(10))
+        guard !Task.isCancelled, let self else { return }
+        guard let stationUrl = self.urlStreamPlayer?.currentStation?.streamUrl else {
+          print("Error -- stationId should exist")
+          return
         }
-      })
+        self.reportOrExtendListeningSession(stationUrl)
+      }
+    }
   }
 
   private func stopPeriodicNotifications() {
-    self.timer?.invalidate()
+    notificationTask?.cancel()
+    notificationTask = nil
   }
 
   private func createPostRequest(url: URL, jsonData: Data) -> URLRequest? {

--- a/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
+++ b/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
@@ -125,7 +125,7 @@ public class UrlStreamListeningSessionReporter {
         guard !Task.isCancelled, let self else { return }
         guard let stationUrl = self.urlStreamPlayer?.currentStation?.streamUrl else {
           print("Error -- stationId should exist")
-          return
+          continue
         }
         self.reportOrExtendListeningSession(stationUrl)
       }

--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -197,6 +197,8 @@ class AuthService: @unchecked Sendable {
     @Shared(.airings) var airings
     @Shared(.lastNotificationSentAt) var lastNotificationSentAt
     @Shared(.isBroadcaster) var isBroadcaster
+    @Shared(.welcomeMessageEligible) var welcomeMessageEligible
+    @Shared(.welcomeMessageShownThisSession) var welcomeMessageShownThisSession
 
     let jwt = auth.jwt
     let deviceId = registeredDeviceId
@@ -214,6 +216,8 @@ class AuthService: @unchecked Sendable {
     $airings.withLock { $0 = [] }
     $lastNotificationSentAt.withLock { $0 = [:] }
     $isBroadcaster.withLock { $0 = false }
+    $welcomeMessageEligible.withLock { $0 = false }
+    $welcomeMessageShownThisSession.withLock { $0 = false }
 
     UserDefaults.standard.removeObject(forKey: "analytics_session_paused_at")
   }

--- a/PlayolaRadio/Models/RewardsProfile.swift
+++ b/PlayolaRadio/Models/RewardsProfile.swift
@@ -10,4 +10,9 @@ struct RewardsProfile: Codable, Sendable {
   let totalTimeListenedMS: Int
   let totalMSAvailableForRewards: Int
   let accurateAsOfTime: Date
+
+  // Server-computed welcome-message eligibility. `var` + default so the synthesized
+  // memberwise init stays source-compatible with existing call sites while the optional
+  // is still decoded (decodeIfPresent → nil when the server omits it).
+  var shouldShowWelcomeMessage: Bool?
 }

--- a/PlayolaRadio/Models/StationList.swift
+++ b/PlayolaRadio/Models/StationList.swift
@@ -259,21 +259,30 @@ struct APIStationItem: Codable {
   var visibility: StationListItemVisibility
   var station: PlayolaPlayer.Station?
   var urlStation: UrlStation?
+  // Decoded from the nested station JSON (PlayolaPlayer.Station drops unknown keys).
+  // Non-nil means the station has a welcome-message recording attached.
+  var welcomeMessageAudioBlockId: String?
 
   init(
     sortOrder: Int,
     visibility: StationListItemVisibility = .visible,
     station: PlayolaPlayer.Station?,
-    urlStation: UrlStation?
+    urlStation: UrlStation?,
+    welcomeMessageAudioBlockId: String? = nil
   ) {
     self.sortOrder = sortOrder
     self.visibility = visibility
     self.station = station
     self.urlStation = urlStation
+    self.welcomeMessageAudioBlockId = welcomeMessageAudioBlockId
   }
 
   private enum CodingKeys: String, CodingKey {
-    case sortOrder, visibility, station, urlStation
+    case sortOrder, visibility, station, urlStation, welcomeMessageAudioBlockId
+  }
+
+  private struct StationWelcomeMessageProbe: Decodable {
+    let welcomeMessageAudioBlockId: String?
   }
 
   init(from decoder: Decoder) throws {
@@ -284,6 +293,12 @@ struct APIStationItem: Codable {
       ?? .visible
     station = try container.decodeIfPresent(PlayolaPlayer.Station.self, forKey: .station)
     urlStation = try container.decodeIfPresent(UrlStation.self, forKey: .urlStation)
+    // Server payload nests the id inside station; our own cached encoding stores it top-level.
+    welcomeMessageAudioBlockId =
+      (try? container.decodeIfPresent(StationWelcomeMessageProbe.self, forKey: .station))?
+      .welcomeMessageAudioBlockId
+      ?? (try? container.decodeIfPresent(String.self, forKey: .welcomeMessageAudioBlockId))
+      ?? nil
   }
 }
 

--- a/PlayolaRadio/State/SharedUserDefaults.swift
+++ b/PlayolaRadio/State/SharedUserDefaults.swift
@@ -29,6 +29,19 @@ extension SharedKey where Self == InMemoryKey<Bool>.Default {
   static var stationListsLoaded: Self {
     Self[.inMemory("stationListsLoaded"), default: false]
   }
+
+  /// Server-computed welcome-message eligibility, refreshed from the rewards profile on launch.
+  /// In-memory only — the durable "seen" state lives on the server.
+  static var welcomeMessageEligible: Self {
+    Self[.inMemory("welcomeMessageEligible"), default: false]
+  }
+
+  /// Local, refresh-proof suppression: set once the welcome has been presented this launch.
+  /// Kept separate from `welcomeMessageEligible` so a rewards-profile refresh (which may still
+  /// report eligible until the server records "seen") cannot re-arm a second presentation.
+  static var welcomeMessageShownThisSession: Self {
+    Self[.inMemory("welcomeMessageShownThisSession"), default: false]
+  }
 }
 
 extension SharedKey

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -33,6 +33,9 @@ class HomePageModel: ViewModel {
   var mainContainerNavigationCoordinator
   @ObservationIgnored @Shared(.unreadSupportCount) var unreadSupportCount
   @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+  @ObservationIgnored @Shared(.welcomeMessageEligible) var welcomeMessageEligible: Bool = false
+  @ObservationIgnored @Shared(.welcomeMessageShownThisSession)
+  var welcomeMessageShownThisSession: Bool = false
 
   // MARK: - Properties
 
@@ -159,6 +162,16 @@ class HomePageModel: ViewModel {
   }
 
   func stationTapped(_ station: AnyStation) async {
+    if let item = stationItem(for: station),
+      WelcomeMessagePageModel.shouldPresent(
+        for: item,
+        eligible: welcomeMessageEligible,
+        alreadyShownThisSession: welcomeMessageShownThisSession)
+    {
+      presentWelcomeMessage(for: station)
+      return
+    }
+
     await analytics.track(
       .startedStation(
         station: StationInfo(from: station),
@@ -189,6 +202,20 @@ class HomePageModel: ViewModel {
   }
 
   // MARK: - Private Helpers
+
+  private func stationItem(for station: AnyStation) -> APIStationItem? {
+    stationLists
+      .flatMap { $0.stationItems(includeHidden: true) }
+      .first { $0.anyStation.id == station.id }
+  }
+
+  // Mirrors StationListModel.presentWelcomeMessage — the server "seen" stamp happens in
+  // WelcomeMessagePageModel once the recording actually plays.
+  private func presentWelcomeMessage(for station: AnyStation) {
+    $welcomeMessageShownThisSession.withLock { $0 = true }
+    mainContainerNavigationCoordinator.presentedSheet = .welcomeMessage(
+      WelcomeMessagePageModel(station: station))
+  }
 
   private func checkForScheduledShows() async {
     guard let jwt = auth.jwt else { return }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -48,7 +48,7 @@ struct MainContainer: View {
       item: Binding(
         get: {
           switch model.mainContainerNavigationCoordinator.presentedSheet {
-          case .player, .feedbackSheet, .share, .redeemPrize, .artistSuggestion:
+          case .player, .feedbackSheet, .share, .redeemPrize, .artistSuggestion, .welcomeMessage:
             return model.mainContainerNavigationCoordinator.presentedSheet
           default:
             return nil
@@ -73,6 +73,8 @@ struct MainContainer: View {
             RedeemPrizeSheetView(model: redeemModel)
           case .artistSuggestion(let artistSuggestionModel):
             StationSuggestionPageView(model: artistSuggestionModel)
+          case .welcomeMessage(let welcomeModel):
+            WelcomeMessagePageView(model: welcomeModel)
           default:
             EmptyView()
           }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -27,6 +27,7 @@ class MainContainerModel: ViewModel {
   @ObservationIgnored @Shared(.stationListsLoaded) var stationListsLoaded: Bool = false
   @ObservationIgnored @Shared(.airings) var airings: IdentifiedArrayOf<Airing> = []
   @ObservationIgnored @Shared(.listeningTracker) var listeningTracker
+  @ObservationIgnored @Shared(.welcomeMessageEligible) var welcomeMessageEligible: Bool = false
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.activeTab) var activeTab
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
@@ -183,6 +184,7 @@ class MainContainerModel: ViewModel {
     do {
       let rewards = try await api.getRewardsProfile(authJWT)
       self.$listeningTracker.withLock { $0 = ListeningTracker(rewardsProfile: rewards) }
+      self.$welcomeMessageEligible.withLock { $0 = rewards.shouldShowWelcomeMessage ?? false }
     } catch let err {
       // TODO: Show inline error state on the listening hours tile (instead of
       // a modal alert) — see PR #272 review. Background tile loads shouldn't

--- a/PlayolaRadio/Views/Pages/MainContainer/WelcomeMessageEligibilityTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/WelcomeMessageEligibilityTests.swift
@@ -1,0 +1,308 @@
+//
+//  WelcomeMessageEligibilityTests.swift
+//  PlayolaRadio
+//
+//  Welcome-message eligibility wiring: the server-computed flag rides on the rewards
+//  profile and is plumbed into @Shared(.welcomeMessageEligible) on launch.
+//
+
+import ConcurrencyExtras
+import Dependencies
+import Foundation
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct WelcomeMessageEligibilityTests {
+  @Test
+  func testLoadListeningTrackerSetsWelcomeMessageEligibleWhenServerSaysShow() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    @Shared(.welcomeMessageEligible) var welcomeMessageEligible = false
+
+    let model = withDependencies {
+      $0.api.getRewardsProfile = { _ in
+        RewardsProfile(
+          totalTimeListenedMS: 0,
+          totalMSAvailableForRewards: 0,
+          accurateAsOfTime: Date(),
+          shouldShowWelcomeMessage: true
+        )
+      }
+    } operation: {
+      MainContainerModel()
+    }
+
+    await model.loadListeningTracker()
+
+    #expect(welcomeMessageEligible == true)
+  }
+
+  @Test
+  func testLoadListeningTrackerClearsWelcomeMessageEligibleWhenServerSaysNo() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    @Shared(.welcomeMessageEligible) var welcomeMessageEligible = true
+
+    let model = withDependencies {
+      $0.api.getRewardsProfile = { _ in
+        RewardsProfile(
+          totalTimeListenedMS: 999_999,
+          totalMSAvailableForRewards: 0,
+          accurateAsOfTime: Date(),
+          shouldShowWelcomeMessage: false
+        )
+      }
+    } operation: {
+      MainContainerModel()
+    }
+
+    await model.loadListeningTracker()
+
+    #expect(welcomeMessageEligible == false)
+  }
+
+  // Guards against the Codable footgun where a `let` property with a default is excluded
+  // from synthesis: an optional `var` is still decoded, defaulting to nil when absent.
+  @Test
+  func testRewardsProfileDecodesWelcomeFlagAndDefaultsToNilWhenAbsent() throws {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+
+    let withFlag = """
+      {"totalTimeListenedMS":0,"totalMSAvailableForRewards":0,\
+      "accurateAsOfTime":"2026-01-01T00:00:00Z","shouldShowWelcomeMessage":true}
+      """.data(using: .utf8)!
+    #expect(
+      try decoder.decode(RewardsProfile.self, from: withFlag).shouldShowWelcomeMessage == true)
+
+    let withoutFlag = """
+      {"totalTimeListenedMS":0,"totalMSAvailableForRewards":0,\
+      "accurateAsOfTime":"2026-01-01T00:00:00Z"}
+      """.data(using: .utf8)!
+    #expect(
+      try decoder.decode(RewardsProfile.self, from: withoutFlag).shouldShowWelcomeMessage == nil)
+  }
+
+  // MARK: - Trigger (StationListModel)
+
+  @Test
+  func testStationSelectedPresentsWelcomeForEligiblePlayolaStation() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    @Shared(.welcomeMessageEligible) var welcomeMessageEligible = true
+    @Shared(.welcomeMessageShownThisSession) var shown = false
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
+
+    let seen = LockIsolated<[String]>([])
+    let player = StationPlayerMock.mockStoppedPlayer()
+    let model = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+      $0.api.markWelcomeMessageSeen = { _, stationId in seen.withValue { $0.append(stationId) } }
+    } operation: {
+      StationListModel()
+    }
+
+    let item = makeEligibleWelcomePlayolaItem()
+    await model.stationSelected(item)
+
+    #expect(player.callsToPlay.isEmpty)
+    #expect(shown == true)
+    // The server "seen" stamp belongs to the page (fires only once playback starts).
+    #expect(seen.value.isEmpty)
+    #expect(isWelcomeMessageSheet(coordinator.presentedSheet))
+  }
+
+  @Test
+  func testStationSelectedPlaysNormallyWhenNotEligible() async {
+    @Shared(.welcomeMessageEligible) var welcomeMessageEligible = false
+    @Shared(.welcomeMessageShownThisSession) var shown = false
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
+
+    let player = StationPlayerMock.mockStoppedPlayer()
+    let model = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+    } operation: {
+      StationListModel()
+    }
+
+    let item = makeEligibleWelcomePlayolaItem()
+    await model.stationSelected(item)
+
+    #expect(player.callsToPlay.map(\.id) == [item.anyStation.id])
+    #expect(isWelcomeMessageSheet(coordinator.presentedSheet) == false)
+  }
+
+  // Eligible user, but the station has NO welcome-message recording → plays normally and
+  // stays eligible for a later station that does have one (the Jason/Bri-before-Radney case).
+  @Test
+  func testStationSelectedPlaysNormallyWhenStationHasNoWelcomeRecording() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    @Shared(.welcomeMessageEligible) var welcomeMessageEligible = true
+    @Shared(.welcomeMessageShownThisSession) var shown = false
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
+
+    let player = StationPlayerMock.mockStoppedPlayer()
+    let model = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+    } operation: {
+      StationListModel()
+    }
+
+    let item = makeEligibleWelcomePlayolaItem(welcomeMessageAudioBlockId: nil)
+    await model.stationSelected(item)
+
+    #expect(player.callsToPlay.map(\.id) == [item.anyStation.id])
+    #expect(isWelcomeMessageSheet(coordinator.presentedSheet) == false)
+    #expect(shown == false)
+    #expect(welcomeMessageEligible == true)
+  }
+
+  @Test
+  func testAPIStationItemDecodesWelcomeMessageAudioBlockIdFromNestedStation() throws {
+    let json = """
+      {"sortOrder":0,"visibility":"visible","station":{"id":"s1","name":"Radney Radio",\
+      "curatorName":"Radney Foster","description":"d","createdAt":"2026-01-01T00:00:00Z",\
+      "updatedAt":"2026-01-01T00:00:00Z","welcomeMessageAudioBlockId":"ab-123"}}
+      """.data(using: .utf8)!
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let item = try decoder.decode(APIStationItem.self, from: json)
+    #expect(item.welcomeMessageAudioBlockId == "ab-123")
+    #expect(item.station?.id == "s1")
+
+    let withoutId = """
+      {"sortOrder":0,"visibility":"visible","station":{"id":"s1","name":"Radney Radio",\
+      "curatorName":"Radney Foster","description":"d","createdAt":"2026-01-01T00:00:00Z",\
+      "updatedAt":"2026-01-01T00:00:00Z"}}
+      """.data(using: .utf8)!
+    #expect(
+      try decoder.decode(APIStationItem.self, from: withoutId).welcomeMessageAudioBlockId == nil)
+  }
+
+  // MARK: - Trigger (HomePageModel "For You")
+
+  @Test
+  func testHomeStationTappedPresentsWelcomeForEligiblePlayolaStation() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    @Shared(.welcomeMessageEligible) var welcomeMessageEligible = true
+    @Shared(.welcomeMessageShownThisSession) var shown = false
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
+    let item = makeEligibleWelcomePlayolaItem()
+    @Shared(.stationLists) var stationLists = makeWelcomeTestStationLists(items: [item])
+
+    let player = StationPlayerMock.mockStoppedPlayer()
+    let model = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+    } operation: {
+      HomePageModel()
+    }
+
+    await model.stationTapped(item.anyStation)
+
+    #expect(player.callsToPlay.isEmpty)
+    #expect(shown == true)
+    #expect(isWelcomeMessageSheet(coordinator.presentedSheet))
+  }
+
+  @Test
+  func testHomeStationTappedPlaysNormallyWhenStationHasNoWelcomeRecording() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    @Shared(.welcomeMessageEligible) var welcomeMessageEligible = true
+    @Shared(.welcomeMessageShownThisSession) var shown = false
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
+    let item = makeEligibleWelcomePlayolaItem(welcomeMessageAudioBlockId: nil)
+    @Shared(.stationLists) var stationLists = makeWelcomeTestStationLists(items: [item])
+
+    let player = StationPlayerMock.mockStoppedPlayer()
+    let model = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+    } operation: {
+      HomePageModel()
+    }
+
+    await model.stationTapped(item.anyStation)
+
+    #expect(player.callsToPlay.map(\.id) == [item.anyStation.id])
+    #expect(isWelcomeMessageSheet(coordinator.presentedSheet) == false)
+    #expect(welcomeMessageEligible == true)
+  }
+
+  // A rewards-profile refresh can leave welcomeMessageEligible == true before the server
+  // records "seen". The separate session flag must still prevent a second presentation.
+  @Test
+  func testStationSelectedDoesNotReshowWhenAlreadyShownThisSession() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    @Shared(.welcomeMessageEligible) var welcomeMessageEligible = true
+    @Shared(.welcomeMessageShownThisSession) var shown = true
+    @Shared(.mainContainerNavigationCoordinator) var coordinator =
+      MainContainerNavigationCoordinator()
+
+    let player = StationPlayerMock.mockStoppedPlayer()
+    let model = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+    } operation: {
+      StationListModel()
+    }
+
+    let item = makeEligibleWelcomePlayolaItem()
+    await model.stationSelected(item)
+
+    #expect(player.callsToPlay.map(\.id) == [item.anyStation.id])
+    #expect(isWelcomeMessageSheet(coordinator.presentedSheet) == false)
+  }
+}
+
+private func isWelcomeMessageSheet(_ sheet: PlayolaSheet?) -> Bool {
+  if case .welcomeMessage = sheet { return true }
+  return false
+}
+
+private func makeWelcomeTestStationLists(items: [APIStationItem])
+  -> IdentifiedArrayOf<StationList>
+{
+  [
+    StationList(
+      id: "artist-list-id",
+      name: "Artist Stations",
+      slug: StationList.artistListSlug,
+      createdAt: Date(),
+      updatedAt: Date(),
+      items: items
+    )
+  ]
+}
+
+private func makeEligibleWelcomePlayolaItem(
+  welcomeMessageAudioBlockId: String? = "welcome-audio-block-1"
+) -> APIStationItem {
+  let station = PlayolaPlayer.Station(
+    id: "welcome-station",
+    name: "Moondog Radio",
+    curatorName: "Jacob Stelly",
+    imageUrl: URL(string: "https://example.com/moondog.png"),
+    description: "A playable station",
+    active: true,
+    createdAt: Date(),
+    updatedAt: Date()
+  )
+  return APIStationItem(
+    sortOrder: 0,
+    visibility: .visible,
+    station: station,
+    urlStation: nil,
+    welcomeMessageAudioBlockId: welcomeMessageAudioBlockId
+  )
+}

--- a/PlayolaRadio/Views/Pages/MainContainer/WelcomeMessageEligibilityTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/WelcomeMessageEligibilityTests.swift
@@ -71,17 +71,19 @@ struct WelcomeMessageEligibilityTests {
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
 
-    let withFlag = """
+    let withFlag = Data(
+      """
       {"totalTimeListenedMS":0,"totalMSAvailableForRewards":0,\
       "accurateAsOfTime":"2026-01-01T00:00:00Z","shouldShowWelcomeMessage":true}
-      """.data(using: .utf8)!
+      """.utf8)
     #expect(
       try decoder.decode(RewardsProfile.self, from: withFlag).shouldShowWelcomeMessage == true)
 
-    let withoutFlag = """
+    let withoutFlag = Data(
+      """
       {"totalTimeListenedMS":0,"totalMSAvailableForRewards":0,\
       "accurateAsOfTime":"2026-01-01T00:00:00Z"}
-      """.data(using: .utf8)!
+      """.utf8)
     #expect(
       try decoder.decode(RewardsProfile.self, from: withoutFlag).shouldShowWelcomeMessage == nil)
   }
@@ -167,22 +169,24 @@ struct WelcomeMessageEligibilityTests {
 
   @Test
   func testAPIStationItemDecodesWelcomeMessageAudioBlockIdFromNestedStation() throws {
-    let json = """
+    let json = Data(
+      """
       {"sortOrder":0,"visibility":"visible","station":{"id":"s1","name":"Radney Radio",\
       "curatorName":"Radney Foster","description":"d","createdAt":"2026-01-01T00:00:00Z",\
       "updatedAt":"2026-01-01T00:00:00Z","welcomeMessageAudioBlockId":"ab-123"}}
-      """.data(using: .utf8)!
+      """.utf8)
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .iso8601
     let item = try decoder.decode(APIStationItem.self, from: json)
     #expect(item.welcomeMessageAudioBlockId == "ab-123")
     #expect(item.station?.id == "s1")
 
-    let withoutId = """
+    let withoutId = Data(
+      """
       {"sortOrder":0,"visibility":"visible","station":{"id":"s1","name":"Radney Radio",\
       "curatorName":"Radney Foster","description":"d","createdAt":"2026-01-01T00:00:00Z",\
       "updatedAt":"2026-01-01T00:00:00Z"}}
-      """.data(using: .utf8)!
+      """.utf8)
     #expect(
       try decoder.decode(APIStationItem.self, from: withoutId).welcomeMessageAudioBlockId == nil)
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -80,6 +80,9 @@ class StationListModel: ViewModel {
   var pendingPresetRemovalStationIds: Set<String> = []
   @ObservationIgnored @Shared(.hasAskedForNotificationPermission)
   var hasAskedForNotificationPermission: Bool
+  @ObservationIgnored @Shared(.welcomeMessageEligible) var welcomeMessageEligible: Bool = false
+  @ObservationIgnored @Shared(.welcomeMessageShownThisSession)
+  var welcomeMessageShownThisSession: Bool = false
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
 
@@ -331,6 +334,11 @@ class StationListModel: ViewModel {
         totalStations: allStations.count
       ))
 
+    if shouldShowWelcomeMessage(for: item) {
+      presentWelcomeMessage(for: station)
+      return
+    }
+
     await analytics.track(
       .startedStation(
         station: StationInfo(from: station),
@@ -338,6 +346,22 @@ class StationListModel: ViewModel {
       ))
 
     await stationPlayer.play(station: station)
+  }
+
+  private func shouldShowWelcomeMessage(for item: APIStationItem) -> Bool {
+    WelcomeMessagePageModel.shouldPresent(
+      for: item,
+      eligible: welcomeMessageEligible,
+      alreadyShownThisSession: welcomeMessageShownThisSession)
+  }
+
+  // The server "seen" stamp happens in WelcomeMessagePageModel once the recording actually
+  // plays — a fetch/playback failure must not burn the user's one welcome. The session flag
+  // here still prevents repeat presentations this launch.
+  private func presentWelcomeMessage(for station: AnyStation) {
+    $welcomeMessageShownThisSession.withLock { $0 = true }
+    mainContainerNavigationCoordinator.presentedSheet = .welcomeMessage(
+      WelcomeMessagePageModel(station: station))
   }
 
   // MARK: - View Helpers

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageModel.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageModel.swift
@@ -71,7 +71,7 @@ class WelcomeMessagePageModel: ViewModel {
       text: "Sometimes Broadcasts Live", revealAtFraction: 0.75),
   ]
 
-  // MARK: - State
+  // MARK: - Properties
 
   var playbackState: PlaybackState = .idle
   var isComplete = false
@@ -79,61 +79,6 @@ class WelcomeMessagePageModel: ViewModel {
   @ObservationIgnored private var playbackSession: PlaybackSession?
   @ObservationIgnored private var hasStartedPlaying = false
   @ObservationIgnored private var isStartingStation = false
-
-  // MARK: - View Helpers
-
-  var curatorName: String { station.name }
-  var personalDJLabel: String { "Is Your Personal DJ" }
-  var imageURL: URL? { station.imageUrl }
-
-  var progress: Double { isComplete ? 1 : playbackState.progress }
-
-  func isChipRevealed(_ chip: WelcomeMessageChip) -> Bool {
-    progress >= chip.revealAtFraction
-  }
-
-  func chipOpacity(_ chip: WelcomeMessageChip) -> Double {
-    isChipRevealed(chip) ? 1 : 0
-  }
-
-  func chipOffset(_ chip: WelcomeMessageChip) -> CGFloat {
-    isChipRevealed(chip) ? 0 : 10
-  }
-
-  // Chips hand off to the "Now playing" card once the message wraps.
-  var chipStackOpacity: Double { isComplete ? 0 : 1 }
-  var nowPlayingCardOpacity: Double { isComplete ? 1 : 0 }
-  var nowPlayingCardLabel: String { "Now Playing" }
-
-  // Best-effort preview of what's airing on the station now, derived live from the
-  // fetched schedule + the current clock (the station itself isn't playing yet). Falls
-  // back to the station/curator when there's no schedule or nothing is airing.
-  var nowPlayingSpin: Spin? { schedule?.nowPlaying() }
-
-  var nowPlayingCardTitle: String {
-    guard let audioBlock = nowPlayingSpin?.audioBlock else { return station.stationName }
-    if audioBlock.type == "commercial" { return "Playola Pays" }
-    if audioBlock.type == "song" { return audioBlock.title }
-    return nowPlayingSpin?.airing?.episode?.title ?? station.stationName
-  }
-
-  var nowPlayingCardSubtitle: String {
-    guard let audioBlock = nowPlayingSpin?.audioBlock, audioBlock.type == "song" else {
-      return "with \(station.name)"
-    }
-    return audioBlock.artist
-  }
-
-  var equalizerOpacity: Double { isComplete ? 0 : 1 }
-
-  var skipButtonTitle: String { "Skip" }
-  var skipButtonOpacity: Double { isComplete ? 0 : 1 }
-
-  var primaryButtonTitle: String { "Start Listening" }
-  var isPrimaryButtonEnabled: Bool { isComplete }
-  var primaryButtonBackground: Color { isComplete ? .playolaRed : Color(hex: "#2A1313") }
-  var primaryButtonForeground: Color { isComplete ? .white : .white.opacity(0.35) }
-  var primaryButtonGlowOpacity: Double { isComplete ? 0.5 : 0 }
 
   // MARK: - User Actions
 
@@ -198,6 +143,61 @@ class WelcomeMessagePageModel: ViewModel {
     }
   }
 
+  // MARK: - View Helpers
+
+  var curatorName: String { station.name }
+  var personalDJLabel: String { "IS YOUR PERSONAL DJ" }
+  var imageURL: URL? { station.imageUrl }
+
+  var progress: Double { isComplete ? 1 : playbackState.progress }
+
+  func isChipRevealed(_ chip: WelcomeMessageChip) -> Bool {
+    progress >= chip.revealAtFraction
+  }
+
+  func chipOpacity(_ chip: WelcomeMessageChip) -> Double {
+    isChipRevealed(chip) ? 1 : 0
+  }
+
+  func chipOffset(_ chip: WelcomeMessageChip) -> CGFloat {
+    isChipRevealed(chip) ? 0 : 10
+  }
+
+  // Chips hand off to the "Now playing" card once the message wraps.
+  var chipStackOpacity: Double { isComplete ? 0 : 1 }
+  var nowPlayingCardOpacity: Double { isComplete ? 1 : 0 }
+  var nowPlayingCardLabel: String { "NOW PLAYING" }
+
+  // Best-effort preview of what's airing on the station now, derived live from the
+  // fetched schedule + the current clock (the station itself isn't playing yet). Falls
+  // back to the station/curator when there's no schedule or nothing is airing.
+  var nowPlayingSpin: Spin? { schedule?.nowPlaying() }
+
+  var nowPlayingCardTitle: String {
+    guard let audioBlock = nowPlayingSpin?.audioBlock else { return station.stationName }
+    if audioBlock.type == "commercial" { return "Playola Pays" }
+    if audioBlock.type == "song" { return audioBlock.title }
+    return nowPlayingSpin?.airing?.episode?.title ?? station.stationName
+  }
+
+  var nowPlayingCardSubtitle: String {
+    guard let audioBlock = nowPlayingSpin?.audioBlock, audioBlock.type == "song" else {
+      return "with \(station.name)"
+    }
+    return audioBlock.artist
+  }
+
+  var equalizerOpacity: Double { isComplete ? 0 : 1 }
+
+  var skipButtonTitle: String { "Skip" }
+  var skipButtonOpacity: Double { isComplete ? 0 : 1 }
+
+  var primaryButtonTitle: String { "Start Listening" }
+  var isPrimaryButtonEnabled: Bool { isComplete }
+  var primaryButtonBackground: Color { isComplete ? .playolaRed : Color(hex: "#2A1313") }
+  var primaryButtonForeground: Color { isComplete ? .white : .white.opacity(0.35) }
+  var primaryButtonGlowOpacity: Double { isComplete ? 0.5 : 0 }
+
   // MARK: - Private Helpers
 
   private func loadSchedule() async {
@@ -206,7 +206,11 @@ class WelcomeMessagePageModel: ViewModel {
       guard !isStartingStation else { return }
       schedule = Schedule(
         stationId: station.id, spins: spins, dateProvider: DependencyDateProvider())
-    } catch {}
+    } catch {
+      // Best-effort: the schedule only feeds the optional Now Playing card. Log so an API
+      // regression stays visible rather than silently dropping the error.
+      print("WelcomeMessagePageModel: loadSchedule failed — \(error)")
+    }
   }
 
   private func playbackStateChanged(_ state: PlaybackState) {

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageModel.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageModel.swift
@@ -1,0 +1,246 @@
+//
+//  WelcomeMessagePageModel.swift
+//  PlayolaRadio
+//
+//  One-time welcome shown the first time an eligible user opens an artist station that has
+//  a welcome-message recording. Plays the recording; progress and chip reveals are driven
+//  by the recording's real duration. Then the station starts.
+//
+
+import Dependencies
+import Foundation
+import PlayolaPlayer
+import Sharing
+import SwiftUI
+
+struct WelcomeMessageChip: Identifiable, Equatable {
+  let id: String
+  let systemImageName: String
+  let text: String
+  let revealAtFraction: Double
+}
+
+@MainActor
+@Observable
+class WelcomeMessagePageModel: ViewModel {
+
+  // MARK: - Presentation Gate
+
+  // Single gate shared by every play entry point (station list, home "For You").
+  static func shouldPresent(
+    for item: APIStationItem, eligible: Bool, alreadyShownThisSession: Bool
+  ) -> Bool {
+    guard eligible, !alreadyShownThisSession else { return false }
+    guard item.welcomeMessageAudioBlockId != nil else { return false }
+    if case .playola = item.anyStation { return true }
+    return false
+  }
+
+  // MARK: - Dependencies
+
+  @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.audioPlayer) var audioPlayer
+  @ObservationIgnored @Dependency(\.analytics) var analytics
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
+
+  // MARK: - Shared State
+
+  @ObservationIgnored @Shared(.auth) var auth
+
+  // MARK: - Initialization
+
+  let station: AnyStation
+
+  init(station: AnyStation) {
+    self.station = station
+    super.init()
+  }
+
+  // MARK: - Constants
+
+  // Three chips spaced equidistant along the recording.
+  let chips: [WelcomeMessageChip] = [
+    WelcomeMessageChip(
+      id: "songs", systemImageName: "music.note",
+      text: "Hand-Picked Every Song", revealAtFraction: 0.25),
+    WelcomeMessageChip(
+      id: "stories", systemImageName: "mic.fill",
+      text: "Recorded All the Stories", revealAtFraction: 0.5),
+    WelcomeMessageChip(
+      id: "live", systemImageName: "antenna.radiowaves.left.and.right",
+      text: "Sometimes Broadcasts Live", revealAtFraction: 0.75),
+  ]
+
+  // MARK: - State
+
+  var playbackState: PlaybackState = .idle
+  var isComplete = false
+  var schedule: Schedule?
+  @ObservationIgnored private var playbackSession: PlaybackSession?
+  @ObservationIgnored private var hasStartedPlaying = false
+  @ObservationIgnored private var isStartingStation = false
+
+  // MARK: - View Helpers
+
+  var curatorName: String { station.name }
+  var personalDJLabel: String { "Is Your Personal DJ" }
+  var imageURL: URL? { station.imageUrl }
+
+  var progress: Double { isComplete ? 1 : playbackState.progress }
+
+  func isChipRevealed(_ chip: WelcomeMessageChip) -> Bool {
+    progress >= chip.revealAtFraction
+  }
+
+  func chipOpacity(_ chip: WelcomeMessageChip) -> Double {
+    isChipRevealed(chip) ? 1 : 0
+  }
+
+  func chipOffset(_ chip: WelcomeMessageChip) -> CGFloat {
+    isChipRevealed(chip) ? 0 : 10
+  }
+
+  // Chips hand off to the "Now playing" card once the message wraps.
+  var chipStackOpacity: Double { isComplete ? 0 : 1 }
+  var nowPlayingCardOpacity: Double { isComplete ? 1 : 0 }
+  var nowPlayingCardLabel: String { "Now Playing" }
+
+  // Best-effort preview of what's airing on the station now, derived live from the
+  // fetched schedule + the current clock (the station itself isn't playing yet). Falls
+  // back to the station/curator when there's no schedule or nothing is airing.
+  var nowPlayingSpin: Spin? { schedule?.nowPlaying() }
+
+  var nowPlayingCardTitle: String {
+    guard let audioBlock = nowPlayingSpin?.audioBlock else { return station.stationName }
+    if audioBlock.type == "commercial" { return "Playola Pays" }
+    if audioBlock.type == "song" { return audioBlock.title }
+    return nowPlayingSpin?.airing?.episode?.title ?? station.stationName
+  }
+
+  var nowPlayingCardSubtitle: String {
+    guard let audioBlock = nowPlayingSpin?.audioBlock, audioBlock.type == "song" else {
+      return "with \(station.name)"
+    }
+    return audioBlock.artist
+  }
+
+  var equalizerOpacity: Double { isComplete ? 0 : 1 }
+
+  var skipButtonTitle: String { "Skip" }
+  var skipButtonOpacity: Double { isComplete ? 0 : 1 }
+
+  var primaryButtonTitle: String { "Start Listening" }
+  var isPrimaryButtonEnabled: Bool { isComplete }
+  var primaryButtonBackground: Color { isComplete ? .playolaRed : Color(hex: "#2A1313") }
+  var primaryButtonForeground: Color { isComplete ? .white : .white.opacity(0.35) }
+  var primaryButtonGlowOpacity: Double { isComplete ? 0.5 : 0 }
+
+  // MARK: - User Actions
+
+  func task() async {
+    async let scheduleLoad: Void = loadSchedule()
+    await playWelcomeRecording()
+    await scheduleLoad
+  }
+
+  private func playWelcomeRecording() async {
+    guard let jwt = auth.jwt else {
+      await startStation()
+      return
+    }
+
+    let downloadUrl: URL?
+    do {
+      downloadUrl = try await api.getStationWelcomeMessage(jwt, station.id)?.downloadUrl
+    } catch {
+      downloadUrl = nil
+    }
+
+    // The user may have tapped Skip while the recording was being fetched — the station is
+    // already starting, so don't begin welcome playback over it.
+    guard !isStartingStation else { return }
+
+    guard let downloadUrl else {
+      await startStation()
+      return
+    }
+
+    do {
+      let session = try await audioPlayer.startPlayback(downloadUrl) { [weak self] state in
+        self?.playbackStateChanged(state)
+      }
+      guard !isStartingStation else {
+        await session.stop()
+        session.cancel()
+        return
+      }
+      playbackSession = session
+      reportSeen(jwt: jwt)
+    } catch {
+      await startStation()
+    }
+  }
+
+  func skipButtonTapped() async {
+    await startStation()
+  }
+
+  func primaryButtonTapped() async {
+    await startStation()
+  }
+
+  func viewDisappeared() {
+    let session = playbackSession
+    playbackSession = nil
+    Task {
+      await session?.stop()
+      session?.cancel()
+    }
+  }
+
+  // MARK: - Private Helpers
+
+  private func loadSchedule() async {
+    do {
+      let spins = try await api.fetchSchedule(station.id, false)
+      guard !isStartingStation else { return }
+      schedule = Schedule(
+        stationId: station.id, spins: spins, dateProvider: DependencyDateProvider())
+    } catch {}
+  }
+
+  private func playbackStateChanged(_ state: PlaybackState) {
+    playbackState = state
+    if state.isPlaying {
+      hasStartedPlaying = true
+    }
+    // Completion needs near-the-end progress, not just isPlaying == false — a buffering
+    // stall mid-recording also reports not-playing and must not end the welcome early.
+    guard hasStartedPlaying, !isComplete else { return }
+    if state.progress >= 0.995 || (!state.isPlaying && state.progress >= 0.97) {
+      isComplete = true
+    }
+  }
+
+  // Server-stamps "seen" only once the recording is actually playing — a failed fetch or
+  // playback fallback must NOT burn the user's one welcome. Unstructured Task so sheet
+  // dismissal can't cancel the write mid-flight.
+  private func reportSeen(jwt: String) {
+    let api = api
+    let stationId = station.id
+    Task.detached {
+      try? await api.markWelcomeMessageSeen(jwt, stationId)
+    }
+  }
+
+  private func startStation() async {
+    guard !isStartingStation else { return }
+    isStartingStation = true
+    await playbackSession?.stop()
+    playbackSession?.cancel()
+    playbackSession = nil
+    await analytics.track(
+      .startedStation(station: StationInfo(from: station), entryPoint: "welcome_message"))
+    await stationPlayer.play(station: station)
+  }
+}

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageTests.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageTests.swift
@@ -1,0 +1,318 @@
+//
+//  WelcomeMessagePageTests.swift
+//  PlayolaRadio
+//
+
+import ConcurrencyExtras
+import Dependencies
+import Foundation
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct WelcomeMessagePageModelTests {
+
+  @Test
+  func testTaskPlaysRecordingAndDrivesChipsFromRealDuration() async throws {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    let player = StationPlayerMock()
+    let capturedURL = LockIsolated<URL?>(nil)
+    let stateSink = LockIsolated<(@MainActor @Sendable (PlaybackState) -> Void)?>(nil)
+    let seenCalls = LockIsolated<[String]>([])
+
+    let model = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+      $0.api.fetchSchedule = { _, _ in [] }
+      $0.api.getStationWelcomeMessage = { _, _ in
+        AudioBlock.mockWith(
+          durationMS: 8_000,
+          downloadUrl: URL(string: "https://example.com/welcome.m4a")
+        )
+      }
+      $0.api.markWelcomeMessageSeen = { _, stationId in
+        seenCalls.withValue { $0.append(stationId) }
+      }
+      $0.audioPlayer.startPlayback = { url, onStateChange in
+        capturedURL.setValue(url)
+        stateSink.setValue(onStateChange)
+        return PlaybackSession(play: {}, pause: {}, stop: {}, seek: { _ in }, cancel: {})
+      }
+    } operation: {
+      WelcomeMessagePageModel(station: .mockPlayola(id: "station-123"))
+    }
+
+    await model.task()
+
+    #expect(capturedURL.value == URL(string: "https://example.com/welcome.m4a"))
+    #expect(player.callsToPlay.isEmpty)
+    for _ in 0..<100 {
+      await Task.yield()
+      if !seenCalls.value.isEmpty { break }
+    }
+    #expect(seenCalls.value == ["station-123"])
+    let send = try #require(stateSink.value)
+
+    send(PlaybackState(currentTime: 1, duration: 8, isPlaying: true))
+    #expect(model.chips.allSatisfy { model.isChipRevealed($0) == false })
+    #expect(model.isPrimaryButtonEnabled == false)
+    #expect(model.skipButtonOpacity == 1)
+
+    send(PlaybackState(currentTime: 2, duration: 8, isPlaying: true))
+    #expect(model.chips.filter { model.isChipRevealed($0) }.map(\.id) == ["songs"])
+
+    send(PlaybackState(currentTime: 4, duration: 8, isPlaying: true))
+    #expect(model.chips.filter { model.isChipRevealed($0) }.map(\.id) == ["songs", "stories"])
+
+    // A buffering stall (not playing, mid-recording) must NOT count as completion.
+    send(PlaybackState(currentTime: 4, duration: 8, isPlaying: false))
+    #expect(model.isComplete == false)
+
+    send(PlaybackState(currentTime: 6, duration: 8, isPlaying: true))
+    #expect(model.chips.allSatisfy { model.isChipRevealed($0) })
+    #expect(model.isComplete == false)
+
+    send(PlaybackState(currentTime: 8, duration: 8, isPlaying: false))
+    #expect(model.isComplete == true)
+    #expect(model.progress == 1)
+    #expect(model.primaryButtonTitle == "Start Listening")
+    #expect(model.isPrimaryButtonEnabled == true)
+    #expect(model.nowPlayingCardOpacity == 1)
+    #expect(model.skipButtonOpacity == 0)
+  }
+
+  // Tapping Skip while the recording is still being fetched must not start welcome audio
+  // over the already-starting station.
+  @Test
+  func testSkipDuringFetchDoesNotStartWelcomeAudio() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    let player = StationPlayerMock()
+    let startPlaybackCalled = LockIsolated(false)
+    let (gateStream, gateContinuation) = AsyncStream<Void>.makeStream()
+
+    let model = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+      $0.api.fetchSchedule = { _, _ in [] }
+      $0.api.getStationWelcomeMessage = { _, _ in
+        var iterator = gateStream.makeAsyncIterator()
+        _ = await iterator.next()
+        return AudioBlock.mockWith(downloadUrl: URL(string: "https://example.com/welcome.m4a"))
+      }
+      $0.audioPlayer.startPlayback = { _, _ in
+        startPlaybackCalled.setValue(true)
+        return PlaybackSession(play: {}, pause: {}, stop: {}, seek: { _ in }, cancel: {})
+      }
+    } operation: {
+      WelcomeMessagePageModel(station: .mockPlayola(id: "station-123"))
+    }
+
+    let taskHandle = Task { await model.task() }
+    await Task.yield()
+    await model.skipButtonTapped()
+    gateContinuation.yield()
+    gateContinuation.finish()
+    await taskHandle.value
+
+    #expect(startPlaybackCalled.value == false)
+    #expect(player.callsToPlay.map(\.id) == ["station-123"])
+  }
+
+  @Test
+  func testTaskStartsStationDirectlyWhenRecordingMissing() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    let player = StationPlayerMock()
+    let events = LockIsolated<[AnalyticsEvent]>([])
+
+    let model = withDependencies {
+      $0.analytics.track = { event in events.withValue { $0.append(event) } }
+      $0.stationPlayer = player
+      $0.api.fetchSchedule = { _, _ in [] }
+      $0.api.getStationWelcomeMessage = { _, _ in nil }
+    } operation: {
+      WelcomeMessagePageModel(station: .mockPlayola(id: "station-123"))
+    }
+
+    await model.task()
+
+    #expect(player.callsToPlay.map(\.id) == ["station-123"])
+    #expect(events.value.count == 1)
+  }
+
+  // A failed fetch must not burn the user's one welcome — no server "seen" stamp.
+  @Test
+  func testTaskStartsStationDirectlyWhenFetchFailsWithoutMarkingSeen() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    let player = StationPlayerMock()
+    let seenCalls = LockIsolated(0)
+
+    let model = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+      $0.api.fetchSchedule = { _, _ in [] }
+      $0.api.getStationWelcomeMessage = { _, _ in throw APIError.dataNotValid }
+      $0.api.markWelcomeMessageSeen = { _, _ in seenCalls.withValue { $0 += 1 } }
+    } operation: {
+      WelcomeMessagePageModel(station: .mockPlayola(id: "station-123"))
+    }
+
+    await model.task()
+
+    #expect(player.callsToPlay.map(\.id) == ["station-123"])
+    #expect(seenCalls.value == 0)
+  }
+
+  // Skip and Start Listening both route to the same start-once path — mashing
+  // either (or both) must only start the station a single time.
+  @Test
+  func testSkipAndPrimaryButtonsStartStationOnlyOnce() async {
+    let player = StationPlayerMock()
+    let events = LockIsolated<[AnalyticsEvent]>([])
+
+    let model = withDependencies {
+      $0.analytics.track = { event in events.withValue { $0.append(event) } }
+      $0.stationPlayer = player
+    } operation: {
+      WelcomeMessagePageModel(station: .mockPlayola(id: "station-xyz"))
+    }
+
+    await model.skipButtonTapped()
+    await model.skipButtonTapped()
+    await model.primaryButtonTapped()
+
+    #expect(player.callsToPlay.map(\.id) == ["station-xyz"])
+    #expect(events.value.count == 1)
+  }
+
+  // MARK: - Now Playing card (live schedule preview)
+
+  // The card shows the song airing on the station right now, derived from the fetched
+  // schedule and the current clock (the station itself isn't playing yet).
+  @Test
+  func testNowPlayingCardShowsCurrentlyAiringSong() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let spins = [
+      Spin.mockWith(
+        id: "spin-1",
+        airtime: now.addingTimeInterval(-30),
+        stationId: "station-123",
+        audioBlock: AudioBlock.mockWith(
+          title: "Sea of Heartbreak", artist: "Radney Foster", endOfMessageMS: 180_000, type: "song"
+        )
+      )
+    ]
+
+    await withDependencies {
+      $0.date.now = now
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = StationPlayerMock()
+      $0.api.fetchSchedule = { _, _ in spins }
+      $0.api.getStationWelcomeMessage = { _, _ in
+        AudioBlock.mockWith(downloadUrl: URL(string: "https://example.com/welcome.m4a"))
+      }
+      $0.audioPlayer.startPlayback = { _, _ in
+        PlaybackSession(play: {}, pause: {}, stop: {}, seek: { _ in }, cancel: {})
+      }
+    } operation: {
+      let model = WelcomeMessagePageModel(
+        station: .mockPlayola(
+          id: "station-123", name: "Bordertown Radio", curatorName: "Radney Foster"))
+      await model.task()
+
+      #expect(model.nowPlayingSpin?.id == "spin-1")
+      #expect(model.nowPlayingCardTitle == "Sea of Heartbreak")
+      #expect(model.nowPlayingCardSubtitle == "Radney Foster")
+    }
+  }
+
+  // When nothing is airing (between spins / after the schedule ends / fetch failed),
+  // the card falls back to the curator rather than showing a stale spin.
+  @Test
+  func testNowPlayingCardFallsBackToCuratorWhenNothingAiring() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    let now = Date(timeIntervalSince1970: 1_000_000)
+    let endedSpin = [
+      Spin.mockWith(
+        id: "spin-old",
+        airtime: now.addingTimeInterval(-600),
+        stationId: "station-123",
+        audioBlock: AudioBlock.mockWith(endOfMessageMS: 60_000, type: "song")
+      )
+    ]
+
+    await withDependencies {
+      $0.date.now = now
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = StationPlayerMock()
+      $0.api.fetchSchedule = { _, _ in endedSpin }
+      $0.api.getStationWelcomeMessage = { _, _ in
+        AudioBlock.mockWith(downloadUrl: URL(string: "https://example.com/welcome.m4a"))
+      }
+      $0.audioPlayer.startPlayback = { _, _ in
+        PlaybackSession(play: {}, pause: {}, stop: {}, seek: { _ in }, cancel: {})
+      }
+    } operation: {
+      let model = WelcomeMessagePageModel(
+        station: .mockPlayola(
+          id: "station-123", name: "Bordertown Radio", curatorName: "Radney Foster"))
+      await model.task()
+
+      #expect(model.nowPlayingSpin == nil)
+      #expect(model.nowPlayingCardTitle == "Bordertown Radio")
+      #expect(model.nowPlayingCardSubtitle == "with Radney Foster")
+    }
+  }
+
+  // The card is live: the same fetched schedule yields a different airing track as the
+  // clock advances past a spin boundary (no refetch, no player).
+  @Test
+  func testNowPlayingCardUpdatesAsScheduleAdvances() async {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    let start = Date(timeIntervalSince1970: 1_000_000)
+    let spins = [
+      Spin.mockWith(
+        id: "spin-1",
+        airtime: start,
+        stationId: "station-123",
+        audioBlock: AudioBlock.mockWith(
+          title: "First Song", artist: "A", endOfMessageMS: 60_000, type: "song")
+      ),
+      Spin.mockWith(
+        id: "spin-2",
+        airtime: start.addingTimeInterval(60),
+        stationId: "station-123",
+        audioBlock: AudioBlock.mockWith(
+          title: "Second Song", artist: "B", endOfMessageMS: 60_000, type: "song")
+      ),
+    ]
+
+    let model = await withDependencies {
+      $0.date.now = start.addingTimeInterval(10)
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = StationPlayerMock()
+      $0.api.fetchSchedule = { _, _ in spins }
+      $0.api.getStationWelcomeMessage = { _, _ in
+        AudioBlock.mockWith(downloadUrl: URL(string: "https://example.com/welcome.m4a"))
+      }
+      $0.audioPlayer.startPlayback = { _, _ in
+        PlaybackSession(play: {}, pause: {}, stop: {}, seek: { _ in }, cancel: {})
+      }
+    } operation: {
+      let model = WelcomeMessagePageModel(station: .mockPlayola(id: "station-123"))
+      await model.task()
+      #expect(model.nowPlayingCardTitle == "First Song")
+      return model
+    }
+
+    withDependencies {
+      $0.date.now = start.addingTimeInterval(75)
+    } operation: {
+      #expect(model.nowPlayingSpin?.id == "spin-2")
+      #expect(model.nowPlayingCardTitle == "Second Song")
+    }
+  }
+}

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageTests.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageTests.swift
@@ -16,35 +16,15 @@ import Testing
 struct WelcomeMessagePageModelTests {
 
   @Test
-  func testTaskPlaysRecordingAndDrivesChipsFromRealDuration() async throws {
+  func testTaskPlaysRecordingAndMarksSeen() async {
     @Shared(.auth) var auth = Auth(jwt: "test-jwt")
     let player = StationPlayerMock()
     let capturedURL = LockIsolated<URL?>(nil)
     let stateSink = LockIsolated<(@MainActor @Sendable (PlaybackState) -> Void)?>(nil)
     let seenCalls = LockIsolated<[String]>([])
 
-    let model = withDependencies {
-      $0.analytics.track = { _ in }
-      $0.stationPlayer = player
-      $0.api.fetchSchedule = { _, _ in [] }
-      $0.api.getStationWelcomeMessage = { _, _ in
-        AudioBlock.mockWith(
-          durationMS: 8_000,
-          downloadUrl: URL(string: "https://example.com/welcome.m4a")
-        )
-      }
-      $0.api.markWelcomeMessageSeen = { _, stationId in
-        seenCalls.withValue { $0.append(stationId) }
-      }
-      $0.audioPlayer.startPlayback = { url, onStateChange in
-        capturedURL.setValue(url)
-        stateSink.setValue(onStateChange)
-        return PlaybackSession(play: {}, pause: {}, stop: {}, seek: { _ in }, cancel: {})
-      }
-    } operation: {
-      WelcomeMessagePageModel(station: .mockPlayola(id: "station-123"))
-    }
-
+    let model = makeRecordingModel(
+      player: player, capturedURL: capturedURL, stateSink: stateSink, seenCalls: seenCalls)
     await model.task()
 
     #expect(capturedURL.value == URL(string: "https://example.com/welcome.m4a"))
@@ -54,6 +34,19 @@ struct WelcomeMessagePageModelTests {
       if !seenCalls.value.isEmpty { break }
     }
     #expect(seenCalls.value == ["station-123"])
+  }
+
+  @Test
+  func testChipRevealsAndCompletionFollowRealDuration() async throws {
+    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
+    let player = StationPlayerMock()
+    let capturedURL = LockIsolated<URL?>(nil)
+    let stateSink = LockIsolated<(@MainActor @Sendable (PlaybackState) -> Void)?>(nil)
+    let seenCalls = LockIsolated<[String]>([])
+
+    let model = makeRecordingModel(
+      player: player, capturedURL: capturedURL, stateSink: stateSink, seenCalls: seenCalls)
+    await model.task()
     let send = try #require(stateSink.value)
 
     send(PlaybackState(currentTime: 1, duration: 8, isPlaying: true))
@@ -82,6 +75,35 @@ struct WelcomeMessagePageModelTests {
     #expect(model.isPrimaryButtonEnabled == true)
     #expect(model.nowPlayingCardOpacity == 1)
     #expect(model.skipButtonOpacity == 0)
+  }
+
+  private func makeRecordingModel(
+    player: StationPlayerMock,
+    capturedURL: LockIsolated<URL?>,
+    stateSink: LockIsolated<(@MainActor @Sendable (PlaybackState) -> Void)?>,
+    seenCalls: LockIsolated<[String]>
+  ) -> WelcomeMessagePageModel {
+    withDependencies {
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+      $0.api.fetchSchedule = { _, _ in [] }
+      $0.api.getStationWelcomeMessage = { _, _ in
+        AudioBlock.mockWith(
+          durationMS: 8_000,
+          downloadUrl: URL(string: "https://example.com/welcome.m4a")
+        )
+      }
+      $0.api.markWelcomeMessageSeen = { _, stationId in
+        seenCalls.withValue { $0.append(stationId) }
+      }
+      $0.audioPlayer.startPlayback = { url, onStateChange in
+        capturedURL.setValue(url)
+        stateSink.setValue(onStateChange)
+        return PlaybackSession(play: {}, pause: {}, stop: {}, seek: { _ in }, cancel: {})
+      }
+    } operation: {
+      WelcomeMessagePageModel(station: .mockPlayola(id: "station-123"))
+    }
   }
 
   // Tapping Skip while the recording is still being fetched must not start welcome audio

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
@@ -1,0 +1,230 @@
+//
+//  WelcomeMessagePageView.swift
+//  PlayolaRadio
+//
+
+import SDWebImageSwiftUI
+import SwiftUI
+
+private enum WelcomePalette {
+  static let background = Color(hex: "#130000")
+  static let cardSurface = Color(hex: "#3A1212")
+  static let textSecondary = Color(hex: "#D7BFBF")
+}
+
+struct WelcomeMessagePageView: View {
+  let model: WelcomeMessagePageModel
+
+  var body: some View {
+    GeometryReader { geo in
+      VStack(spacing: 0) {
+        ZStack(alignment: .bottom) {
+          WebImage(url: model.imageURL) { image in
+            image.resizable()
+          } placeholder: {
+            WelcomePalette.cardSurface
+          }
+          .aspectRatio(contentMode: .fill)
+          .frame(width: geo.size.width, height: geo.size.height * 0.44)
+          .clipped()
+
+          LinearGradient(
+            colors: [WelcomePalette.background.opacity(0), WelcomePalette.background],
+            startPoint: .top,
+            endPoint: .bottom
+          )
+          .frame(height: 112)
+
+          WelcomeEqualizerView()
+            .opacity(model.equalizerOpacity)
+            .animation(.easeInOut, value: model.equalizerOpacity)
+            .padding(.bottom, 12)
+        }
+        .frame(height: geo.size.height * 0.44)
+
+        VStack(spacing: 4) {
+          Text(model.curatorName)
+            .font(.custom(FontNames.Inter_700_Bold, size: 30))
+            .foregroundColor(.white)
+            .multilineTextAlignment(.center)
+          Text(model.personalDJLabel.uppercased())
+            .font(.custom(FontNames.Inter_500_Medium, size: 14))
+            .kerning(1.7)
+            .foregroundColor(.playolaRed)
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 12)
+
+        ZStack {
+          VStack(spacing: 12) {
+            ForEach(model.chips) { chip in
+              WelcomeMessageChipView(chip: chip)
+                .opacity(model.chipOpacity(chip))
+                .offset(y: model.chipOffset(chip))
+                .animation(
+                  .timingCurve(0.32, 0.72, 0, 1, duration: 0.45),
+                  value: model.chipOpacity(chip))
+            }
+          }
+          .opacity(model.chipStackOpacity)
+
+          TimelineView(.periodic(from: .now, by: 1)) { _ in
+            WelcomeNowPlayingCardView(
+              label: model.nowPlayingCardLabel,
+              title: model.nowPlayingCardTitle,
+              subtitle: model.nowPlayingCardSubtitle
+            )
+          }
+          .opacity(model.nowPlayingCardOpacity)
+        }
+        .animation(.easeInOut(duration: 0.45), value: model.nowPlayingCardOpacity)
+        .frame(maxWidth: 320)
+        .frame(maxHeight: .infinity)
+        .padding(.horizontal, 24)
+
+        VStack(spacing: 16) {
+          GeometryReader { barGeo in
+            ZStack(alignment: .leading) {
+              Capsule().fill(Color.white.opacity(0.14))
+              Capsule()
+                .fill(Color.playolaRed)
+                .frame(width: barGeo.size.width * model.progress)
+            }
+          }
+          .frame(height: 3)
+          .animation(.linear(duration: 0.12), value: model.progress)
+
+          Button {
+            Task { await model.primaryButtonTapped() }
+          } label: {
+            Text(model.primaryButtonTitle)
+              .font(.custom(FontNames.Inter_600_SemiBold, size: 17))
+              .foregroundColor(model.primaryButtonForeground)
+              .frame(maxWidth: .infinity)
+              .padding(.vertical, 15)
+              .background(
+                RoundedRectangle(cornerRadius: 14).fill(model.primaryButtonBackground)
+              )
+              .shadow(
+                color: Color.playolaRed.opacity(model.primaryButtonGlowOpacity),
+                radius: 13
+              )
+          }
+          .disabled(!model.isPrimaryButtonEnabled)
+          .animation(.easeInOut(duration: 0.3), value: model.isPrimaryButtonEnabled)
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 8)
+        .padding(.bottom, 20)
+      }
+      .frame(width: geo.size.width, height: geo.size.height)
+      .background(WelcomePalette.background.ignoresSafeArea())
+      .overlay(alignment: .top) {
+        Capsule()
+          .fill(Color.white.opacity(0.5))
+          .frame(width: 36, height: 5)
+          .padding(.top, 10)
+      }
+      .overlay(alignment: .topTrailing) {
+        Button {
+          Task { await model.skipButtonTapped() }
+        } label: {
+          Text(model.skipButtonTitle)
+            .font(.custom(FontNames.Inter_500_Medium, size: 14))
+            .foregroundColor(.white.opacity(0.85))
+            .padding(.horizontal, 16)
+            .padding(.vertical, 12)
+        }
+        .opacity(model.skipButtonOpacity)
+        .animation(.easeInOut(duration: 0.4), value: model.skipButtonOpacity)
+      }
+    }
+    .interactiveDismissDisabled()
+    .task { await model.task() }
+    .onDisappear { model.viewDisappeared() }
+  }
+}
+
+struct WelcomeMessageChipView: View {
+  let chip: WelcomeMessageChip
+
+  var body: some View {
+    HStack(spacing: 12) {
+      ZStack {
+        Circle()
+          .fill(Color.playolaRed.opacity(0.18))
+          .frame(width: 36, height: 36)
+        Image(systemName: chip.systemImageName)
+          .font(.system(size: 15, weight: .semibold))
+          .foregroundColor(.playolaRed)
+      }
+      Text(chip.text)
+        .font(.custom(FontNames.Inter_500_Medium, size: 16))
+        .foregroundColor(.white)
+      Spacer(minLength: 0)
+    }
+    .padding(.horizontal, 16)
+    .padding(.vertical, 12)
+    .background(RoundedRectangle(cornerRadius: 14).fill(WelcomePalette.cardSurface))
+  }
+}
+
+struct WelcomeNowPlayingCardView: View {
+  let label: String
+  let title: String
+  let subtitle: String
+
+  var body: some View {
+    VStack(spacing: 8) {
+      Text(label.uppercased())
+        .font(.custom(FontNames.Inter_600_SemiBold, size: 12))
+        .kerning(1.7)
+        .foregroundColor(WelcomePalette.textSecondary)
+      Text(title)
+        .font(.custom(FontNames.Inter_600_SemiBold, size: 19))
+        .foregroundColor(.white)
+        .multilineTextAlignment(.center)
+      Text(subtitle)
+        .font(.custom(FontNames.Inter_400_Regular, size: 15))
+        .foregroundColor(WelcomePalette.textSecondary)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(.horizontal, 20)
+    .padding(.vertical, 20)
+    .background(RoundedRectangle(cornerRadius: 16).fill(WelcomePalette.cardSurface))
+  }
+}
+
+// Thin "audio is live" equalizer over the photo — staggered delays so the bars
+// ripple rather than pulse in unison, reading as a real recording.
+struct WelcomeEqualizerView: View {
+  @State private var animating = false
+  private let barDelays: [Double] = [0, 0.18, 0.36, 0.12, 0.3, 0.06, 0.24]
+
+  var body: some View {
+    HStack(spacing: 3) {
+      Circle()
+        .fill(Color.playolaRed)
+        .frame(width: 7, height: 7)
+        .opacity(animating ? 0.6 : 1)
+        .animation(
+          .easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: animating
+        )
+        .padding(.trailing, 4)
+      ForEach(Array(barDelays.enumerated()), id: \.offset) { _, delay in
+        Capsule()
+          .fill(Color.white)
+          .frame(width: 3, height: 16)
+          .scaleEffect(y: animating ? 1 : 0.35, anchor: .center)
+          .animation(
+            .easeInOut(duration: 0.9).repeatForever(autoreverses: true).delay(delay),
+            value: animating
+          )
+      }
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 7)
+    .background(Capsule().fill(Color.black.opacity(0.45)))
+    .onAppear { animating = true }
+  }
+}

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
@@ -47,7 +47,7 @@ struct WelcomeMessagePageView: View {
             .font(.custom(FontNames.Inter_700_Bold, size: 30))
             .foregroundColor(.white)
             .multilineTextAlignment(.center)
-          Text(model.personalDJLabel.uppercased())
+          Text(model.personalDJLabel)
             .font(.custom(FontNames.Inter_500_Medium, size: 14))
             .kerning(1.7)
             .foregroundColor(.playolaRed)
@@ -176,7 +176,7 @@ struct WelcomeNowPlayingCardView: View {
 
   var body: some View {
     VStack(spacing: 8) {
-      Text(label.uppercased())
+      Text(label)
         .font(.custom(FontNames.Inter_600_SemiBold, size: 12))
         .kerning(1.7)
         .foregroundColor(WelcomePalette.textSecondary)

--- a/PlayolaRadio/Views/Reusable Components/PlayolaSheet.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaSheet.swift
@@ -30,4 +30,5 @@ enum PlayolaSheet: Hashable, Identifiable, Equatable {
   case share(ShareSheetModel)
   case redeemPrize(RedeemPrizeSheetModel)
   case artistSuggestion(StationSuggestionPageModel)
+  case welcomeMessage(WelcomeMessagePageModel)
 }


### PR DESCRIPTION
Adds a one-time welcome sheet shown the first time an eligible user (server flag `shouldShowWelcomeMessage` on the rewards profile) opens a playola station that has a welcome-message recording attached, triggered from both the station list and the home "For You" rail. The sheet plays the station's welcome recording, reveals three chips at 25/50/75% of its real duration, and shows a live "Now Playing" card derived from the station schedule before handing off to the station. Presentation is gated by a per-session guard, and the write-once server "seen" stamp fires only after playback actually starts, so a failed fetch or fallback never burns the user's one welcome. Also migrates `UrlStreamListeningSessionReporter`'s repeating `Timer` to a `Task` so its nonisolated `deinit` compiles under Swift 6.

Tests: new `WelcomeMessagePageModelTests` and `WelcomeMessageEligibilityTests` cover eligibility wiring, the gate, recording playback, chip/completion timing, the skip-during-fetch race, the seen-stamp rules, and the live now-playing card; full HomePage/StationList/MainContainer/Broadcast suites pass with no regressions.