### PR TITLE
CI release hardening: base64 ASC key + build staging on each release tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,41 @@ jobs:
       - store_test_results:
           path: fastlane/test_output
 
+  release_staging_build:
+    macos:
+      xcode: 26.2
+    resource_class: m4pro.medium
+    steps:
+      - checkout
+      - run:
+          name: Set up SSH for match (fastlane-match-certs-and-profiles)
+          command: |
+            mkdir -p ~/.ssh
+            chmod 700 ~/.ssh
+            printf '%s' "$MATCH_GIT_PRIVATE_KEY_B64" | base64 --decode > ~/.ssh/id_rsa
+            chmod 600 ~/.ssh/id_rsa
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run:
+          name: Install Bundler
+          command: gem install bundler
+      - run:
+          name: Install Fastlane
+          command: bundle install
+      - run:
+          name: Install xcbeautify and xcresultparser
+          command: brew install xcbeautify xcresultparser
+      - run:
+          name: Decode xcconfig secrets
+          command: bash scripts/ci-write-secrets.sh
+      - run:
+          name: Resolve Swift Package Dependencies
+          command: xcodebuild -resolvePackageDependencies -project PlayolaRadio.xcodeproj
+      - run:
+          name: Fastlane release_staging (build + upload to staging TestFlight + Sentry dSYMs)
+          command: bundle exec fastlane release_staging
+      - store_artifacts:
+          path: build
+
   adhoc:
     macos:
       xcode: 26.2
@@ -129,6 +164,15 @@ workflows:
     jobs:
       - release_build:
           context: ios-release
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - release_staging_build:
+          context: ios-release
+          requires:
+            - release_build
           filters:
             tags:
               only: /^v.*/

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -109,7 +109,7 @@ release workflow. Names only; values live in CircleCI.
 |---|---|
 | `APP_STORE_CONNECT_API_KEY_ID` | ASC API key identifier. |
 | `APP_STORE_CONNECT_API_ISSUER_ID` | ASC issuer UUID. |
-| `APP_STORE_CONNECT_API_KEY_CONTENT` | Contents of the `.p8` private key used by fastlane to authenticate to App Store Connect. |
+| `APP_STORE_CONNECT_API_KEY_CONTENT` | The `.p8` private key for App Store Connect auth. **Prefer base64** — set it to `base64 -i AuthKey_XXXX.p8 \| tr -d '\n'`. (The raw `.p8` also works, but CircleCI env vars often strip the multi-line PEM's newlines, which corrupts the key and fails the release with OpenSSL `invalid curve name`. The Fastfile auto-detects base64 vs raw via the `-----BEGIN` header.) |
 | `MATCH_PASSWORD` | Passphrase that decrypts the fastlane-match certificate repo. |
 | `MATCH_GIT_PRIVATE_KEY` | SSH key with read access to the `fastlane-match-certs-and-profiles` repo. |
 | `SECRETS_XCCONFIG_B64` | Base64 of `PlayolaRadio/Config/Secrets.xcconfig`. |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,6 +38,26 @@ platform :ios do
     setup_circle_ci if ENV['CI']
   end
 
+  # Resolve the App Store Connect API key, accepting EITHER the raw .p8 PEM or a
+  # base64-encoded .p8 in APP_STORE_CONNECT_API_KEY_CONTENT. base64 is preferred
+  # for CI because a single-line value can't be corrupted by env-var newline
+  # mangling — mangled newlines turn a valid key into OpenSSL "invalid curve
+  # name" at auth time. Falls back to the .p8 file at
+  # APP_STORE_CONNECT_API_KEY_PATH for local runs.
+  private_lane :asc_api_key do
+    key = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] ||
+          (ENV["APP_STORE_CONNECT_API_KEY_PATH"] && File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])) ||
+          UI.user_error!("Set APP_STORE_CONNECT_API_KEY_CONTENT (CI; raw .p8 or base64 of it) or APP_STORE_CONNECT_API_KEY_PATH (local)")
+    app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
+      key_content: key,
+      # A raw PEM always contains the literal "-----BEGIN"; base64 never can
+      # (its alphabet has no dashes), so this disambiguates the two reliably.
+      is_key_content_base64: !key.include?("-----BEGIN")
+    )
+  end
+
   desc "Release STAGING build to TestFlight (Internal Only)"
   lane :release_staging do
     ensure_git_status_clean
