### PR TITLE
feat: Siri voice control to play a station

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -435,6 +435,8 @@
 		D3A1B2C001000000000000E5 /* PlayStationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000E2 /* PlayStationIntent.swift */; };
 		D3A1B2C001000000000000F4 /* PlayolaShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */; };
 		D3A1B2C001000000000000F5 /* PlayolaShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */; };
+		D3A1B2C001000000000000F6 /* SiriShortcutsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */; };
+		D3A1B2C001000000000000F7 /* SiriShortcutsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */; };
 		D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = D3FF74D42FA7CA760052D500 /* CustomDump */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
 		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
@@ -693,6 +695,7 @@
 		D3A1B2C001000000000000D2 /* RadioStationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioStationEntity.swift; sourceTree = "<group>"; };
 		D3A1B2C001000000000000E2 /* PlayStationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationIntent.swift; sourceTree = "<group>"; };
 		D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaShortcuts.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiriShortcutsClient.swift; sourceTree = "<group>"; };
 		D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageView.swift; sourceTree = "<group>"; };
 		D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageModel.swift; sourceTree = "<group>"; };
 		FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetErrorReportingTests.swift; sourceTree = "<group>"; };
@@ -1328,6 +1331,7 @@
 				D3A1B2C001000000000000D2 /* RadioStationEntity.swift */,
 				D3A1B2C001000000000000E2 /* PlayStationIntent.swift */,
 				D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */,
+				D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */,
 			);
 			path = SiriIntents;
 			sourceTree = "<group>";
@@ -1940,6 +1944,7 @@
 				D3A1B2C001000000000000D5 /* RadioStationEntity.swift in Sources */,
 				D3A1B2C001000000000000E5 /* PlayStationIntent.swift in Sources */,
 				D3A1B2C001000000000000F5 /* PlayolaShortcuts.swift in Sources */,
+				D3A1B2C001000000000000F7 /* SiriShortcutsClient.swift in Sources */,
 				D30F00912E8592F0007BCC73 /* APIClient.swift in Sources */,
 				D35EFC3C2F192C76000F64A4 /* SupportPageModel.swift in Sources */,
 				D35EFC3D2F192C76000F64A4 /* SupportPageView.swift in Sources */,
@@ -2109,6 +2114,7 @@
 				D3A1B2C001000000000000D4 /* RadioStationEntity.swift in Sources */,
 				D3A1B2C001000000000000E4 /* PlayStationIntent.swift in Sources */,
 				D3A1B2C001000000000000F4 /* PlayolaShortcuts.swift in Sources */,
+				D3A1B2C001000000000000F6 /* SiriShortcutsClient.swift in Sources */,
 				D339E5692BFD1C0800B9E35B /* APIClient.swift in Sources */,
 				D35EFC392F192C76000F64A4 /* SupportPageModel.swift in Sources */,
 				D35EFC3A2F192C76000F64A4 /* SupportPageView.swift in Sources */,

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -421,6 +421,9 @@
 		D3FEC80B2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */; };
 		D3FEC80C2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */; };
 		D3FEC80D2EDF689F00A33AE8 /* ChooseStationToBroadcastPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */; };
+		D3A1B2C001000000000000A4 /* StationVoiceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */; };
+		D3A1B2C001000000000000A5 /* StationVoiceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */; };
+		D3A1B2C001000000000000A6 /* StationVoiceCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */; };
 		D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = D3FF74D42FA7CA760052D500 /* CustomDump */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
 		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
@@ -671,6 +674,8 @@
 		D3FACE010000000000000004 /* ArtistSuggestionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestionTests.swift; sourceTree = "<group>"; };
 		D3FE88832E37EF24009AE7B7 /* PrizeTier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrizeTier.swift; sourceTree = "<group>"; };
 		D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageTests.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationVoiceCatalog.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationVoiceCatalogTests.swift; sourceTree = "<group>"; };
 		D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageView.swift; sourceTree = "<group>"; };
 		D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageModel.swift; sourceTree = "<group>"; };
 		FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetErrorReportingTests.swift; sourceTree = "<group>"; };
@@ -1289,9 +1294,19 @@
 				D378CCD82E58C6CE00497A4A /* Mail */,
 				D378CCD52E58C42D00497A4A /* Navigation */,
 				D37B74852EC9441C009806C6 /* PushNotifications */,
+				D3A1B2C001000000000000A1 /* SiriIntents */,
 				D302576E2E63429000F4228B /* Toast */,
 			);
 			path = Core;
+			sourceTree = "<group>";
+		};
+		D3A1B2C001000000000000A1 /* SiriIntents */ = {
+			isa = PBXGroup;
+			children = (
+				D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */,
+				D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */,
+			);
+			path = SiriIntents;
 			sourceTree = "<group>";
 		};
 		D378CCD22E58C38D00497A4A /* Analytics */ = {
@@ -1896,6 +1911,7 @@
 				D39728712F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */,
 				D30F00902E8592F0007BCC73 /* ToastView.swift in Sources */,
 				D3FEC80C2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */,
+				D3A1B2C001000000000000A5 /* StationVoiceCatalog.swift in Sources */,
 				D30F00912E8592F0007BCC73 /* APIClient.swift in Sources */,
 				D35EFC3C2F192C76000F64A4 /* SupportPageModel.swift in Sources */,
 				D35EFC3D2F192C76000F64A4 /* SupportPageView.swift in Sources */,
@@ -2059,6 +2075,7 @@
 				D39728722F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */,
 				D30257762E6342C900F4228B /* ToastView.swift in Sources */,
 				D3FEC80B2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */,
+				D3A1B2C001000000000000A4 /* StationVoiceCatalog.swift in Sources */,
 				D339E5692BFD1C0800B9E35B /* APIClient.swift in Sources */,
 				D35EFC392F192C76000F64A4 /* SupportPageModel.swift in Sources */,
 				D35EFC3A2F192C76000F64A4 /* SupportPageView.swift in Sources */,
@@ -2096,6 +2113,7 @@
 				D3219C1F2EDD22360008AFDA /* BroadcastPageTests.swift in Sources */,
 				D3137DC62D39BEE00070033A /* URLStreamPlayerMock.swift in Sources */,
 				D3FEC80D2EDF689F00A33AE8 /* ChooseStationToBroadcastPageTests.swift in Sources */,
+				D3A1B2C001000000000000A6 /* StationVoiceCatalogTests.swift in Sources */,
 				D3B744CB2E313B230042A427 /* ListeningTimeTileTests.swift in Sources */,
 				D3B744C52E31318A0042A427 /* RewardsPageTests.swift in Sources */,
 				D35EFC172F159728000F64A4 /* SeriesListPageTests.swift in Sources */,

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -429,6 +429,12 @@
 		D3A1B2C001000000000000C4 /* PlayStationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C2 /* PlayStationAction.swift */; };
 		D3A1B2C001000000000000C5 /* PlayStationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C2 /* PlayStationAction.swift */; };
 		D3A1B2C001000000000000C6 /* PlayStationActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */; };
+		D3A1B2C001000000000000D4 /* RadioStationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000D2 /* RadioStationEntity.swift */; };
+		D3A1B2C001000000000000D5 /* RadioStationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000D2 /* RadioStationEntity.swift */; };
+		D3A1B2C001000000000000E4 /* PlayStationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000E2 /* PlayStationIntent.swift */; };
+		D3A1B2C001000000000000E5 /* PlayStationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000E2 /* PlayStationIntent.swift */; };
+		D3A1B2C001000000000000F4 /* PlayolaShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */; };
+		D3A1B2C001000000000000F5 /* PlayolaShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */; };
 		D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = D3FF74D42FA7CA760052D500 /* CustomDump */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
 		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
@@ -684,6 +690,9 @@
 		D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBootstrap.swift; sourceTree = "<group>"; };
 		D3A1B2C001000000000000C2 /* PlayStationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationAction.swift; sourceTree = "<group>"; };
 		D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationActionTests.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000D2 /* RadioStationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioStationEntity.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000E2 /* PlayStationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationIntent.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaShortcuts.swift; sourceTree = "<group>"; };
 		D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageView.swift; sourceTree = "<group>"; };
 		D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageModel.swift; sourceTree = "<group>"; };
 		FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetErrorReportingTests.swift; sourceTree = "<group>"; };
@@ -1316,6 +1325,9 @@
 				D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */,
 				D3A1B2C001000000000000C2 /* PlayStationAction.swift */,
 				D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */,
+				D3A1B2C001000000000000D2 /* RadioStationEntity.swift */,
+				D3A1B2C001000000000000E2 /* PlayStationIntent.swift */,
+				D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */,
 			);
 			path = SiriIntents;
 			sourceTree = "<group>";
@@ -1925,6 +1937,9 @@
 				D3A1B2C001000000000000A5 /* StationVoiceCatalog.swift in Sources */,
 				D3A1B2C001000000000000B5 /* PlaybackBootstrap.swift in Sources */,
 				D3A1B2C001000000000000C5 /* PlayStationAction.swift in Sources */,
+				D3A1B2C001000000000000D5 /* RadioStationEntity.swift in Sources */,
+				D3A1B2C001000000000000E5 /* PlayStationIntent.swift in Sources */,
+				D3A1B2C001000000000000F5 /* PlayolaShortcuts.swift in Sources */,
 				D30F00912E8592F0007BCC73 /* APIClient.swift in Sources */,
 				D35EFC3C2F192C76000F64A4 /* SupportPageModel.swift in Sources */,
 				D35EFC3D2F192C76000F64A4 /* SupportPageView.swift in Sources */,
@@ -2091,6 +2106,9 @@
 				D3A1B2C001000000000000A4 /* StationVoiceCatalog.swift in Sources */,
 				D3A1B2C001000000000000B4 /* PlaybackBootstrap.swift in Sources */,
 				D3A1B2C001000000000000C4 /* PlayStationAction.swift in Sources */,
+				D3A1B2C001000000000000D4 /* RadioStationEntity.swift in Sources */,
+				D3A1B2C001000000000000E4 /* PlayStationIntent.swift in Sources */,
+				D3A1B2C001000000000000F4 /* PlayolaShortcuts.swift in Sources */,
 				D339E5692BFD1C0800B9E35B /* APIClient.swift in Sources */,
 				D35EFC392F192C76000F64A4 /* SupportPageModel.swift in Sources */,
 				D35EFC3A2F192C76000F64A4 /* SupportPageView.swift in Sources */,

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -424,6 +424,11 @@
 		D3A1B2C001000000000000A4 /* StationVoiceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */; };
 		D3A1B2C001000000000000A5 /* StationVoiceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */; };
 		D3A1B2C001000000000000A6 /* StationVoiceCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */; };
+		D3A1B2C001000000000000B4 /* PlaybackBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */; };
+		D3A1B2C001000000000000B5 /* PlaybackBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */; };
+		D3A1B2C001000000000000C4 /* PlayStationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C2 /* PlayStationAction.swift */; };
+		D3A1B2C001000000000000C5 /* PlayStationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C2 /* PlayStationAction.swift */; };
+		D3A1B2C001000000000000C6 /* PlayStationActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */; };
 		D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = D3FF74D42FA7CA760052D500 /* CustomDump */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
 		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
@@ -676,6 +681,9 @@
 		D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageTests.swift; sourceTree = "<group>"; };
 		D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationVoiceCatalog.swift; sourceTree = "<group>"; };
 		D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationVoiceCatalogTests.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBootstrap.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000C2 /* PlayStationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationAction.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationActionTests.swift; sourceTree = "<group>"; };
 		D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageView.swift; sourceTree = "<group>"; };
 		D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageModel.swift; sourceTree = "<group>"; };
 		FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetErrorReportingTests.swift; sourceTree = "<group>"; };
@@ -1305,6 +1313,9 @@
 			children = (
 				D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */,
 				D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */,
+				D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */,
+				D3A1B2C001000000000000C2 /* PlayStationAction.swift */,
+				D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */,
 			);
 			path = SiriIntents;
 			sourceTree = "<group>";
@@ -1912,6 +1923,8 @@
 				D30F00902E8592F0007BCC73 /* ToastView.swift in Sources */,
 				D3FEC80C2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */,
 				D3A1B2C001000000000000A5 /* StationVoiceCatalog.swift in Sources */,
+				D3A1B2C001000000000000B5 /* PlaybackBootstrap.swift in Sources */,
+				D3A1B2C001000000000000C5 /* PlayStationAction.swift in Sources */,
 				D30F00912E8592F0007BCC73 /* APIClient.swift in Sources */,
 				D35EFC3C2F192C76000F64A4 /* SupportPageModel.swift in Sources */,
 				D35EFC3D2F192C76000F64A4 /* SupportPageView.swift in Sources */,
@@ -2076,6 +2089,8 @@
 				D30257762E6342C900F4228B /* ToastView.swift in Sources */,
 				D3FEC80B2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */,
 				D3A1B2C001000000000000A4 /* StationVoiceCatalog.swift in Sources */,
+				D3A1B2C001000000000000B4 /* PlaybackBootstrap.swift in Sources */,
+				D3A1B2C001000000000000C4 /* PlayStationAction.swift in Sources */,
 				D339E5692BFD1C0800B9E35B /* APIClient.swift in Sources */,
 				D35EFC392F192C76000F64A4 /* SupportPageModel.swift in Sources */,
 				D35EFC3A2F192C76000F64A4 /* SupportPageView.swift in Sources */,
@@ -2114,6 +2129,7 @@
 				D3137DC62D39BEE00070033A /* URLStreamPlayerMock.swift in Sources */,
 				D3FEC80D2EDF689F00A33AE8 /* ChooseStationToBroadcastPageTests.swift in Sources */,
 				D3A1B2C001000000000000A6 /* StationVoiceCatalogTests.swift in Sources */,
+				D3A1B2C001000000000000C6 /* PlayStationActionTests.swift in Sources */,
 				D3B744CB2E313B230042A427 /* ListeningTimeTileTests.swift in Sources */,
 				D3B744C52E31318A0042A427 /* RewardsPageTests.swift in Sources */,
 				D35EFC172F159728000F64A4 /* SeriesListPageTests.swift in Sources */,

--- a/PlayolaRadio/Core/SiriIntents/PlayStationAction.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationAction.swift
@@ -1,0 +1,22 @@
+import Dependencies
+import Sharing
+
+enum PlayStationOutcome: Equatable {
+  case requiresSignIn
+  case notFound
+  case playing(stationName: String)
+}
+
+@MainActor
+struct PlayStationAction {
+  @Shared(.auth) var auth
+  @Dependency(\.stationPlayer) var stationPlayer
+
+  func run(stationID: String) async -> PlayStationOutcome {
+    guard auth.isLoggedIn else { return .requiresSignIn }
+    guard let station = StationVoiceCatalog().station(id: stationID) else { return .notFound }
+    PlaybackBootstrap().prepareForPlayback()
+    await stationPlayer.play(station: station)
+    return .playing(stationName: station.stationName)
+  }
+}

--- a/PlayolaRadio/Core/SiriIntents/PlayStationAction.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationAction.swift
@@ -14,9 +14,11 @@ struct PlayStationAction {
 
   func run(stationID: String) async -> PlayStationOutcome {
     guard auth.isLoggedIn else { return .requiresSignIn }
-    guard let station = StationVoiceCatalog().station(id: stationID) else { return .notFound }
+    let catalog = StationVoiceCatalog()
+    guard let station = catalog.station(id: stationID) else { return .notFound }
+    let label = catalog.match(id: stationID)?.label ?? station.stationName
     PlaybackBootstrap().prepareForPlayback()
     await stationPlayer.play(station: station)
-    return .playing(stationName: station.stationName)
+    return .playing(stationName: label)
   }
 }

--- a/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
@@ -62,4 +62,35 @@ struct PlayStationActionTests {
     #expect(outcome == .playing(stationName: "KOKE FM"))
     #expect(player.currentStation?.id == "koke-fm-id")
   }
+
+  // A Playola (artist) station's `stationName` is the internal show name
+  // ("Bordertown Radio"), but Siri must confirm the curator-possessive label
+  // ("Radney Foster's Station") that the entity/suggestions surfaced. This drives
+  // `PlayStationAction().run` end to end so it genuinely guards the action's
+  // return value (a regression to `station.stationName` would fail here).
+  //
+  // Network is avoided by injecting `StationPlayerMock`, which overrides
+  // `play(station:)` to record the call instead of reaching the Playola schedule
+  // API (`StationPlayer`'s real Playola path calls
+  // `PlayolaStationPlayer.shared.play(stationId:)`, whose non-networking init is
+  // internal to the PlayolaPlayer package and unreachable from this test target).
+  @Test
+  func testPlayolaStationUsesCuratorPossessiveLabelInDialog() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    let artistList = StationList.mockArtistList(items: [
+      APIStationItem(
+        sortOrder: 0,
+        station: Station.mockWith(
+          id: "rf-id", name: "Bordertown Radio", curatorName: "Radney Foster"), urlStation: nil)
+    ])
+    @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [artistList])
+    let player = StationPlayerMock()
+    let outcome = await withDependencies {
+      $0.stationPlayer = player
+    } operation: {
+      await PlayStationAction().run(stationID: "rf-id")
+    }
+    #expect(outcome == .playing(stationName: "Radney Foster's Station"))
+    #expect(player.callsToPlay.map(\.id) == ["rf-id"])
+  }
 }

--- a/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
@@ -1,0 +1,65 @@
+import Dependencies
+import Foundation
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct PlayStationActionTests {
+  private func makeStationLists() -> IdentifiedArrayOf<StationList> {
+    let fm = StationList(
+      id: "fm_list", name: "FM", slug: "fm_list", hidden: false, sortOrder: 0,
+      createdAt: Date(timeIntervalSince1970: 0), updatedAt: Date(timeIntervalSince1970: 0),
+      items: [
+        APIStationItem(
+          sortOrder: 0, station: nil,
+          urlStation: UrlStation(
+            id: "koke-fm-id", name: "KOKE FM", streamUrl: "https://example.com/stream",
+            imageUrl: "https://example.com/i.png", description: "desc", website: nil,
+            location: "Austin, TX", active: true, createdAt: Date(), updatedAt: Date()))
+      ]
+    )
+    return IdentifiedArrayOf(uniqueElements: [fm])
+  }
+
+  @Test
+  func testLoggedOutReturnsRequiresSignIn() async {
+    @Shared(.auth) var auth = Auth()
+    @Shared(.stationLists) var stationLists = makeStationLists()
+    let outcome = await withDependencies {
+      $0.stationPlayer = StationPlayer()
+    } operation: {
+      await PlayStationAction().run(stationID: "koke-fm-id")
+    }
+    #expect(outcome == .requiresSignIn)
+  }
+
+  @Test
+  func testUnknownStationReturnsNotFound() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.stationLists) var stationLists = makeStationLists()
+    let outcome = await withDependencies {
+      $0.stationPlayer = StationPlayer()
+    } operation: {
+      await PlayStationAction().run(stationID: "does-not-exist")
+    }
+    #expect(outcome == .notFound)
+  }
+
+  @Test
+  func testLoggedInValidStationPlaysAndReturnsPlaying() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.stationLists) var stationLists = makeStationLists()
+    let player = StationPlayer()
+    let outcome = await withDependencies {
+      $0.stationPlayer = player
+    } operation: {
+      await PlayStationAction().run(stationID: "koke-fm-id")
+    }
+    #expect(outcome == .playing(stationName: "KOKE FM"))
+    #expect(player.currentStation?.id == "koke-fm-id")
+  }
+}

--- a/PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift
@@ -1,0 +1,22 @@
+import AppIntents
+
+struct PlayStationIntent: AppIntent {
+  static var title: LocalizedStringResource = "Play Station"
+  static var openAppWhenRun = true
+
+  @Parameter(title: "Station")
+  var station: RadioStationEntity
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    let outcome = await PlayStationAction().run(stationID: station.id)
+    switch outcome {
+    case .requiresSignIn:
+      return .result(dialog: "Open Playola to sign in first")
+    case .notFound:
+      return .result(dialog: "I couldn't find that station on Playola")
+    case .playing(let name):
+      return .result(dialog: "Playing \(name)")
+    }
+  }
+}

--- a/PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift
@@ -1,0 +1,12 @@
+import AVFoundation
+
+/// Ensures the audio session is active before playback begins from a Siri
+/// cold-launch, where the normal app-launch path may not have run yet.
+@MainActor
+struct PlaybackBootstrap {
+  func prepareForPlayback() {
+    let session = AVAudioSession.sharedInstance()
+    try? session.setCategory(.playback, mode: .default)
+    try? session.setActive(true)
+  }
+}

--- a/PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift
@@ -1,4 +1,5 @@
 import AVFoundation
+import IssueReporting
 
 /// Ensures the audio session is active before playback begins from a Siri
 /// cold-launch, where the normal app-launch path may not have run yet.
@@ -6,7 +7,18 @@ import AVFoundation
 struct PlaybackBootstrap {
   func prepareForPlayback() {
     let session = AVAudioSession.sharedInstance()
-    try? session.setCategory(.playback, mode: .default)
-    try? session.setActive(true)
+    // Best-effort, independent steps: a failed category set must not skip
+    // activation, and each failure is reported on its own so a cold-launch
+    // silence has a signal instead of being swallowed.
+    do {
+      try session.setCategory(.playback, mode: .default)
+    } catch {
+      reportIssue("PlaybackBootstrap failed to set the audio session category: \(error)")
+    }
+    do {
+      try session.setActive(true)
+    } catch {
+      reportIssue("PlaybackBootstrap failed to activate the audio session: \(error)")
+    }
   }
 }

