### PR TITLE
Fix staging code signing + auto-trigger CircleCI release build on tag

### DIFF
--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -71,37 +71,45 @@ jobs:
             echo "::error::CCI_TOKEN secret is not set — cannot trigger the release build."
             exit 1
           fi
-          # Idempotency: only trigger if CircleCI has no pipeline for this tag yet.
-          # Combined with the HEAD check above, a re-run RECOVERS a failed trigger
-          # but never duplicates a successful one. FAIL CLOSED — if the pipeline
-          # state can't be determined, do NOT POST (re-running retries the check),
-          # so a flaky API never causes a duplicate release build/upload.
-          # Note: the pipeline list is most-recent-first; a tag's pipeline is
-          # created within the same release cycle, so it is always on the first
-          # page relative to a re-run of this workflow.
-          LIST=$(mktemp)
-          GET_HTTP=$(curl -sS -o "$LIST" -w '%{http_code}' \
-            -H "Circle-Token: $CIRCLECI_TOKEN" \
-            "https://circleci.com/api/v2/project/gh/playola-radio/playola-radio-ios/pipeline")
-          if [ "$GET_HTTP" != "200" ]; then
-            echo "::error::Could not query existing CircleCI pipelines (HTTP $GET_HTTP); refusing to trigger to avoid a duplicate. Re-run this job to retry."
-            cat "$LIST"; exit 1
-          fi
-          EXISTING=$(jq -r --arg t "$TAG" 'if (.items | type) == "array" then ([.items[] | select(((.vcs // {}).tag // "") == $t)] | length) else "INVALID" end' "$LIST")
-          if ! printf '%s' "$EXISTING" | grep -qE '^[0-9]+$'; then
-            echo "::error::Unexpected response while checking existing pipelines; refusing to trigger. Re-run this job to retry."
-            cat "$LIST"; exit 1
-          fi
-          if [ "$EXISTING" != "0" ]; then
-            echo "CircleCI already has a pipeline for tag $TAG ($EXISTING found); skipping (idempotent)."
+          # Idempotency: page through the CircleCI pipeline list (most-recent-first)
+          # looking for an existing pipeline for this tag. Combined with the HEAD
+          # check above, a re-run RECOVERS a failed trigger but never duplicates a
+          # successful one. FAIL CLOSED — if the pipeline state can't be
+          # determined, do NOT POST (re-running retries the check), so a flaky API
+          # never causes a duplicate release build/upload. Paginating (not just the
+          # first page) keeps this correct even if other pipelines ran in between.
+          PAGE_TOKEN=""
+          FOUND=0
+          for _ in $(seq 1 10); do
+            URL="https://circleci.com/api/v2/project/gh/playola-radio/playola-radio-ios/pipeline"
+            [ -n "$PAGE_TOKEN" ] && URL="${URL}?page-token=${PAGE_TOKEN}"
+            LIST=$(mktemp)
+            GET_HTTP=$(curl -sS -o "$LIST" -w '%{http_code}' \
+              -H "Circle-Token: $CIRCLECI_TOKEN" "$URL")
+            if [ "$GET_HTTP" != "200" ]; then
+              echo "::error::Could not query existing CircleCI pipelines (HTTP $GET_HTTP); refusing to trigger to avoid a duplicate. Re-run this job to retry."
+              cat "$LIST"; exit 1
+            fi
+            if ! jq -e '(.items | type) == "array"' "$LIST" >/dev/null 2>&1; then
+              echo "::error::Unexpected response while checking existing pipelines; refusing to trigger. Re-run this job to retry."
+              cat "$LIST"; exit 1
+            fi
+            MATCH=$(jq -r --arg t "$TAG" '[.items[] | select(((.vcs // {}).tag // "") == $t)] | length' "$LIST")
+            if [ "$MATCH" != "0" ]; then FOUND=1; break; fi
+            PAGE_TOKEN=$(jq -r '.next_page_token // ""' "$LIST")
+            [ -z "$PAGE_TOKEN" ] && break
+          done
+          if [ "$FOUND" != "0" ]; then
+            echo "CircleCI already has a pipeline for tag $TAG; skipping (idempotent)."
             exit 0
           fi
           echo "Triggering CircleCI release pipeline for tag $TAG"
