### PR TITLE
Use WebImage instead of AsyncImage for all remote artwork

### DIFF
--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
@@ -5,6 +5,7 @@
 //  Created by Claude on 1/2/26.
 //
 
+import SDWebImageSwiftUI
 import SwiftUI
 
 struct NotificationsSettingsPageView: View {
@@ -140,7 +141,7 @@ struct NotificationsSettingsPageView: View {
 
   private func stationRow(item: StationNotificationItem) -> some View {
     HStack(spacing: 16) {
-      AsyncImage(url: item.station.imageUrl) { image in
+      WebImage(url: item.station.imageUrl) { image in
         image
           .resizable()
           .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 6/12/25.
 //
 
+import SDWebImageSwiftUI
 import SwiftUI
 
 struct PlayerPage: View {
@@ -53,7 +54,7 @@ struct PlayerPage: View {
       ScrollView {
 
         // Main Image
-        AsyncImage(url: model.stationArtUrl) { image in
+        WebImage(url: model.stationArtUrl) { image in
           image
             .resizable()
             .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
@@ -4,6 +4,7 @@
 //
 
 import PlayolaPlayer
+import SDWebImageSwiftUI
 import SwiftUI
 
 struct SeriesCard: View {
@@ -85,7 +86,7 @@ struct SeriesCard: View {
     HStack(alignment: .top, spacing: 12) {
       // Station Image
       if let imageUrl = model.showWithAirings.station?.imageUrl {
-        AsyncImage(url: imageUrl) { image in
+        WebImage(url: imageUrl) { image in
           image
             .resizable()
             .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
@@ -6,6 +6,7 @@
 //
 
 import PlayolaPlayer
+import SDWebImageSwiftUI
 import SwiftUI
 
 struct SongDrawerView: View {
@@ -16,7 +17,7 @@ struct SongDrawerView: View {
 
       // HEADER
       HStack(spacing: 16) {
-        AsyncImage(url: model.audioBlock.imageUrl) { image in
+        WebImage(url: model.audioBlock.imageUrl) { image in
           image
             .resizable()
             .aspectRatio(contentMode: .fill)


### PR DESCRIPTION
## What

Converts the four remaining `AsyncImage` sites to SDWebImageSwiftUI's `WebImage`:

- `PlayerPage.swift` — station art (the main hero image)
- `SongDrawerView.swift` — liked-song artwork
- `SeriesCard.swift` — station avatar
- `NotificationsSettingsPageView.swift` — station rows

After this, **zero `AsyncImage` usages remain** in the app.

## Why

`AsyncImage` and `WebImage` **do not share a cache**:

- `WebImage` uses SDWebImage's `SDImageCache` — a two-tier cache with an in-memory layer (decoded `UIImage`s in an `NSCache`) plus disk, keyed by URL.
- `AsyncImage` has no decoded-image cache of its own; it goes through `URLCache.shared` (raw HTTP bytes) and re-decodes on every appearance.

So artwork already loaded in a station list (which uses `WebImage`) landed in `SDImageCache`, but opening the Player page hit `AsyncImage` → `URLCache` found nothing SDWebImage put there → the image was re-fetched and the user waited again.

With `WebImage` everywhere, the same artwork URL is the same cache key, so an image already loaded in a list renders **instantly** from the shared in-memory cache — no flash, no spinner. This also matches the project convention (`AsyncImage` drops images on scroll).

## Notes

- Drop-in change: `WebImage(url:) { image in … } placeholder: { … }` has the same closure API as `AsyncImage`, so only the type name + `import SDWebImageSwiftUI` changed in each file.
- Verified with a clean simulator build (`BUILD SUCCEEDED`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)