### PR TITLE
Move hardcoded view strings to models and adopt playolaAlert

### DIFF
--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageModel.swift
@@ -65,6 +65,32 @@ class AskQuestionPageModel: ViewModel {
     station.curatorName
   }
 
+  var navigationTitle: String {
+    "Ask \(curatorName)"
+  }
+
+  var instructionsText: String {
+    "Start with your name and where you’re listening from, then ask "
+      + "\(curatorName) a question. If they choose yours, your "
+      + "question and their response will air on the station."
+  }
+
+  let cancelButtonTitle = "Cancel"
+  let waveformPlaceholderText = "Your recording will appear here"
+  let recordingIndicatorText = "Recording"
+  let recordButtonLabelIdle = "Tap to Record"
+  let recordButtonLabelRecording = "Tap to Stop"
+  let recordButtonLabelReview = "Try Again"
+  let sendButtonTitle = "Send Question"
+
+  var recordButtonLabel: String {
+    switch recordingPhase {
+    case .idle: return recordButtonLabelIdle
+    case .recording: return recordButtonLabelRecording
+    case .review: return recordButtonLabelReview
+    }
+  }
+
   var displayTime: String {
     formatTime(recordingDuration)
   }

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageView.swift
@@ -37,7 +37,7 @@ struct AskQuestionPageView: View {
       }
       .padding()
     }