+          PAYLOAD=$(jq -nc --arg t "$TAG" '{tag: $t}')
           HTTP=$(curl -sS -o /tmp/cci-response.json -w '%{http_code}' \
             -X POST "https://circleci.com/api/v2/project/gh/playola-radio/playola-radio-ios/pipeline" \
             -H "Circle-Token: $CIRCLECI_TOKEN" \
             -H "Content-Type: application/json" \
-            -d "{\"tag\":\"$TAG\"}")
+            -d "$PAYLOAD")
           echo "CircleCI responded HTTP $HTTP:"
           cat /tmp/cci-response.json
           echo

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -49,6 +49,67 @@ jobs:
           git tag -a "${{ steps.version.outputs.tag }}" -m "Release ${{ steps.version.outputs.version }} build ${{ steps.version.outputs.build }}"
           git push origin "${{ steps.version.outputs.tag }}"
 
+      - name: Trigger CircleCI release build
+        env:
+          CIRCLECI_TOKEN: ${{ secrets.CCI_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # Trigger whenever the release tag points at the current commit, so a
+          # re-run of this workflow recovers the case where a previous run pushed
+          # the tag but the trigger failed (bad CCI_TOKEN, transient network/API
+          # error). Skip if the tag is absent or points at an older release
+          # commit, so ordinary pushes to main don't rebuild a past release.
+          if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG does not exist yet; nothing to trigger."
+            exit 0
+          fi
+          if [ "$(git rev-list -n1 "$TAG")" != "$(git rev-parse HEAD)" ]; then
+            echo "Tag $TAG does not point at HEAD; skipping (not a new release for this commit)."
+            exit 0
+          fi
+          if [ -z "$CIRCLECI_TOKEN" ]; then
+            echo "::error::CCI_TOKEN secret is not set — cannot trigger the release build."
+            exit 1
+          fi
+          # Idempotency: only trigger if CircleCI has no pipeline for this tag yet.
+          # Combined with the HEAD check above, a re-run RECOVERS a failed trigger
+          # but never duplicates a successful one. FAIL CLOSED — if the pipeline
+          # state can't be determined, do NOT POST (re-running retries the check),
+          # so a flaky API never causes a duplicate release build/upload.
+          # Note: the pipeline list is most-recent-first; a tag's pipeline is
+          # created within the same release cycle, so it is always on the first
+          # page relative to a re-run of this workflow.
+          LIST=$(mktemp)
+          GET_HTTP=$(curl -sS -o "$LIST" -w '%{http_code}' \
+            -H "Circle-Token: $CIRCLECI_TOKEN" \
+            "https://circleci.com/api/v2/project/gh/playola-radio/playola-radio-ios/pipeline")
+          if [ "$GET_HTTP" != "200" ]; then
+            echo "::error::Could not query existing CircleCI pipelines (HTTP $GET_HTTP); refusing to trigger to avoid a duplicate. Re-run this job to retry."
+            cat "$LIST"; exit 1
+          fi
+          EXISTING=$(jq -r --arg t "$TAG" 'if (.items | type) == "array" then ([.items[] | select(((.vcs // {}).tag // "") == $t)] | length) else "INVALID" end' "$LIST")
+          if ! printf '%s' "$EXISTING" | grep -qE '^[0-9]+$'; then
+            echo "::error::Unexpected response while checking existing pipelines; refusing to trigger. Re-run this job to retry."
+            cat "$LIST"; exit 1
+          fi
+          if [ "$EXISTING" != "0" ]; then
+            echo "CircleCI already has a pipeline for tag $TAG ($EXISTING found); skipping (idempotent)."
+            exit 0
+          fi
+          echo "Triggering CircleCI release pipeline for tag $TAG"
+          HTTP=$(curl -sS -o /tmp/cci-response.json -w '%{http_code}' \
+            -X POST "https://circleci.com/api/v2/project/gh/playola-radio/playola-radio-ios/pipeline" \
+            -H "Circle-Token: $CIRCLECI_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "{\"tag\":\"$TAG\"}")
+          echo "CircleCI responded HTTP $HTTP:"
+          cat /tmp/cci-response.json
+          echo
+          if [ "$HTTP" != "200" ] && [ "$HTTP" != "201" ]; then
+            echo "::error::CircleCI pipeline trigger failed (HTTP $HTTP)"
+            exit 1
+          fi
+
       - name: Summary
         run: |
           echo "## Release Tag" >> $GITHUB_STEP_SUMMARY

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2265,8 +2265,8 @@
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				ASSETCATALOG_COMPILER_INCLUDE_ALL_APPICON_ASSETS = NO;
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
-				CODE_SIGN_IDENTITY = "Apple Development";
-				CODE_SIGN_STYLE = Automatic;
+				CODE_SIGN_IDENTITY = "Apple Distribution";
+				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 90;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2291,7 +2291,7 @@
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
-				PROVISIONING_PROFILE_SPECIFIER = "";
+				PROVISIONING_PROFILE_SPECIFIER = "match AppStore fm.playola.playolaradio.staging";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
 				SWIFT_EMIT_LOC_STRINGS = YES;


### PR DESCRIPTION
## Summary

Fixes the iOS code-signing situation "once and for all" and makes new release tags actually build + upload to TestFlight automatically.

### 1. Staging code signing (cert consolidation)
Staging archives were failing because the staging **Release** config used `Automatic` signing, so Xcode auto-provisioned (push, Sign In with Apple) under the team and failed. Root cause was two identically-named `Apple Distribution` certs — one match-managed (production) and one hand-made (only a non-match staging profile trusted it) — which Xcode couldn't disambiguate.

- Staging Release now mirrors production: **Manual + `Apple Distribution` + `match AppStore fm.playola.playolaradio.staging`** (this commit).
- Staging is now **match-managed on the single shared distribution cert** for the first time (so CI's `release_staging` lane will work too). The redundant hand-made distribution cert has been **revoked** and removed locally. (Portal/keychain/match-repo changes done out-of-band; this diff is just the build setting.)
- Verified: `PlayolaRadio-Staging` archives cleanly and signs as `Apple Distribution`.

### 2. Auto build + upload on each release tag
The CircleCI `release` workflow (tag `/^v.*/` → `release_production` → TestFlight) has existed since April but **never ran once** — release tags are pushed by `github-actions[bot]` via the default `GITHUB_TOKEN`, and GitHub does not let `GITHUB_TOKEN`-pushed refs trigger downstream CI. That's why uploads have been manual.

`auto-tag-release.yml` now explicitly triggers the CircleCI pipeline via the v2 API after the tag is pushed, using the existing `CCI_TOKEN` secret. The trigger is:
- **retry-safe** — runs whenever the tag points at `HEAD`, so re-running the workflow recovers a failed trigger;
- **idempotent** — queries CircleCI for an existing pipeline for the tag and skips if found, so a re-run never starts a duplicate build;
- **fail-closed** — if pipeline state can't be determined (non-200, malformed response), it refuses to trigger rather than risk a duplicate upload.

The `ios-release` CircleCI context already has all required secrets. This proves out on the next real release.

## Not included
- **Push notifications**: untouched — entitlements unchanged; APNs uses a separate key, independent of code-signing certs.
- **Sentry dSYM "Upload Symbols Failed" warning**: root-caused (Sentry is a precompiled *dynamic* XCFramework whose dSYM isn't copied into the archive). Fix is being handled in a separate branch.

## Review
Adversarial review by Codex (review + 3 challenge rounds): final verdict **SOUND**. The trigger logic was hardened from happy-path to idempotent/retry-safe/fail-closed; edge cases verified with a local self-test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