--- a/PlayolaRadio/Core/SiriIntents/PlayolaShortcuts.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayolaShortcuts.swift
@@ -1,0 +1,15 @@
+import AppIntents
+
+struct PlayolaShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: PlayStationIntent(),
+      phrases: [
+        "Play \(\.$station) on \(.applicationName)",
+        "Start \(\.$station) on \(.applicationName)",
+      ],
+      shortTitle: "Play Station",
+      systemImageName: "radio"
+    )
+  }
+}

--- a/PlayolaRadio/Core/SiriIntents/RadioStationEntity.swift
+++ b/PlayolaRadio/Core/SiriIntents/RadioStationEntity.swift
@@ -1,0 +1,35 @@
+import AppIntents
+
+struct RadioStationEntity: AppEntity {
+  static var typeDisplayRepresentation: TypeDisplayRepresentation {
+    TypeDisplayRepresentation(name: "Station")
+  }
+  static var defaultQuery = RadioStationEntityQuery()
+
+  let id: String
+  let name: String
+
+  var displayRepresentation: DisplayRepresentation { DisplayRepresentation(title: "\(name)") }
+}
+
+struct RadioStationEntityQuery: EntityQuery, EntityStringQuery {
+  @MainActor
+  func entities(for identifiers: [String]) async throws -> [RadioStationEntity] {
+    let catalog = StationVoiceCatalog()
+    return identifiers.compactMap { id in
+      catalog.match(id: id).map { RadioStationEntity(id: $0.id, name: $0.label) }
+    }
+  }
+
+  @MainActor
+  func suggestedEntities() async throws -> [RadioStationEntity] {
+    StationVoiceCatalog().suggestedStations().map { RadioStationEntity(id: $0.id, name: $0.label) }
+  }
+
+  @MainActor
+  func entities(matching string: String) async throws -> [RadioStationEntity] {
+    StationVoiceCatalog().matches(query: string).map {
+      RadioStationEntity(id: $0.id, name: $0.label)
+    }
+  }
+}

--- a/PlayolaRadio/Core/SiriIntents/SiriShortcutsClient.swift
+++ b/PlayolaRadio/Core/SiriIntents/SiriShortcutsClient.swift
@@ -1,0 +1,32 @@
+import AppIntents
+import Dependencies
+import DependenciesMacros
+
+/// Refreshes the system's App Shortcuts parameter index so Siri/Spotlight
+/// per-station suggestions reflect the current station list.
+@DependencyClient
+struct SiriShortcutsClient: Sendable {
+  var refreshSuggestions: @Sendable () -> Void
+}
+
+extension SiriShortcutsClient: DependencyKey {
+  static let liveValue = Self(
+    refreshSuggestions: {
+      PlayolaShortcuts.updateAppShortcutParameters()
+    }
+  )
+}
+
+extension SiriShortcutsClient: TestDependencyKey {
+  // No-op in tests so the many existing MainContainerModel tests that hit the
+  // station-list load path don't trip an unimplemented dependency. Tests that
+  // assert the refresh override it with a spy.
+  static let testValue = Self(refreshSuggestions: {})
+}
+
+extension DependencyValues {
+  var siriShortcuts: SiriShortcutsClient {
+    get { self[SiriShortcutsClient.self] }
+    set { self[SiriShortcutsClient.self] = newValue }
+  }
+}