-    .navigationTitle("Ask \(model.curatorName)")
+    .navigationTitle(model.navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .navigationBarBackButtonHidden(true)
     .toolbarBackground(.visible, for: .navigationBar)
@@ -46,14 +46,14 @@ struct AskQuestionPageView: View {
     .toolbar {
       if !model.isUploading {
         ToolbarItem(placement: .navigationBarLeading) {
-          Button("Cancel") {
+          Button(model.cancelButtonTitle) {
             Task { await model.cancelTapped() }
           }
           .foregroundColor(.white)
         }
       }
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
     .task {
       await model.viewAppeared()
     }
@@ -63,18 +63,14 @@ struct AskQuestionPageView: View {
 
   @ViewBuilder
   private var instructionsHeader: some View {
-    Text(
-      "Start with your name and where you’re listening from, then ask "
-        + "\(model.curatorName) a question. If they choose yours, your "
-        + "question and their response will air on the station."
-    )
-    .font(.custom(FontNames.Inter_500_Medium, size: 16))
-    .foregroundColor(.white)
-    .multilineTextAlignment(.center)
-    .padding(.vertical, 16)
-    .padding(.horizontal, 12)
-    .background(Color(hex: "#1A1A1A"))
-    .cornerRadius(12)
+    Text(model.instructionsText)
+      .font(.custom(FontNames.Inter_500_Medium, size: 16))
+      .foregroundColor(.white)
+      .multilineTextAlignment(.center)
+      .padding(.vertical, 16)
+      .padding(.horizontal, 12)
+      .background(Color(hex: "#1A1A1A"))
+      .cornerRadius(12)
   }
 
   // MARK: - Waveform Section
@@ -86,7 +82,7 @@ struct AskQuestionPageView: View {
       RoundedRectangle(cornerRadius: 8)
         .fill(Color(hex: "#1A1A1A"))
         .overlay(
-          Text("Your recording will appear here")
+          Text(model.waveformPlaceholderText)
             .font(.custom(FontNames.Inter_400_Regular, size: 14))
             .foregroundColor(Color(hex: "#4A4A4A"))
         )
@@ -110,7 +106,7 @@ struct AskQuestionPageView: View {
           Circle()
             .fill(Color.playolaRed)
             .frame(width: 10, height: 10)
-          Text("Recording")
+          Text(model.recordingIndicatorText)
             .font(.custom(FontNames.Inter_600_SemiBold, size: 14))
             .foregroundColor(.playolaRed)
         }
@@ -178,22 +174,10 @@ struct AskQuestionPageView: View {
 
   // MARK: - Button Label
 
-  @ViewBuilder
   private var buttonLabel: some View {
-    switch model.recordingPhase {
-    case .idle:
-      Text("Tap to Record")
-        .font(.custom(FontNames.Inter_400_Regular, size: 16))
-        .foregroundColor(.playolaGray)
-    case .recording:
-      Text("Tap to Stop")
-        .font(.custom(FontNames.Inter_400_Regular, size: 16))
-        .foregroundColor(.playolaGray)
-    case .review:
-      Text("Try Again")
-        .font(.custom(FontNames.Inter_400_Regular, size: 16))
-        .foregroundColor(.playolaGray)
-    }
+    Text(model.recordButtonLabel)
+      .font(.custom(FontNames.Inter_400_Regular, size: 16))
+      .foregroundColor(.playolaGray)
   }
 
   // MARK: - Review Controls
@@ -218,7 +202,7 @@ struct AskQuestionPageView: View {
       } label: {
         HStack(spacing: 6) {
           Image(systemName: "paperplane.fill")
-          Text("Send Question")
+          Text(model.sendButtonTitle)
         }
         .font(.custom(FontNames.Inter_600_SemiBold, size: 15))
         .foregroundColor(.white)

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageView.swift
@@ -53,7 +53,7 @@ struct AskQuestionPageView: View {
         }
       }
     }
-    .playolaAlert($model.presentedAlert)
+    .alert(item: $model.presentedAlert) { $0.alert }
     .task {
       await model.viewAppeared()
     }

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageModel.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageModel.swift
@@ -101,10 +101,14 @@ class BroadcastPageModel: ViewModel {
     """
   }
 
-  func airtimeLabel(for spin: Spin) -> String {
+  private static let airtimeFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "h:mm:ssa"
-    let timeString = formatter.string(from: spin.airtime).lowercased()
+    return formatter
+  }()
+
+  func airtimeLabel(for spin: Spin) -> String {
+    let timeString = Self.airtimeFormatter.string(from: spin.airtime).lowercased()
     return "at \(timeString)"
   }
 

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageModel.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageModel.swift
@@ -82,6 +82,32 @@ class BroadcastPageModel: ViewModel {
     providedStationName ?? fetchedStationName ?? "My Station"
   }
 
+  var voiceTrackButtonLabel: String { "VoiceTrack" }
+  var addSongButtonLabel: String { "Add Song" }
+  var notifyButtonLabel: String { "Notify" }
+  var stagingSectionTitle: String { "READY TO PLACE" }
+  var liveNowLabel: String { "LIVE NOW" }
+  var notifyListenersTitle: String { "Notify Listeners" }
+  var notifyListenersPrompt: String { "Tell your listeners you're about to go live." }
+  var sendNotificationButtonTitle: String { "Send Notification" }
+  var cancelButtonTitle: String { "Cancel" }
+
+  var notifyMessagePlaceholder: String {
+    """
+    Tell your listeners what you're up to...
+
+    "I'm going live from the van!"
+    "Playing my favorite road songs today"
+    """
+  }
+
+  func airtimeLabel(for spin: Spin) -> String {
+    let formatter = DateFormatter()
+    formatter.dateFormat = "h:mm:ssa"
+    let timeString = formatter.string(from: spin.airtime).lowercased()
+    return "at \(timeString)"
+  }
+
   private var userName: String {
     auth.currentUser?.fullName ?? "Unknown"
   }

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
@@ -26,19 +26,19 @@ struct BroadcastPageView: View {
 
           BroadcastActionButton(
             icon: .asset("BroadcastMicIcon", width: 32, height: 40),
-            label: "VoiceTrack",
+            label: model.voiceTrackButtonLabel,
             action: model.onAddVoiceTrackTapped
           )
 
           BroadcastActionButton(
             icon: .asset("BroadcastAddSongIcon", width: 40, height: 40),
-            label: "Add Song",
+            label: model.addSongButtonLabel,
             action: { Task { await model.onAddSongTapped() } }
           )
 
           BroadcastActionButton(
             icon: .system("bell.fill"),
-            label: "Notify",
+            label: model.notifyButtonLabel,
             isEnabled: model.canSendNotification,
             sublabel: model.notificationRestTimeRemainingString,
             action: model.onNotifyListenersTapped
@@ -68,7 +68,7 @@ struct BroadcastPageView: View {
             // Now Playing (fixed, doesn't scroll)
             if let nowPlaying = model.nowPlaying {
               VStack(spacing: 0) {
-                NowPlayingContentView(spin: nowPlaying)
+                NowPlayingContentView(spin: nowPlaying, liveNowLabel: model.liveNowLabel)
                   .id(nowPlaying.id)
                   .transition(.opacity)
 
@@ -94,6 +94,7 @@ struct BroadcastPageView: View {
 
                   ScheduleRowView(
                     spin: spin,
+                    airtimeLabel: model.airtimeLabel(for: spin),
                     isBeingRescheduled: model.spinIdsBeingRescheduled.contains(spin.id),
                     isDeletable: isDeletable
                   )
@@ -145,7 +146,7 @@ struct BroadcastPageView: View {
     .task {
       await model.viewAppeared()
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
     .sheet(isPresented: $model.showNotifyListenersSheet) {
       NotifyListenersSheet(model: model)
     }
@@ -155,7 +156,7 @@ struct BroadcastPageView: View {
 
   private var stagingSection: some View {
     VStack(alignment: .leading, spacing: 0) {
-      Text("READY TO PLACE")
+      Text(model.stagingSectionTitle)
         .font(.custom(FontNames.Inter_600_SemiBold, size: 12))
         .foregroundColor(.playolaGray)
         .padding(.horizontal, 16)
@@ -248,6 +249,7 @@ struct StagingRowView: View {
 
 struct NowPlayingContentView: View {
   let spin: Spin
+  let liveNowLabel: String
 
   var body: some View {
     HStack(spacing: 12) {
@@ -271,7 +273,7 @@ struct NowPlayingContentView: View {
       Spacer()
 
       // Live Now badge
-      Text("LIVE NOW")
+      Text(liveNowLabel)
         .font(.custom(FontNames.Inter_600_SemiBold, size: 10))
         .foregroundColor(.playolaRed)
         .padding(.horizontal, 8)
@@ -291,22 +293,23 @@ struct NowPlayingContentView: View {
 
 struct ScheduleRowView: View {
   let spin: Spin
+  let airtimeLabel: String
   let isBeingRescheduled: Bool
   let isDeletable: Bool
 
-  init(spin: Spin, isBeingRescheduled: Bool = false, isDeletable: Bool = true) {
+  init(
+    spin: Spin,
+    airtimeLabel: String,
+    isBeingRescheduled: Bool = false,
+    isDeletable: Bool = true
+  ) {
     self.spin = spin
+    self.airtimeLabel = airtimeLabel
     self.isBeingRescheduled = isBeingRescheduled
     self.isDeletable = isDeletable
   }
 
   var isGrouped: Bool { spin.spinGroupId != nil }
-
-  private var timeString: String {
-    let formatter = DateFormatter()
-    formatter.dateFormat = "h:mm:ssa"
-    return formatter.string(from: spin.airtime).lowercased()
-  }
 
   private var rowBackgroundColor: Color {
     if spin.audioBlock.type == "commercial" {
@@ -362,7 +365,7 @@ struct ScheduleRowView: View {
             .tint(.playolaGray)
             .scaleEffect(0.8)
         } else {
-          Text("at \(timeString)")
+          Text(airtimeLabel)
             .font(.custom(FontNames.Inter_400_Regular, size: 11))
             .foregroundColor(.playolaGray)
         }
@@ -386,20 +389,13 @@ struct NotifyListenersSheet: View {
   @Bindable var model: BroadcastPageModel
   @FocusState private var isTextFieldFocused: Bool
 
-  private let placeholderText = """
-    Tell your listeners what you're up to...
-
-    "I'm going live from the van!"
-    "Playing my favorite road songs today"
-    """
-
   var body: some View {
     NavigationStack {
       ZStack {
         Color.black.ignoresSafeArea()
 
         VStack(spacing: 20) {
-          Text("Tell your listeners you're about to go live.")
+          Text(model.notifyListenersPrompt)
             .font(.custom(FontNames.Inter_400_Regular, size: 14))
             .foregroundColor(.playolaGray)
             .multilineTextAlignment(.center)
@@ -407,7 +403,7 @@ struct NotifyListenersSheet: View {
 
           ZStack(alignment: .topLeading) {
             if model.notifyMessage.isEmpty {
-              Text(placeholderText)
+              Text(model.notifyMessagePlaceholder)
                 .font(.custom(FontNames.Inter_400_Regular, size: 16))
                 .foregroundColor(Color(hex: "#666666"))
                 .padding(.horizontal, 12)
@@ -443,7 +439,7 @@ struct NotifyListenersSheet: View {
                 .frame(maxWidth: .infinity)
                 .frame(height: 50)
             } else {
-              Text("Send Notification")
+              Text(model.sendNotificationButtonTitle)
                 .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
                 .foregroundColor(.white)
                 .frame(maxWidth: .infinity)
@@ -465,14 +461,14 @@ struct NotifyListenersSheet: View {
         }
         .padding(.top, 20)
       }
-      .navigationTitle("Notify Listeners")
+      .navigationTitle(model.notifyListenersTitle)
       .navigationBarTitleDisplayMode(.inline)
       .toolbarBackground(.visible, for: .navigationBar)
       .toolbarBackground(Color.black, for: .navigationBar)
       .toolbarColorScheme(.dark, for: .navigationBar)
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
-          Button("Cancel") {
+          Button(model.cancelButtonTitle) {
             model.cancelNotifyListeners()
           }
           .foregroundColor(.white)
@@ -483,7 +479,7 @@ struct NotifyListenersSheet: View {
     .onAppear {
       isTextFieldFocused = true
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 }
 

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageModel.swift
@@ -49,8 +49,17 @@ class BroadcastersListenerQuestionPageModel: ViewModel {
   // MARK: - Properties
 
   let stationId: String
-  let navigationTitle = "Questions from Listeners"
+  let navigationTitle = "Listener Questions"
   let filterOptions: [ListenerQuestionFilter] = [.pending, .answered, .all]
+
+  let emptyStateTitle = "No Questions Yet"
+  let emptyStateMessage = "When listeners send you questions,\nthey'll appear here."
+  let declineButtonText = "Decline"
+  let answeredBadgeText = "Answered"
+  let missingTranscriptionText = "No transcription available"
+  let unknownListenerText = "Unknown Listener"
+  let showMoreText = "Show more"
+  let showLessText = "Show less"
 
   var questions: IdentifiedArrayOf<ListenerQuestion> = []
   var expandedQuestionIds: Set<String> = []

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageModel.swift
@@ -168,6 +168,10 @@ class BroadcastersListenerQuestionPageModel: ViewModel {
     expandedQuestionIds.contains(questionId)
   }
 
+  func expandToggleText(for questionId: String) -> String {
+    isExpanded(questionId) ? showLessText : showMoreText
+  }
+
   func isPlaying(_ questionId: String) -> Bool {
     playingQuestionId == questionId
   }

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageView.swift
@@ -29,7 +29,7 @@ struct BroadcastersListenerQuestionPageView: View {
         }
       }
     }
-    .navigationTitle("Listener Questions")
+    .navigationTitle(model.navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .toolbarBackground(.visible, for: .navigationBar)
     .toolbarBackground(Color.background, for: .navigationBar)
@@ -37,7 +37,7 @@ struct BroadcastersListenerQuestionPageView: View {
     .onAppear {
       Task { await model.viewAppeared() }
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 
   // MARK: - Filter Pills
@@ -76,11 +76,11 @@ struct BroadcastersListenerQuestionPageView: View {
         .font(.system(size: 48))
         .foregroundColor(.textSecondary)
 
-      Text("No Questions Yet")
+      Text(model.emptyStateTitle)
         .font(.custom(FontNames.Inter_600_SemiBold, size: 18))
         .foregroundColor(.textPrimary)
 
-      Text("When listeners send you questions,\nthey'll appear here.")
+      Text(model.emptyStateMessage)
         .font(.custom(FontNames.Inter_400_Regular, size: 14))
         .foregroundColor(.textSecondary)
         .multilineTextAlignment(.center)
@@ -114,6 +114,11 @@ struct BroadcastersListenerQuestionPageView: View {
       ForEach(model.filteredQuestions) { question in
         ListenerQuestionRow(
           question: question,
+          answeredBadgeText: model.answeredBadgeText,
+          missingTranscriptionText: model.missingTranscriptionText,
+          unknownListenerText: model.unknownListenerText,
+          showMoreText: model.showMoreText,
+          showLessText: model.showLessText,
           isExpanded: model.isExpanded(question.id),
           isPlaying: model.isPlaying(question.id),
           onExpandTapped: { model.showMoreButtonTapped(question.id) },
@@ -128,7 +133,7 @@ struct BroadcastersListenerQuestionPageView: View {
             Button(role: .destructive) {
               Task { await model.declineQuestionSwiped(question) }
             } label: {
-              Label("Decline", systemImage: "xmark.circle")
+              Label(model.declineButtonText, systemImage: "xmark.circle")
             }
             .tint(Color.error)
           }
@@ -147,6 +152,11 @@ struct BroadcastersListenerQuestionPageView: View {
 
 struct ListenerQuestionRow: View {
   let question: ListenerQuestion
+  var answeredBadgeText: String = "Answered"
+  var missingTranscriptionText: String = "No transcription available"
+  var unknownListenerText: String = "Unknown Listener"
+  var showMoreText: String = "Show more"
+  var showLessText: String = "Show less"
   let isExpanded: Bool
   let isPlaying: Bool
   let onExpandTapped: () -> Void
@@ -156,11 +166,11 @@ struct ListenerQuestionRow: View {
   private let collapsedLineLimit = 2
 
   private var transcription: String {
-    question.transcription ?? "No transcription available"
+    question.transcription ?? missingTranscriptionText
   }
 
   private var listenerName: String {
-    question.listener?.fullName ?? "Unknown Listener"
+    question.listener?.fullName ?? unknownListenerText
   }
 
   private var timeAgo: String {
@@ -229,7 +239,7 @@ struct ListenerQuestionRow: View {
               }
             } label: {
               HStack(spacing: 4) {
-                Text(isExpanded ? "Show less" : "Show more")
+                Text(isExpanded ? showLessText : showMoreText)
                   .font(.custom(FontNames.Inter_500_Medium, size: 13))
                   .foregroundColor(.playolaRed)
 
@@ -280,7 +290,7 @@ struct ListenerQuestionRow: View {
   }
 
   private var statusBadge: some View {
-    Text("Answered")
+    Text(answeredBadgeText)
       .font(.custom(FontNames.Inter_500_Medium, size: 11))
       .foregroundColor(.textPrimary)
       .padding(.horizontal, 8)

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageView.swift
@@ -117,8 +117,7 @@ struct BroadcastersListenerQuestionPageView: View {
           answeredBadgeText: model.answeredBadgeText,
           missingTranscriptionText: model.missingTranscriptionText,
           unknownListenerText: model.unknownListenerText,
-          showMoreText: model.showMoreText,
-          showLessText: model.showLessText,
+          expandToggleText: model.expandToggleText(for: question.id),
           isExpanded: model.isExpanded(question.id),
           isPlaying: model.isPlaying(question.id),
           onExpandTapped: { model.showMoreButtonTapped(question.id) },
@@ -155,8 +154,7 @@ struct ListenerQuestionRow: View {
   var answeredBadgeText: String
   var missingTranscriptionText: String
   var unknownListenerText: String
-  var showMoreText: String
-  var showLessText: String
+  let expandToggleText: String
   let isExpanded: Bool
   let isPlaying: Bool
   let onExpandTapped: () -> Void
@@ -239,7 +237,7 @@ struct ListenerQuestionRow: View {
               }
             } label: {
               HStack(spacing: 4) {
-                Text(isExpanded ? showLessText : showMoreText)
+                Text(expandToggleText)
                   .font(.custom(FontNames.Inter_500_Medium, size: 13))
                   .foregroundColor(.playolaRed)
 

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageView.swift
@@ -152,11 +152,11 @@ struct BroadcastersListenerQuestionPageView: View {
 
 struct ListenerQuestionRow: View {
   let question: ListenerQuestion
-  var answeredBadgeText: String = "Answered"
-  var missingTranscriptionText: String = "No transcription available"
-  var unknownListenerText: String = "Unknown Listener"
-  var showMoreText: String = "Show more"
-  var showLessText: String = "Show less"
+  var answeredBadgeText: String
+  var missingTranscriptionText: String
+  var unknownListenerText: String
+  var showMoreText: String
+  var showLessText: String
   let isExpanded: Bool
   let isPlaying: Bool
   let onExpandTapped: () -> Void

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -72,6 +72,15 @@ class ContactPageModel: ViewModel {
     return false
   }
 
+  var navigationTitle: String { "Your Profile" }
+  var switchToListeningModeLabel: String { "Switch to Listening Mode" }
+  var switchToBroadcastingModeLabel: String { "Switch to Broadcasting Mode" }
+  var likedSongsLabel: String { "Liked Songs" }
+  var notificationsLabel: String { "Notifications" }
+  var contactUsLabel: String { "Contact Us" }
+  var askArtistLabel: String { "Ask An Artist A Question" }
+  var logOutLabel: String { "Log out" }
+
   func switchToListeningMode() {
     mainContainerNavigationCoordinator.switchToListeningMode()
   }

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -72,15 +72,6 @@ class ContactPageModel: ViewModel {
     return false
   }
 
-  var navigationTitle: String { "Your Profile" }
-  var switchToListeningModeLabel: String { "Switch to Listening Mode" }
-  var switchToBroadcastingModeLabel: String { "Switch to Broadcasting Mode" }
-  var likedSongsLabel: String { "Liked Songs" }
-  var notificationsLabel: String { "Notifications" }
-  var contactUsLabel: String { "Contact Us" }
-  var askArtistLabel: String { "Ask An Artist A Question" }
-  var logOutLabel: String { "Log out" }
-
   func switchToListeningMode() {
     mainContainerNavigationCoordinator.switchToListeningMode()
   }
@@ -194,6 +185,17 @@ class ContactPageModel: ViewModel {
       await handleRegularUserFlow(jwt: jwt)
     }
   }
+
+  // MARK: - View Helpers
+
+  var navigationTitle: String { "Your Profile" }
+  var switchToListeningModeLabel: String { "Switch to Listening Mode" }
+  var switchToBroadcastingModeLabel: String { "Switch to Broadcasting Mode" }
+  var likedSongsLabel: String { "Liked Songs" }
+  var notificationsLabel: String { "Notifications" }
+  var contactUsLabel: String { "Contact Us" }
+  var askArtistLabel: String { "Ask An Artist A Question" }
+  var logOutLabel: String { "Log out" }
 
   private func handleRegularUserFlow(jwt: String) async {
     do {

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
@@ -16,7 +16,7 @@ struct ContactPageView: View {
     VStack(spacing: 0) {
       // Title
       HStack {
-        Text("Your Profile")
+        Text(model.navigationTitle)
           .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 32))
           .foregroundColor(.white)
         Spacer()
@@ -100,7 +100,7 @@ struct ContactPageView: View {
                     .foregroundColor(.white)
                     .font(.system(size: 16))
 
-                  Text("Switch to Listening Mode")
+                  Text(model.switchToListeningModeLabel)
                     .font(.custom(FontNames.Inter_500_Medium, size: 16))
                     .foregroundColor(.white)
 
@@ -132,7 +132,7 @@ struct ContactPageView: View {
                     .foregroundColor(.white)
                     .font(.system(size: 16))
 
-                  Text("Switch to Broadcasting Mode")
+                  Text(model.switchToBroadcastingModeLabel)
                     .font(.custom(FontNames.Inter_500_Medium, size: 16))
                     .foregroundColor(.white)
 
@@ -161,7 +161,7 @@ struct ContactPageView: View {
                   .foregroundColor(.white)
                   .font(.system(size: 16))
 
-                Text("Liked Songs")
+                Text(model.likedSongsLabel)
                   .font(.custom(FontNames.Inter_500_Medium, size: 16))
                   .foregroundColor(.white)
 
@@ -189,7 +189,7 @@ struct ContactPageView: View {
                   .foregroundColor(.white)
                   .font(.system(size: 16))
 
-                Text("Notifications")
+                Text(model.notificationsLabel)
                   .font(.custom(FontNames.Inter_500_Medium, size: 16))
                   .foregroundColor(.white)
 
@@ -236,7 +236,7 @@ struct ContactPageView: View {
                   }
                 }
 
-                Text("Contact Us")
+                Text(model.contactUsLabel)
                   .font(.custom(FontNames.Inter_500_Medium, size: 16))
                   .foregroundColor(.white)
 
@@ -265,7 +265,7 @@ struct ContactPageView: View {
                   .foregroundColor(.white)
                   .font(.system(size: 16))
 
-                Text("Ask An Artist A Question")
+                Text(model.askArtistLabel)
                   .font(.custom(FontNames.Inter_500_Medium, size: 16))
                   .foregroundColor(.white)
 
@@ -293,7 +293,7 @@ struct ContactPageView: View {
                   .renderingMode(.template)
                   .foregroundColor(.white)
 
-                Text("Log out")
+                Text(model.logOutLabel)
                   .font(.custom(FontNames.Inter_500_Medium, size: 16))
                   .foregroundColor(.white)
               }
@@ -315,7 +315,7 @@ struct ContactPageView: View {
     .task {
       await model.onViewAppeared()
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 }
 

--- a/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageModel.swift
@@ -19,9 +19,6 @@ class ConversationListPageModel: ViewModel {
   var isLoading = true
   var presentedAlert: PlayolaAlert?
 
-  var navigationTitle: String { "Support Conversations" }
-  var emptyStateMessage: String { "No conversations" }
-
   /// Conversations sorted with unread first, then by most recent
   var sortedConversations: [AdminConversationResponse] {
     conversations.sorted { first, second in
@@ -88,6 +85,11 @@ class ConversationListPageModel: ViewModel {
   func refresh() async {
     await loadConversations()
   }
+
+  // MARK: - View Helpers
+
+  var navigationTitle: String { "Support Conversations" }
+  var emptyStateMessage: String { "No conversations" }
 }
 
 extension PlayolaAlert {

--- a/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageModel.swift
@@ -19,6 +19,9 @@ class ConversationListPageModel: ViewModel {
   var isLoading = true
   var presentedAlert: PlayolaAlert?
 
+  var navigationTitle: String { "Support Conversations" }
+  var emptyStateMessage: String { "No conversations" }
+
   /// Conversations sorted with unread first, then by most recent
   var sortedConversations: [AdminConversationResponse] {
     conversations.sorted { first, second in

--- a/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageView.swift
+++ b/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageView.swift
@@ -21,7 +21,7 @@ struct ConversationListPageView: View {
         conversationList
       }
     }
-    .navigationTitle("Support Conversations")
+    .navigationTitle(model.navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .toolbarBackground(.visible, for: .navigationBar)
     .toolbarBackground(Color.black, for: .navigationBar)
@@ -32,7 +32,7 @@ struct ConversationListPageView: View {
     .refreshable {
       await model.refresh()
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 
   private var emptyState: some View {
@@ -41,7 +41,7 @@ struct ConversationListPageView: View {
         .font(.system(size: 48))
         .foregroundColor(Color(hex: "#666666"))
 
-      Text("No conversations")
+      Text(model.emptyStateMessage)
         .font(.custom(FontNames.Inter_500_Medium, size: 16))
         .foregroundColor(Color(hex: "#888888"))
     }

--- a/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageModel.swift
+++ b/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageModel.swift
@@ -25,6 +25,15 @@ class EditProfilePageModel: ViewModel {
 
   var presentedAlert: PlayolaAlert?
 
+  var navigationTitle: String { "Edit Profile" }
+  var firstNameLabel: String { "First Name" }
+  var lastNameLabel: String { "Last Name" }
+  var emailLabel: String { "Email" }
+  var emailHelpText: String {
+    "This email is linked to your Apple ID and can't be changed here."
+  }
+  var saveButtonTitle: String { "Save Profile" }
+
   var isSaveButtonEnabled: Bool {
     let originalFirstName = auth.currentUser?.firstName ?? ""
     let originalLastName = auth.currentUser?.lastName ?? ""

--- a/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageModel.swift
+++ b/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageModel.swift
@@ -25,15 +25,6 @@ class EditProfilePageModel: ViewModel {
 
   var presentedAlert: PlayolaAlert?
 
-  var navigationTitle: String { "Edit Profile" }
-  var firstNameLabel: String { "First Name" }
-  var lastNameLabel: String { "Last Name" }
-  var emailLabel: String { "Email" }
-  var emailHelpText: String {
-    "This email is linked to your Apple ID and can't be changed here."
-  }
-  var saveButtonTitle: String { "Save Profile" }
-
   var isSaveButtonEnabled: Bool {
     let originalFirstName = auth.currentUser?.firstName ?? ""
     let originalLastName = auth.currentUser?.lastName ?? ""
@@ -77,6 +68,17 @@ class EditProfilePageModel: ViewModel {
     self.lastName = auth.currentUser?.lastName ?? ""
     self.email = auth.currentUser?.email ?? ""
   }
+
+  // MARK: - View Helpers
+
+  var navigationTitle: String { "Edit Profile" }
+  var firstNameLabel: String { "First Name" }
+  var lastNameLabel: String { "Last Name" }
+  var emailLabel: String { "Email" }
+  var emailHelpText: String {
+    "This email is linked to your Apple ID and can't be changed here."
+  }
+  var saveButtonTitle: String { "Save Profile" }
 }
 
 extension PlayolaAlert {

--- a/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageView.swift
+++ b/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageView.swift
@@ -17,7 +17,7 @@ struct EditProfilePageView: View {
       VStack(spacing: 16) {
         // First Name Section
         VStack(alignment: .leading) {
-          Text("First Name")
+          Text(model.firstNameLabel)
             .font(.custom(FontNames.Inter_500_Medium, size: 16))
             .foregroundColor(.white)
 
@@ -33,7 +33,7 @@ struct EditProfilePageView: View {
 
         // Last Name Section
         VStack(alignment: .leading) {
-          Text("Last Name")
+          Text(model.lastNameLabel)
             .font(.custom(FontNames.Inter_500_Medium, size: 16))
             .foregroundColor(.white)
 
@@ -49,7 +49,7 @@ struct EditProfilePageView: View {
 
         // Email Section
         VStack(alignment: .leading) {
-          Text("Email")
+          Text(model.emailLabel)
             .font(.custom(FontNames.Inter_500_Medium, size: 16))
             .foregroundColor(.white)
 
@@ -63,7 +63,7 @@ struct EditProfilePageView: View {
             .font(.custom(FontNames.Inter_500_Medium, size: 16))
             .disabled(true)
 
-          Text("This email is linked to your Apple ID and can't be changed here.")
+          Text(model.emailHelpText)
             .font(.custom(FontNames.Inter_400_Regular, size: 12))
             .foregroundColor(Color(hex: "#BABABA"))
             .padding(.top, 4)
@@ -75,7 +75,7 @@ struct EditProfilePageView: View {
             Task { await model.saveButtonTapped() }
           },
           label: {
-            Text("Save Profile")
+            Text(model.saveButtonTitle)
               .font(.custom(FontNames.Inter_500_Medium, size: 16))
               .foregroundColor(.white)
               .frame(maxWidth: .infinity)
@@ -95,7 +95,7 @@ struct EditProfilePageView: View {
       .padding(.top, 24)
     }
     .background(Color.black)
-    .navigationTitle("Edit Profile")
+    .navigationTitle(model.navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .navigationBarBackButtonHidden(true)
     .toolbar {
@@ -127,7 +127,7 @@ struct EditProfilePageView: View {
 
       model.viewAppeared()
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 }
 

--- a/PlayolaRadio/Views/Pages/FeedbackSheet/FeedbackSheetView.swift
+++ b/PlayolaRadio/Views/Pages/FeedbackSheet/FeedbackSheetView.swift
@@ -92,6 +92,6 @@ struct FeedbackSheetView: View {
     .onAppear {
       isTextFieldFocused = true
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 }

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -70,6 +70,10 @@ class HomePageModel: ViewModel {
     }
   }
 
+  var introMessage: String { "Discover music through independent artist made radio stations." }
+
+  var stationListTitle: String { "Artist stations for you" }
+
   var supportMessageTileContent: String {
     let count = unreadSupportCount
     return count == 1 ? "1 New Message" : "\(count) New Messages"

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
@@ -25,6 +25,7 @@ struct HomePageView: View {
 
         ScrollView {
           HomeIntroSection(
+            introMessage: model.introMessage,
             onIconTapped10Times: model.playolaIconTapped10Times)
 
           if model.hasUnreadSupportMessages {
@@ -50,6 +51,7 @@ struct HomePageView: View {
           ListeningTimeTile(model: model.listeningTimeTileModel)
 
           HomePageStationList(
+            title: model.stationListTitle,
             stations: model.forYouStations,
             liveStatusForStation: model.liveStatusForStation,
             hasUpcomingGiveawayForStation: model.hasUpcomingGiveawayForStation
@@ -63,7 +65,7 @@ struct HomePageView: View {
       .circleBackground(offsetY: -180)
     }
     .background(Color.black.ignoresSafeArea())
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
     .onAppear { Task { await model.viewAppeared() } }
   }
 }

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/CircleSection.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/CircleSection.swift
@@ -7,7 +7,7 @@
 import SwiftUI
 
 struct HomeIntroSection: View {
-  var introMessage: String = "Discover music through independent artist made radio stations."
+  var introMessage: String
   var onIconTapped10Times: () -> Void = {}
 
   var body: some View {
@@ -42,8 +42,10 @@ struct HomeIntroSection: View {
 
 struct CircleSection_Previews: PreviewProvider {
   static var previews: some View {
-    HomeIntroSection()
-      .padding(.horizontal, 24)
-      .background(Color.black)
+    HomeIntroSection(
+      introMessage: "Discover music through independent artist made radio stations."
+    )
+    .padding(.horizontal, 24)
+    .background(Color.black)
   }
 }

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/CircleSection.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/CircleSection.swift
@@ -7,6 +7,7 @@
 import SwiftUI
 
 struct HomeIntroSection: View {
+  var introMessage: String = "Discover music through independent artist made radio stations."
   var onIconTapped10Times: () -> Void = {}
 
   var body: some View {
@@ -22,7 +23,7 @@ struct HomeIntroSection: View {
             count: 10,
             perform: onIconTapped10Times)
 
-        Text("Discover music through independent artist made radio stations.")
+        Text(introMessage)
           .foregroundColor(.white)
           .font(.custom("Inter-Regular", size: 20))
           .tracking(0.10)

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
@@ -82,7 +82,7 @@ struct StationCardView: View {
 }
 
 struct HomePageStationList: View {
-  var title: String = "Artist stations for you"
+  var title: String
   var stations: IdentifiedArrayOf<AnyStation>
   var liveStatusForStation: (String) -> LiveStatus?
   var hasUpcomingGiveawayForStation: (String) -> Bool
@@ -115,6 +115,7 @@ struct HomePageStationList: View {
 struct HomePageStationList_Previews: PreviewProvider {
   static var previews: some View {
     HomePageStationList(
+      title: "Artist stations for you",
       stations: IdentifiedArray(uniqueElements: [AnyStation.mock]),
       liveStatusForStation: { _ in nil },
       hasUpcomingGiveawayForStation: { _ in false },

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
@@ -82,6 +82,7 @@ struct StationCardView: View {
 }
 
 struct HomePageStationList: View {
+  var title: String = "Artist stations for you"
   var stations: IdentifiedArrayOf<AnyStation>
   var liveStatusForStation: (String) -> LiveStatus?
   var hasUpcomingGiveawayForStation: (String) -> Bool
@@ -89,7 +90,7 @@ struct HomePageStationList: View {
 
   var body: some View {
     VStack(alignment: .leading) {
-      Text("Artist stations for you")
+      Text(title)
         .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 24))
         .fontWeight(.bold)
         .foregroundColor(.white)

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageModel.swift
@@ -68,6 +68,7 @@ class ListenerQuestionDetailPageModel: ViewModel {
   let responseSectionTitle = "YOUR RESPONSE"
   let discardButtonTitle = "Discard"
   let uploadButtonTitle = "Upload Response"
+  let recordingIndicatorText = "Recording"
 
   var recordButtonLabel: String {
     switch recordingPhase {

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
@@ -29,7 +29,7 @@ struct ListenerQuestionDetailPageView: View {
     .toolbarBackground(.visible, for: .navigationBar)
     .toolbarBackground(Color.background, for: .navigationBar)
     .toolbarColorScheme(.dark, for: .navigationBar)
-    .playolaAlert($model.presentedAlert)
+    .alert(item: $model.presentedAlert) { $0.alert }
     .task { await model.viewAppeared() }
     .onDisappear { Task { await model.viewDisappeared() } }
   }

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
@@ -29,7 +29,7 @@ struct ListenerQuestionDetailPageView: View {
     .toolbarBackground(.visible, for: .navigationBar)
     .toolbarBackground(Color.background, for: .navigationBar)
     .toolbarColorScheme(.dark, for: .navigationBar)
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
     .task { await model.viewAppeared() }
     .onDisappear { Task { await model.viewDisappeared() } }
   }
@@ -198,7 +198,7 @@ struct ListenerQuestionDetailPageView: View {
         .fill(Color.playolaRed)
         .frame(width: 10, height: 10)
 
-      Text("Recording")
+      Text(model.recordingIndicatorText)
         .font(.custom(FontNames.Inter_600_SemiBold, size: 14))
         .foregroundColor(.playolaRed)
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -165,7 +165,7 @@ struct MainContainer: View {
     }
     .tabItem {
       Image("HomeTabImage")
-      Text("Home")
+      Text(model.homeTabTitle)
     }
     .tag(MainContainerModel.ActiveTab.home)
   }
@@ -182,7 +182,7 @@ struct MainContainer: View {
     }
     .tabItem {
       Image("RadioStationsTabImage")
-      Text("Radio Stations")
+      Text(model.stationsTabTitle)
     }
     .tag(MainContainerModel.ActiveTab.stationsList)
   }
@@ -199,7 +199,7 @@ struct MainContainer: View {
     }
     .tabItem {
       Image("gift")
-      Text("Rewards")
+      Text(model.rewardsTabTitle)
     }
     .tag(MainContainerModel.ActiveTab.rewards)
   }
@@ -216,7 +216,7 @@ struct MainContainer: View {
     }
     .tabItem {
       Image("ProfileTabImage")
-      Text("Your Profile")
+      Text(model.profileTabTitle)
     }
     .tag(MainContainerModel.ActiveTab.profile)
   }
@@ -237,7 +237,7 @@ struct MainContainer: View {
     }
     .tabItem {
       Image(systemName: "antenna.radiowaves.left.and.right")
-      Text("Broadcast")
+      Text(model.broadcastTabTitle)
     }
     .tag(MainContainerModel.ActiveTab.broadcast)
   }
@@ -256,7 +256,7 @@ struct MainContainer: View {
     }
     .tabItem {
       Image(systemName: "music.note.list")
-      Text("Library")
+      Text(model.libraryTabTitle)
     }
     .tag(MainContainerModel.ActiveTab.library)
   }
@@ -275,7 +275,7 @@ struct MainContainer: View {
     }
     .tabItem {
       Image(systemName: "bubble.left.and.bubble.right")
-      Text("Listeners")
+      Text(model.listenersTabTitle)
     }
     .tag(MainContainerModel.ActiveTab.listeners)
   }
@@ -292,7 +292,7 @@ struct MainContainer: View {
     }
     .tabItem {
       Image("ProfileTabImage")
-      Text("Profile")
+      Text(model.settingsTabTitle)
     }
     .tag(MainContainerModel.ActiveTab.settings)
   }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -64,6 +64,15 @@ class MainContainerModel: ViewModel {
   var presentedAlert: PlayolaAlert?
   var presentedToast: PlayolaToast?
 
+  var homeTabTitle: String { "Home" }
+  var stationsTabTitle: String { "Radio Stations" }
+  var rewardsTabTitle: String { "Rewards" }
+  var profileTabTitle: String { "Your Profile" }
+  var broadcastTabTitle: String { "Broadcast" }
+  var libraryTabTitle: String { "Library" }
+  var listenersTabTitle: String { "Listeners" }
+  var settingsTabTitle: String { "Profile" }
+
   var homePageModel = HomePageModel()
   var stationListModel = StationListModel()
   var rewardsPageModel = RewardsPageModel()

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageModel.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageModel.swift
@@ -61,6 +61,13 @@ class NotificationsSettingsPageModel: ViewModel {
   private var subscriptions: [PushNotificationSubscription] = []
   var togglingStationIds: Set<String> = []
 
+  var navigationTitle: String { "Notifications" }
+  var emptyStateTitle: String { "No stations available" }
+  var emptyStateMessage: String { "No stations are currently available for notifications." }
+  var allNotificationsTitle: String { "All Notifications" }
+  var allNotificationsSubtitle: String { "Enable or disable all station notifications" }
+  var stationsSectionTitle: String { "Stations" }
+
   var stationItems: [StationNotificationItem] {
     let allStations = stationLists.flatMap { $0.playolaStations }
       .filter { $0.active ?? true }

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageModel.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageModel.swift
@@ -61,13 +61,6 @@ class NotificationsSettingsPageModel: ViewModel {
   private var subscriptions: [PushNotificationSubscription] = []
   var togglingStationIds: Set<String> = []
 
-  var navigationTitle: String { "Notifications" }
-  var emptyStateTitle: String { "No stations available" }
-  var emptyStateMessage: String { "No stations are currently available for notifications." }
-  var allNotificationsTitle: String { "All Notifications" }
-  var allNotificationsSubtitle: String { "Enable or disable all station notifications" }
-  var stationsSectionTitle: String { "Stations" }
-
   var stationItems: [StationNotificationItem] {
     let allStations = stationLists.flatMap { $0.playolaStations }
       .filter { $0.active ?? true }
@@ -203,6 +196,15 @@ class NotificationsSettingsPageModel: ViewModel {
 
     togglingStationIds.removeAll()
   }
+
+  // MARK: - View Helpers
+
+  var navigationTitle: String { "Notifications" }
+  var emptyStateTitle: String { "No stations available" }
+  var emptyStateMessage: String { "No stations are currently available for notifications." }
+  var allNotificationsTitle: String { "All Notifications" }
+  var allNotificationsSubtitle: String { "Enable or disable all station notifications" }
+  var stationsSectionTitle: String { "Stations" }
 }
 
 extension PlayolaAlert {

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
@@ -36,7 +36,7 @@ struct NotificationsSettingsPageView: View {
       }
     }
     .background(Color.black)
-    .navigationTitle("Notifications")
+    .navigationTitle(model.navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .navigationBarBackButtonHidden(true)
     .toolbar {
@@ -68,7 +68,7 @@ struct NotificationsSettingsPageView: View {
     .task {
       await model.viewAppeared()
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 
   private var emptyStateView: some View {
@@ -77,10 +77,10 @@ struct NotificationsSettingsPageView: View {
       Image(systemName: "bell.slash")
         .font(.system(size: 48))
         .foregroundColor(Color(hex: "#666666"))
-      Text("No stations available")
+      Text(model.emptyStateTitle)
         .font(.custom(FontNames.Inter_500_Medium, size: 18))
         .foregroundColor(Color(hex: "#BABABA"))
-      Text("No stations are currently available for notifications.")
+      Text(model.emptyStateMessage)
         .font(.custom(FontNames.Inter_400_Regular, size: 14))
         .foregroundColor(Color(hex: "#666666"))
         .multilineTextAlignment(.center)
@@ -93,10 +93,10 @@ struct NotificationsSettingsPageView: View {
     VStack(alignment: .leading, spacing: 8) {
       HStack {
         VStack(alignment: .leading, spacing: 4) {
-          Text("All Notifications")
+          Text(model.allNotificationsTitle)
             .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
             .foregroundColor(.white)
-          Text("Enable or disable all station notifications")
+          Text(model.allNotificationsSubtitle)
             .font(.custom(FontNames.Inter_400_Regular, size: 12))
             .foregroundColor(Color(hex: "#BABABA"))
         }
@@ -121,7 +121,7 @@ struct NotificationsSettingsPageView: View {
 
   private var stationListSection: some View {
     VStack(alignment: .leading, spacing: 0) {
-      Text("Stations")
+      Text(model.stationsSectionTitle)
         .font(.custom(FontNames.Inter_600_SemiBold, size: 14))
         .foregroundColor(Color(hex: "#BABABA"))
         .padding(.horizontal, 20)

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
@@ -56,6 +56,24 @@ class RecordPageModel: ViewModel {
     recordingPhase == .idle
   }
 
+  var navigationTitle: String { "Audio Recording" }
+
+  var doneButtonTitle: String { "Done" }
+
+  var waveformPlaceholderText: String { "Your recording will appear here" }
+
+  var recordingStatusText: String { "Recording" }
+
+  var recordButtonLabel: String { "Tap to Record" }
+
+  var stopButtonLabel: String { "Tap to Stop" }
+
+  var reRecordButtonLabel: String { "Try Again" }
+
+  var discardButtonTitle: String { "Discard" }
+
+  var useRecordingButtonTitle: String { "Use Recording" }
+
   // MARK: - Lifecycle
 
   func viewAppeared() async {

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
@@ -70,6 +70,14 @@ class RecordPageModel: ViewModel {
 
   var reRecordButtonLabel: String { "Try Again" }
 
+  var currentButtonLabel: String {
+    switch recordingPhase {
+    case .idle: return recordButtonLabel
+    case .recording: return stopButtonLabel
+    case .review: return reRecordButtonLabel
+    }
+  }
+
   var discardButtonTitle: String { "Discard" }
 
   var useRecordingButtonTitle: String { "Use Recording" }

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageModel.swift
@@ -56,32 +56,6 @@ class RecordPageModel: ViewModel {
     recordingPhase == .idle
   }
 
-  var navigationTitle: String { "Audio Recording" }
-
-  var doneButtonTitle: String { "Done" }
-
-  var waveformPlaceholderText: String { "Your recording will appear here" }
-
-  var recordingStatusText: String { "Recording" }
-
-  var recordButtonLabel: String { "Tap to Record" }
-
-  var stopButtonLabel: String { "Tap to Stop" }
-
-  var reRecordButtonLabel: String { "Try Again" }
-
-  var currentButtonLabel: String {
-    switch recordingPhase {
-    case .idle: return recordButtonLabel
-    case .recording: return stopButtonLabel
-    case .review: return reRecordButtonLabel
-    }
-  }
-
-  var discardButtonTitle: String { "Discard" }
-
-  var useRecordingButtonTitle: String { "Use Recording" }
-
   // MARK: - Lifecycle
 
   func viewAppeared() async {
@@ -224,6 +198,34 @@ class RecordPageModel: ViewModel {
   func onDoneTapped() {
     mainContainerNavigationCoordinator.presentedSheet = nil
   }
+
+  // MARK: - View Helpers
+
+  var navigationTitle: String { "Audio Recording" }
+
+  var doneButtonTitle: String { "Done" }
+
+  var waveformPlaceholderText: String { "Your recording will appear here" }
+
+  var recordingStatusText: String { "Recording" }
+
+  var recordButtonLabel: String { "Tap to Record" }
+
+  var stopButtonLabel: String { "Tap to Stop" }
+
+  var reRecordButtonLabel: String { "Try Again" }
+
+  var currentButtonLabel: String {
+    switch recordingPhase {
+    case .idle: return recordButtonLabel
+    case .recording: return stopButtonLabel
+    case .review: return reRecordButtonLabel
+    }
+  }
+
+  var discardButtonTitle: String { "Discard" }
+
+  var useRecordingButtonTitle: String { "Use Recording" }
 
   // MARK: - Helpers
 

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
@@ -55,7 +55,7 @@ struct RecordPageView: View {
         }
       }
     }
-    .playolaAlert($model.presentedAlert)
+    .alert(item: $model.presentedAlert) { $0.alert }
     .task {
       await model.viewAppeared()
     }

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
@@ -158,22 +158,10 @@ struct RecordPageView: View {
 
   // MARK: - Button Label Section
 
-  @ViewBuilder
   private var buttonLabelSection: some View {
-    switch model.recordingPhase {
-    case .idle:
-      Text(model.recordButtonLabel)
-        .font(.custom(FontNames.Inter_400_Regular, size: 16))
-        .foregroundColor(.playolaGray)
-    case .recording:
-      Text(model.stopButtonLabel)
-        .font(.custom(FontNames.Inter_400_Regular, size: 16))
-        .foregroundColor(.playolaGray)
-    case .review:
-      Text(model.reRecordButtonLabel)
-        .font(.custom(FontNames.Inter_400_Regular, size: 16))
-        .foregroundColor(.playolaGray)
-    }
+    Text(model.currentButtonLabel)
+      .font(.custom(FontNames.Inter_400_Regular, size: 16))
+      .foregroundColor(.playolaGray)
   }
 
   // MARK: - Bottom Section

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageView.swift
@@ -40,7 +40,7 @@ struct RecordPageView: View {
         bottomSection
       }
     }
-    .navigationTitle("Audio Recording")
+    .navigationTitle(model.navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .toolbarBackground(.visible, for: .navigationBar)
     .toolbarBackground(Color.black, for: .navigationBar)
@@ -48,14 +48,14 @@ struct RecordPageView: View {
     .toolbar {
       if model.shouldShowDoneButton {
         ToolbarItem(placement: .navigationBarTrailing) {
-          Button("Done") {
+          Button(model.doneButtonTitle) {
             model.onDoneTapped()
           }
           .foregroundColor(.white)
         }
       }
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
     .task {
       await model.viewAppeared()
     }
@@ -70,7 +70,7 @@ struct RecordPageView: View {
       RoundedRectangle(cornerRadius: 8)
         .fill(Color(hex: "#1A1A1A"))
         .overlay(
-          Text("Your recording will appear here")
+          Text(model.waveformPlaceholderText)
             .font(.custom(FontNames.Inter_400_Regular, size: 14))
             .foregroundColor(Color(hex: "#4A4A4A"))
         )
@@ -94,7 +94,7 @@ struct RecordPageView: View {
           Circle()
             .fill(Color.playolaRed)
             .frame(width: 10, height: 10)
-          Text("Recording")
+          Text(model.recordingStatusText)
             .font(.custom(FontNames.Inter_600_SemiBold, size: 14))
             .foregroundColor(.playolaRed)
         }
@@ -162,15 +162,15 @@ struct RecordPageView: View {
   private var buttonLabelSection: some View {
     switch model.recordingPhase {
     case .idle:
-      Text("Tap to Record")
+      Text(model.recordButtonLabel)
         .font(.custom(FontNames.Inter_400_Regular, size: 16))
         .foregroundColor(.playolaGray)
     case .recording:
-      Text("Tap to Stop")
+      Text(model.stopButtonLabel)
         .font(.custom(FontNames.Inter_400_Regular, size: 16))
         .foregroundColor(.playolaGray)
     case .review:
-      Text("Try Again")
+      Text(model.reRecordButtonLabel)
         .font(.custom(FontNames.Inter_400_Regular, size: 16))
         .foregroundColor(.playolaGray)
     }
@@ -197,7 +197,7 @@ struct RecordPageView: View {
           } label: {
             HStack(spacing: 6) {
               Image(systemName: "trash")
-              Text("Discard")
+              Text(model.discardButtonTitle)
             }
             .font(.custom(FontNames.Inter_600_SemiBold, size: 15))
             .foregroundColor(.playolaRed)
@@ -214,7 +214,7 @@ struct RecordPageView: View {
           } label: {
             HStack(spacing: 6) {
               Image(systemName: "checkmark")
-              Text("Use Recording")
+              Text(model.useRecordingButtonTitle)
             }
             .font(.custom(FontNames.Inter_600_SemiBold, size: 15))
             .foregroundColor(.white)

--- a/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
@@ -15,6 +15,7 @@ struct PrizeTierRow: View {
   let status: RedemptionStatus
   let buttonText: String
   let redeemedText: String
+  let hoursToGoText: String
   let onRedeem: () -> Void
 
   private var isRedeemed: Bool {
@@ -90,13 +91,13 @@ struct PrizeTierRow: View {
             .cornerRadius(6)
         }
 
-      case .moreTimeRequired(let hoursToGo):
+      case .moreTimeRequired:
         HStack(spacing: 4) {
           Image(systemName: "lock.fill")
             .foregroundColor(.white)
             .font(.system(size: 14))
 
-          Text("\(hoursToGo) hours to go")
+          Text(hoursToGoText)
             .lineLimit(1)
             .font(.custom(FontNames.Inter_600_SemiBold, size: 14))
             .foregroundColor(.white)
@@ -122,6 +123,7 @@ struct PrizeTierRow_Previews: PreviewProvider {
       status: .redeemable,
       buttonText: "Redeem",
       redeemedText: "Redeemed",
+      hoursToGoText: "5 hours to go",
       onRedeem: {})
   }
 }

--- a/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageModel.swift
@@ -72,6 +72,19 @@ class RewardsPageModel: ViewModel {
   var prizeTierButtonText: String { "Redeem" }
   var prizeTierRedeemedText: String { "Redeemed" }
 
+  var navigationTitle: String { "Listener Rewards" }
+  var yourRewardsTitle: String { "Your rewards" }
+  var yourRewardsSubtitle: String {
+    "Earn rewards from your fav artists for being an early Playola listener!"
+  }
+
+  func prizeTierHoursToGoText(for prizeTier: PrizeTier) -> String {
+    if case .moreTimeRequired(let hoursToGo) = redemptionStatus(for: prizeTier) {
+      return "\(hoursToGo) hours to go"
+    }
+    return ""
+  }
+
   // MARK: - User Actions
 
   func viewAppeared() async {

--- a/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageModel.swift
@@ -80,7 +80,7 @@ class RewardsPageModel: ViewModel {
 
   func prizeTierHoursToGoText(for prizeTier: PrizeTier) -> String {
     if case .moreTimeRequired(let hoursToGo) = redemptionStatus(for: prizeTier) {
-      return "\(hoursToGo) hours to go"
+      return "\(hoursToGo) \(hoursToGo == 1 ? "hour" : "hours") to go"
     }
     return ""
   }

--- a/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageModel.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageModel.swift
@@ -32,6 +32,35 @@ class RewardsPageModel: ViewModel {
   var redeemedPrizeTierIds: Set<String> = []
   var presentedAlert: PlayolaAlert?
 
+  // MARK: - User Actions
+
+  func viewAppeared() async {
+    let currentHours = getCurrentListeningHours()
+    await analytics.track(.viewedRewardsScreen(currentHours: currentHours))
+
+    await loadPrizeTiers()
+    await loadUserPrizes()
+  }
+
+  func redeemPrizeTapped(for prizeTier: PrizeTier) async {
+    let currentHours = getCurrentListeningHours()
+    await analytics.track(.tappedRedeemRewards(currentHours: currentHours))
+
+    let sheetModel = RedeemPrizeSheetModel(
+      prizeTier: prizeTier,
+      onSuccess: { [weak self] userPrize in
+        guard let self else { return }
+        if let prize = userPrize.prize {
+          self.redeemedPrizeTierIds.insert(prize.prizeTierId)
+        } else {
+          self.redeemedPrizeTierIds.insert(prizeTier.id)
+        }
+        self.presentedAlert = .prizeRedeemed
+      }
+    )
+    mainContainerNavigationCoordinator.presentedSheet = .redeemPrize(sheetModel)
+  }
+
   // MARK: - View Helpers
 
   struct PrizeTierInfo {
@@ -83,35 +112,6 @@ class RewardsPageModel: ViewModel {
       return "\(hoursToGo) \(hoursToGo == 1 ? "hour" : "hours") to go"
     }
     return ""
-  }
-
-  // MARK: - User Actions
-
-  func viewAppeared() async {
-    let currentHours = getCurrentListeningHours()
-    await analytics.track(.viewedRewardsScreen(currentHours: currentHours))
-
-    await loadPrizeTiers()
-    await loadUserPrizes()
-  }
-
-  func redeemPrizeTapped(for prizeTier: PrizeTier) async {
-    let currentHours = getCurrentListeningHours()
-    await analytics.track(.tappedRedeemRewards(currentHours: currentHours))
-
-    let sheetModel = RedeemPrizeSheetModel(
-      prizeTier: prizeTier,
-      onSuccess: { [weak self] userPrize in
-        guard let self else { return }
-        if let prize = userPrize.prize {
-          self.redeemedPrizeTierIds.insert(prize.prizeTierId)
-        } else {
-          self.redeemedPrizeTierIds.insert(prizeTier.id)
-        }
-        self.presentedAlert = .prizeRedeemed
-      }
-    )
-    mainContainerNavigationCoordinator.presentedSheet = .redeemPrize(sheetModel)
   }
 
   // MARK: - Private Helpers

--- a/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageView.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageView.swift
@@ -21,7 +21,7 @@ struct RewardsPageView: View {
     VStack(spacing: 0) {
       // Sticky Title
       HStack {
-        Text("Listener Rewards")
+        Text(model.navigationTitle)
           .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 32))
           .foregroundColor(.white)
         Spacer()
@@ -42,11 +42,11 @@ struct RewardsPageView: View {
           // Your Rewards Section
           VStack(alignment: .leading, spacing: 16) {
             VStack(alignment: .leading, spacing: 8) {
-              Text("Your rewards")
+              Text(model.yourRewardsTitle)
                 .font(.custom("Inter_700_Bold", size: 24))
                 .foregroundColor(.white)
 
-              Text("Earn rewards from your fav artists for being an early Playola listener!")
+              Text(model.yourRewardsSubtitle)
                 .font(.custom(FontNames.Inter_500_Medium, size: 16))
                 .foregroundColor(.white)
                 .lineLimit(nil)
@@ -64,6 +64,7 @@ struct RewardsPageView: View {
                   status: model.redemptionStatus(for: prizeTier),
                   buttonText: model.prizeTierButtonText,
                   redeemedText: model.prizeTierRedeemedText,
+                  hoursToGoText: model.prizeTierHoursToGoText(for: prizeTier),
                   onRedeem: {
                     Task { await model.redeemPrizeTapped(for: prizeTier) }
                   }

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRow.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRow.swift
@@ -13,7 +13,7 @@ struct EpisodeRow: View {
     VStack(alignment: .leading, spacing: 8) {
       // Episode Title row
       HStack {
-        Text(model.airing.episode?.title ?? "Unknown Episode")
+        Text(model.episodeTitle)
           .font(.custom(FontNames.Inter_600_SemiBold, size: 15))
           .foregroundColor(.white)
 

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
@@ -37,6 +37,8 @@ class EpisodeRowModel: ViewModel {
     }
   }
 
+  var episodeTitle: String { airing.episode?.title ?? "Unknown Episode" }
+
   // MARK: - Private Helpers
 
   private var formattedTime: String {

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
@@ -23,6 +23,8 @@ class EpisodeRowModel: ViewModel {
     airing.airtime > now
   }
 
+  // MARK: - View Helpers
+
   var tuneInText: String {
     let time = formattedTime
     let dayOfWeek = dayOfWeekString

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
@@ -18,7 +18,7 @@ struct SeriesCard: View {
         .padding(.bottom, 16)
 
       // Show Title
-      Text(model.showWithAirings.show.title)
+      Text(model.showTitle)
         .font(.custom(FontNames.Inter_700_Bold, size: 21))
         .foregroundColor(.white)
         .padding(.bottom, 12)
@@ -36,14 +36,14 @@ struct SeriesCard: View {
 
       // Upcoming Episodes Header
       HStack {
-        Text("UPCOMING EPISODES")
+        Text(model.upcomingEpisodesHeader)
           .font(.custom(FontNames.Inter_500_Medium, size: 12))
           .tracking(0.06)
           .foregroundColor(Color(hex: "#c7c7c7"))
 
         Spacer()
 
-        Text("\(model.showWithAirings.upcomingAiringsCount) total")
+        Text(model.upcomingEpisodesCountText)
           .font(.custom(FontNames.Inter_400_Regular, size: 12))
           .foregroundColor(Color(hex: "#c7c7c7"))
       }
@@ -61,7 +61,7 @@ struct SeriesCard: View {
         Button {
           Task { await model.remindMeTapped() }
         } label: {
-          Text("Remind Me")
+          Text(model.remindMeButtonTitle)
             .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
             .foregroundColor(.white)
             .frame(maxWidth: .infinity)
@@ -109,12 +109,12 @@ struct SeriesCard: View {
 
       // Station Info
       VStack(alignment: .leading, spacing: 2) {
-        Text(model.showWithAirings.station?.name ?? "Unknown Station")
+        Text(model.stationName)
           .font(.custom(FontNames.Inter_500_Medium, size: 12))
           .tracking(0.06)
           .foregroundColor(Color(hex: "#c7c7c7"))
 
-        Text(model.showWithAirings.station?.curatorName ?? "")
+        Text(model.curatorName)
           .font(.custom(FontNames.Inter_500_Medium, size: 14))
           .foregroundColor(.white)
       }

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardModel.swift
@@ -25,18 +25,6 @@ class SeriesCardModel: ViewModel {
     super.init()
   }
 
-  var showTitle: String { showWithAirings.show.title }
-
-  var stationName: String { showWithAirings.station?.name ?? "Unknown Station" }
-
-  var curatorName: String { showWithAirings.station?.curatorName ?? "" }
-
-  var upcomingEpisodesHeader: String { "UPCOMING EPISODES" }
-
-  var upcomingEpisodesCountText: String { "\(showWithAirings.upcomingAiringsCount) total" }
-
-  var remindMeButtonTitle: String { "Remind Me" }
-
   func remindMeTapped() async {
     guard let jwt = auth.jwt else { return }
     guard let stationId = showWithAirings.station?.id else { return }
@@ -52,6 +40,20 @@ class SeriesCardModel: ViewModel {
       presentedAlert = .subscribeErrorAlert
     }
   }
+
+  // MARK: - View Helpers
+
+  var showTitle: String { showWithAirings.show.title }
+
+  var stationName: String { showWithAirings.station?.name ?? "Unknown Station" }
+
+  var curatorName: String { showWithAirings.station?.curatorName ?? "" }
+
+  var upcomingEpisodesHeader: String { "UPCOMING EPISODES" }
+
+  var upcomingEpisodesCountText: String { "\(showWithAirings.upcomingAiringsCount) total" }
+
+  var remindMeButtonTitle: String { "Remind Me" }
 }
 
 extension PlayolaAlert {

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardModel.swift
@@ -25,6 +25,18 @@ class SeriesCardModel: ViewModel {
     super.init()
   }
 
+  var showTitle: String { showWithAirings.show.title }
+
+  var stationName: String { showWithAirings.station?.name ?? "Unknown Station" }
+
+  var curatorName: String { showWithAirings.station?.curatorName ?? "" }
+
+  var upcomingEpisodesHeader: String { "UPCOMING EPISODES" }
+
+  var upcomingEpisodesCountText: String { "\(showWithAirings.upcomingAiringsCount) total" }
+
+  var remindMeButtonTitle: String { "Remind Me" }
+
   func remindMeTapped() async {
     guard let jwt = auth.jwt else { return }
     guard let stationId = showWithAirings.station?.id else { return }

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPage.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPage.swift
@@ -12,7 +12,7 @@ struct SeriesListPage: View {
     VStack(spacing: 0) {
       // Page Title
       HStack {
-        Text("Radio Shows")
+        Text(model.navigationTitle)
           .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 24))
           .tracking(0.12)
           .foregroundColor(.white)
@@ -42,7 +42,7 @@ struct SeriesListPage: View {
     .navigationBarTitleDisplayMode(.inline)
     .toolbarBackground(.hidden, for: .navigationBar)
     .onAppear { Task { await model.viewAppeared() } }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 }
 

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageModel.swift
@@ -25,8 +25,6 @@ class SeriesListPageModel: ViewModel {
   var isLoading = false
   var presentedAlert: PlayolaAlert?
 
-  var navigationTitle: String { "Radio Shows" }
-
   // MARK: - Init
 
   override init() {
@@ -38,6 +36,10 @@ class SeriesListPageModel: ViewModel {
   func viewAppeared() async {
     await loadShows()
   }
+
+  // MARK: - View Helpers
+
+  var navigationTitle: String { "Radio Shows" }
 
   private func loadShows() async {
     guard let jwtToken = auth.jwt else { return }

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageModel.swift
@@ -25,6 +25,8 @@ class SeriesListPageModel: ViewModel {
   var isLoading = false
   var presentedAlert: PlayolaAlert?
 
+  var navigationTitle: String { "Radio Shows" }
+
   // MARK: - Init
 
   override init() {

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageModel.swift
@@ -34,6 +34,12 @@ class SignInPageModel: ViewModel {
   var presentedAlert: PlayolaAlert?
 
   var googleSignInButtonTitle: String { "Sign in with Google" }
+  var welcomeTitle: String { "Welcome to Playola" }
+  var welcomeSubtitle: String { "Sign in to access your personalized radio stations" }
+  var termsAgreementText: String { "By signing in, you agree to our" }
+  var termsOfServiceText: String { "Terms of Service" }
+  var termsConjunctionText: String { "and" }
+  var privacyPolicyText: String { "Privacy Policy" }
 
   @ObservationIgnored
   var keyWindowProvider: @MainActor () -> UIViewController? = {

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -44,12 +44,12 @@ struct SignInPage: View {
           .padding(.bottom, 40)
 
           // Welcome text
-          Text("Welcome to Playola")
+          Text(model.welcomeTitle)
             .font(.title)
             .fontWeight(.bold)
             .foregroundColor(.white)
 
-          Text("Sign in to access your personalized radio stations")
+          Text(model.welcomeSubtitle)
             .font(.subheadline)
             .foregroundColor(Color.white.opacity(0.7))
             .multilineTextAlignment(.center)
@@ -80,21 +80,21 @@ struct SignInPage: View {
 
           // Footer
           VStack(spacing: 8) {
-            Text("By signing in, you agree to our")
+            Text(model.termsAgreementText)
               .font(.footnote)
               .foregroundColor(Color.white.opacity(0.6))
 
             HStack(spacing: 4) {
-              Text("Terms of Service")
+              Text(model.termsOfServiceText)
                 .font(.footnote)
                 .foregroundColor(.playolaRed)
                 .underline()
 
-              Text("and")
+              Text(model.termsConjunctionText)
                 .font(.footnote)
                 .foregroundColor(Color.white.opacity(0.6))
 
-              Text("Privacy Policy")
+              Text(model.privacyPolicyText)
                 .font(.footnote)
                 .foregroundColor(.playolaRed)
                 .underline()

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageModel.swift
@@ -60,18 +60,6 @@ class SongSearchPageModel: ViewModel {
     onAddedToLibrary != nil
   }
 
-  var songSeedsSectionHeader: String {
-    isLibraryAddMode ? "APPLE MUSIC" : "AVAILABLE SOON BY REQUEST"
-  }
-
-  var emptyPromptMessage: String { "Search for songs to add to your schedule" }
-  var noResultsMessage: String { "No songs found" }
-  var librarySectionHeader: String { "LIBRARY" }
-  var searchFieldPlaceholder: String { "Search for songs" }
-  var cancelButtonText: String { "Cancel" }
-  var selectButtonText: String { "SELECT" }
-  var songSeedActionButtonText: String { isLibraryAddMode ? "ADD" : "REQUEST" }
-
   private func onSearchTextChanged() {
     debounceTask?.cancel()
 
@@ -194,6 +182,20 @@ class SongSearchPageModel: ViewModel {
       presentedAlert = .libraryAddError(error.localizedDescription)
     }
   }
+
+  // MARK: - View Helpers
+
+  var songSeedsSectionHeader: String {
+    isLibraryAddMode ? "APPLE MUSIC" : "AVAILABLE SOON BY REQUEST"
+  }
+
+  var emptyPromptMessage: String { "Search for songs to add to your schedule" }
+  var noResultsMessage: String { "No songs found" }
+  var librarySectionHeader: String { "LIBRARY" }
+  var searchFieldPlaceholder: String { "Search for songs" }
+  var cancelButtonText: String { "Cancel" }
+  var selectButtonText: String { "SELECT" }
+  var songSeedActionButtonText: String { isLibraryAddMode ? "ADD" : "REQUEST" }
 
   private func updateSongRequestToRequested(_ songRequest: SongRequest) {
     guard

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageModel.swift
@@ -64,6 +64,14 @@ class SongSearchPageModel: ViewModel {
     isLibraryAddMode ? "APPLE MUSIC" : "AVAILABLE SOON BY REQUEST"
   }
 
+  var emptyPromptMessage: String { "Search for songs to add to your schedule" }
+  var noResultsMessage: String { "No songs found" }
+  var librarySectionHeader: String { "LIBRARY" }
+  var searchFieldPlaceholder: String { "Search for songs" }
+  var cancelButtonText: String { "Cancel" }
+  var selectButtonText: String { "SELECT" }
+  var songSeedActionButtonText: String { isLibraryAddMode ? "ADD" : "REQUEST" }
+
   private func onSearchTextChanged() {
     debounceTask?.cancel()
 

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
@@ -142,7 +142,7 @@ struct SongSearchPageView: View {
 struct SongSearchResultRow: View {
   @Environment(\.displayScale) private var displayScale
   let audioBlock: AudioBlock
-  var buttonText: String = "SELECT"
+  var buttonText: String
   let onSelect: () -> Void
 
   var body: some View {
@@ -200,7 +200,7 @@ struct SongSearchResultRow: View {
 struct SongRequestResultRow: View {
   @Environment(\.displayScale) private var displayScale
   let songRequest: SongRequest
-  var buttonText: String = "REQUEST"
+  var buttonText: String
   var isProcessing: Bool = false
   let onRequest: () -> Void
 

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
@@ -33,7 +33,7 @@ struct SongSearchPageView: View {
             Image(systemName: "music.note.list")
               .font(.system(size: 48))
               .foregroundColor(.playolaGray)
-            Text("Search for songs to add to your schedule")
+            Text(model.emptyPromptMessage)
               .font(.custom(FontNames.Inter_400_Regular, size: 16))
               .foregroundColor(.playolaGray)
               .multilineTextAlignment(.center)
@@ -46,7 +46,7 @@ struct SongSearchPageView: View {
             Image(systemName: "magnifyingglass")
               .font(.system(size: 48))
               .foregroundColor(.playolaGray)
-            Text("No songs found")
+            Text(model.noResultsMessage)
               .font(.custom(FontNames.Inter_400_Regular, size: 16))
               .foregroundColor(.playolaGray)
           }
@@ -57,7 +57,10 @@ struct SongSearchPageView: View {
             if model.searchMode != .seedsOnly && !model.searchResults.isEmpty {
               Section {
                 ForEach(model.searchResults, id: \.id) { audioBlock in
-                  SongSearchResultRow(audioBlock: audioBlock) {
+                  SongSearchResultRow(
+                    audioBlock: audioBlock,
+                    buttonText: model.selectButtonText
+                  ) {
                     model.onSelectSong(audioBlock)
                   }
                   .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
@@ -65,7 +68,7 @@ struct SongSearchPageView: View {
                   .listRowBackground(Color.clear)
                 }
               } header: {
-                Text("LIBRARY")
+                Text(model.librarySectionHeader)
                   .font(.custom(FontNames.Inter_600_SemiBold, size: 12))
                   .foregroundColor(.playolaGray)
               }
@@ -77,7 +80,7 @@ struct SongSearchPageView: View {
                 ForEach(model.songRequestResults, id: \.id) { songRequest in
                   SongRequestResultRow(
                     songRequest: songRequest,
-                    buttonText: model.isLibraryAddMode ? "ADD" : "REQUEST",
+                    buttonText: model.songSeedActionButtonText,
                     isProcessing: model.isProcessingAdd(for: songRequest)
                   ) {
                     Task {
@@ -112,7 +115,7 @@ struct SongSearchPageView: View {
             .font(.system(size: 16))
             .foregroundColor(.playolaGray)
 
-          TextField("Search for songs", text: $model.searchText)
+          TextField(model.searchFieldPlaceholder, text: $model.searchText)
             .font(.custom(FontNames.Inter_400_Regular, size: 16))
             .foregroundColor(.white)
             .autocorrectionDisabled()
@@ -122,7 +125,7 @@ struct SongSearchPageView: View {
         .background(Color(hex: "#333333"))
         .cornerRadius(8)
 
-        Button("Cancel") {
+        Button(model.cancelButtonText) {
           model.onCancelTapped()
         }
         .font(.custom(FontNames.Inter_500_Medium, size: 16))
@@ -132,13 +135,14 @@ struct SongSearchPageView: View {
       .padding(.vertical, 12)
       .background(Color.black)
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
   }
 }
 
 struct SongSearchResultRow: View {
   @Environment(\.displayScale) private var displayScale
   let audioBlock: AudioBlock
+  var buttonText: String = "SELECT"
   let onSelect: () -> Void
 
   var body: some View {
@@ -178,7 +182,7 @@ struct SongSearchResultRow: View {
       Spacer()
 
       Button(action: onSelect) {
-        Text("SELECT")
+        Text(buttonText)
           .font(.custom(FontNames.Inter_600_SemiBold, size: 12))
           .foregroundColor(.white)
           .padding(.horizontal, 12)

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift
@@ -125,7 +125,7 @@ class StationSuggestionPageModel: ViewModel {
   }
 
   func voteCountLabel(_ suggestion: ArtistSuggestion) -> String {
-    "\(voteCountText(suggestion)) votes"
+    "\(suggestion.voteCount) \(suggestion.voteCount == 1 ? "vote" : "votes")"
   }
 
   func inDevelopmentBadgeText(_ suggestion: ArtistSuggestion) -> String? {

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageModel.swift
@@ -124,6 +124,10 @@ class StationSuggestionPageModel: ViewModel {
     "\(suggestion.voteCount)"
   }
 
+  func voteCountLabel(_ suggestion: ArtistSuggestion) -> String {
+    "\(voteCountText(suggestion)) votes"
+  }
+
   func inDevelopmentBadgeText(_ suggestion: ArtistSuggestion) -> String? {
     suggestion.status == .inDevelopment ? "IN DEVELOPMENT" : nil
   }

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageView.swift
@@ -34,7 +34,7 @@ struct StationSuggestionPageView: View {
       }
       .toolbarBackground(.visible, for: .navigationBar)
       .toolbarBackground(Color.background, for: .navigationBar)
-      .alert(item: $model.presentedAlert) { $0.alert }
+      .playolaAlert($model.presentedAlert)
     }
     .onAppear { Task { await model.viewAppeared() } }
   }
@@ -149,7 +149,7 @@ struct StationSuggestionPageView: View {
           InDevelopmentBadge(text: model.inDevelopmentBadgeText(suggestion))
         }
 
-        Text("\(model.voteCountText(suggestion)) votes")
+        Text(model.voteCountLabel(suggestion))
           .font(.custom(FontNames.Inter_400_Regular, size: 13))
           .foregroundColor(.textSecondary)
       }

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
@@ -33,9 +33,6 @@ class SupportPageModel: ViewModel {
     !newMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending
   }
 
-  var navigationTitle: String { "Contact Us" }
-  var messageFieldPlaceholder: String { "Message" }
-
   func onViewAppeared() async {
     guard let jwt = auth.jwt else { return }
 
@@ -120,6 +117,11 @@ class SupportPageModel: ViewModel {
     guard phase == .active else { return }
     await refreshMessages()
   }
+
+  // MARK: - View Helpers
+
+  var navigationTitle: String { "Contact Us" }
+  var messageFieldPlaceholder: String { "Message" }
 }
 
 extension PlayolaAlert {

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageModel.swift
@@ -33,6 +33,9 @@ class SupportPageModel: ViewModel {
     !newMessage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty && !isSending
   }
 
+  var navigationTitle: String { "Contact Us" }
+  var messageFieldPlaceholder: String { "Message" }
+
   func onViewAppeared() async {
     guard let jwt = auth.jwt else { return }
 

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageView.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageView.swift
@@ -22,7 +22,7 @@ struct SupportPageView: View {
         ChatView(model: model)
       }
     }
-    .navigationTitle("Contact Us")
+    .navigationTitle(model.navigationTitle)
     .navigationBarTitleDisplayMode(.inline)
     .toolbarBackground(.visible, for: .navigationBar)
     .toolbarBackground(Color.black, for: .navigationBar)
@@ -33,7 +33,7 @@ struct SupportPageView: View {
     .task {
       await model.observeRefreshNotifications()
     }
-    .alert(item: $model.presentedAlert) { $0.alert }
+    .playolaAlert($model.presentedAlert)
     .onChange(of: scenePhase) { _, newPhase in
       Task { await model.handleScenePhaseChange(newPhase) }
     }
@@ -83,7 +83,7 @@ struct ChatView: View {
         .background(Color(hex: "#333333"))
 
       HStack(spacing: 12) {
-        TextField("Message", text: $model.newMessage, axis: .vertical)
+        TextField(model.messageFieldPlaceholder, text: $model.newMessage, axis: .vertical)
           .font(.custom(FontNames.Inter_400_Regular, size: 16))
           .foregroundColor(.white)
           .padding(.horizontal, 16)

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTile.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTile.swift
@@ -19,7 +19,7 @@ struct ListeningTimeTile: View {
         Image("listening-time-icon")
           .foregroundColor(.white)
 
-        Text("Listening Time")
+        Text(model.titleText)
           .font(.custom(FontNames.SpaceGrotesk_500_Medium, size: 16))
           .foregroundColor(.white)
 

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
@@ -49,6 +49,8 @@ class ListeningTimeTileModel: ViewModel {
     return "\(hourString)h \(minString)m \(secString)s"
   }
 
+  var titleText: String { "Listening Time" }
+
   private var refreshTask: Task<Void, Never>?
 
   func viewAppeared() {


### PR DESCRIPTION
Moves ~95 hardcoded user-facing strings (nav titles, labels, button text, empty-state copy, placeholders) out of 24 page views into computed properties on their `@Observable` models, so the model owns all display text per the MV architecture. Also swaps raw `.alert(item: $model.presentedAlert) { $0.alert }` for the project's `.playolaAlert($model.presentedAlert)` modifier wherever it's behavior-preserving. RecordPage, AskQuestionPage, and ListenerQuestionDetailPage keep the legacy `.alert` because their alerts carry a `dismissButton` action or a secondary button, which `.playolaAlert`'s button builder does not yet support (it would render an inert OK and drop the action). PlayerPage is intentionally left for a follow-up PR (it also needs a `UIScreen.main` layout migration). Behavior is unchanged: full test suite passes and an independent Codex review confirmed no regressions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved clarity and consistency of in-app text across profiles, support, rewards, search, recording, broadcasting, series browsing, and questions.
  * Enhanced rewards interactions, including prize redemption updates and clearer progress messaging.
* **Bug Fixes**
  * Standardized alert presentation for a more consistent experience.
  * Refined display wording and formatting, including recording labels, schedule times, and pluralized vote counts.
* **Refactor**
  * Centralized user-facing copy for more consistent UI text across screens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->