@@ -76,11 +96,7 @@ platform :ios do
       include_sources: true
     )
 
-    api_key = app_store_connect_api_key(
-      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
-      issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
-      key_content: File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])
-    )
+    api_key = asc_api_key
 
     upload_to_testflight(
       api_key: api_key,
@@ -148,14 +164,7 @@ platform :ios do
       include_sources: true
     )
 
-    key_content = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] ||
-                  (ENV["APP_STORE_CONNECT_API_KEY_PATH"] && File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])) ||
-                  UI.user_error!("Set APP_STORE_CONNECT_API_KEY_CONTENT (CI) or APP_STORE_CONNECT_API_KEY_PATH (local)")
-    api_key = app_store_connect_api_key(
-      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
-      issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
-      key_content: key_content
-    )
+    api_key = asc_api_key
 
     upload_to_testflight(
       api_key: api_key,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,7 +61,7 @@ platform :ios do
   desc "Release STAGING build to TestFlight (Internal Only)"
   lane :release_staging do
     ensure_git_status_clean
-    ensure_git_branch(branch: 'develop')
+    ensure_git_branch(branch: 'develop') unless ENV['CI']
 
     match(
       type: "appstore",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,9 +45,9 @@ platform :ios do
   # name" at auth time. Falls back to the .p8 file at
   # APP_STORE_CONNECT_API_KEY_PATH for local runs.
   private_lane :asc_api_key do
-    key = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] ||
-          (ENV["APP_STORE_CONNECT_API_KEY_PATH"] && File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])) ||
-          UI.user_error!("Set APP_STORE_CONNECT_API_KEY_CONTENT (CI; raw .p8 or base64 of it) or APP_STORE_CONNECT_API_KEY_PATH (local)")
+    key = (ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] || "").strip
+    key = File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"]).strip if key.empty? && ENV["APP_STORE_CONNECT_API_KEY_PATH"]
+    UI.user_error!("Set APP_STORE_CONNECT_API_KEY_CONTENT (CI; raw .p8 or base64 of it) or APP_STORE_CONNECT_API_KEY_PATH (local)") if key.empty?
     app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],


### PR DESCRIPTION
## Summary

Make the CI release flow robust and complete for **both** apps.

### 1. Accept base64 App Store Connect key (fixes the release-blocking auth failure)
The first real CI release (`v7.2.0-b91`) failed at `app_store_connect_api_key` with `OpenSSL … invalid curve name` — CircleCI had stripped the newlines from the raw multi-line `.p8` stored in `APP_STORE_CONNECT_API_KEY_CONTENT`, corrupting the key. New shared `asc_api_key` private lane (used by both release lanes) accepts **either** the raw `.p8` PEM **or** a base64-encoded `.p8`, auto-detecting via the `-----BEGIN` header (base64 has no dashes) and setting `is_key_content_base64`. Empty/whitespace values now fail with a clear error instead of an opaque OpenSSL one. RELEASE.md recommends base64.

**No flag day:** the current raw-PEM secret keeps working; migrate it to `base64 -i AuthKey.p8 | tr -d '\n'` after this lands on main to fully harden.

### 2. Build + upload staging TestFlight on each release tag
New `release_staging_build` CircleCI job in the `release` workflow, on the same `v*` tags as production. It `requires: release_build`, so staging only ships **after** the release passes its full test suite + production upload. Uses the single shared distribution cert / match staging profile and the `asc_api_key` lane. Relaxed `release_staging`'s `ensure_git_branch('develop')` to skip in CI (`unless ENV['CI']`) so it runs on the detached tag checkout, mirroring `release_production`. Each release tag is a unique build number, so staging uploads never collide.

Reviewed by Codex (no issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