--- a/PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift
+++ b/PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift
@@ -109,7 +109,7 @@ struct StationVoiceCatalog {
       let score: Int?
       if hay == needle {
         score = 100
-      } else if hay.hasPrefix(needle) || needle.hasPrefix(hay) {
+      } else if hay.hasPrefix(needle) {
         score = 60
       } else if needleWords.isSubset(of: hayWords) || hayWords.isSubset(of: needleWords) {
         score = 40  // every word of one side appears as a whole word in the other

--- a/PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift
+++ b/PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift
@@ -1,0 +1,118 @@
+import Foundation
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+
+/// A station resolved from a spoken/typed query, with the label the App Intents
+/// layer shows. FM → station name; Artist → "[Artist]'s Station".
+struct StationMatch: Equatable, Identifiable {
+  let id: String  // AnyStation.id
+  let label: String
+}
+
+@MainActor
+struct StationVoiceCatalog {
+  @Shared(.stationLists) var stationLists
+
+  /// Lowercase, strip possessive "'s", strip punctuation, drop the filler words
+  /// "radio"/"station", collapse whitespace. Applied to both station aliases and
+  /// the incoming query so matching is symmetric.
+  static func normalize(_ raw: String) -> String {
+    var text = raw.lowercased()
+    text = text.replacingOccurrences(of: "'s", with: "")
+    text = text.replacingOccurrences(of: "\u{2019}s", with: "")  // curly apostrophe
+    let allowed = CharacterSet.alphanumerics.union(.whitespaces)
+    text = String(text.unicodeScalars.map { allowed.contains($0) ? Character($0) : " " })
+    let filler: Set<String> = ["radio", "station"]
+    let words = text.split(separator: " ").map(String.init).filter { !filler.contains($0) }
+    return words.joined(separator: " ")
+  }
+
+  /// All playable (visible, non-coming-soon) stations as matches.
+  func suggestedStations() -> [StationMatch] {
+    allStations().map(makeMatch(for:))
+  }
+
+  /// Best-effort fuzzy matches for a spoken/typed query, ordered best-first.
+  /// Fails closed: returns [] when nothing clears the confidence bar.
+  func matches(query: String) -> [StationMatch] {
+    let needle = Self.normalize(query)
+    guard !needle.isEmpty else { return [] }
+    return allStations().enumerated().compactMap { index, station -> ScoredMatch? in
+      guard let score = bestScore(for: station, needle: needle), score > 0 else { return nil }
+      return ScoredMatch(match: makeMatch(for: station), score: score, catalogIndex: index)
+    }
+    .sorted { lhs, rhs in
+      // Higher score first; break ties by catalog order for deterministic results.
+      lhs.score != rhs.score ? lhs.score > rhs.score : lhs.catalogIndex < rhs.catalogIndex
+    }
+    .map(\.match)
+  }
+
+  /// Match for a known id (used to rehydrate an entity by id).
+  func match(id: String) -> StationMatch? {
+    allStations().first { $0.id == id }.map(makeMatch(for:))
+  }
+
+  /// Resolve a match id back to the real station for playback.
+  func station(id: String) -> AnyStation? {
+    allStations().first { $0.id == id }
+  }
+
+  // MARK: - Private
+
+  private struct ScoredMatch {
+    let match: StationMatch
+    let score: Int
+    let catalogIndex: Int
+  }
+
+  private func allStations() -> [AnyStation] {
+    stationLists
+      .filter { !$0.hidden }
+      .flatMap { list in
+        list.stationItems(includeHidden: false, includeComingSoon: false).map(\.anyStation)
+      }
+  }
+
+  private func aliases(for station: AnyStation) -> [String] {
+    switch station {
+    case .url(let station): return [station.name]
+    case .playola(let station):
+      return [station.curatorName, "\(station.curatorName)'s Station", station.name]
+    }
+  }
+
+  private func label(for station: AnyStation) -> String {
+    switch station {
+    case .url(let station): return station.name
+    case .playola(let station): return "\(station.curatorName)'s Station"
+    }
+  }
+
+  private func makeMatch(for station: AnyStation) -> StationMatch {
+    StationMatch(id: station.id, label: label(for: station))
+  }
+
+  /// Exact normalized alias match beats prefix beats contains; nil = no relation
+  /// (fail closed).
+  private func bestScore(for station: AnyStation, needle: String) -> Int? {
+    var best: Int?
+    for alias in aliases(for: station) {
+      let hay = Self.normalize(alias)
+      guard !hay.isEmpty else { continue }
+      let score: Int?
+      if hay == needle {
+        score = 100
+      } else if hay.hasPrefix(needle) || needle.hasPrefix(hay) {
+        score = 60
+      } else if hay.contains(needle) || needle.contains(hay) {
+        score = 30
+      } else {
+        score = nil
+      }
+      if let score, score > (best ?? 0) { best = score }
+    }
+    return best
+  }
+}

--- a/PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift
+++ b/PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift
@@ -19,6 +19,7 @@ struct StationVoiceCatalog {
   /// the incoming query so matching is symmetric.
   static func normalize(_ raw: String) -> String {
     var text = raw.lowercased()
+    text = text.folding(options: .diacriticInsensitive, locale: nil)
     text = text.replacingOccurrences(of: "'s", with: "")
     text = text.replacingOccurrences(of: "\u{2019}s", with: "")  // curly apostrophe
     let allowed = CharacterSet.alphanumerics.union(.whitespaces)
@@ -94,20 +95,24 @@ struct StationVoiceCatalog {
     StationMatch(id: station.id, label: label(for: station))
   }
 
-  /// Exact normalized alias match beats prefix beats contains; nil = no relation
-  /// (fail closed).
+  /// Exact normalized alias match beats prefix beats whole-word containment.
+  /// Fails closed: fragments shorter than 3 chars, and loose mid-word substrings,
+  /// score nil so a misheard syllable never confidently plays the wrong station.
   private func bestScore(for station: AnyStation, needle: String) -> Int? {
+    guard needle.count >= 3 else { return nil }
+    let needleWords = Set(needle.split(separator: " ").map(String.init))
     var best: Int?
     for alias in aliases(for: station) {
       let hay = Self.normalize(alias)
       guard !hay.isEmpty else { continue }
+      let hayWords = Set(hay.split(separator: " ").map(String.init))
       let score: Int?
       if hay == needle {
         score = 100
       } else if hay.hasPrefix(needle) || needle.hasPrefix(hay) {
         score = 60
-      } else if hay.contains(needle) || needle.contains(hay) {
-        score = 30
+      } else if needleWords.isSubset(of: hayWords) || hayWords.isSubset(of: needleWords) {
+        score = 40  // every word of one side appears as a whole word in the other
       } else {
         score = nil
       }

--- a/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
@@ -85,4 +85,25 @@ struct StationVoiceCatalogTests {
     #expect(StationVoiceCatalog.normalize("KOKE-FM") == "koke fm")
     #expect(StationVoiceCatalog.normalize("Q102/Z") == "q102 z")
   }
+
+  @Test
+  func testShortFragmentsFailClosed() {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    let catalog = StationVoiceCatalog()
+    #expect(catalog.matches(query: "k").isEmpty)
+    #expect(catalog.matches(query: "fm").isEmpty)
+    #expect(catalog.matches(query: "q").isEmpty)
+  }
+
+  @Test
+  func testLegitimatePartialStillMatches() {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    // "koke" is a real prefix of "KOKE FM" and should still resolve.
+    #expect(StationVoiceCatalog().matches(query: "koke").first?.id == "koke-fm-id")
+  }
+
+  @Test
+  func testNormalizeFoldsDiacritics() {
+    #expect(StationVoiceCatalog.normalize("Beyoncé") == "beyonce")
+  }
 }

--- a/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
@@ -106,4 +106,16 @@ struct StationVoiceCatalogTests {
   func testNormalizeFoldsDiacritics() {
     #expect(StationVoiceCatalog.normalize("Beyoncé") == "beyonce")
   }
+
+  @Test
+  func testLongerQueryDoesNotPrefixMatchShortStation() {
+    let list = StationList.mockArtistList(items: [
+      APIStationItem(
+        sortOrder: 0,
+        station: Station.mockWith(
+          id: "rock-id", name: "Rock", curatorName: "Rock"), urlStation: nil)
+    ])
+    @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [list])
+    #expect(StationVoiceCatalog().matches(query: "rockabilly").isEmpty)
+  }
 }

--- a/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
@@ -1,0 +1,88 @@
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct StationVoiceCatalogTests {
+  @Test
+  func testNormalizeLowercasesStripsPunctuationAndPossessive() {
+    #expect(StationVoiceCatalog.normalize("Radney Foster's Station") == "radney foster")
+    #expect(StationVoiceCatalog.normalize("Bordertown Radio!") == "bordertown")
+    #expect(StationVoiceCatalog.normalize("  KOKE  FM ") == "koke fm")
+  }
+
+  @Test
+  func testSuggestedStationsFMLabelIsStationName() {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    let koke = StationVoiceCatalog().suggestedStations().first { $0.id == "koke-fm-id" }
+    #expect(koke?.label == "KOKE FM")
+  }
+
+  @Test
+  func testSuggestedStationsArtistLabelIsArtistPossessive() {
+    let artistList = StationList.mockArtistList(items: [
+      APIStationItem(
+        sortOrder: 0,
+        station: Station.mockWith(
+          id: "rf-id", name: "Bordertown Radio", curatorName: "Radney Foster"), urlStation: nil)
+    ])
+    @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [artistList])
+    let match = StationVoiceCatalog().suggestedStations().first { $0.id == "rf-id" }
+    #expect(match?.label == "Radney Foster's Station")
+  }
+
+  @Test
+  func testMatchesResolvesByStationNameAndCuratorName() {
+    let artistList = StationList.mockArtistList(items: [
+      APIStationItem(
+        sortOrder: 0,
+        station: Station.mockWith(
+          id: "rf-id", name: "Bordertown Radio", curatorName: "Radney Foster"), urlStation: nil)
+    ])
+    @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [artistList])
+    let catalog = StationVoiceCatalog()
+    #expect(catalog.matches(query: "Bordertown Radio").first?.id == "rf-id")
+    #expect(catalog.matches(query: "Radney Foster").first?.id == "rf-id")
+    #expect(catalog.matches(query: "Radney Foster's Station").first?.id == "rf-id")
+  }
+
+  @Test
+  func testMatchesFailsClosedOnNoConfidentMatch() {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    #expect(StationVoiceCatalog().matches(query: "totally unrelated zzzz").isEmpty)
+  }
+
+  @Test
+  func testMatchByIdReturnsLabel() {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    #expect(StationVoiceCatalog().match(id: "koke-fm-id")?.label == "KOKE FM")
+    #expect(StationVoiceCatalog().match(id: "nope") == nil)
+  }
+
+  @Test
+  func testStationByIdReturnsAnyStation() {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    #expect(StationVoiceCatalog().station(id: "koke-fm-id")?.id == "koke-fm-id")
+    #expect(StationVoiceCatalog().station(id: "nonexistent") == nil)
+  }
+
+  @Test
+  func testHiddenListStationsAreExcluded() {
+    // StationList.mocks includes a hidden "in_development_list" containing a
+    // visible playola station (id "mock-playola-id"). It must never surface to Siri.
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    let catalog = StationVoiceCatalog()
+    #expect(catalog.suggestedStations().contains { $0.id == "mock-playola-id" } == false)
+    #expect(catalog.station(id: "mock-playola-id") == nil)
+    #expect(catalog.match(id: "mock-playola-id") == nil)
+  }
+
+  @Test
+  func testNormalizeReplacesPunctuationWithSpace() {
+    #expect(StationVoiceCatalog.normalize("KOKE-FM") == "koke fm")
+    #expect(StationVoiceCatalog.normalize("Q102/Z") == "q102 z")
+  }
+}

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -21,6 +21,7 @@ class MainContainerModel: ViewModel {
   @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.toast) var toast
   @ObservationIgnored @Dependency(\.pushNotifications) var pushNotifications
+  @ObservationIgnored @Dependency(\.siriShortcuts) var siriShortcuts
   @ObservationIgnored @Dependency(\.appRating) var appRating
   @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
   @ObservationIgnored @Shared(.stationLists) var stationLists
@@ -105,7 +106,7 @@ class MainContainerModel: ViewModel {
     if !stationListsLoaded {
       do {
         let retrievedStationsLists = try await api.getStations()
-        self.$stationLists.withLock { $0 = retrievedStationsLists }
+        applyStationLists(retrievedStationsLists)
         self.$stationListsLoaded.withLock { $0 = true }
       } catch {
         presentedAlert = .errorLoadingStations
@@ -138,7 +139,7 @@ class MainContainerModel: ViewModel {
   func refreshOnForeground() async {
     do {
       let retrievedStationsLists = try await api.getStations()
-      self.$stationLists.withLock { $0 = retrievedStationsLists }
+      applyStationLists(retrievedStationsLists)
     } catch {
       await analytics.track(
         .apiError(
@@ -149,6 +150,11 @@ class MainContainerModel: ViewModel {
 
     await loadAirings()
     await fetchUnreadSupportCount()
+  }
+
+  private func applyStationLists(_ lists: IdentifiedArrayOf<StationList>) {
+    $stationLists.withLock { $0 = lists }
+    siriShortcuts.refreshSuggestions()
   }
 
   func handleScenePhaseChange(_ phase: ScenePhase) {

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -6,6 +6,7 @@
 //
 
 // swiftlint:disable force_try
+// swiftlint:disable file_length
 
 import ConcurrencyExtras
 import Dependencies
@@ -99,6 +100,21 @@ struct MainContainerTests {
     #expect(getStationsCallCount.value == 1)
     #expect(stationLists == StationList.mocks)
     #expect(stationListsLoaded)
+  }
+
+  @Test
+  func testViewAppearedRefreshesSiriShortcutSuggestions() async {
+    @Shared(.stationListsLoaded) var stationListsLoaded = false
+    let didRefresh = LockIsolated(false)
+    let mainContainerModel = withDependencies {
+      $0.api.getStations = { StationList.mocks }
+      $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.siriShortcuts.refreshSuggestions = { didRefresh.setValue(true) }
+    } operation: {
+      MainContainerModel()
+    }
+    await mainContainerModel.viewAppeared()
+    #expect(didRefresh.value == true)
   }
 
   @Test

--- a/docs/superpowers/plans/2026-06-10-siri-play-station.md
+++ b/docs/superpowers/plans/2026-06-10-siri-play-station.md
@@ -1,0 +1,695 @@
+# Siri "Play [Station]" Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Before writing any Swift, invoke the relevant `pfw-*` skills (pfw-dependencies, pfw-sharing, pfw-observable-models, pfw-testing, pfw-custom-dump, pfw-case-paths).
+
+**Goal:** Let a user start a Playola station by voice through Siri ("Play Bordertown Radio", "Play Radney Foster's Station").
+
+**Architecture:** App Intents in the main app target. A testable `@MainActor` core (`StationVoiceCatalog` matching, `PlayStationAction` auth+play, `PlaybackBootstrap` audio session) does all real work. Thin App Intents shells conform to Apple's `.audio` schema (`playAudio` intent, `liveRadioStation` / `algorithmicRadioStation` entities, an `IntentValueQuery` for matching) so the new Siri plays stations with bare phrases, plus an `AppShortcutsProvider` registering "Play [Station] on Playola" as the universal fallback.
+
+**Tech Stack:** Swift, App Intents (iOS 18+, `.audio` schema domain), swift-dependencies, swift-sharing, Swift Testing (`import Testing`).
+
+**Spec:** `docs/superpowers/specs/2026-06-10-siri-play-station-design.md`
+
+---
+
+## Conventions for every task
+
+- **Tests:** Swift Testing (`import Testing`, `@Test`, `#expect`, `@MainActor struct XxxTests`), colocated next to the file under test. For value comparisons prefer custom-dump's `expectNoDifference` (pfw-custom-dump).
+- **`@Shared` in tests:** declare locally per test, e.g. `@Shared(.auth) var auth = Auth(jwtToken: "test-jwt")`. Never class-level.
+- **New files MUST be hand-registered in `PlayolaRadio.xcodeproj/project.pbxproj`** (explicit file refs — this project does not use synced folders). Task 9 does this in one batch; until then new files won't compile in Xcode. If a per-task build is needed sooner, register the file as you add it.
+- **Run tests (CLI):**
+  ```bash
+  xcodebuild test -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
+    -destination 'platform=iOS Simulator,id=CC4A4FCF-D331-4CB2-BADC-523BD1728852' \
+    -skipPackagePluginValidation \
+    -only-testing:PlayolaRadioTests/<TestStructName> 2>&1 | xcbeautify
+  ```
+  (Booted sim id above is `iPhone 15`; substitute any booted simulator. `-skipPackagePluginValidation` is required or the SwiftLint build plugin fails the run. The user may also run in Xcode.)
+- **New code lives in** `PlayolaRadio/Core/SiriIntents/` (create the group). Tests colocated in the same folder.
+
+---
+
+## Task 1: Spike — pin the `.audio` schema API against the installed SDK
+
+The `.audio` App Intents schema shipped with WWDC 2026 and its exact Swift signatures are only knowable from the SDK in Xcode 26.5. This task produces a notes file that later tasks consume. **No production code ships from this task.**
+
+**Files:**
+- Create: `docs/superpowers/specs/audio-schema-notes.md` (scratch notes, not shipped to users)
+
+- [ ] **Step 1: Generate the schema templates in Xcode**
+
+In Xcode, create a throwaway Swift file and type each of these, accepting Xcode's autocomplete template expansion:
+- `audio_playAudio` → expands the `playAudio` intent template
+- `audio_liveRadioStation` → expands the live-radio-station entity template
+- `audio_algorithmicRadioStation` → expands the algorithmic-radio-station entity template
+
+- [ ] **Step 2: Record the exact API into the notes file**
+
+Capture, verbatim from the generated templates:
+1. The macro name actually used (`@AppIntent(schema:)` vs `@AssistantIntent(schema:)`) and the module to `import` (e.g. `AppIntents`, and whether `MediaIntents` / Media Intents framework must be imported).
+2. The `playAudio` intent's required properties (parameter name(s) and types for the target audio item / search, e.g. an entity parameter or a `MediaSearch`-style value) and its `perform()` return type.
+3. The required properties of the `liveRadioStation` and `algorithmicRadioStation` entity schemas (which properties are mandatory: id, title/name, etc.).
+4. The query type the intent expects for resolving its audio parameter (the `IntentValueQuery` / Media Intents query protocol name and its associated `Value` / method signatures).
+5. The `@available` annotation Xcode attaches (the iOS floor — e.g. `iOS 18.4` or `iOS 26`). Record it exactly.
+6. Whether one intent/query can return BOTH entity kinds, or whether the schema forces a single entity type (decides Task 6/7 shape).
+
+- [ ] **Step 3: Delete the throwaway file. Commit the notes.**
+
+```bash
+git add docs/superpowers/specs/audio-schema-notes.md
+git commit -m "docs: pin .audio App Intents schema API from SDK"
+```
+
+**Gate:** Later tasks reference `audio-schema-notes.md` for every place this plan says "(per Task 1 notes)". If Step 1 reveals the `.audio` schema is unavailable in this SDK or its floor is unacceptable, STOP and revisit the spec (fallback: ship the custom-intent + AppShortcuts path only, dropping schema conformance — the testable core in Tasks 2-5 is unchanged).
+
+---
+
+## Task 2: `StationMatch` value type + name normalization
+
+**Files:**
+- Create: `PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift`
+- Test: `PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift`
+
+- [ ] **Step 1: Write the failing test for normalization**
+
+```swift
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct StationVoiceCatalogTests {
+  @Test
+  func testNormalizeLowercasesStripsPunctuationAndPossessive() {
+    #expect(StationVoiceCatalog.normalize("Radney Foster's Station") == "radney foster")
+    #expect(StationVoiceCatalog.normalize("Bordertown Radio!") == "bordertown")
+    #expect(StationVoiceCatalog.normalize("  KOKE  FM ") == "koke fm")
+  }
+}
+```
+
+- [ ] **Step 2: Run it, verify it fails**
+
+Run the test command with `-only-testing:PlayolaRadioTests/StationVoiceCatalogTests`. Expected: FAIL (no `StationVoiceCatalog`).
+
+- [ ] **Step 3: Implement `StationMatch` and `normalize`**
+
+```swift
+import Foundation
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+
+/// The entity kind a station maps to in Apple's `.audio` schema domain.
+enum StationEntityKind: Equatable {
+  case liveRadioStation       // UrlStation / FM
+  case algorithmicRadioStation  // PlayolaPlayer.Station / artist
+}
+
+/// A station resolved from a spoken/typed query, with the label and entity kind
+/// the App Intents layer needs.
+struct StationMatch: Equatable, Identifiable {
+  let id: String          // AnyStation.id
+  let label: String       // FM: station name; Artist: "[Artist]'s Station"
+  let kind: StationEntityKind
+}
+
+@MainActor
+struct StationVoiceCatalog {
+  @Shared(.stationLists) var stationLists
+
+  /// Lowercase, strip possessive "'s", strip punctuation, drop the filler words
+  /// "radio"/"station", collapse whitespace. Used on both station aliases and the
+  /// incoming query so matching is symmetric.
+  static func normalize(_ raw: String) -> String {
+    var s = raw.lowercased()
+    s = s.replacingOccurrences(of: "'s", with: "")
+    s = s.replacingOccurrences(of: "\u{2019}s", with: "")  // curly apostrophe
+    let allowed = CharacterSet.alphanumerics.union(.whitespaces)
+    s = String(s.unicodeScalars.filter { allowed.contains($0) })
+    let filler: Set<String> = ["radio", "station"]
+    let words = s.split(whereSeparator: { $0 == " " }).map(String.init).filter { !filler.contains($0) }
+    return words.joined(separator: " ")
+  }
+}
+```
+
+- [ ] **Step 4: Run the test, verify it passes**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
+git commit -m "feat: add StationMatch and station name normalization"
+```
+
+---
+
+## Task 3: `StationVoiceCatalog` aliases, suggestions, and lookup
+
+`AnyStation.name` returns the curator name for artist stations and the station name for FM stations; `AnyStation.stationName` returns the underlying station name for both. Aliases per station:
+- FM (`.url`): `name` (= station name)
+- Artist (`.playola`): `name` (= curatorName), `"[curatorName]'s Station"`, `stationName`
+
+**Files:**
+- Modify: `PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift`
+- Test: `PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift`
+
+- [ ] **Step 1: Write failing tests for suggestions, labels, and matching**
+
+```swift
+@Test
+func testSuggestedStationsLabelsAndKinds() {
+  @Shared(.stationLists) var stationLists = StationList.mocks
+
+  let catalog = StationVoiceCatalog()
+  let suggestions = catalog.suggestedStations()
+
+  // FM station label is the station name; kind is liveRadioStation.
+  let koke = suggestions.first { $0.id == "koke-fm-id" }
+  #expect(koke?.label == "KOKE FM")
+  #expect(koke?.kind == .liveRadioStation)
+}
+
+@Test
+func testSuggestedStationsArtistLabelIsArtistPossessive() {
+  let artistList = StationList.mockArtistList(items: [
+    APIStationItem(sortOrder: 0, station: Station.mockWith(
+      id: "rf-id", name: "Bordertown Radio", curatorName: "Radney Foster"), urlStation: nil)
+  ])
+  @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [artistList])
+
+  let match = StationVoiceCatalog().suggestedStations().first { $0.id == "rf-id" }
+  #expect(match?.label == "Radney Foster's Station")
+  #expect(match?.kind == .algorithmicRadioStation)
+}
+
+@Test
+func testMatchesResolvesByStationNameAndCuratorName() {
+  let artistList = StationList.mockArtistList(items: [
+    APIStationItem(sortOrder: 0, station: Station.mockWith(
+      id: "rf-id", name: "Bordertown Radio", curatorName: "Radney Foster"), urlStation: nil)
+  ])
+  @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [artistList])
+  let catalog = StationVoiceCatalog()
+
+  #expect(catalog.matches(query: "Bordertown Radio").first?.id == "rf-id")
+  #expect(catalog.matches(query: "Radney Foster").first?.id == "rf-id")
+  #expect(catalog.matches(query: "Radney Foster's Station").first?.id == "rf-id")
+}
+
+@Test
+func testMatchesFailsClosedOnNoConfidentMatch() {
+  @Shared(.stationLists) var stationLists = StationList.mocks
+  #expect(StationVoiceCatalog().matches(query: "totally unrelated zzzz").isEmpty)
+}
+
+@Test
+func testStationByIdReturnsAnyStation() {
+  @Shared(.stationLists) var stationLists = StationList.mocks
+  #expect(StationVoiceCatalog().station(id: "koke-fm-id")?.id == "koke-fm-id")
+  #expect(StationVoiceCatalog().station(id: "nonexistent") == nil)
+}
+```
+
+- [ ] **Step 2: Run, verify failure** (missing `suggestedStations`, `matches`, `station(id:)`).
+
+- [ ] **Step 3: Implement the methods**
+
+Add to `StationVoiceCatalog`:
+
+```swift
+/// All playable (visible, non-coming-soon) stations as matches.
+func suggestedStations() -> [StationMatch] {
+  allStations().map(makeMatch(for:))
+}
+
+/// Best-effort fuzzy matches for a spoken/typed query, ordered best-first.
+/// Fails closed: returns [] when nothing clears the confidence bar.
+func matches(query: String) -> [StationMatch] {
+  let needle = Self.normalize(query)
+  guard !needle.isEmpty else { return [] }
+
+  return allStations().compactMap { station -> (StationMatch, Int)? in
+    let score = bestScore(for: station, needle: needle)
+    guard let score, score > 0 else { return nil }
+    return (makeMatch(for: station), score)
+  }
+  .sorted { $0.1 > $1.1 }
+  .map(\.0)
+}
+
+/// Resolve a match id back to the real station for playback.
+func station(id: String) -> AnyStation? {
+  allStations().first { $0.id == id }
+}
+
+// MARK: - Private
+
+private func allStations() -> [AnyStation] {
+  stationLists.flatMap { list in
+    list.stationItems(includeHidden: false, includeComingSoon: false).map(\.anyStation)
+  }
+}
+
+private func aliases(for station: AnyStation) -> [String] {
+  switch station {
+  case .url(let s):
+    return [s.name]
+  case .playola(let s):
+    return [s.curatorName, "\(s.curatorName)'s Station", s.name]
+  }
+}
+
+private func label(for station: AnyStation) -> String {
+  switch station {
+  case .url(let s): return s.name
+  case .playola(let s): return "\(s.curatorName)'s Station"
+  }
+}
+
+private func kind(for station: AnyStation) -> StationEntityKind {
+  station.isPlayolaStation ? .algorithmicRadioStation : .liveRadioStation
+}
+
+private func makeMatch(for station: AnyStation) -> StationMatch {
+  StationMatch(id: station.id, label: label(for: station), kind: kind(for: station))
+}
+
+/// Confidence score: exact normalized alias match beats prefix beats contains.
+/// Returns nil when no alias relates to the needle (fail closed).
+private func bestScore(for station: AnyStation, needle: String) -> Int? {
+  var best: Int?
+  for alias in aliases(for: station) {
+    let hay = Self.normalize(alias)
+    guard !hay.isEmpty else { continue }
+    let score: Int?
+    if hay == needle { score = 100 }
+    else if hay.hasPrefix(needle) || needle.hasPrefix(hay) { score = 60 }
+    else if hay.contains(needle) || needle.contains(hay) { score = 30 }
+    else { score = nil }
+    if let score, score > (best ?? 0) { best = score }
+  }
+  return best
+}
+```
+
+- [ ] **Step 4: Run, verify all pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
+git commit -m "feat: add station matching, suggestions, and lookup to StationVoiceCatalog"
+```
+
+---
+
+## Task 4: `PlaybackBootstrap` — explicit audio session
+
+Makes the implicit audio-session setup explicit before a Siri cold-launch play. Kept thin; the system `AVAudioSession` is not unit-tested (verified manually on device in Task 10).
+
+**Files:**
+- Create: `PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift`
+
+- [ ] **Step 1: Implement**
+
+```swift
+import AVFoundation
+import Dependencies
+
+/// Ensures the audio session is active before playback begins from a Siri
+/// cold-launch, where the normal app-launch path may not have run yet.
+@MainActor
+struct PlaybackBootstrap {
+  func prepareForPlayback() {
+    let session = AVAudioSession.sharedInstance()
+    try? session.setCategory(.playback, mode: .default)
+    try? session.setActive(true)
+  }
+}
+```
+
+- [ ] **Step 2: Build to confirm it compiles** (register in pbxproj now or defer to Task 9; if deferring, this builds in Task 9's batch).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift
+git commit -m "feat: add PlaybackBootstrap for explicit audio session setup"
+```
+
+---
+
+## Task 5: `PlayStationAction` — auth gate + lookup + play
+
+`StationPlayer.play(station:)` synchronously sets `state` to `.loading(station)` before any await, so `stationPlayer.currentStation` reflects the requested station immediately — tests assert on that without a mock. Use a URL station in the "plays" test to avoid the network path the playola branch takes.
+
+**Files:**
+- Create: `PlayolaRadio/Core/SiriIntents/PlayStationAction.swift`
+- Test: `PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift`
+
+- [ ] **Step 1: Write failing tests**
+
+```swift
+import Dependencies
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct PlayStationActionTests {
+  private func makeStationLists() -> IdentifiedArrayOf<StationList> {
+    let fm = StationList(
+      id: "fm_list", name: "FM", slug: "fm_list", hidden: false, sortOrder: 0,
+      createdAt: Date(timeIntervalSince1970: 0), updatedAt: Date(timeIntervalSince1970: 0),
+      items: [APIStationItem(sortOrder: 0, station: nil, urlStation: UrlStation(
+        id: "koke-fm-id", name: "KOKE FM", streamUrl: "https://example.com/stream",
+        imageUrl: "https://example.com/i.png", description: "desc", website: nil,
+        location: "Austin, TX", active: true, createdAt: Date(), updatedAt: Date()))]
+    )
+    return IdentifiedArrayOf(uniqueElements: [fm])
+  }
+
+  @Test
+  func testLoggedOutReturnsRequiresSignIn() async {
+    @Shared(.auth) var auth = Auth()                     // jwt nil → logged out
+    @Shared(.stationLists) var stationLists = makeStationLists()
+
+    let outcome = await withDependencies {
+      $0.stationPlayer = StationPlayer()
+    } operation: {
+      await PlayStationAction().run(stationID: "koke-fm-id")
+    }
+
+    #expect(outcome == .requiresSignIn)
+  }
+
+  @Test
+  func testUnknownStationReturnsNotFound() async {
+    @Shared(.auth) var auth = Auth(jwtToken: "jwt")
+    @Shared(.stationLists) var stationLists = makeStationLists()
+
+    let outcome = await withDependencies {
+      $0.stationPlayer = StationPlayer()
+    } operation: {
+      await PlayStationAction().run(stationID: "does-not-exist")
+    }
+
+    #expect(outcome == .notFound)
+  }
+
+  @Test
+  func testLoggedInValidStationPlaysAndReturnsPlaying() async {
+    @Shared(.auth) var auth = Auth(jwtToken: "jwt")
+    @Shared(.stationLists) var stationLists = makeStationLists()
+    let player = StationPlayer()
+
+    let outcome = await withDependencies {
+      $0.stationPlayer = player
+    } operation: {
+      await PlayStationAction().run(stationID: "koke-fm-id")
+    }
+
+    #expect(outcome == .playing(stationName: "KOKE FM"))
+    #expect(player.currentStation?.id == "koke-fm-id")
+  }
+}
+```
+
+- [ ] **Step 2: Run, verify failure.**
+
+- [ ] **Step 3: Implement**
+
+```swift
+import Dependencies
+import Sharing
+
+enum PlayStationOutcome: Equatable {
+  case requiresSignIn
+  case notFound
+  case playing(stationName: String)
+}
+
+@MainActor
+struct PlayStationAction {
+  @Shared(.auth) var auth
+  @Dependency(\.stationPlayer) var stationPlayer
+
+  func run(stationID: String) async -> PlayStationOutcome {
+    guard auth.isLoggedIn else { return .requiresSignIn }
+    guard let station = StationVoiceCatalog().station(id: stationID) else { return .notFound }
+    PlaybackBootstrap().prepareForPlayback()
+    await stationPlayer.play(station: station)
+    return .playing(stationName: station.stationName)
+  }
+}
+```
+
+Note: `station.stationName` yields the human station name for both kinds ("KOKE FM", "Bordertown Radio").
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlayolaRadio/Core/SiriIntents/PlayStationAction.swift PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
+git commit -m "feat: add PlayStationAction with auth gate and playback"
+```
+
+---
+
+## Task 6: Station audio entities (`.audio` schema conformance)
+
+Uses the exact API pinned in Task 1's `audio-schema-notes.md`. The shape below is the expected structure; **substitute the precise macro name, required properties, and `@available` floor from the notes.** Entities store ids + display strings only.
+
+**Files:**
+- Create: `PlayolaRadio/Core/SiriIntents/StationAudioEntities.swift`
+
+- [ ] **Step 1: Implement the two entities per Task 1 notes**
+
+Skeleton (fill required members from the generated template):
+
+```swift
+import AppIntents
+// import MediaIntents   // only if Task 1 notes require it
+
+// Substitute @available floor from Task 1 notes (e.g. @available(iOS 18.4, *)).
+@available(iOS 18.4, *)
+@AppEntity(schema: .audio.liveRadioStation)   // macro name per Task 1 notes
+struct LiveRadioStationEntity {
+  let id: String
+  // Required schema properties (name/title, etc.) per Task 1 notes:
+  let title: String
+}
+
+@available(iOS 18.4, *)
+@AppEntity(schema: .audio.algorithmicRadioStation)
+struct AlgorithmicRadioStationEntity {
+  let id: String
+  let title: String
+}
+```
+
+- [ ] **Step 2: Add a bridge from `StationMatch` to the entity types**
+
+```swift
+@available(iOS 18.4, *)
+extension StationMatch {
+  // Returns the schema-correct entity for this match's kind.
+  // Exact entity initializer args follow Task 1 notes.
+  func makeAudioEntity() -> any AppEntity {
+    switch kind {
+    case .liveRadioStation:
+      return LiveRadioStationEntity(id: id, title: label)
+    case .algorithmicRadioStation:
+      return AlgorithmicRadioStationEntity(id: id, title: label)
+    }
+  }
+}
+```
+
+- [ ] **Step 3: Build in Xcode.** Resolve any schema-conformance compiler errors by matching the generated template exactly. Expected: compiles. Commit.
+
+```bash
+git add PlayolaRadio/Core/SiriIntents/StationAudioEntities.swift
+git commit -m "feat: add .audio schema station entities"
+```
+
+> If Task 1 found the schema forces a single entity type (not two), collapse to one entity that carries the kind internally, and update Tasks 7-8 accordingly. Note the deviation in the commit message.
+
+---
+
+## Task 7: `PlayStationIntent` (schema-conformed)
+
+**Files:**
+- Create: `PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift`
+
+- [ ] **Step 1: Implement the intent per Task 1 notes**
+
+```swift
+import AppIntents
+
+@available(iOS 18.4, *)
+@AppIntent(schema: .audio.playAudio)   // macro + schema per Task 1 notes
+struct PlayStationIntent {
+  static let openAppWhenRun = true
+
+  // The parameter(s) the playAudio schema requires (the resolved audio target /
+  // search) — names and types per Task 1 notes. Example placeholder:
+  @Parameter(title: "Station")
+  var target: LiveRadioStationEntity   // or the schema's required parameter type
+
+  @MainActor
+  func perform() async throws -> some IntentResult & ProvidesDialog {
+    let outcome = await PlayStationAction().run(stationID: target.id)
+    switch outcome {
+    case .requiresSignIn:
+      return .result(dialog: "Open Playola to sign in first")
+    case .notFound:
+      return .result(dialog: "I couldn't find that station on Playola")
+    case .playing(let name):
+      return .result(dialog: "Playing \(name)")
+    }
+  }
+}
+```
+
+> The exact parameter wiring (single entity vs `MediaSearch` resolved via the query in Task 8) comes from Task 1. The constant fact this plan guarantees: `perform()` delegates to `PlayStationAction().run(stationID:)` and maps the three outcomes to dialog. Keep `perform()` a thin shell.
+
+- [ ] **Step 2: Build in Xcode.** Match the `playAudio` template's required members until it compiles. Commit.
+
+```bash
+git add PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift
+git commit -m "feat: add PlayStationIntent conforming to .audio.playAudio"
+```
+
+---
+
+## Task 8: `StationIntentValueQuery` — resolve spoken request to entities
+
+The `.audio` `playAudio` flow resolves its audio parameter through a Media Intents query (the `IntentValueQuery`-family protocol named in Task 1). It receives the spoken search and returns matching station entities by delegating to `StationVoiceCatalog`.
+
+**Files:**
+- Create: `PlayolaRadio/Core/SiriIntents/StationIntentValueQuery.swift`
+
+- [ ] **Step 1: Implement per Task 1 notes**
+
+```swift
+import AppIntents
+
+@available(iOS 18.4, *)
+struct StationIntentValueQuery: /* IntentValueQuery / Media Intents query protocol per Task 1 */ {
+  @MainActor
+  func values(for input: /* MediaSearch-style type per Task 1 */) async throws -> [any AppEntity] {
+    // Extract the spoken string from `input` (field name per Task 1 notes),
+    // run it through the matcher, and map to schema entities.
+    let query = /* input.<spoken term> */ ""
+    return StationVoiceCatalog().matches(query: query).map { $0.makeAudioEntity() }
+  }
+}
+```
+
+- [ ] **Step 2: Wire the query to the intent's parameter** as the generated template specifies (e.g. `@Parameter(query:)` or the schema's resolution hook). Build until it compiles.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add PlayolaRadio/Core/SiriIntents/StationIntentValueQuery.swift PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift
+git commit -m "feat: resolve spoken station via StationVoiceCatalog in IntentValueQuery"
+```
+
+> The matching logic is already tested in Task 3. This task is glue: confirm `matches(query:)` is the only matching path, so there is no second, untested matcher.
+
+---
+
+## Task 9: AppShortcuts fallback + register all files + build
+
+**Files:**
+- Create: `PlayolaRadio/Core/SiriIntents/PlayolaShortcuts.swift`
+- Modify: `PlayolaRadio.xcodeproj/project.pbxproj`
+
+- [ ] **Step 1: Implement the fallback shortcuts provider**
+
+For the AppShortcuts phrase path, the parameter must be a station entity the user can pick. If Task 1 shows `PlayStationIntent`'s parameter is not a plain pickable entity (e.g. it's a `MediaSearch`), add a small companion `AppIntent` (`PlayStationByNameIntent`) that takes a single `StationEntity` parameter backed by an `EntityQuery` (delegating to `StationVoiceCatalog`) and calls the same `PlayStationAction`. Use that companion here. Otherwise point the shortcut at `PlayStationIntent` directly.
+
+```swift
+import AppIntents
+
+struct PlayolaShortcuts: AppShortcutsProvider {
+  static var appShortcuts: [AppShortcut] {
+    AppShortcut(
+      intent: PlayStationByNameIntent(),   // or PlayStationIntent(), per Task 1
+      phrases: [
+        "Play \(\.$station) on \(.applicationName)",
+        "Start \(\.$station) on \(.applicationName)",
+      ],
+      shortTitle: "Play Station",
+      systemImageName: "radio"
+    )
+  }
+}
+```
+
+If a companion intent + `StationEntity` (`@AppEntity` with an `EntityQuery` whose `entities(matching:)`/`suggestedEntities()` call `StationVoiceCatalog`) is needed, create it in this file. Its `perform()` also delegates to `PlayStationAction().run(stationID:)`.
+
+- [ ] **Step 2: Register every new file in `project.pbxproj`**
+
+Add explicit `PBXBuildFile` + `PBXFileReference` entries (and group membership under a new `SiriIntents` group) for, in the `PlayolaRadio` target:
+- `StationVoiceCatalog.swift`, `PlaybackBootstrap.swift`, `PlayStationAction.swift`, `StationAudioEntities.swift`, `PlayStationIntent.swift`, `StationIntentValueQuery.swift`, `PlayolaShortcuts.swift`
+
+And in the `PlayolaRadioTests` target:
+- `StationVoiceCatalogTests.swift`, `PlayStationActionTests.swift`
+
+Mirror the pattern of an existing recently-added file (grep `project.pbxproj` for `ChooseStationToBroadcastPage.swift` to copy the four-line registration shape).
+
+- [ ] **Step 3: Build the whole app**
+
+```bash
+xcodebuild build -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
+  -destination 'platform=iOS Simulator,id=CC4A4FCF-D331-4CB2-BADC-523BD1728852' \
+  -skipPackagePluginValidation 2>&1 | xcbeautify
+```
+Expected: BUILD SUCCEEDED.
+
+- [ ] **Step 4: Run the full new test suite**
+
+```bash
+xcodebuild test -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
+  -destination 'platform=iOS Simulator,id=CC4A4FCF-D331-4CB2-BADC-523BD1728852' \
+  -skipPackagePluginValidation \
+  -only-testing:PlayolaRadioTests/StationVoiceCatalogTests \
+  -only-testing:PlayolaRadioTests/PlayStationActionTests 2>&1 | xcbeautify
+```
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlayolaRadio/Core/SiriIntents/PlayolaShortcuts.swift PlayolaRadio.xcodeproj/project.pbxproj
+git commit -m "feat: register Siri intents and add AppShortcuts fallback phrases"
+```
+
+---
+
+## Task 10: Device verification (manual) + adversarial review
+
+App Intents voice behavior cannot be verified in the simulator's unit tests; it needs a real device and Siri.
+
+- [ ] **Step 1: Run on an Apple-Intelligence device** (iPhone 15 Pro+ / 16+). Sign in. Say "Play Bordertown Radio" (bare). Confirm the app foregrounds and the station plays. Say a station that doesn't exist; confirm graceful behavior.
+- [ ] **Step 2: Test the fallback.** In the Shortcuts app (or a non-AI device), confirm "Play [Station] on Playola" appears and runs. Confirm per-station suggestions show in Spotlight/Siri Suggestions.
+- [ ] **Step 3: Logged-out path.** Sign out, invoke by voice, confirm "Open Playola to sign in first" and the app opens to sign-in.
+- [ ] **Step 4: Cold launch.** Force-quit the app, invoke by voice, confirm audio starts (validates `PlaybackBootstrap`).
+- [ ] **Step 5: Adversarial review (Codex).** Run `/codex review` then `/codex challenge` on the branch diff. Fix anything surfaced; re-run if fixes were non-trivial.
+- [ ] **Step 6:** Delete `docs/superpowers/specs/audio-schema-notes.md` if it was scratch-only, or fold any durable API facts into the spec. Commit.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** login gate (Task 5), fuzzy match on name + curator (Task 3), fail-closed (Task 3), FM/artist labels + entity kinds (Task 3), `.audio` schema conformance (Tasks 6-8), AppShortcuts fallback (Task 9), `PlaybackBootstrap` (Task 4), availability gating (Tasks 6-8 `@available`), native no-match (Task 7 maps only the three outcomes; unmatched speech never reaches `perform()`). All covered.
+- **Type consistency:** `PlayStationOutcome` (`.requiresSignIn` / `.notFound` / `.playing(stationName:)`), `StationMatch(id/label/kind)`, `StationEntityKind`, and `StationVoiceCatalog.{normalize, suggestedStations, matches, station(id:)}` are used identically across Tasks 3, 5, 6, 8.
+- **Known SDK-dependent gaps (by design):** Tasks 6-8 carry skeletons because the `.audio` schema's exact Swift signatures ship in the SDK and are pinned by Task 1, not guessable beforehand. Every such spot says "per Task 1 notes." This is deliberate, not a placeholder for missing thinking — the testable core (Tasks 2-5) is fully specified.

--- a/docs/superpowers/plans/2026-06-10-siri-play-station.md
+++ b/docs/superpowers/plans/2026-06-10-siri-play-station.md
@@ -1,22 +1,24 @@
-# Siri "Play [Station]" Implementation Plan
+# Siri "Play [Station]" Implementation Plan (Option B — custom App Intent)
 
-> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Before writing any Swift, invoke the relevant `pfw-*` skills (pfw-dependencies, pfw-sharing, pfw-observable-models, pfw-testing, pfw-custom-dump, pfw-case-paths).
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans, task-by-task. Steps use checkbox (`- [ ]`). Before writing any Swift, invoke the relevant `pfw-*` skills (pfw-dependencies, pfw-sharing, pfw-observable-models, pfw-testing, pfw-custom-dump).
 
-**Goal:** Let a user start a Playola station by voice through Siri ("Play Bordertown Radio", "Play Radney Foster's Station").
+**Goal:** Let a user start a Playola station by voice through Siri ("Play Bordertown Radio on Playola").
 
-**Architecture:** App Intents in the main app target. A testable `@MainActor` core (`StationVoiceCatalog` matching, `PlayStationAction` auth+play, `PlaybackBootstrap` audio session) does all real work. Thin App Intents shells conform to Apple's `.audio` schema (`playAudio` intent, `liveRadioStation` / `algorithmicRadioStation` entities, an `IntentValueQuery` for matching) so the new Siri plays stations with bare phrases, plus an `AppShortcutsProvider` registering "Play [Station] on Playola" as the universal fallback.
+**Architecture:** App Intents in the main app target. A testable `@MainActor` core (`StationVoiceCatalog` matching, `PlayStationAction` auth+play, `PlaybackBootstrap` audio session) does all real work. Thin custom App Intents shells — `RadioStationEntity` + `EntityQuery`, `PlayStationIntent`, `AppShortcutsProvider` — expose it to Siri/Shortcuts. **No `.audio` schema conformance** (not in the installed SDK; iOS-26-only `IntentValueQuery`). Schema upgrade is a deferred fast-follow; the core is unchanged by it.
 
-**Tech Stack:** Swift, App Intents (iOS 18+, `.audio` schema domain), swift-dependencies, swift-sharing, Swift Testing (`import Testing`).
+**Tech Stack:** Swift, App Intents (iOS 18), swift-dependencies, swift-sharing, Swift Testing (`import Testing`).
 
 **Spec:** `docs/superpowers/specs/2026-06-10-siri-play-station-design.md`
+**SDK spike notes:** `docs/superpowers/specs/audio-schema-notes.md`
 
 ---
 
 ## Conventions for every task
 
-- **Tests:** Swift Testing (`import Testing`, `@Test`, `#expect`, `@MainActor struct XxxTests`), colocated next to the file under test. For value comparisons prefer custom-dump's `expectNoDifference` (pfw-custom-dump).
-- **`@Shared` in tests:** declare locally per test, e.g. `@Shared(.auth) var auth = Auth(jwtToken: "test-jwt")`. Never class-level.
-- **New files MUST be hand-registered in `PlayolaRadio.xcodeproj/project.pbxproj`** (explicit file refs — this project does not use synced folders). Task 9 does this in one batch; until then new files won't compile in Xcode. If a per-task build is needed sooner, register the file as you add it.
+- **Tests:** Swift Testing (`import Testing`, `@Test`, `#expect`, `@MainActor struct XxxTests`), colocated. Prefer custom-dump `expectNoDifference` for value comparisons.
+- **`@Shared` in tests:** declare locally per test (e.g. `@Shared(.auth) var auth = Auth(jwtToken: "jwt")`). Never class-level.
+- **New files MUST be hand-registered in `PlayolaRadio.xcodeproj/project.pbxproj`** (explicit refs — no synced folders). Task 9 batches this; register sooner if a per-task Xcode build is needed.
+- **New code lives in** `PlayolaRadio/Core/SiriIntents/` (new group). Tests colocated.
 - **Run tests (CLI):**
   ```bash
   xcodebuild test -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
@@ -24,43 +26,13 @@
     -skipPackagePluginValidation \
     -only-testing:PlayolaRadioTests/<TestStructName> 2>&1 | xcbeautify
   ```
-  (Booted sim id above is `iPhone 15`; substitute any booted simulator. `-skipPackagePluginValidation` is required or the SwiftLint build plugin fails the run. The user may also run in Xcode.)
-- **New code lives in** `PlayolaRadio/Core/SiriIntents/` (create the group). Tests colocated in the same folder.
+  (Booted sim above is `iPhone 15`; substitute any booted sim. `-skipPackagePluginValidation` is required or the SwiftLint build plugin fails the run.)
 
 ---
 
-## Task 1: Spike — pin the `.audio` schema API against the installed SDK
+## Task 1: Spike — pin `.audio` schema API ✅ DONE
 
-The `.audio` App Intents schema shipped with WWDC 2026 and its exact Swift signatures are only knowable from the SDK in Xcode 26.5. This task produces a notes file that later tasks consume. **No production code ships from this task.**
-
-**Files:**
-- Create: `docs/superpowers/specs/audio-schema-notes.md` (scratch notes, not shipped to users)
-
-- [ ] **Step 1: Generate the schema templates in Xcode**
-
-In Xcode, create a throwaway Swift file and type each of these, accepting Xcode's autocomplete template expansion:
-- `audio_playAudio` → expands the `playAudio` intent template
-- `audio_liveRadioStation` → expands the live-radio-station entity template
-- `audio_algorithmicRadioStation` → expands the algorithmic-radio-station entity template
-
-- [ ] **Step 2: Record the exact API into the notes file**
-
-Capture, verbatim from the generated templates:
-1. The macro name actually used (`@AppIntent(schema:)` vs `@AssistantIntent(schema:)`) and the module to `import` (e.g. `AppIntents`, and whether `MediaIntents` / Media Intents framework must be imported).
-2. The `playAudio` intent's required properties (parameter name(s) and types for the target audio item / search, e.g. an entity parameter or a `MediaSearch`-style value) and its `perform()` return type.
-3. The required properties of the `liveRadioStation` and `algorithmicRadioStation` entity schemas (which properties are mandatory: id, title/name, etc.).
-4. The query type the intent expects for resolving its audio parameter (the `IntentValueQuery` / Media Intents query protocol name and its associated `Value` / method signatures).
-5. The `@available` annotation Xcode attaches (the iOS floor — e.g. `iOS 18.4` or `iOS 26`). Record it exactly.
-6. Whether one intent/query can return BOTH entity kinds, or whether the schema forces a single entity type (decides Task 6/7 shape).
-
-- [ ] **Step 3: Delete the throwaway file. Commit the notes.**
-
-```bash
-git add docs/superpowers/specs/audio-schema-notes.md
-git commit -m "docs: pin .audio App Intents schema API from SDK"
-```
-
-**Gate:** Later tasks reference `audio-schema-notes.md` for every place this plan says "(per Task 1 notes)". If Step 1 reveals the `.audio` schema is unavailable in this SDK or its floor is unacceptable, STOP and revisit the spec (fallback: ship the custom-intent + AppShortcuts path only, dropping schema conformance — the testable core in Tasks 2-5 is unchanged).
+Found `.audio` is **not** in the installed Xcode 26.5 SDK and its `IntentValueQuery` is iOS-26-only. Decision: Option B (custom intent). Notes committed at `docs/superpowers/specs/audio-schema-notes.md`. No further action.
 
 ---
 
@@ -70,7 +42,7 @@ git commit -m "docs: pin .audio App Intents schema API from SDK"
 - Create: `PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift`
 - Test: `PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift`
 
-- [ ] **Step 1: Write the failing test for normalization**
+- [ ] **Step 1: Write the failing test**
 
 ```swift
 import Testing
@@ -88,9 +60,7 @@ struct StationVoiceCatalogTests {
 }
 ```
 
-- [ ] **Step 2: Run it, verify it fails**
-
-Run the test command with `-only-testing:PlayolaRadioTests/StationVoiceCatalogTests`. Expected: FAIL (no `StationVoiceCatalog`).
+- [ ] **Step 2: Run it, verify it fails** (`-only-testing:PlayolaRadioTests/StationVoiceCatalogTests`). Expected: FAIL (no `StationVoiceCatalog`).
 
 - [ ] **Step 3: Implement `StationMatch` and `normalize`**
 
@@ -100,18 +70,11 @@ import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
 
-/// The entity kind a station maps to in Apple's `.audio` schema domain.
-enum StationEntityKind: Equatable {
-  case liveRadioStation       // UrlStation / FM
-  case algorithmicRadioStation  // PlayolaPlayer.Station / artist
-}
-
-/// A station resolved from a spoken/typed query, with the label and entity kind
-/// the App Intents layer needs.
+/// A station resolved from a spoken/typed query, with the label the App Intents
+/// layer shows. FM → station name; Artist → "[Artist]'s Station".
 struct StationMatch: Equatable, Identifiable {
-  let id: String          // AnyStation.id
-  let label: String       // FM: station name; Artist: "[Artist]'s Station"
-  let kind: StationEntityKind
+  let id: String      // AnyStation.id
+  let label: String
 }
 
 @MainActor
@@ -119,8 +82,8 @@ struct StationVoiceCatalog {
   @Shared(.stationLists) var stationLists
 
   /// Lowercase, strip possessive "'s", strip punctuation, drop the filler words
-  /// "radio"/"station", collapse whitespace. Used on both station aliases and the
-  /// incoming query so matching is symmetric.
+  /// "radio"/"station", collapse whitespace. Applied to both station aliases and
+  /// the incoming query so matching is symmetric.
   static func normalize(_ raw: String) -> String {
     var s = raw.lowercased()
     s = s.replacingOccurrences(of: "'s", with: "")
@@ -128,14 +91,13 @@ struct StationVoiceCatalog {
     let allowed = CharacterSet.alphanumerics.union(.whitespaces)
     s = String(s.unicodeScalars.filter { allowed.contains($0) })
     let filler: Set<String> = ["radio", "station"]
-    let words = s.split(whereSeparator: { $0 == " " }).map(String.init).filter { !filler.contains($0) }
+    let words = s.split(separator: " ").map(String.init).filter { !filler.contains($0) }
     return words.joined(separator: " ")
   }
 }
 ```
 
-- [ ] **Step 4: Run the test, verify it passes**
-
+- [ ] **Step 4: Run, verify pass.**
 - [ ] **Step 5: Commit**
 
 ```bash
@@ -145,30 +107,26 @@ git commit -m "feat: add StationMatch and station name normalization"
 
 ---
 
-## Task 3: `StationVoiceCatalog` aliases, suggestions, and lookup
+## Task 3: `StationVoiceCatalog` aliases, suggestions, lookup
 
-`AnyStation.name` returns the curator name for artist stations and the station name for FM stations; `AnyStation.stationName` returns the underlying station name for both. Aliases per station:
-- FM (`.url`): `name` (= station name)
-- Artist (`.playola`): `name` (= curatorName), `"[curatorName]'s Station"`, `stationName`
+`AnyStation.name` → curatorName for artist stations, station name for FM; `AnyStation.stationName` → underlying station name for both. Aliases: FM → `name`; artist → `curatorName`, `"[curatorName]'s Station"`, `stationName`.
 
 **Files:**
 - Modify: `PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift`
 - Test: `PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift`
 
-- [ ] **Step 1: Write failing tests for suggestions, labels, and matching**
+- [ ] **Step 1: Write failing tests**
 
 ```swift
+import IdentifiedCollections
+import PlayolaPlayer
+import Sharing
+
 @Test
-func testSuggestedStationsLabelsAndKinds() {
+func testSuggestedStationsFMLabelIsStationName() {
   @Shared(.stationLists) var stationLists = StationList.mocks
-
-  let catalog = StationVoiceCatalog()
-  let suggestions = catalog.suggestedStations()
-
-  // FM station label is the station name; kind is liveRadioStation.
-  let koke = suggestions.first { $0.id == "koke-fm-id" }
+  let koke = StationVoiceCatalog().suggestedStations().first { $0.id == "koke-fm-id" }
   #expect(koke?.label == "KOKE FM")
-  #expect(koke?.kind == .liveRadioStation)
 }
 
 @Test
@@ -178,10 +136,8 @@ func testSuggestedStationsArtistLabelIsArtistPossessive() {
       id: "rf-id", name: "Bordertown Radio", curatorName: "Radney Foster"), urlStation: nil)
   ])
   @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [artistList])
-
   let match = StationVoiceCatalog().suggestedStations().first { $0.id == "rf-id" }
   #expect(match?.label == "Radney Foster's Station")
-  #expect(match?.kind == .algorithmicRadioStation)
 }
 
 @Test
@@ -192,7 +148,6 @@ func testMatchesResolvesByStationNameAndCuratorName() {
   ])
   @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [artistList])
   let catalog = StationVoiceCatalog()
-
   #expect(catalog.matches(query: "Bordertown Radio").first?.id == "rf-id")
   #expect(catalog.matches(query: "Radney Foster").first?.id == "rf-id")
   #expect(catalog.matches(query: "Radney Foster's Station").first?.id == "rf-id")
@@ -205,6 +160,13 @@ func testMatchesFailsClosedOnNoConfidentMatch() {
 }
 
 @Test
+func testMatchByIdReturnsLabel() {
+  @Shared(.stationLists) var stationLists = StationList.mocks
+  #expect(StationVoiceCatalog().match(id: "koke-fm-id")?.label == "KOKE FM")
+  #expect(StationVoiceCatalog().match(id: "nope") == nil)
+}
+
+@Test
 func testStationByIdReturnsAnyStation() {
   @Shared(.stationLists) var stationLists = StationList.mocks
   #expect(StationVoiceCatalog().station(id: "koke-fm-id")?.id == "koke-fm-id")
@@ -212,9 +174,9 @@ func testStationByIdReturnsAnyStation() {
 }
 ```
 
-- [ ] **Step 2: Run, verify failure** (missing `suggestedStations`, `matches`, `station(id:)`).
+- [ ] **Step 2: Run, verify failure.**
 
-- [ ] **Step 3: Implement the methods**
+- [ ] **Step 3: Implement**
 
 Add to `StationVoiceCatalog`:
 
@@ -229,14 +191,17 @@ func suggestedStations() -> [StationMatch] {
 func matches(query: String) -> [StationMatch] {
   let needle = Self.normalize(query)
   guard !needle.isEmpty else { return [] }
-
   return allStations().compactMap { station -> (StationMatch, Int)? in
-    let score = bestScore(for: station, needle: needle)
-    guard let score, score > 0 else { return nil }
+    guard let score = bestScore(for: station, needle: needle), score > 0 else { return nil }
     return (makeMatch(for: station), score)
   }
   .sorted { $0.1 > $1.1 }
   .map(\.0)
+}
+
+/// Match for a known id (used to rehydrate an entity by id).
+func match(id: String) -> StationMatch? {
+  allStations().first { $0.id == id }.map(makeMatch(for:))
 }
 
 /// Resolve a match id back to the real station for playback.
@@ -254,10 +219,8 @@ private func allStations() -> [AnyStation] {
 
 private func aliases(for station: AnyStation) -> [String] {
   switch station {
-  case .url(let s):
-    return [s.name]
-  case .playola(let s):
-    return [s.curatorName, "\(s.curatorName)'s Station", s.name]
+  case .url(let s): return [s.name]
+  case .playola(let s): return [s.curatorName, "\(s.curatorName)'s Station", s.name]
   }
 }
 
@@ -268,16 +231,12 @@ private func label(for station: AnyStation) -> String {
   }
 }
 
-private func kind(for station: AnyStation) -> StationEntityKind {
-  station.isPlayolaStation ? .algorithmicRadioStation : .liveRadioStation
-}
-
 private func makeMatch(for station: AnyStation) -> StationMatch {
-  StationMatch(id: station.id, label: label(for: station), kind: kind(for: station))
+  StationMatch(id: station.id, label: label(for: station))
 }
 
-/// Confidence score: exact normalized alias match beats prefix beats contains.
-/// Returns nil when no alias relates to the needle (fail closed).
+/// Exact normalized alias match beats prefix beats contains; nil = no relation
+/// (fail closed).
 private func bestScore(for station: AnyStation, needle: String) -> Int? {
   var best: Int?
   for alias in aliases(for: station) {
@@ -295,7 +254,6 @@ private func bestScore(for station: AnyStation, needle: String) -> Int? {
 ```
 
 - [ ] **Step 4: Run, verify all pass.**
-
 - [ ] **Step 5: Commit**
 
 ```bash
@@ -307,16 +265,12 @@ git commit -m "feat: add station matching, suggestions, and lookup to StationVoi
 
 ## Task 4: `PlaybackBootstrap` — explicit audio session
 
-Makes the implicit audio-session setup explicit before a Siri cold-launch play. Kept thin; the system `AVAudioSession` is not unit-tested (verified manually on device in Task 10).
-
-**Files:**
-- Create: `PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift`
+**Files:** Create `PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift`
 
 - [ ] **Step 1: Implement**
 
 ```swift
 import AVFoundation
-import Dependencies
 
 /// Ensures the audio session is active before playback begins from a Siri
 /// cold-launch, where the normal app-launch path may not have run yet.
@@ -330,9 +284,7 @@ struct PlaybackBootstrap {
 }
 ```
 
-- [ ] **Step 2: Build to confirm it compiles** (register in pbxproj now or defer to Task 9; if deferring, this builds in Task 9's batch).
-
-- [ ] **Step 3: Commit**
+- [ ] **Step 2: Commit** (compiles as part of Task 9's batch build if not registered yet)
 
 ```bash
 git add PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift
@@ -343,7 +295,7 @@ git commit -m "feat: add PlaybackBootstrap for explicit audio session setup"
 
 ## Task 5: `PlayStationAction` — auth gate + lookup + play
 
-`StationPlayer.play(station:)` synchronously sets `state` to `.loading(station)` before any await, so `stationPlayer.currentStation` reflects the requested station immediately — tests assert on that without a mock. Use a URL station in the "plays" test to avoid the network path the playola branch takes.
+`StationPlayer.play(station:)` synchronously sets `state` to `.loading(station)` before any await, so `stationPlayer.currentStation` reflects the requested station immediately — assert on that without a mock. Use a URL station in the "plays" test to avoid the network path the playola branch takes.
 
 **Files:**
 - Create: `PlayolaRadio/Core/SiriIntents/PlayStationAction.swift`
@@ -376,15 +328,13 @@ struct PlayStationActionTests {
 
   @Test
   func testLoggedOutReturnsRequiresSignIn() async {
-    @Shared(.auth) var auth = Auth()                     // jwt nil → logged out
+    @Shared(.auth) var auth = Auth()
     @Shared(.stationLists) var stationLists = makeStationLists()
-
     let outcome = await withDependencies {
       $0.stationPlayer = StationPlayer()
     } operation: {
       await PlayStationAction().run(stationID: "koke-fm-id")
     }
-
     #expect(outcome == .requiresSignIn)
   }
 
@@ -392,13 +342,11 @@ struct PlayStationActionTests {
   func testUnknownStationReturnsNotFound() async {
     @Shared(.auth) var auth = Auth(jwtToken: "jwt")
     @Shared(.stationLists) var stationLists = makeStationLists()
-
     let outcome = await withDependencies {
       $0.stationPlayer = StationPlayer()
     } operation: {
       await PlayStationAction().run(stationID: "does-not-exist")
     }
-
     #expect(outcome == .notFound)
   }
 
@@ -407,13 +355,11 @@ struct PlayStationActionTests {
     @Shared(.auth) var auth = Auth(jwtToken: "jwt")
     @Shared(.stationLists) var stationLists = makeStationLists()
     let player = StationPlayer()
-
     let outcome = await withDependencies {
       $0.stationPlayer = player
     } operation: {
       await PlayStationAction().run(stationID: "koke-fm-id")
     }
-
     #expect(outcome == .playing(stationName: "KOKE FM"))
     #expect(player.currentStation?.id == "koke-fm-id")
   }
@@ -449,10 +395,7 @@ struct PlayStationAction {
 }
 ```
 
-Note: `station.stationName` yields the human station name for both kinds ("KOKE FM", "Bordertown Radio").
-
 - [ ] **Step 4: Run, verify pass.**
-
 - [ ] **Step 5: Commit**
 
 ```bash
@@ -462,90 +405,77 @@ git commit -m "feat: add PlayStationAction with auth gate and playback"
 
 ---
 
-## Task 6: Station audio entities (`.audio` schema conformance)
+## Task 6: `RadioStationEntity` + `EntityQuery`
 
-Uses the exact API pinned in Task 1's `audio-schema-notes.md`. The shape below is the expected structure; **substitute the precise macro name, required properties, and `@available` floor from the notes.** Entities store ids + display strings only.
+One `AppEntity` covers both station kinds (id + display name). The query delegates entirely to `StationVoiceCatalog` so there is no second, untested matcher.
 
-**Files:**
-- Create: `PlayolaRadio/Core/SiriIntents/StationAudioEntities.swift`
+**Files:** Create `PlayolaRadio/Core/SiriIntents/RadioStationEntity.swift`
 
-- [ ] **Step 1: Implement the two entities per Task 1 notes**
-
-Skeleton (fill required members from the generated template):
+- [ ] **Step 1: Implement**
 
 ```swift
 import AppIntents
-// import MediaIntents   // only if Task 1 notes require it
 
-// Substitute @available floor from Task 1 notes (e.g. @available(iOS 18.4, *)).
-@available(iOS 18.4, *)
-@AppEntity(schema: .audio.liveRadioStation)   // macro name per Task 1 notes
-struct LiveRadioStationEntity {
+struct RadioStationEntity: AppEntity {
+  static var typeDisplayRepresentation: TypeDisplayRepresentation { TypeDisplayRepresentation(name: "Station") }
+  static var defaultQuery = RadioStationEntityQuery()
+
   let id: String
-  // Required schema properties (name/title, etc.) per Task 1 notes:
-  let title: String
+  let name: String
+
+  var displayRepresentation: DisplayRepresentation { DisplayRepresentation(title: "\(name)") }
 }
 
-@available(iOS 18.4, *)
-@AppEntity(schema: .audio.algorithmicRadioStation)
-struct AlgorithmicRadioStationEntity {
-  let id: String
-  let title: String
-}
-```
-
-- [ ] **Step 2: Add a bridge from `StationMatch` to the entity types**
-
-```swift
-@available(iOS 18.4, *)
-extension StationMatch {
-  // Returns the schema-correct entity for this match's kind.
-  // Exact entity initializer args follow Task 1 notes.
-  func makeAudioEntity() -> any AppEntity {
-    switch kind {
-    case .liveRadioStation:
-      return LiveRadioStationEntity(id: id, title: label)
-    case .algorithmicRadioStation:
-      return AlgorithmicRadioStationEntity(id: id, title: label)
+struct RadioStationEntityQuery: EntityQuery, EntityStringQuery {
+  @MainActor
+  func entities(for identifiers: [String]) async throws -> [RadioStationEntity] {
+    let catalog = StationVoiceCatalog()
+    return identifiers.compactMap { id in
+      catalog.match(id: id).map { RadioStationEntity(id: $0.id, name: $0.label) }
     }
+  }
+
+  @MainActor
+  func suggestedEntities() async throws -> [RadioStationEntity] {
+    StationVoiceCatalog().suggestedStations().map { RadioStationEntity(id: $0.id, name: $0.label) }
+  }
+
+  @MainActor
+  func entities(matching string: String) async throws -> [RadioStationEntity] {
+    StationVoiceCatalog().matches(query: string).map { RadioStationEntity(id: $0.id, name: $0.label) }
   }
 }
 ```
 
-- [ ] **Step 3: Build in Xcode.** Resolve any schema-conformance compiler errors by matching the generated template exactly. Expected: compiles. Commit.
+- [ ] **Step 2: Register in pbxproj (or defer to Task 9), build in Xcode.** Expected: compiles.
+- [ ] **Step 3: Commit**
 
 ```bash
-git add PlayolaRadio/Core/SiriIntents/StationAudioEntities.swift
-git commit -m "feat: add .audio schema station entities"
+git add PlayolaRadio/Core/SiriIntents/RadioStationEntity.swift
+git commit -m "feat: add RadioStationEntity and EntityQuery backed by StationVoiceCatalog"
 ```
-
-> If Task 1 found the schema forces a single entity type (not two), collapse to one entity that carries the kind internally, and update Tasks 7-8 accordingly. Note the deviation in the commit message.
 
 ---
 
-## Task 7: `PlayStationIntent` (schema-conformed)
+## Task 7: `PlayStationIntent`
 
-**Files:**
-- Create: `PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift`
+**Files:** Create `PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift`
 
-- [ ] **Step 1: Implement the intent per Task 1 notes**
+- [ ] **Step 1: Implement**
 
 ```swift
 import AppIntents
 
-@available(iOS 18.4, *)
-@AppIntent(schema: .audio.playAudio)   // macro + schema per Task 1 notes
-struct PlayStationIntent {
-  static let openAppWhenRun = true
+struct PlayStationIntent: AppIntent {
+  static var title: LocalizedStringResource = "Play Station"
+  static var openAppWhenRun = true
 
-  // The parameter(s) the playAudio schema requires (the resolved audio target /
-  // search) — names and types per Task 1 notes. Example placeholder:
   @Parameter(title: "Station")
-  var target: LiveRadioStationEntity   // or the schema's required parameter type
+  var station: RadioStationEntity
 
   @MainActor
   func perform() async throws -> some IntentResult & ProvidesDialog {
-    let outcome = await PlayStationAction().run(stationID: target.id)
+    let outcome = await PlayStationAction().run(stationID: station.id)
     switch outcome {
     case .requiresSignIn:
       return .result(dialog: "Open Playola to sign in first")
@@ -558,63 +488,25 @@ struct PlayStationIntent {
 }
 ```
 
-> The exact parameter wiring (single entity vs `MediaSearch` resolved via the query in Task 8) comes from Task 1. The constant fact this plan guarantees: `perform()` delegates to `PlayStationAction().run(stationID:)` and maps the three outcomes to dialog. Keep `perform()` a thin shell.
-
-- [ ] **Step 2: Build in Xcode.** Match the `playAudio` template's required members until it compiles. Commit.
-
-```bash
-git add PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift
-git commit -m "feat: add PlayStationIntent conforming to .audio.playAudio"
-```
-
----
-
-## Task 8: `StationIntentValueQuery` — resolve spoken request to entities
-
-The `.audio` `playAudio` flow resolves its audio parameter through a Media Intents query (the `IntentValueQuery`-family protocol named in Task 1). It receives the spoken search and returns matching station entities by delegating to `StationVoiceCatalog`.
-
-**Files:**
-- Create: `PlayolaRadio/Core/SiriIntents/StationIntentValueQuery.swift`
-
-- [ ] **Step 1: Implement per Task 1 notes**
-
-```swift
-import AppIntents
-
-@available(iOS 18.4, *)
-struct StationIntentValueQuery: /* IntentValueQuery / Media Intents query protocol per Task 1 */ {
-  @MainActor
-  func values(for input: /* MediaSearch-style type per Task 1 */) async throws -> [any AppEntity] {
-    // Extract the spoken string from `input` (field name per Task 1 notes),
-    // run it through the matcher, and map to schema entities.
-    let query = /* input.<spoken term> */ ""
-    return StationVoiceCatalog().matches(query: query).map { $0.makeAudioEntity() }
-  }
-}
-```
-
-- [ ] **Step 2: Wire the query to the intent's parameter** as the generated template specifies (e.g. `@Parameter(query:)` or the schema's resolution hook). Build until it compiles.
-
+- [ ] **Step 2: Build in Xcode.** Expected: compiles.
 - [ ] **Step 3: Commit**
 
 ```bash
-git add PlayolaRadio/Core/SiriIntents/StationIntentValueQuery.swift PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift
-git commit -m "feat: resolve spoken station via StationVoiceCatalog in IntentValueQuery"
+git add PlayolaRadio/Core/SiriIntents/PlayStationIntent.swift
+git commit -m "feat: add PlayStationIntent delegating to PlayStationAction"
 ```
-
-> The matching logic is already tested in Task 3. This task is glue: confirm `matches(query:)` is the only matching path, so there is no second, untested matcher.
 
 ---
 
-## Task 9: AppShortcuts fallback + register all files + build
+## Task 9: AppShortcuts + register all files + build
+
+(Task 8 removed — Option B has no `IntentValueQuery`; the query lives in Task 6.)
 
 **Files:**
 - Create: `PlayolaRadio/Core/SiriIntents/PlayolaShortcuts.swift`
 - Modify: `PlayolaRadio.xcodeproj/project.pbxproj`
 
-- [ ] **Step 1: Implement the fallback shortcuts provider**
-
-For the AppShortcuts phrase path, the parameter must be a station entity the user can pick. If Task 1 shows `PlayStationIntent`'s parameter is not a plain pickable entity (e.g. it's a `MediaSearch`), add a small companion `AppIntent` (`PlayStationByNameIntent`) that takes a single `StationEntity` parameter backed by an `EntityQuery` (delegating to `StationVoiceCatalog`) and calls the same `PlayStationAction`. Use that companion here. Otherwise point the shortcut at `PlayStationIntent` directly.
+- [ ] **Step 1: Implement the shortcuts provider**
 
 ```swift
 import AppIntents
@@ -622,7 +514,7 @@ import AppIntents
 struct PlayolaShortcuts: AppShortcutsProvider {
   static var appShortcuts: [AppShortcut] {
     AppShortcut(
-      intent: PlayStationByNameIntent(),   // or PlayStationIntent(), per Task 1
+      intent: PlayStationIntent(),
       phrases: [
         "Play \(\.$station) on \(.applicationName)",
         "Start \(\.$station) on \(.applicationName)",
@@ -634,17 +526,9 @@ struct PlayolaShortcuts: AppShortcutsProvider {
 }
 ```
 
-If a companion intent + `StationEntity` (`@AppEntity` with an `EntityQuery` whose `entities(matching:)`/`suggestedEntities()` call `StationVoiceCatalog`) is needed, create it in this file. Its `perform()` also delegates to `PlayStationAction().run(stationID:)`.
-
 - [ ] **Step 2: Register every new file in `project.pbxproj`**
 
-Add explicit `PBXBuildFile` + `PBXFileReference` entries (and group membership under a new `SiriIntents` group) for, in the `PlayolaRadio` target:
-- `StationVoiceCatalog.swift`, `PlaybackBootstrap.swift`, `PlayStationAction.swift`, `StationAudioEntities.swift`, `PlayStationIntent.swift`, `StationIntentValueQuery.swift`, `PlayolaShortcuts.swift`
-
-And in the `PlayolaRadioTests` target:
-- `StationVoiceCatalogTests.swift`, `PlayStationActionTests.swift`
-
-Mirror the pattern of an existing recently-added file (grep `project.pbxproj` for `ChooseStationToBroadcastPage.swift` to copy the four-line registration shape).
+Add explicit `PBXBuildFile` + `PBXFileReference` entries and a new `SiriIntents` group. In the **PlayolaRadio** target: `StationVoiceCatalog.swift`, `PlaybackBootstrap.swift`, `PlayStationAction.swift`, `RadioStationEntity.swift`, `PlayStationIntent.swift`, `PlayolaShortcuts.swift`. In the **PlayolaRadioTests** target: `StationVoiceCatalogTests.swift`, `PlayStationActionTests.swift`. Copy the four-line registration shape from an existing recently-added file (grep `project.pbxproj` for `ChooseStationToBroadcastPage.swift`).
 
 - [ ] **Step 3: Build the whole app**
 
@@ -655,7 +539,7 @@ xcodebuild build -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
 ```
 Expected: BUILD SUCCEEDED.
 
-- [ ] **Step 4: Run the full new test suite**
+- [ ] **Step 4: Run the new test suites**
 
 ```bash
 xcodebuild test -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
@@ -670,26 +554,23 @@ Expected: all pass.
 
 ```bash
 git add PlayolaRadio/Core/SiriIntents/PlayolaShortcuts.swift PlayolaRadio.xcodeproj/project.pbxproj
-git commit -m "feat: register Siri intents and add AppShortcuts fallback phrases"
+git commit -m "feat: register Siri intents and add AppShortcuts phrases"
 ```
 
 ---
 
 ## Task 10: Device verification (manual) + adversarial review
 
-App Intents voice behavior cannot be verified in the simulator's unit tests; it needs a real device and Siri.
-
-- [ ] **Step 1: Run on an Apple-Intelligence device** (iPhone 15 Pro+ / 16+). Sign in. Say "Play Bordertown Radio" (bare). Confirm the app foregrounds and the station plays. Say a station that doesn't exist; confirm graceful behavior.
-- [ ] **Step 2: Test the fallback.** In the Shortcuts app (or a non-AI device), confirm "Play [Station] on Playola" appears and runs. Confirm per-station suggestions show in Spotlight/Siri Suggestions.
-- [ ] **Step 3: Logged-out path.** Sign out, invoke by voice, confirm "Open Playola to sign in first" and the app opens to sign-in.
-- [ ] **Step 4: Cold launch.** Force-quit the app, invoke by voice, confirm audio starts (validates `PlaybackBootstrap`).
-- [ ] **Step 5: Adversarial review (Codex).** Run `/codex review` then `/codex challenge` on the branch diff. Fix anything surfaced; re-run if fixes were non-trivial.
-- [ ] **Step 6:** Delete `docs/superpowers/specs/audio-schema-notes.md` if it was scratch-only, or fold any durable API facts into the spec. Commit.
+- [ ] **Step 1:** On a device, sign in. Say "Play KOKE FM on Playola" and "Play Radney Foster's Station on Playola". Confirm the app foregrounds and the station plays.
+- [ ] **Step 2:** In the Shortcuts app, confirm the "Play [Station] on Playola" shortcut appears and runs; per-station entries surface as suggestions in Spotlight/Siri Suggestions.
+- [ ] **Step 3:** Sign out, invoke by voice, confirm "Open Playola to sign in first" and the app opens to sign-in.
+- [ ] **Step 4:** Force-quit the app, invoke by voice, confirm audio starts (validates `PlaybackBootstrap`).
+- [ ] **Step 5:** Run `/codex review` then `/codex challenge` on the branch diff. Fix anything surfaced; re-run if fixes were non-trivial.
 
 ---
 
 ## Self-review notes
 
-- **Spec coverage:** login gate (Task 5), fuzzy match on name + curator (Task 3), fail-closed (Task 3), FM/artist labels + entity kinds (Task 3), `.audio` schema conformance (Tasks 6-8), AppShortcuts fallback (Task 9), `PlaybackBootstrap` (Task 4), availability gating (Tasks 6-8 `@available`), native no-match (Task 7 maps only the three outcomes; unmatched speech never reaches `perform()`). All covered.
-- **Type consistency:** `PlayStationOutcome` (`.requiresSignIn` / `.notFound` / `.playing(stationName:)`), `StationMatch(id/label/kind)`, `StationEntityKind`, and `StationVoiceCatalog.{normalize, suggestedStations, matches, station(id:)}` are used identically across Tasks 3, 5, 6, 8.
-- **Known SDK-dependent gaps (by design):** Tasks 6-8 carry skeletons because the `.audio` schema's exact Swift signatures ship in the SDK and are pinned by Task 1, not guessable beforehand. Every such spot says "per Task 1 notes." This is deliberate, not a placeholder for missing thinking — the testable core (Tasks 2-5) is fully specified.
+- **Spec coverage:** login gate (Task 5), fuzzy match on name + curator + possessive (Task 3), fail-closed (Task 3), FM/artist labels (Task 3), custom entity/query/intent/shortcuts (Tasks 6-9), `PlaybackBootstrap` (Task 4), native no-match (Task 7 maps only the three outcomes; unmatched speech never reaches `perform()`). All covered.
+- **Type consistency:** `PlayStationOutcome` (`.requiresSignIn`/`.notFound`/`.playing(stationName:)`), `StationMatch(id,label)`, and `StationVoiceCatalog.{normalize, suggestedStations, matches, match(id:), station(id:)}` are used identically across Tasks 3, 5, 6.
+- **All code is concrete** — Option B uses the stable iOS 18 App Intents API, so there are no SDK-dependent skeletons. The deferred `.audio` upgrade is documented in the spec, not this plan.

--- a/docs/superpowers/specs/2026-06-10-siri-play-station-design.md
+++ b/docs/superpowers/specs/2026-06-10-siri-play-station-design.md
@@ -1,0 +1,172 @@
+# Siri Voice Control — "Play [Station] on Playola"
+
+**Date:** 2026-06-10
+**Status:** Design approved, ready for implementation plan
+**Branch:** `briankeane/siri-play-station-intent`
+
+## Goal
+
+Let a user start playback by voice through Siri, e.g. *"Play Bordertown Radio on
+Playola"* or *"Play Radney Foster's Station on Playola"*. Match the spoken name
+against the user's station list and start the matching station via the existing
+`StationPlayer`.
+
+## Decisions (locked with user)
+
+1. **Both phrasings (within iOS limits).** One parameterized intent gives the
+   reliable spoken phrase *"Play [Station] on Playola"*, plus per-station entries
+   that surface as **suggestions** in the Shortcuts app, Spotlight, and Siri
+   Suggestions. Bare cold phrases ("Play Bordertown Radio" with no app name) are
+   **not** registered — iOS requires `\(.applicationName)` in every App Shortcut
+   phrase or the phrase silently never triggers. The supported bare-phrase path is
+   the user self-assigning a custom phrase to a suggestion in the Shortcuts app,
+   which the entity design enables for free.
+2. **Login required.** If not authenticated, Siri says *"Open Playola to sign in
+   first"* and foregrounds the app (`openAppWhenRun = true`). No silent failure.
+3. **Best-effort fuzzy match, no disambiguation in v1.** Match on both the
+   station name and the curator/artist name. On no confident match, accept iOS's
+   native "no match" behavior (Siri's own UI). A custom spoken "couldn't find
+   that station" reply is deferred — it would require a separate string-parameter
+   intent path.
+4. **Suggested-phrase labels.** FM/URL stations → station name. Artist stations →
+   "[Artist]'s Station".
+
+## Architecture
+
+App Intents (iOS 18) in the **main app target** — no separate extension. The
+intent runs in the app process so it can reach the live `StationPlayer` (audio
+session, already-initialized singleton) and `@Shared` auth/station state. Siri may
+cold-launch the app to run the intent; `PlayolaRadioApp.init` runs, dependencies
+initialize, and `@Shared(.auth)` / `@Shared(.stationLists)` load from their
+`FileStorage` caches on access.
+
+All real logic lives in two plain, `@MainActor`, dependency-injected,
+unit-testable types. The `AppIntent` itself is a thin shell that adapts an outcome
+to spoken dialog.
+
+### New types
+
+**`StationVoiceCatalog`** (`@MainActor` struct) — the single home for matching and
+lookup. Reads `@Shared(.stationLists)`. Methods:
+- `suggestedEntities() -> [StationEntity]` — current playable stations as entities.
+- `entities(ids:) -> [StationEntity]` — rehydrate entities by id.
+- `matches(query:) -> [StationMatch]` — normalized fuzzy match for the Shortcuts
+  search field.
+- `station(id:) -> AnyStation?` — resolve an id back to a real station.
+
+Per-station aliases used for matching:
+- FM/URL: `name`, `stationName`
+- Artist: `curatorName`, `"[curatorName]'s Station"`, `name`
+
+Normalization: lowercase, strip punctuation, drop possessive suffix ("'s"),
+collapse whitespace, careful handling of trailing "radio"/"station" words.
+Matching **fails closed** — when no candidate clears the confidence threshold,
+return nothing rather than play the wrong station.
+
+**`PlayStationAction`** (`@MainActor` struct) — auth gate + play. Holds
+`@Shared(.auth)`, `@Shared(.stationLists)`, `@Dependency(\.stationPlayer)`.
+`run(stationID:) async -> PlayStationOutcome` where `PlayStationOutcome` is an enum
+(`.requiresSignIn`, `.notFound`, `.playing(stationName:)`). Logic:
+1. Not logged in → `.requiresSignIn`.
+2. `StationVoiceCatalog().station(id:)` is nil → `.notFound`.
+3. Else run `PlaybackBootstrap`, call `await stationPlayer.play(station:)`,
+   return `.playing`.
+
+**`PlaybackBootstrap`** (`@MainActor` struct) — makes the currently-implicit audio
+setup explicit before a Siri-triggered cold play. Sets
+`AVAudioSession.sharedInstance()` category `.playback` and active, and ensures the
+remote command center / now-playing wiring is live. Info.plist already declares the
+`audio` background mode, so playback survives backgrounding.
+
+### App Intents types
+
+**`StationEntity`** — `AppEntity, Identifiable, Hashable`. Stores **ids and display
+strings only** (`id`, `displayTitle`, `suggestedPhraseLabel`), never an embedded
+`AnyStation` (avoids serialization / `Sendable` issues). `displayRepresentation`
+uses `suggestedPhraseLabel`. `defaultQuery = StationEntityQuery()`.
+
+**`StationEntityQuery`** — `EntityStringQuery`, `@MainActor`. Delegates to
+`StationVoiceCatalog`: `entities(for:)`, `suggestedEntities()`, and
+`entities(matching:)` (string search for the Shortcuts UI).
+
+**`PlayStationIntent`** — `AppIntent`. `openAppWhenRun = true`. One
+`@Parameter var station: StationEntity`. `perform()` is `@MainActor`, calls
+`PlayStationAction().run(stationID:)`, maps the outcome to a `ProvidesDialog`
+result.
+
+**`PlayolaShortcuts`** — `AppShortcutsProvider`. Phrases (all include the app
+name): `"Play \(\.$station) on \(.applicationName)"`,
+`"Start \(\.$station) on \(.applicationName)"`.
+
+## Data flow
+
+1. User: *"Play Bordertown Radio on Playola"*.
+2. Siri resolves the spoken station against `StationEntityQuery.entities(matching:)`
+   → `StationEntity`.
+3. `PlayStationIntent.perform()` → `PlayStationAction.run(stationID:)`.
+4. Auth check → station lookup → `PlaybackBootstrap` → `stationPlayer.play(station:)`.
+5. App foregrounds (`openAppWhenRun`), now-playing UI shows; Siri speaks
+   *"Playing Bordertown Radio on Playola"*.
+
+## Error handling
+
+- **Logged out** → `.requiresSignIn` → dialog *"Open Playola to sign in first"*;
+  app foregrounds to sign-in.
+- **No matching station** (after Siri resolves to an id we can't find, or empty
+  cache) → `.notFound` → dialog *"I couldn't find that station on Playola."*
+- **Unresolvable speech** (Siri can't match to any entity) → iOS native no-match
+  UI. Accepted for v1.
+- **Empty station cache on cold launch** → `.notFound` for v1. (Possible later:
+  trigger a `getStations` refresh inside the intent before failing.)
+
+## Testing
+
+Unit tests against the testable seam (`withDependencies` overrides, `@Shared`
+declared locally per test):
+- Logged out → `.requiresSignIn`; `stationPlayer.play` not called.
+- Logged in + valid id → `.playing`; `stationPlayer.play` called with the right
+  station.
+- Unknown id → `.notFound`.
+- FM station suggested label == station name.
+- Artist station suggested label == "[Artist]'s Station".
+- Fuzzy query matches both `name` and `curatorName` ("radney foster",
+  "radney foster's station", "bordertown radio").
+- Low-confidence query → no entity (fail closed).
+- Empty station list → clear failure outcome.
+
+## Out of scope (v1)
+
+- Bare cold spoken phrases without "on Playola".
+- Multi-step spoken disambiguation for ambiguous names.
+- Custom spoken "couldn't find that station" for unresolvable speech (needs a
+  string-parameter intent).
+- In-intent `getStations` network refresh on empty cache.
+- Pause/stop/next/previous voice intents (already covered by the lock-screen
+  remote command center; could be added as intents later).
+
+## Risks
+
+1. **Bare phrases are not registered.** Setting expectations: cold "Play X" without
+   "on Playola" only works if the user self-assigns it in Shortcuts.
+2. **Cold-launch empty cache.** If the user never opened the app post-install, the
+   station list may be empty and any play fails. v1 fails cleanly.
+3. **`@MainActor` isolation.** All query/action/bootstrap code is `@MainActor`;
+   never read `@Shared` from arbitrary executor contexts.
+4. **Audio session must be explicit** before `stationPlayer.play` on a Siri cold
+   start — that's what `PlaybackBootstrap` is for.
+5. **Fuzzy threshold tuning** — too loose plays the wrong station; default to fail
+   closed.
+6. **`openAppWhenRun = true`** foregrounds on every play (including sign-in
+   failure). Accepted tradeoff for a radio app.
+
+## New project files (must be hand-registered in `project.pbxproj`)
+
+- `StationVoiceCatalog.swift` (+ tests)
+- `PlayStationAction.swift` (+ tests)
+- `PlaybackBootstrap.swift`
+- `StationEntity.swift`
+- `StationEntityQuery.swift`
+- `PlayStationIntent.swift`
+- `PlayolaShortcuts.swift`
+
+Exact file grouping/placement to be decided in the implementation plan.

--- a/docs/superpowers/specs/2026-06-10-siri-play-station-design.md
+++ b/docs/superpowers/specs/2026-06-10-siri-play-station-design.md
@@ -1,4 +1,4 @@
-# Siri Voice Control — "Play [Station] on Playola"
+# Siri Voice Control — "Play [Station]"
 
 **Date:** 2026-06-10
 **Status:** Design approved, ready for implementation plan
@@ -6,167 +6,210 @@
 
 ## Goal
 
-Let a user start playback by voice through Siri, e.g. *"Play Bordertown Radio on
-Playola"* or *"Play Radney Foster's Station on Playola"*. Match the spoken name
-against the user's station list and start the matching station via the existing
-`StationPlayer`.
+Let a user start playback by voice through Siri, e.g. *"Play Bordertown Radio"* or
+*"Play Radney Foster's Station"*. Match the spoken name against the user's station
+list and start it via the existing `StationPlayer`.
+
+## Approach: adopt Apple's `.audio` App Intents domain
+
+WWDC 2026 made App Intents the mandatory Siri integration surface (SiriKit
+formally deprecated) and the new conversational Siri routes natural language to
+apps through **assistant schemas** with no fixed phrases to define. Apple ships a
+first-class **`.audio`** schema domain whose entity types map onto Playola almost
+exactly:
+
+| Playola concept | `.audio` schema |
+|---|---|
+| Play action | **`playAudio`** intent schema (example phrase: "Play music") |
+| FM / `UrlStation` (e.g. KOKE FM) | **`liveRadioStation`** entity schema |
+| Artist / `PlayolaPlayer.Station` (e.g. Radney Foster) | **`algorithmicRadioStation`** entity schema |
+
+Conforming to `playAudio` lets the new Siri play a Playola station with the **same
+bare phrases** users say for any audio app ("Play Bordertown Radio" — no "on
+Playola"), on Apple-Intelligence-capable devices. We **also** register classic
+AppShortcuts phrases ("Play [Station] on Playola") so every other
+device/context (non-AI iPhones, the Shortcuts app, CarPlay) keeps working. One
+schema-conformed intent serves both paths.
+
+### Device-capability reality
+
+- Bare-phrase voice requires Apple Intelligence: iPhone 15 Pro / 15 Pro Max (A17
+  Pro) and **all** iPhone 16 and newer. Base iPhone 15 / 15 Plus and older do not
+  qualify and fall back to the "on Playola" AppShortcuts phrases.
+- Install-base capability % is not reliably available from Sentry (model field is
+  not indexed on the error dataset; only a ~7-user perf sample carries it). The
+  authoritative source is App Store Connect → Analytics → Devices. The decision
+  does not depend on the exact %: capable devices get the bonus, everyone else
+  gets the fallback, and the capable share grows over time.
 
 ## Decisions (locked with user)
 
-1. **Both phrasings (within iOS limits).** One parameterized intent gives the
-   reliable spoken phrase *"Play [Station] on Playola"*, plus per-station entries
-   that surface as **suggestions** in the Shortcuts app, Spotlight, and Siri
-   Suggestions. Bare cold phrases ("Play Bordertown Radio" with no app name) are
-   **not** registered — iOS requires `\(.applicationName)` in every App Shortcut
-   phrase or the phrase silently never triggers. The supported bare-phrase path is
-   the user self-assigning a custom phrase to a suggestion in the Shortcuts app,
-   which the entity design enables for free.
+1. **Adopt the `.audio` schema now (Option A).** Conform the play intent to
+   `playAudio`, model stations as `liveRadioStation` / `algorithmicRadioStation`
+   entities, implement an `IntentValueQuery` for matching, and keep AppShortcuts
+   "Play [Station] on Playola" phrases as the universal fallback.
 2. **Login required.** If not authenticated, Siri says *"Open Playola to sign in
    first"* and foregrounds the app (`openAppWhenRun = true`). No silent failure.
-3. **Best-effort fuzzy match, no disambiguation in v1.** Match on both the
-   station name and the curator/artist name. On no confident match, accept iOS's
-   native "no match" behavior (Siri's own UI). A custom spoken "couldn't find
-   that station" reply is deferred — it would require a separate string-parameter
-   intent path.
-4. **Suggested-phrase labels.** FM/URL stations → station name. Artist stations →
-   "[Artist]'s Station".
+3. **Best-effort fuzzy match, no disambiguation in v1.** Match on both station
+   name and curator/artist name. On no confident match, accept the system's native
+   "no match" behavior. Custom "couldn't find that station" spoken reply deferred.
+4. **Suggested-phrase / entity labels.** FM/URL stations → station name. Artist
+   stations → "[Artist]'s Station".
 
 ## Architecture
 
-App Intents (iOS 18) in the **main app target** — no separate extension. The
+App Intents (iOS 18+) in the **main app target** — no separate extension. The
 intent runs in the app process so it can reach the live `StationPlayer` (audio
 session, already-initialized singleton) and `@Shared` auth/station state. Siri may
 cold-launch the app to run the intent; `PlayolaRadioApp.init` runs, dependencies
 initialize, and `@Shared(.auth)` / `@Shared(.stationLists)` load from their
 `FileStorage` caches on access.
 
-All real logic lives in two plain, `@MainActor`, dependency-injected,
-unit-testable types. The `AppIntent` itself is a thin shell that adapts an outcome
-to spoken dialog.
+All real logic lives in plain, `@MainActor`, dependency-injected, unit-testable
+types. The schema-conformed `AppIntent` and the `IntentValueQuery` are thin shells
+over them.
 
-### New types
+### Testable core (no App Intents dependency — unit-testable directly)
 
-**`StationVoiceCatalog`** (`@MainActor` struct) — the single home for matching and
+**`StationVoiceCatalog`** (`@MainActor` struct) — single home for matching and
 lookup. Reads `@Shared(.stationLists)`. Methods:
-- `suggestedEntities() -> [StationEntity]` — current playable stations as entities.
-- `entities(ids:) -> [StationEntity]` — rehydrate entities by id.
-- `matches(query:) -> [StationMatch]` — normalized fuzzy match for the Shortcuts
-  search field.
+- `suggestedStations() -> [StationMatch]` — current playable stations.
+- `matches(query:) -> [StationMatch]` — normalized fuzzy match for a spoken/typed
+  query, used by the `IntentValueQuery` and the AppShortcuts entity search.
 - `station(id:) -> AnyStation?` — resolve an id back to a real station.
 
-Per-station aliases used for matching:
+Per-station match aliases:
 - FM/URL: `name`, `stationName`
 - Artist: `curatorName`, `"[curatorName]'s Station"`, `name`
 
-Normalization: lowercase, strip punctuation, drop possessive suffix ("'s"),
-collapse whitespace, careful handling of trailing "radio"/"station" words.
-Matching **fails closed** — when no candidate clears the confidence threshold,
-return nothing rather than play the wrong station.
+Normalization: lowercase, strip punctuation, drop possessive "'s", collapse
+whitespace, careful handling of trailing "radio"/"station". **Fails closed** — no
+candidate over threshold returns nothing rather than playing the wrong station.
+
+`StationMatch` carries the station id, the chosen display label (FM → station
+name; artist → "[Artist]'s Station"), and which audio-entity kind it maps to
+(`liveRadioStation` vs `algorithmicRadioStation`).
 
 **`PlayStationAction`** (`@MainActor` struct) — auth gate + play. Holds
 `@Shared(.auth)`, `@Shared(.stationLists)`, `@Dependency(\.stationPlayer)`.
-`run(stationID:) async -> PlayStationOutcome` where `PlayStationOutcome` is an enum
-(`.requiresSignIn`, `.notFound`, `.playing(stationName:)`). Logic:
+`run(stationID:) async -> PlayStationOutcome` where `PlayStationOutcome` is
+`.requiresSignIn`, `.notFound`, or `.playing(stationName:)`:
 1. Not logged in → `.requiresSignIn`.
-2. `StationVoiceCatalog().station(id:)` is nil → `.notFound`.
-3. Else run `PlaybackBootstrap`, call `await stationPlayer.play(station:)`,
-   return `.playing`.
+2. `StationVoiceCatalog().station(id:)` nil → `.notFound`.
+3. Else run `PlaybackBootstrap`, `await stationPlayer.play(station:)`, `.playing`.
 
 **`PlaybackBootstrap`** (`@MainActor` struct) — makes the currently-implicit audio
-setup explicit before a Siri-triggered cold play. Sets
-`AVAudioSession.sharedInstance()` category `.playback` and active, and ensures the
-remote command center / now-playing wiring is live. Info.plist already declares the
+setup explicit before a Siri cold-launch play. Sets
+`AVAudioSession.sharedInstance()` category `.playback` and active, ensures the
+remote command / now-playing wiring is live. Info.plist already declares the
 `audio` background mode, so playback survives backgrounding.
 
-### App Intents types
+### App Intents layer (thin shells; schema shape verified against the SDK)
 
-**`StationEntity`** — `AppEntity, Identifiable, Hashable`. Stores **ids and display
-strings only** (`id`, `displayTitle`, `suggestedPhraseLabel`), never an embedded
-`AnyStation` (avoids serialization / `Sendable` issues). `displayRepresentation`
-uses `suggestedPhraseLabel`. `defaultQuery = StationEntityQuery()`.
+**Station entities** — conform to the audio entity schemas:
+`@AppEntity(schema: .audio.liveRadioStation)` for FM stations and
+`@AppEntity(schema: .audio.algorithmicRadioStation)` for artist stations. Store
+**ids and display strings only**, never an embedded `AnyStation` (avoids
+serialization / `Sendable` issues). The exact required properties of each schema
+are generated by Xcode (`audio_` template) and pinned in Task 1.
 
-**`StationEntityQuery`** — `EntityStringQuery`, `@MainActor`. Delegates to
-`StationVoiceCatalog`: `entities(for:)`, `suggestedEntities()`, and
-`entities(matching:)` (string search for the Shortcuts UI).
+**`PlayStationIntent`** — conforms to `@AppIntent(schema: .audio.playAudio)`.
+`openAppWhenRun = true`. `perform()` is `@MainActor`, resolves the target
+station's id, calls `PlayStationAction().run(stationID:)`, maps the outcome to a
+dialog result. The `playAudio` schema's exact parameter and result contract is
+pinned in Task 1.
 
-**`PlayStationIntent`** — `AppIntent`. `openAppWhenRun = true`. One
-`@Parameter var station: StationEntity`. `perform()` is `@MainActor`, calls
-`PlayStationAction().run(stationID:)`, maps the outcome to a `ProvidesDialog`
-result.
+**`StationIntentValueQuery`** — the `IntentValueQuery` (Media Intents framework)
+that receives the spoken audio search/playback request and returns matching
+station entities by delegating to `StationVoiceCatalog().matches(query:)`.
 
-**`PlayolaShortcuts`** — `AppShortcutsProvider`. Phrases (all include the app
-name): `"Play \(\.$station) on \(.applicationName)"`,
+**`PlayolaShortcuts`** — `AppShortcutsProvider`. Fallback phrases (all include the
+app name): `"Play \(\.$station) on \(.applicationName)"`,
 `"Start \(\.$station) on \(.applicationName)"`.
+
+### Availability gating
+
+The `.audio` schema may require a higher iOS floor than the app's 18.0/18.1
+deployment target (Apple shipped these domains in waves). Gate the
+schema-conformed types with `@available` as needed (exact floor pinned in Task 1);
+the AppShortcuts fallback covers anything below the floor.
 
 ## Data flow
 
-1. User: *"Play Bordertown Radio on Playola"*.
-2. Siri resolves the spoken station against `StationEntityQuery.entities(matching:)`
-   → `StationEntity`.
+1. User: *"Play Bordertown Radio"* (AI device) or *"…on Playola"* (any device).
+2. Siri routes via the `playAudio` schema (AI) or the AppShortcuts phrase (classic)
+   → resolves the station through `StationIntentValueQuery` →
+   `StationVoiceCatalog().matches(query:)`.
 3. `PlayStationIntent.perform()` → `PlayStationAction.run(stationID:)`.
 4. Auth check → station lookup → `PlaybackBootstrap` → `stationPlayer.play(station:)`.
-5. App foregrounds (`openAppWhenRun`), now-playing UI shows; Siri speaks
-   *"Playing Bordertown Radio on Playola"*.
+5. App foregrounds; now-playing UI shows; Siri confirms *"Playing Bordertown Radio."*
 
 ## Error handling
 
 - **Logged out** → `.requiresSignIn` → dialog *"Open Playola to sign in first"*;
   app foregrounds to sign-in.
-- **No matching station** (after Siri resolves to an id we can't find, or empty
-  cache) → `.notFound` → dialog *"I couldn't find that station on Playola."*
-- **Unresolvable speech** (Siri can't match to any entity) → iOS native no-match
-  UI. Accepted for v1.
-- **Empty station cache on cold launch** → `.notFound` for v1. (Possible later:
-  trigger a `getStations` refresh inside the intent before failing.)
+- **No matching station** (resolved id not in cache, or empty cache) → `.notFound`
+  → dialog *"I couldn't find that station on Playola."*
+- **Unresolvable speech** → system native no-match. Accepted for v1.
+- **Empty station cache on cold launch** → `.notFound` for v1.
 
 ## Testing
 
-Unit tests against the testable seam (`withDependencies` overrides, `@Shared`
+Unit tests against the testable core (`withDependencies` overrides, `@Shared`
 declared locally per test):
 - Logged out → `.requiresSignIn`; `stationPlayer.play` not called.
 - Logged in + valid id → `.playing`; `stationPlayer.play` called with the right
   station.
 - Unknown id → `.notFound`.
-- FM station suggested label == station name.
-- Artist station suggested label == "[Artist]'s Station".
-- Fuzzy query matches both `name` and `curatorName` ("radney foster",
-  "radney foster's station", "bordertown radio").
-- Low-confidence query → no entity (fail closed).
+- FM station label == station name; entity kind == `liveRadioStation`.
+- Artist station label == "[Artist]'s Station"; entity kind ==
+  `algorithmicRadioStation`.
+- Fuzzy query matches both `name` and `curatorName` ("radney foster", "radney
+  foster's station", "bordertown radio").
+- Low-confidence query → no match (fail closed).
 - Empty station list → clear failure outcome.
+
+Where practical, also validate the intent end-to-end with the **App Intents
+Testing framework** (WWDC 2026) rather than UI automation.
 
 ## Out of scope (v1)
 
-- Bare cold spoken phrases without "on Playola".
 - Multi-step spoken disambiguation for ambiguous names.
-- Custom spoken "couldn't find that station" for unresolvable speech (needs a
-  string-parameter intent).
+- Custom spoken "couldn't find that station" for unresolvable speech.
 - In-intent `getStations` network refresh on empty cache.
-- Pause/stop/next/previous voice intents (already covered by the lock-screen
-  remote command center; could be added as intents later).
+- Other `.audio` schemas (`addToLibrary`, `createStation`, `recognizeAudio`,
+  affinity/like) and pause/stop/next/previous voice intents (lock-screen remote
+  command center already covers transport).
+- Raising Sentry device indexing / traces sample rate (separate task).
 
-## Risks
+## Risks / verification items
 
-1. **Bare phrases are not registered.** Setting expectations: cold "Play X" without
-   "on Playola" only works if the user self-assigns it in Shortcuts.
-2. **Cold-launch empty cache.** If the user never opened the app post-install, the
-   station list may be empty and any play fails. v1 fails cleanly.
-3. **`@MainActor` isolation.** All query/action/bootstrap code is `@MainActor`;
-   never read `@Shared` from arbitrary executor contexts.
-4. **Audio session must be explicit** before `stationPlayer.play` on a Siri cold
-   start — that's what `PlaybackBootstrap` is for.
-5. **Fuzzy threshold tuning** — too loose plays the wrong station; default to fail
-   closed.
-6. **`openAppWhenRun = true`** foregrounds on every play (including sign-in
-   failure). Accepted tradeoff for a radio app.
+1. **Exact `playAudio` schema contract** (parameters, result type, how it hands us
+   the search request) and the **macro name** (`@AppIntent(schema:)` vs the older
+   `@AssistantIntent(schema:)`) must be pinned against the installed SDK in Task 1
+   via Xcode's `audio_` template generation.
+2. **Two entity kinds vs one** — confirm whether `playAudio` accepts both
+   `liveRadioStation` and `algorithmicRadioStation` from one query/result, or needs
+   separate handling.
+3. **iOS availability floor** of the `.audio` schema vs the 18.0 deployment target;
+   gate with `@available`, fallback covers the rest.
+4. **Cold-launch empty cache** — fails cleanly in v1.
+5. **`@MainActor` isolation** — all catalog/action/bootstrap/query code is
+   `@MainActor`; never read `@Shared` from arbitrary executor contexts.
+6. **Audio session must be explicit** before `stationPlayer.play` on a Siri cold
+   start — that is `PlaybackBootstrap`.
+7. **Fuzzy threshold** — too loose plays the wrong station; default fail-closed.
+8. **`openAppWhenRun = true`** foregrounds on every play; accepted for a radio app.
 
 ## New project files (must be hand-registered in `project.pbxproj`)
 
 - `StationVoiceCatalog.swift` (+ tests)
 - `PlayStationAction.swift` (+ tests)
 - `PlaybackBootstrap.swift`
-- `StationEntity.swift`
-- `StationEntityQuery.swift`
+- `StationAudioEntities.swift` (the `liveRadioStation` / `algorithmicRadioStation`
+  entities)
+- `StationIntentValueQuery.swift`
 - `PlayStationIntent.swift`
 - `PlayolaShortcuts.swift`
 
-Exact file grouping/placement to be decided in the implementation plan.
+Exact file grouping/placement decided in the implementation plan.

--- a/docs/superpowers/specs/2026-06-10-siri-play-station-design.md
+++ b/docs/superpowers/specs/2026-06-10-siri-play-station-design.md
@@ -1,215 +1,158 @@
 # Siri Voice Control — "Play [Station]"
 
 **Date:** 2026-06-10
-**Status:** Design approved, ready for implementation plan
+**Status:** Design approved (Option B), executing
 **Branch:** `briankeane/siri-play-station-intent`
 
 ## Goal
 
-Let a user start playback by voice through Siri, e.g. *"Play Bordertown Radio"* or
-*"Play Radney Foster's Station"*. Match the spoken name against the user's station
-list and start it via the existing `StationPlayer`.
+Let a user start playback by voice through Siri, e.g. *"Play Bordertown Radio on
+Playola"* / *"Play Radney Foster's Station on Playola"*. Match the spoken name
+against the user's station list and start it via the existing `StationPlayer`.
 
-## Approach: adopt Apple's `.audio` App Intents domain
+## Approach: custom App Intents now, `.audio` schema deferred
 
-WWDC 2026 made App Intents the mandatory Siri integration surface (SiriKit
-formally deprecated) and the new conversational Siri routes natural language to
-apps through **assistant schemas** with no fixed phrases to define. Apple ships a
-first-class **`.audio`** schema domain whose entity types map onto Playola almost
-exactly:
+WWDC 2026 made App Intents the mandatory Siri surface (SiriKit deprecated) and
+introduced a first-class `.audio` schema domain (`playAudio` intent;
+`liveRadioStation` / `algorithmicRadioStation` entities) that would let the new
+Siri play stations with bare phrases. **However, a Task 1 SDK spike found that
+`.audio` is not yet in the installed Xcode 26.5 SDK, and its `IntentValueQuery`
+mechanism is iOS 26.0-only — above the app's iOS 18 deployment target.** Apple's
+docs are ahead of the shipping tooling. See `audio-schema-notes.md`.
 
-| Playola concept | `.audio` schema |
-|---|---|
-| Play action | **`playAudio`** intent schema (example phrase: "Play music") |
-| FM / `UrlStation` (e.g. KOKE FM) | **`liveRadioStation`** entity schema |
-| Artist / `PlayolaPlayer.Station` (e.g. Radney Foster) | **`algorithmicRadioStation`** entity schema |
+**Decision: ship a custom (non-schema) App Intent now**, compatible with iOS 18
+and the whole user base. Re-skin to the `.audio` schema as a fast-follow once it
+ships in a release Xcode and iOS 26 adoption grows. The tested core
+(`StationVoiceCatalog`, `PlayStationAction`, `PlaybackBootstrap`) is identical
+between the two approaches, so the later upgrade is cheap.
 
-Conforming to `playAudio` lets the new Siri play a Playola station with the **same
-bare phrases** users say for any audio app ("Play Bordertown Radio" — no "on
-Playola"), on Apple-Intelligence-capable devices. We **also** register classic
-AppShortcuts phrases ("Play [Station] on Playola") so every other
-device/context (non-AI iPhones, the Shortcuts app, CarPlay) keeps working. One
-schema-conformed intent serves both paths.
+### Phrase reality (custom approach)
 
-### Device-capability reality
-
-- Bare-phrase voice requires Apple Intelligence: iPhone 15 Pro / 15 Pro Max (A17
-  Pro) and **all** iPhone 16 and newer. Base iPhone 15 / 15 Plus and older do not
-  qualify and fall back to the "on Playola" AppShortcuts phrases.
-- Install-base capability % is not reliably available from Sentry (model field is
-  not indexed on the error dataset; only a ~7-user perf sample carries it). The
-  authoritative source is App Store Connect → Analytics → Devices. The decision
-  does not depend on the exact %: capable devices get the bonus, everyone else
-  gets the fallback, and the capable share grows over time.
+Every App Shortcut phrase must contain `\(.applicationName)` or it silently never
+triggers. So the reliable spoken phrase is **"Play [Station] on Playola"**. Bare
+"Play [Station]" is not registered; it surfaces as a **suggestion** (Shortcuts
+app, Spotlight, Siri Suggestions) the user can tap or self-assign a custom phrase
+to. (The bare-phrase-without-setup experience needs the deferred `.audio` schema.)
 
 ## Decisions (locked with user)
 
-1. **Adopt the `.audio` schema now (Option A).** Conform the play intent to
-   `playAudio`, model stations as `liveRadioStation` / `algorithmicRadioStation`
-   entities, implement an `IntentValueQuery` for matching, and keep AppShortcuts
-   "Play [Station] on Playola" phrases as the universal fallback.
+1. **Custom App Intent (Option B).** A `PlayStationIntent` (`AppIntent`) with a
+   single `RadioStationEntity` parameter backed by an `EntityQuery`, plus an
+   `AppShortcutsProvider` registering "Play [Station] on Playola". No schema
+   conformance, no `IntentValueQuery`.
 2. **Login required.** If not authenticated, Siri says *"Open Playola to sign in
    first"* and foregrounds the app (`openAppWhenRun = true`). No silent failure.
 3. **Best-effort fuzzy match, no disambiguation in v1.** Match on both station
-   name and curator/artist name. On no confident match, accept the system's native
-   "no match" behavior. Custom "couldn't find that station" spoken reply deferred.
-4. **Suggested-phrase / entity labels.** FM/URL stations → station name. Artist
+   name and curator/artist name. No confident match → native no-match behavior.
+4. **Entity / suggestion labels.** FM/URL stations → station name. Artist
    stations → "[Artist]'s Station".
 
 ## Architecture
 
-App Intents (iOS 18+) in the **main app target** — no separate extension. The
-intent runs in the app process so it can reach the live `StationPlayer` (audio
-session, already-initialized singleton) and `@Shared` auth/station state. Siri may
-cold-launch the app to run the intent; `PlayolaRadioApp.init` runs, dependencies
-initialize, and `@Shared(.auth)` / `@Shared(.stationLists)` load from their
-`FileStorage` caches on access.
+App Intents (iOS 18) in the **main app target** — no extension. The intent runs in
+the app process so it reaches the live `StationPlayer` and `@Shared` auth/station
+state. Siri may cold-launch the app; `PlayolaRadioApp.init` runs, dependencies
+init, and `@Shared(.auth)` / `@Shared(.stationLists)` load from `FileStorage`.
 
 All real logic lives in plain, `@MainActor`, dependency-injected, unit-testable
-types. The schema-conformed `AppIntent` and the `IntentValueQuery` are thin shells
-over them.
+types. The `AppEntity`, `EntityQuery`, and `AppIntent` are thin shells over them.
 
-### Testable core (no App Intents dependency — unit-testable directly)
+### Testable core (no App Intents dependency)
 
-**`StationVoiceCatalog`** (`@MainActor` struct) — single home for matching and
-lookup. Reads `@Shared(.stationLists)`. Methods:
+**`StationVoiceCatalog`** (`@MainActor` struct) — matching and lookup over
+`@Shared(.stationLists)`:
 - `suggestedStations() -> [StationMatch]` — current playable stations.
-- `matches(query:) -> [StationMatch]` — normalized fuzzy match for a spoken/typed
-  query, used by the `IntentValueQuery` and the AppShortcuts entity search.
-- `station(id:) -> AnyStation?` — resolve an id back to a real station.
+- `matches(query:) -> [StationMatch]` — normalized fuzzy match, used by the
+  entity query.
+- `match(id:) -> StationMatch?` — id → match (for `entities(for:)`).
+- `station(id:) -> AnyStation?` — id → real station for playback.
 
-Per-station match aliases:
-- FM/URL: `name`, `stationName`
-- Artist: `curatorName`, `"[curatorName]'s Station"`, `name`
-
-Normalization: lowercase, strip punctuation, drop possessive "'s", collapse
-whitespace, careful handling of trailing "radio"/"station". **Fails closed** — no
-candidate over threshold returns nothing rather than playing the wrong station.
-
-`StationMatch` carries the station id, the chosen display label (FM → station
-name; artist → "[Artist]'s Station"), and which audio-entity kind it maps to
-(`liveRadioStation` vs `algorithmicRadioStation`).
+`StationMatch` carries `id` and a display `label` (FM → station name; artist →
+"[Artist]'s Station"). Match aliases: FM → `name`; artist → `curatorName`,
+`"[curatorName]'s Station"`, `stationName`. Normalize: lowercase, strip
+possessive, strip punctuation, drop "radio"/"station" filler, collapse
+whitespace. **Fails closed.**
 
 **`PlayStationAction`** (`@MainActor` struct) — auth gate + play. Holds
-`@Shared(.auth)`, `@Shared(.stationLists)`, `@Dependency(\.stationPlayer)`.
-`run(stationID:) async -> PlayStationOutcome` where `PlayStationOutcome` is
-`.requiresSignIn`, `.notFound`, or `.playing(stationName:)`:
-1. Not logged in → `.requiresSignIn`.
-2. `StationVoiceCatalog().station(id:)` nil → `.notFound`.
-3. Else run `PlaybackBootstrap`, `await stationPlayer.play(station:)`, `.playing`.
+`@Shared(.auth)`, `@Dependency(\.stationPlayer)`.
+`run(stationID:) async -> PlayStationOutcome` (`.requiresSignIn` / `.notFound` /
+`.playing(stationName:)`): logged out → `.requiresSignIn`; unknown id →
+`.notFound`; else `PlaybackBootstrap` then `await stationPlayer.play(station:)`.
 
-**`PlaybackBootstrap`** (`@MainActor` struct) — makes the currently-implicit audio
-setup explicit before a Siri cold-launch play. Sets
-`AVAudioSession.sharedInstance()` category `.playback` and active, ensures the
-remote command / now-playing wiring is live. Info.plist already declares the
-`audio` background mode, so playback survives backgrounding.
+**`PlaybackBootstrap`** (`@MainActor` struct) — explicit `AVAudioSession`
+`.playback` activation before a Siri cold-launch play. Info.plist already declares
+the `audio` background mode.
 
-### App Intents layer (thin shells; schema shape verified against the SDK)
+### App Intents layer (thin shells)
 
-**Station entities** — conform to the audio entity schemas:
-`@AppEntity(schema: .audio.liveRadioStation)` for FM stations and
-`@AppEntity(schema: .audio.algorithmicRadioStation)` for artist stations. Store
-**ids and display strings only**, never an embedded `AnyStation` (avoids
-serialization / `Sendable` issues). The exact required properties of each schema
-are generated by Xcode (`audio_` template) and pinned in Task 1.
-
-**`PlayStationIntent`** — conforms to `@AppIntent(schema: .audio.playAudio)`.
-`openAppWhenRun = true`. `perform()` is `@MainActor`, resolves the target
-station's id, calls `PlayStationAction().run(stationID:)`, maps the outcome to a
-dialog result. The `playAudio` schema's exact parameter and result contract is
-pinned in Task 1.
-
-**`StationIntentValueQuery`** — the `IntentValueQuery` (Media Intents framework)
-that receives the spoken audio search/playback request and returns matching
-station entities by delegating to `StationVoiceCatalog().matches(query:)`.
-
-**`PlayolaShortcuts`** — `AppShortcutsProvider`. Fallback phrases (all include the
-app name): `"Play \(\.$station) on \(.applicationName)"`,
-`"Start \(\.$station) on \(.applicationName)"`.
-
-### Availability gating
-
-The `.audio` schema may require a higher iOS floor than the app's 18.0/18.1
-deployment target (Apple shipped these domains in waves). Gate the
-schema-conformed types with `@available` as needed (exact floor pinned in Task 1);
-the AppShortcuts fallback covers anything below the floor.
+- **`RadioStationEntity`** — `AppEntity` with `id` + `name`, `defaultQuery =
+  RadioStationEntityQuery()`. One entity covers both station kinds.
+- **`RadioStationEntityQuery`** — `EntityQuery` + `EntityStringQuery`;
+  `entities(for:)`, `suggestedEntities()`, `entities(matching:)` delegate to
+  `StationVoiceCatalog`.
+- **`PlayStationIntent`** — `AppIntent`, `openAppWhenRun = true`, one
+  `@Parameter var station: RadioStationEntity`; `perform()` calls
+  `PlayStationAction` and maps the outcome to a dialog.
+- **`PlayolaShortcuts`** — `AppShortcutsProvider`; phrases
+  `"Play \(\.$station) on \(.applicationName)"`,
+  `"Start \(\.$station) on \(.applicationName)"`.
 
 ## Data flow
 
-1. User: *"Play Bordertown Radio"* (AI device) or *"…on Playola"* (any device).
-2. Siri routes via the `playAudio` schema (AI) or the AppShortcuts phrase (classic)
-   → resolves the station through `StationIntentValueQuery` →
-   `StationVoiceCatalog().matches(query:)`.
+1. User: *"Play Bordertown Radio on Playola"*.
+2. Siri resolves the spoken station via `RadioStationEntityQuery.entities(matching:)`
+   → `StationVoiceCatalog().matches(query:)` → `RadioStationEntity`.
 3. `PlayStationIntent.perform()` → `PlayStationAction.run(stationID:)`.
-4. Auth check → station lookup → `PlaybackBootstrap` → `stationPlayer.play(station:)`.
-5. App foregrounds; now-playing UI shows; Siri confirms *"Playing Bordertown Radio."*
+4. Auth → lookup → `PlaybackBootstrap` → `stationPlayer.play(station:)`.
+5. App foregrounds; now-playing shows; Siri confirms *"Playing Bordertown Radio."*
 
 ## Error handling
 
-- **Logged out** → `.requiresSignIn` → dialog *"Open Playola to sign in first"*;
-  app foregrounds to sign-in.
-- **No matching station** (resolved id not in cache, or empty cache) → `.notFound`
-  → dialog *"I couldn't find that station on Playola."*
+- **Logged out** → `.requiresSignIn` → *"Open Playola to sign in first"*; foreground sign-in.
+- **No matching station** (resolved id not in cache / empty cache) → `.notFound` →
+  *"I couldn't find that station on Playola."*
 - **Unresolvable speech** → system native no-match. Accepted for v1.
-- **Empty station cache on cold launch** → `.notFound` for v1.
 
 ## Testing
 
-Unit tests against the testable core (`withDependencies` overrides, `@Shared`
-declared locally per test):
-- Logged out → `.requiresSignIn`; `stationPlayer.play` not called.
-- Logged in + valid id → `.playing`; `stationPlayer.play` called with the right
-  station.
-- Unknown id → `.notFound`.
-- FM station label == station name; entity kind == `liveRadioStation`.
-- Artist station label == "[Artist]'s Station"; entity kind ==
-  `algorithmicRadioStation`.
-- Fuzzy query matches both `name` and `curatorName` ("radney foster", "radney
-  foster's station", "bordertown radio").
-- Low-confidence query → no match (fail closed).
-- Empty station list → clear failure outcome.
-
-Where practical, also validate the intent end-to-end with the **App Intents
-Testing framework** (WWDC 2026) rather than UI automation.
+Unit tests against the testable core (`withDependencies`, local `@Shared`):
+logged-out → `.requiresSignIn` (no play); valid id → `.playing` + play called;
+unknown id → `.notFound`; FM label == station name; artist label ==
+"[Artist]'s Station"; fuzzy matches name + curator + possessive; low-confidence →
+no match (fail closed); empty list → clear failure.
 
 ## Out of scope (v1)
 
-- Multi-step spoken disambiguation for ambiguous names.
-- Custom spoken "couldn't find that station" for unresolvable speech.
-- In-intent `getStations` network refresh on empty cache.
-- Other `.audio` schemas (`addToLibrary`, `createStation`, `recognizeAudio`,
-  affinity/like) and pause/stop/next/previous voice intents (lock-screen remote
-  command center already covers transport).
-- Raising Sentry device indexing / traces sample rate (separate task).
+- `.audio` schema conformance / bare-phrase-without-setup (deferred fast-follow).
+- Multi-step disambiguation; custom dialog for unresolvable speech; in-intent
+  `getStations` refresh; other audio intents (pause/stop/next handled by the
+  existing lock-screen remote command center).
+- Sentry device indexing / traces sample-rate bump (separate task).
 
-## Risks / verification items
+## Risks
 
-1. **Exact `playAudio` schema contract** (parameters, result type, how it hands us
-   the search request) and the **macro name** (`@AppIntent(schema:)` vs the older
-   `@AssistantIntent(schema:)`) must be pinned against the installed SDK in Task 1
-   via Xcode's `audio_` template generation.
-2. **Two entity kinds vs one** — confirm whether `playAudio` accepts both
-   `liveRadioStation` and `algorithmicRadioStation` from one query/result, or needs
-   separate handling.
-3. **iOS availability floor** of the `.audio` schema vs the 18.0 deployment target;
-   gate with `@available`, fallback covers the rest.
-4. **Cold-launch empty cache** — fails cleanly in v1.
-5. **`@MainActor` isolation** — all catalog/action/bootstrap/query code is
-   `@MainActor`; never read `@Shared` from arbitrary executor contexts.
-6. **Audio session must be explicit** before `stationPlayer.play` on a Siri cold
-   start — that is `PlaybackBootstrap`.
-7. **Fuzzy threshold** — too loose plays the wrong station; default fail-closed.
-8. **`openAppWhenRun = true`** foregrounds on every play; accepted for a radio app.
+1. **Bare phrases need "on Playola"** (set expectations); bare-without-setup awaits
+   the deferred `.audio` upgrade.
+2. **Cold-launch empty cache** → fails cleanly in v1.
+3. **`@MainActor` isolation** — all catalog/action/bootstrap/query code is
+   `@MainActor`.
+4. **Explicit audio session** before play on cold start (`PlaybackBootstrap`).
+5. **Fuzzy threshold** — fail closed.
+6. **`openAppWhenRun = true`** foregrounds every play; accepted for a radio app.
 
-## New project files (must be hand-registered in `project.pbxproj`)
+## New project files (hand-register in `project.pbxproj`)
 
 - `StationVoiceCatalog.swift` (+ tests)
 - `PlayStationAction.swift` (+ tests)
 - `PlaybackBootstrap.swift`
-- `StationAudioEntities.swift` (the `liveRadioStation` / `algorithmicRadioStation`
-  entities)
-- `StationIntentValueQuery.swift`
+- `RadioStationEntity.swift` (entity + query)
 - `PlayStationIntent.swift`
 - `PlayolaShortcuts.swift`
 
-Exact file grouping/placement decided in the implementation plan.
+## Deferred: `.audio` schema upgrade (future)
+
+When `.audio` ships in a release Xcode and iOS 26 adoption is meaningful: conform
+`PlayStationIntent` → `.audio.playAudio`, model stations as `liveRadioStation` /
+`algorithmicRadioStation`, replace the entity query with the Media Intents
+`IntentValueQuery` (delegating to the same `StationVoiceCatalog`), gated by
+`@available`. The tested core is unchanged. See `audio-schema-notes.md`.

--- a/docs/superpowers/specs/audio-schema-notes.md
+++ b/docs/superpowers/specs/audio-schema-notes.md
@@ -1,0 +1,262 @@
+# Audio App Intents Schema — SDK API Notes (Research Spike, Task 1)
+
+**Status: CRITICAL FINDING — the `.audio` schema domain described in the task does NOT exist in the installed SDK.**
+
+This Xcode/SDK predates the WWDC 2026 `.audio` App Intents domain. The schema-based App
+Intents domains that DO ship here are the iOS 18.x "Apple Intelligence" domains (Books,
+Mail, Photos, Browser, etc.). There is **no** `playAudio` intent schema, **no**
+`liveRadioStation` / `algorithmicRadioStation` entity schema, and **no** Music/Audio/Radio
+domain marker protocol anywhere in the `AppIntents` module interface.
+
+## Environment
+
+- `xcode-select -p` → `/Applications/Xcode-26.5.0.app/Contents/Developer`
+- `xcodebuild -version` → **Xcode 26.5, Build 17F42**
+- iPhoneOS SDK: `/Applications/Xcode-26.5.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk` (`CanonicalName: iphoneos26.5`, `Version: 26.5`)
+- iPhoneSimulator SDK: `…/iPhoneSimulator26.5.sdk`
+- Other installed Xcodes: `Xcode-26.3.0`, `Xcode-26.4.1`, `Xcode-26.5.0` (26.5 is the newest — none newer to probe).
+
+### Files read (source of truth)
+
+- **Device interface:**
+  `/Applications/Xcode-26.5.0.app/Contents/Developer/Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS26.5.sdk/System/Library/Frameworks/AppIntents.framework/Modules/AppIntents.swiftmodule/arm64e-apple-ios.swiftinterface`
+  (11,752 lines; built Apr 18 2026 per file mtime)
+- **Simulator interface (cross-checked, identical domain set):**
+  `…/iPhoneSimulator26.5.sdk/System/Library/Frameworks/AppIntents.framework/Modules/AppIntents.swiftmodule/x86_64-apple-ios-simulator.swiftinterface`
+
+There is **no** separate `MediaIntents` or `AssistantIntents` framework in this SDK. The
+only framework dirs matching intent/assistant/media are: `AppIntents.framework`,
+`Intents.framework` (legacy SiriKit), `IntentsUI.framework`, and the private
+`_AppIntents_SwiftUI` / `_AppIntents_UIKit` glue frameworks. All schema machinery lives
+inside `AppIntents`.
+
+---
+
+## 1. Macro name + imports
+
+**SOURCE:** device `.swiftinterface`, lines 83, 669, 1482, 2300, 10292.
+
+The current schema-conformance macros are `@AppIntent(schema:)`, `@AppEntity(schema:)`,
+`@AppEnum(schema:)`. The older `@AssistantIntent(schema:)` / `@AssistantEntity(schema:)`
+spellings still exist but are **deprecated, renamed to the `@App*` forms**.
+
+Verbatim:
+
+```swift
+// line 2300 — current entity macro
+@attached(memberAttribute) @attached(extension, conformances: AppIntents.AppEntity, AppIntents.AssistantSchemaEntity, AppIntents.FileEntity, AppIntents.UniqueAppEntity, AppIntents.URLRepresentableEntity, names: named(__assistantSchemaEntity)) public macro AppEntity<T>(schema: T) = #externalMacro(module: "AppIntentsMacros", type: "AppEntityMacro") where T : AppIntents.AssistantSchemas.Entity
+
+// line 10292 — current intent macro
+@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)
+@attached(memberAttribute) @attached(extension, conformances: AppIntents.AppIntent, AppIntents.AssistantSchemaIntent, AppIntents.ShowInAppSearchResultsIntent, AppIntents.OpenIntent, AppIntents.DeleteIntent, AppIntents.AudioPlaybackIntent, AppIntents.AudioRecordingIntent, AppIntents.LiveActivityIntent, AppIntents.URLRepresentableIntent, names: named(__assistantSchemaIntent)) public macro AppIntent<T>(schema: T) = #externalMacro(module: "AppIntentsMacros", type: "AppIntentMacro") where T : AppIntents.AssistantSchemas.Intent
+
+// line 1482 — enum macro
+@attached(extension, conformances: AppIntents.AppEnum, AppIntents.AssistantSchemaEnum, names: named(__assistantSchemaEnum)) public macro AppEnum<T>(schema: T) = #externalMacro(module: "AppIntentsMacros", type: "AppEnumMacro") where T : AppIntents.AssistantSchemas.Enum
+
+// line 83 — DEPRECATED entity macro (renamed to AppEntity)
+@available(*, deprecated, renamed: "AppEntity")
+@attached(...) public macro AssistantEntity<T>(schema: T) = #externalMacro(module: "AppIntentsMacros", type: "AssistantEntityMacros") where T : AppIntents.AssistantSchemas.Entity
+```
+
+**Import:** a single `import AppIntents`. No `import MediaIntents` / `import
+AssistantIntents` — those modules do not exist in this SDK.
+
+The `schema:` argument is a value like `.books.audiobook` or `.books.playAudiobook`,
+selected from the `AssistantSchemas.<Domain>Intent` / `<Domain>Entity` marker-protocol
+extensions (see §6). The actual required-property enforcement is done by the
+`AppIntentsMacros` compiler plugin (`AppEntityMacro` / `AppIntentMacro`), **not** declared
+in the text interface — so the per-schema required parameters are not literally quotable
+from the `.swiftinterface`; the macro emits diagnostics at build time if a conforming type
+is missing a required property.
+
+---
+
+## 2. `playAudio` intent schema
+
+**NOT PRESENT IN SDK.** There is no `playAudio` intent and no Audio/Music intent domain.
+
+Searches over the full device interface returned zero hits for `playAudio` (non-audiobook),
+`liveRadio`, `algorithmicRadio`, `RadioStation`, `MusicIntent`, and zero hits total for the
+regex `Music|Radio|Station`.
+
+The closest existing analog (for downstream reference only) is in the **Books** domain:
+
+```swift
+// line 7008 — Books domain "play audiobook" intent schema (string name "PlayAudiobookIntent")
+@_alwaysEmitIntoClient public var playAudiobook: some AppIntents.AssistantSchemas.Intent {
+    get {
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            return AssistantSchema.IntentSchema("PlayAudiobookIntent")
+        } else { fatalError("Do not reference schema types directly") }
+    }
+}
+```
+
+Its required parameter shape (an entity parameter, `perform()` return type, etc.) is NOT
+expressed in the interface — it is enforced by the macro plugin. So we cannot quote
+`playAudio`'s required `mediaItems` / `MediaSearch` parameters from this SDK because the
+schema itself is absent.
+
+Also present but unrelated (these are the legacy *system* media-control protocols, not the
+schema): `AudioPlaybackIntent` (line 1204) and `AudioRecordingIntent` (line 971), both
+`: AppIntents.SystemIntent`. These power play/pause/system audio control, not a
+"play this radio station by name" search intent.
+
+---
+
+## 3. `liveRadioStation` / `algorithmicRadioStation` entity schemas
+
+**NOT PRESENT IN SDK.** No `liveRadioStation`, `algorithmicRadioStation`, or any radio/music
+entity schema exists. Zero hits.
+
+For shape reference, the analogous **Books** entity schemas look like this (string names
+only; required props are macro-enforced, not in the interface):
+
+```swift
+// line 7116 — "audiobook" entity schema (string name "AudiobookEntity")
+@_alwaysEmitIntoClient public var audiobook: some AppIntents.AssistantSchemas.Entity {
+    get {
+        if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *) {
+            return AssistantSchema.EntitySchema("AudiobookEntity")
+        } else { fatalError("Do not reference schema types directly") }
+    }
+}
+```
+
+The conforming entity must satisfy `AssistantSchemaEntity : AssistantEntity : AppEntity`
+(see §7), but the specific required fields (id / title / etc.) for a radio-station schema
+cannot be quoted because the schema does not exist here.
+
+---
+
+## 4. The query type
+
+**SOURCE:** device `.swiftinterface`, lines 624–631.
+
+`IntentValueQuery` **does exist** in this SDK and is the protocol an app implements to
+resolve a value parameter. Verbatim:
+
+```swift
+@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)
+@_alwaysEmitConformanceMetadata public protocol IntentValueQuery : AppIntents.PersistentlyIdentifiable, AppIntents._SupportsAppDependencies, Swift.Sendable {
+  associatedtype Input : AppIntents._IntentValue
+  associatedtype ResultValue = Self.Result.Result.ValueType where Self.ResultValue == Self.Result.Result
+  associatedtype Result : AppIntents.ResultsCollection = [Self.ResultValue]
+  init()
+  func values(for input: Self.Input) async throws -> Self.Result
+}
+```
+
+Key points:
+- The app implements `func values(for input: Input) async throws -> Result`.
+- `Input` is some `_IntentValue` (the search term / criteria); `Result` is a
+  `ResultsCollection`, defaulting to `[ResultValue]`.
+- **`@available` floor is iOS 26.0** (see §5) — newer than `EntityQuery` (iOS 16). This is
+  the query type the WWDC-2026 media docs reference, and it is present even though the audio
+  schema that would use it is not.
+
+Other query protocols present: `EntityQuery` (iOS 16, line 409), `EntityStringQuery`,
+`EntityPropertyQuery`, `EnumerableEntityQuery`, `UniqueAppEntityQuery`.
+
+---
+
+## 5. `@available` floor
+
+**SOURCE:** device `.swiftinterface`, per-symbol annotations.
+
+| Symbol | `@available` (verbatim) | Line |
+|---|---|---|
+| `.audio` domain / `playAudio` / `liveRadioStation` / `algorithmicRadioStation` | **N/A — not in SDK** | — |
+| `AssistantSchemas` enum + `Model`/`Intent`/`Entity`/`Enum` markers + `IntentSchema`/`EntitySchema` structs | `@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)` | 41–63 |
+| Each existing domain marker (`BooksIntent`, `MailIntent`, …) declaration | `@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)` | e.g. 6976, 6977 |
+| The concrete schema *values* inside each domain (e.g. `playAudiobook`, `audiobook`) gate at runtime with | `if #available(iOS 18.0, macOS 15.0, tvOS 18.0, watchOS 11.0, visionOS 2.0, *)` | e.g. 7010, 7118 |
+| `@AppIntent(schema:)` / `@AppEntity(schema:)` macros | `@available(iOS 16.0, macOS 13.0, tvOS 16.0, watchOS 9.0, visionOS 1.0, *)` | 10291, (entity macro un-annotated/inherits) |
+| `AssistantEntity` / `AssistantSchemaEntity` protocols | `@available(macOS 15.0, iOS 18.0, watchOS 11.0, tvOS 18.0, visionOS 2.0, *)` | 1961, 66 |
+| **`IntentValueQuery`** | **`@available(macOS 26.0, iOS 26.0, watchOS 26.0, tvOS 26.0, visionOS 26.0, *)`** | 624 |
+
+Net: the *existing* schema machinery is effectively an **iOS 18.0** floor at runtime
+(markers say 16.0 but every concrete schema value `#available`-gates to 18.0). The
+`IntentValueQuery` resolution protocol is **iOS 26.0**. The app's deployment target is iOS
+18.0/18.1, so `IntentValueQuery` would require `@available(iOS 26, *)` gating regardless.
+
+**The real `.audio` schema floor cannot be measured here because the schema is absent.** Per
+Apple's public docs the `.audio` domain shipped in the iOS 26.x line; this SDK is
+iphoneos26.5 yet still lacks it, so the domain is almost certainly **newer than 26.5**
+(i.e. a later 26.x point release / a 26.6+ or WWDC-2026 seed not installed on this machine).
+
+---
+
+## 6. One entity type vs two (heterogeneous results)
+
+**Cannot be answered from this SDK** because neither `playAudio` nor the two radio entity
+schemas exist. Documenting the structural evidence so the downstream decision is informed:
+
+- Domains expose multiple entity schemas under one marker protocol. Example — the Books
+  domain marker `BooksEntity` exposes `book`, `audiobook`, and `settings` entity schemas
+  (lines 7100–7140). So a single *domain* covering both `liveRadioStation` and
+  `algorithmicRadioStation` is plausible by analogy.
+- **However**, schema conformance binds **one concrete Swift type → one schema**
+  (`@AppEntity(schema: .books.audiobook)`). The `playAudio` intent's audio parameter is
+  resolved by an `IntentValueQuery` whose `Result` is a `ResultsCollection` (default
+  `[ResultValue]`) of a *single* `ResultValue` type. Whether that `ResultValue` can be a
+  protocol/`AnyEntity`-style heterogeneous box (returning both station kinds) vs. one
+  concrete entity is **exactly the detail that lives in the `.audio` schema definition we
+  can't see**. **This must be re-verified against an Xcode that actually contains the
+  `.audio` domain before committing to a one-intent-two-entities design.** (docs-level
+  expectation: a single `playAudio` intent with a `MediaSearch`-style query returning mixed
+  media items, but UNVERIFIED in SDK.)
+
+---
+
+## 7. Anything surprising that would bite an implementer
+
+1. **The `.audio` domain is simply not in Xcode 26.5.** This is the headline. Any code
+   written today against `@AppIntent(schema: .audio.playAudio)` /
+   `@AppEntity(schema: .audio.liveRadioStation)` will **fail to compile** on this machine —
+   the schema accessors don't exist. Implementation is BLOCKED on a newer Xcode, OR the plan
+   must fall back to a **custom (non-schema) App Intent** (a plain `AppIntent` +
+   `AppEntity` + `EntityQuery`/`AppShortcuts`), which works on iOS 18 today and is fully
+   under our control. The fallback is the pragmatic path given the iOS 18.0/18.1 deployment
+   target.
+
+2. **`@AssistantIntent`/`@AssistantEntity` are deprecated → use `@AppIntent`/`@AppEntity`
+   with `schema:`.** Old WWDC-2024 sample code uses the `@Assistant*` spelling; don't copy it.
+
+3. **Required schema properties are invisible in the `.swiftinterface`.** They're enforced by
+   the `AppIntentsMacros` plugin at compile time, surfaced only as build diagnostics. The
+   only way to learn a schema's exact required parameters is to (a) build against an SDK that
+   has it and read the macro error messages, or (b) Apple's online docs. You cannot reverse
+   these from the interface text.
+
+4. **`IntentValueQuery` is iOS 26.0-only.** Even on a future SDK with the `.audio` schema,
+   the resolution query is gated to iOS 26. With our iOS 18.0/18.1 floor, the schema path
+   (intent + query) is unavailable to the bulk of our users at runtime. A custom AppShortcut
+   with a parameterized phrase ("Play {station} on Playola") backed by an `EntityQuery`
+   (iOS 16+) is the portable choice.
+
+5. **`AssistantSchemaEntity` brings `isAssistantOnly` and a default
+   `typeDisplayRepresentation`** (lines 66–82). Schema-conforming entities also pull in
+   `FileEntity`, `UniqueAppEntity`, `URLRepresentableEntity` conformances via the `@AppEntity`
+   macro's `@attached(extension, conformances: …)` list — more surface than a hand-rolled
+   `AppEntity`.
+
+6. **`Sendable` is required** on `IntentValueQuery` and on App Intents generally; entities
+   need `DisplayRepresentation` / `typeDisplayRepresentation` and an `EntityQuery`-typed
+   `defaultQuery`. Standard App Intents requirements, but worth stating for the fallback.
+
+---
+
+## Bottom line for the plan
+
+- **BLOCKED on the SDK premise:** the `.audio` App Intents schema domain (`playAudio`,
+  `liveRadioStation`, `algorithmicRadioStation`) is **not present** in Xcode 26.5 /
+  iphoneos26.5, the newest Xcode on this machine.
+- **Recommended fallback (no newer Xcode needed):** ship a **custom App Intent**, not a
+  schema-conformant one — `AppIntent` + `AppEntity(RadioStation)` + `EntityQuery` +
+  `AppShortcutsProvider` with a parameterized "Play {station} on Playola" phrase. This is
+  iOS 16/18-compatible, matches our deployment target, and keeps one `RadioStation` entity
+  type that can represent both live and algorithmic stations (our own type, our rules — no
+  schema forcing one-vs-two).
+- If we specifically need the system `.audio` "play this on Playola from anywhere" Siri
+  surface, that requires installing the Xcode that actually contains the `.audio` domain and
+  re-running this spike against it.


### PR DESCRIPTION
## What

Adds Siri voice control to start a station: **"Play Bordertown Radio on Playola"** / **"Play Radney Foster's Station on Playola"**. Siri matches the spoken name against the user's station list and starts it via the existing `StationPlayer`.

## Approach (Option B — custom App Intent)

WWDC 2026 introduced a first-class `.audio` App Intents schema that would let the new Siri play stations with *bare* phrases (no "on Playola"). A front-loaded SDK spike (`docs/superpowers/specs/audio-schema-notes.md`) found that domain is **not yet in the installed Xcode 26.5 SDK**, and its `IntentValueQuery` mechanism is **iOS-26-only** — above our iOS 18 deployment target. Apple's docs are ahead of the shipping tooling.

So this ships a **custom (non-schema) App Intent** that builds today and runs on the whole iOS 18 user base. The `.audio` schema upgrade is documented as a clean fast-follow; the tested core is unchanged by it.

## Architecture

A `@MainActor`, dependency-injected, unit-tested core does all the work; thin App Intents shells expose it:

- `StationVoiceCatalog` — normalized fuzzy matching on station name + artist name + "[Artist]'s Station"; **fails closed**; diacritic-folded; excludes hidden lists.
- `PlayStationAction` — auth gate → lookup → play (`.requiresSignIn` / `.notFound` / `.playing`).
- `PlaybackBootstrap` — explicit `AVAudioSession` activation for a Siri cold-launch.
- `RadioStationEntity` + `EntityQuery`, `PlayStationIntent` (`openAppWhenRun`), `PlayolaShortcuts` ("Play [Station] on Playola").

Login-gated: signed-out users get *"Open Playola to sign in first"* and the app foregrounds to sign-in.

## Tests

15 passing (Swift Testing): normalization, FM vs artist labels, fuzzy match by name/curator/possessive, fail-closed on short fragments, hidden-list exclusion, diacritic folding, and the auth-gate/lookup/play outcomes.

## Review

Codex `review` + `challenge` ran over the full diff. Fixes applied from review:
- **Privacy:** hidden "in-development" station lists were leaking into Siri suggestions — now excluded.
- **Correctness:** a misheard fragment ("k", "fm") could confidently play the wrong station — matcher now fails closed (min length + whole-word containment).

## Known limitations (accepted for v1)

- **Cold-launch stale cache:** matching reads the cached station list; a brand-new station added since the user last opened the app returns "not found" until they reopen. Bounded by the auth gate. In-intent refresh deferred.
- **No spoken disambiguation:** ambiguous queries pick the best single match.
- **Bare phrases** ("Play X" without "on Playola") work only via user-pinned Shortcuts suggestions until the deferred `.audio` schema lands.

## Out of scope / follow-ups

- Pre-existing bug found while testing: `Auth(jwtToken:)` crashes on a malformed token (`LoggedInUser.swift:142`, unchecked `segments[1]`). Not touched here.
- `.audio` schema upgrade (bare-phrase Siri) once it ships in a release Xcode + iOS 26 adoption grows.

## Device verification (manual, pending)

Needs a signed-in device: bare/"on Playola" phrases play; Shortcuts + Spotlight suggestions appear; signed-out prompts sign-in; cold-launch starts audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
