### PR TITLE
test: harden Siri play-station tests (mock injection + foreground coverage)

### DIFF
--- a/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
@@ -53,14 +53,14 @@ struct PlayStationActionTests {
   func testLoggedInValidStationPlaysAndReturnsPlaying() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.stationLists) var stationLists = makeStationLists()
-    let player = StationPlayer()
+    let player = StationPlayerMock()
     let outcome = await withDependencies {
       $0.stationPlayer = player
     } operation: {
       await PlayStationAction().run(stationID: "koke-fm-id")
     }
     #expect(outcome == .playing(stationName: "KOKE FM"))
-    #expect(player.currentStation?.id == "koke-fm-id")
+    #expect(player.callsToPlay.map(\.id) == ["koke-fm-id"])
   }
 
   // A Playola (artist) station's `stationName` is the internal show name

--- a/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
@@ -30,7 +30,7 @@ struct PlayStationActionTests {
     @Shared(.auth) var auth = Auth()
     @Shared(.stationLists) var stationLists = makeStationLists()
     let outcome = await withDependencies {
-      $0.stationPlayer = StationPlayer()
+      $0.stationPlayer = StationPlayerMock()
     } operation: {
       await PlayStationAction().run(stationID: "koke-fm-id")
     }
@@ -42,7 +42,7 @@ struct PlayStationActionTests {
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.stationLists) var stationLists = makeStationLists()
     let outcome = await withDependencies {
-      $0.stationPlayer = StationPlayer()
+      $0.stationPlayer = StationPlayerMock()
     } operation: {
       await PlayStationAction().run(stationID: "does-not-exist")
     }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -481,6 +481,21 @@ struct MainContainerTests {
   }
 
   @Test
+  func testRefreshOnForegroundRefreshesSiriShortcutSuggestions() async {
+    @Shared(.stationListsLoaded) var stationListsLoaded = false
+    let didRefresh = LockIsolated(false)
+    let mainContainerModel = withDependencies {
+      $0.api.getStations = { StationList.mocks }
+      $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.siriShortcuts.refreshSuggestions = { didRefresh.setValue(true) }
+    } operation: {
+      MainContainerModel()
+    }
+    await mainContainerModel.refreshOnForeground()
+    #expect(didRefresh.value == true)
+  }
+
+  @Test
   func testRefreshOnForegroundSkipsAiringsWhenNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -486,7 +486,6 @@ struct MainContainerTests {
     let didRefresh = LockIsolated(false)
     let mainContainerModel = withDependencies {
       $0.api.getStations = { StationList.mocks }
-      $0.pushNotifications.registerForRemoteNotifications = {}
       $0.siriShortcuts.refreshSuggestions = { didRefresh.setValue(true) }
     } operation: {
       MainContainerModel()


### PR DESCRIPTION
## Summary

Fixes two test-quality issues Greptile flagged on the Siri play-station feature (originally surfaced on the #319 release PR). **Test-only — no production behavior, signing, or Siri runtime code changed.**

### 1. Real `StationPlayer` used where the mock is expected
`PlayStationActionTests.testLoggedInValidStationPlaysAndReturnsPlaying` injected a live `StationPlayer()` and asserted `player.currentStation?.id` after an `await`. A live player in a unit test is non-hermetic (real playback/network logic, timing) and can flake.

- Inject `StationPlayerMock` instead, matching the adjacent `testPlayolaStationUsesCuratorPossessiveLabelInDialog` exactly.
- Assert against the mock's recorded state: `player.callsToPlay.map(\.id) == ["koke-fm-id"]`.
- Intent preserved: logged-in + valid station → plays → returns `.playing(stationName: "KOKE FM")`.

### 2. `refreshOnForeground` had no Siri-refresh assertion
`applyStationLists` (which calls `siriShortcuts.refreshSuggestions`) runs from both `viewAppeared` and `refreshOnForeground`. Only the `viewAppeared` path was covered, so a regression that skipped the Siri refresh on foreground would go uncaught.

- Added `testRefreshOnForegroundRefreshesSiriShortcutSuggestions`, mirroring `testViewAppearedRefreshesSiriShortcutSuggestions` exactly (same `LockIsolated` spy, same `$0.siriShortcuts.refreshSuggestions` override, same assertion style) but driving `refreshOnForeground()`.

## Testing

`xcodebuild test` on iPhone 16 (iOS 18.6), both affected suites — all 44 tests pass, including the two touched tests. SwiftLint build plugin and swift-format check both clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)