### PR TITLE
fix: silence Sentry missing-dSYM warning via uploadSymbols:false

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -1635,7 +1635,6 @@
 				D35369FD2BFA4F49006942D6 /* Sources */,
 				D35369FE2BFA4F49006942D6 /* Frameworks */,
 				D35369FF2BFA4F49006942D6 /* Resources */,
-				A749B0FA144D4CBFB5A75066 /* Upload Debug Symbols to Sentry */,
 			);
 			buildRules = (
 			);
@@ -1771,25 +1770,6 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXResourcesBuildPhase section */
-
-/* Begin PBXShellScriptBuildPhase section */
-		A749B0FA144D4CBFB5A75066 /* Upload Debug Symbols to Sentry */ = {
-			isa = PBXShellScriptBuildPhase;
-			alwaysOutOfDate = 1;
-			buildActionMask = 2147483647;
-			files = (
-			);
-			inputPaths = (
-				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
-			);
-			name = "Upload Debug Symbols to Sentry";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-			shellPath = /bin/sh;
-			shellScript = "# This script is responsible for uploading debug symbols and source context for Sentry.\nif which sentry-cli >/dev/null; then\n  export SENTRY_ORG=playola-radio\n  export SENTRY_PROJECT=apple-ios\n  sentry-cli debug-files upload --include-sources \"$DWARF_DSYM_FOLDER_PATH\" 2>&1 || echo \"warning: sentry-cli upload failed\"\nelse\n  echo \"warning: sentry-cli not installed, download from https://github.com/getsentry/sentry-cli/releases\"\nfi\n";
-		};
-/* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
 		D30F00492E8592F0007BCC73 /* Sources */ = {

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -56,6 +56,14 @@ platform :ios do
       output_directory: "./build",
       export_options: {
         method: "app-store",
+        # sentry-cocoa's SwiftPM `Sentry` product links statically (its symbols
+        # ship inside PlayolaRadio.app.dSYM), but Xcode still embeds an empty
+        # dynamic Sentry.framework stub with a fresh UUID every build and no
+        # matching dSYM. Handing that to Apple triggers the "missing dSYM for
+        # Sentry.framework" warning. We symbolicate via Sentry (the
+        # sentry_debug_files_upload below uploads the real app dSYM), not Apple's
+        # Organizer, so skip Apple's symbol upload to silence the warning.
+        uploadSymbols: false,
         provisioningProfiles: {
           "fm.playola.playolaradio.staging" => "match AppStore fm.playola.playolaradio.staging"
         }
@@ -122,6 +130,12 @@ platform :ios do
       xcargs: "-skipPackagePluginValidation -skipMacroValidation",
       export_options: {
         method: "app-store",
+        # See release_staging for rationale: Sentry links statically but Xcode
+        # embeds an empty dynamic Sentry.framework stub (fresh UUID, no dSYM).
+        # We symbolicate via Sentry (sentry_debug_files_upload uploads the real
+        # app dSYM), so skip Apple's symbol upload to silence the missing-dSYM
+        # warning.
+        uploadSymbols: false,
         provisioningProfiles: {
           "fm.playola.playolaradio" => "match AppStore fm.playola.playolaradio"
         }


### PR DESCRIPTION
Sentry (sentry-cocoa 9.12.0 via SPM) already links statically into the app binary — its symbols ship inside `PlayolaRadio.app.dSYM` — but Xcode also auto-embeds an empty 32K dynamic `Sentry.framework` stub with a fresh UUID every build and no matching dSYM, which is what makes App Store Connect warn "archive did not include a dSYM for Sentry.framework"; there is no clean project.pbxproj lever to suppress that auto-embed. This sets `uploadSymbols: false` in the `gym` `export_options` of both fastlane release lanes so Xcode stops handing the empty stub's missing dSYM to Apple, while `sentry_debug_files_upload` keeps uploading the real app dSYM to Sentry for full symbolication. It also removes the redundant in-Xcode "Upload Debug Symbols to Sentry" run-script build phase (production target only) that duplicated the fastlane upload, leaving a single upload path. Verified locally: unsigned archive succeeds and the full test suite (1029 tests) passes. Note: the warning is emitted by App Store Connect during processing, so a real TestFlight upload is required to confirm it is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)