### PR TITLE
Release 7.2.0 (build 92)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,6 +88,41 @@ jobs:
       - store_test_results:
           path: fastlane/test_output
 
+  release_staging_build:
+    macos:
+      xcode: 26.2
+    resource_class: m4pro.medium
+    steps:
+      - checkout
+      - run:
+          name: Set up SSH for match (fastlane-match-certs-and-profiles)
+          command: |
+            mkdir -p ~/.ssh
+            chmod 700 ~/.ssh
+            printf '%s' "$MATCH_GIT_PRIVATE_KEY_B64" | base64 --decode > ~/.ssh/id_rsa
+            chmod 600 ~/.ssh/id_rsa
+            ssh-keyscan github.com >> ~/.ssh/known_hosts
+      - run:
+          name: Install Bundler
+          command: gem install bundler
+      - run:
+          name: Install Fastlane
+          command: bundle install
+      - run:
+          name: Install xcbeautify and xcresultparser
+          command: brew install xcbeautify xcresultparser
+      - run:
+          name: Decode xcconfig secrets
+          command: bash scripts/ci-write-secrets.sh
+      - run:
+          name: Resolve Swift Package Dependencies
+          command: xcodebuild -resolvePackageDependencies -project PlayolaRadio.xcodeproj
+      - run:
+          name: Fastlane release_staging (build + upload to staging TestFlight + Sentry dSYMs)
+          command: bundle exec fastlane release_staging
+      - store_artifacts:
+          path: build
+
   adhoc:
     macos:
       xcode: 26.2
@@ -129,6 +164,15 @@ workflows:
     jobs:
       - release_build:
           context: ios-release
+          filters:
+            tags:
+              only: /^v.*/
+            branches:
+              ignore: /.*/
+      - release_staging_build:
+          context: ios-release
+          requires:
+            - release_build
           filters:
             tags:
               only: /^v.*/

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2478,7 +2478,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PlayolaRadio/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "";
+				INFOPLIST_KEY_CFBundleDisplayName = "Playola";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Playola uses the microphone to let you record voicetracks or audio messages.";
@@ -2524,7 +2524,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PlayolaRadio/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "";
+				INFOPLIST_KEY_CFBundleDisplayName = "Playola";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Playola uses the microphone to let you record voicetracks or audio messages.";
@@ -2672,7 +2672,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PlayolaRadio/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "";
+				INFOPLIST_KEY_CFBundleDisplayName = "Playola";
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Playola uses the microphone to let you record voicetracks or audio messages.";

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2217,7 +2217,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 91;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2261,7 +2261,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 91;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2305,7 +2305,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 91;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2470,7 +2470,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 91;
+				CURRENT_PROJECT_VERSION = 92;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = CTFSB7Y8TD;
@@ -2516,7 +2516,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 91;
+				CURRENT_PROJECT_VERSION = 92;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2557,7 +2557,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 91;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2576,7 +2576,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 91;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2664,7 +2664,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 91;
+				CURRENT_PROJECT_VERSION = 92;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = CTFSB7Y8TD;
@@ -2705,7 +2705,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 91;
+				CURRENT_PROJECT_VERSION = 92;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;

--- a/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
@@ -53,14 +53,14 @@ struct PlayStationActionTests {
   func testLoggedInValidStationPlaysAndReturnsPlaying() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.stationLists) var stationLists = makeStationLists()
-    let player = StationPlayer()
+    let player = StationPlayerMock()
     let outcome = await withDependencies {
       $0.stationPlayer = player
     } operation: {
       await PlayStationAction().run(stationID: "koke-fm-id")
     }
     #expect(outcome == .playing(stationName: "KOKE FM"))
-    #expect(player.currentStation?.id == "koke-fm-id")
+    #expect(player.callsToPlay.map(\.id) == ["koke-fm-id"])
   }
 
   // A Playola (artist) station's `stationName` is the internal show name

--- a/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
@@ -30,7 +30,7 @@ struct PlayStationActionTests {
     @Shared(.auth) var auth = Auth()
     @Shared(.stationLists) var stationLists = makeStationLists()
     let outcome = await withDependencies {
-      $0.stationPlayer = StationPlayer()
+      $0.stationPlayer = StationPlayerMock()
     } operation: {
       await PlayStationAction().run(stationID: "koke-fm-id")
     }
@@ -42,7 +42,7 @@ struct PlayStationActionTests {
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.stationLists) var stationLists = makeStationLists()
     let outcome = await withDependencies {
-      $0.stationPlayer = StationPlayer()
+      $0.stationPlayer = StationPlayerMock()
     } operation: {
       await PlayStationAction().run(stationID: "does-not-exist")
     }

--- a/PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift
+++ b/PlayolaRadio/Core/SiriIntents/StationVoiceCatalog.swift
@@ -29,7 +29,8 @@ struct StationVoiceCatalog {
     return words.joined(separator: " ")
   }
 
-  /// All playable (visible, non-coming-soon) stations as matches.
+  /// Every playable station as a match (see `allStations` for what "playable"
+  /// includes). Feeds the system's Siri/Spotlight suggestion index.
   func suggestedStations() -> [StationMatch] {
     allStations().map(makeMatch(for:))
   }
@@ -68,12 +69,26 @@ struct StationVoiceCatalog {
     let catalogIndex: Int
   }
 
+  /// Every station the app considers playable, deduped by id.
+  ///
+  /// Siri fails toward inclusion: hidden lists, hidden items, and coming-soon
+  /// items are all voice-playable regardless of the `showSecretStations` unlock,
+  /// so a user can always say "Play <station>" for anything in their catalog.
+  /// The only exclusion is `active == false` — stations the app itself refuses
+  /// to play (see `StationListModel.stationSelected`); offering those would let
+  /// Siri claim "Playing <name>" and then dead-air. A station can appear in more
+  /// than one list, so we keep the first occurrence to stay dedup-correct and
+  /// preserve catalog order for deterministic match tie-breaking.
   private func allStations() -> [AnyStation] {
-    stationLists
-      .filter { !$0.hidden }
+    var seen = Set<String>()
+    return
+      stationLists
       .flatMap { list in
-        list.stationItems(includeHidden: false, includeComingSoon: false).map(\.anyStation)
+        list.stationItems(includeHidden: true, includeComingSoon: true)
+          .compactMap(\.anyStationIfPresent)
       }
+      .filter(\.active)
+      .filter { seen.insert($0.id).inserted }
   }
 
   private func aliases(for station: AnyStation) -> [String] {

--- a/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
 import Sharing
@@ -70,14 +71,92 @@ struct StationVoiceCatalogTests {
   }
 
   @Test
-  func testHiddenListStationsAreExcluded() {
-    // StationList.mocks includes a hidden "in_development_list" containing a
-    // visible playola station (id "mock-playola-id"). It must never surface to Siri.
+  func testHiddenAndComingSoonStationsAreIncluded() {
+    // Siri fails toward inclusion: a station gated behind the secret-stations
+    // unlock everywhere else is still voice-playable. StationList.mocks covers
+    // all three gated shapes — a hidden list ("mock-playola-id"), a hidden item
+    // ("kftx-id"), and a coming-soon item ("lakes-country-id").
     @Shared(.stationLists) var stationLists = StationList.mocks
     let catalog = StationVoiceCatalog()
-    #expect(catalog.suggestedStations().contains { $0.id == "mock-playola-id" } == false)
-    #expect(catalog.station(id: "mock-playola-id") == nil)
-    #expect(catalog.match(id: "mock-playola-id") == nil)
+    let suggestedIDs = Set(catalog.suggestedStations().map(\.id))
+    #expect(suggestedIDs.contains("mock-playola-id"))
+    #expect(suggestedIDs.contains("kftx-id"))
+    #expect(suggestedIDs.contains("lakes-country-id"))
+    #expect(catalog.station(id: "mock-playola-id")?.id == "mock-playola-id")
+    #expect(catalog.match(id: "kftx-id")?.label == "97.5 KFTX")
+    #expect(catalog.matches(query: "Banned Radio").first?.id == "mock-playola-id")
+  }
+
+  @Test
+  func testInactiveStationsAreExcluded() {
+    // active == false means the app itself refuses to play it (see
+    // StationListModel.stationSelected); Siri must not offer a dead station.
+    // Covers both station kinds plus the nil-default (nil active == playable).
+    let list = StationList.mockArtistList(items: [
+      APIStationItem(
+        sortOrder: 0, station: nil,
+        urlStation: UrlStation.mockWith(id: "dead-url-id", name: "Dead Air FM", active: false)),
+      APIStationItem(
+        sortOrder: 1,
+        station: Station.mockWith(id: "dead-playola-id", name: "Off Air", active: false),
+        urlStation: nil),
+      APIStationItem(
+        sortOrder: 2,
+        station: Station.mockWith(id: "nil-active-id", name: "Defaulted", active: nil),
+        urlStation: nil),
+    ])
+    @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [list])
+    let catalog = StationVoiceCatalog()
+    let ids = Set(catalog.suggestedStations().map(\.id))
+    #expect(ids.contains("dead-url-id") == false)
+    #expect(ids.contains("dead-playola-id") == false)
+    #expect(ids.contains("nil-active-id"))  // nil active defaults to playable
+    #expect(catalog.station(id: "dead-playola-id") == nil)
+    #expect(catalog.matches(query: "Dead Air FM").isEmpty)
+  }
+
+  @Test
+  func testStationInMultipleListsIsDedupedKeepingFirstOccurrence() {
+    // The same id can live in more than one visible list with a different label
+    // per list. It must surface once, and the first list's label wins so
+    // catalog-order tie-breaking in matches() stays deterministic.
+    let now = Date()
+    func list(id: String, sortOrder: Int, label: String) -> StationList {
+      StationList(
+        id: id, name: id, slug: id, hidden: false, sortOrder: sortOrder,
+        createdAt: now, updatedAt: now,
+        items: [
+          APIStationItem(
+            sortOrder: 0, station: nil,
+            urlStation: UrlStation.mockWith(id: "dup-id", name: label))
+        ])
+    }
+    @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [
+      list(id: "list-a", sortOrder: 0, label: "First Label FM"),
+      list(id: "list-b", sortOrder: 1, label: "Second Label FM"),
+    ])
+    let catalog = StationVoiceCatalog()
+    let dupes = catalog.suggestedStations().filter { $0.id == "dup-id" }
+    #expect(dupes.count == 1)
+    #expect(dupes.first?.label == "First Label FM")
+    #expect(catalog.matches(query: "First Label FM").filter { $0.id == "dup-id" }.count == 1)
+  }
+
+  @Test
+  func testPlaceholderRowWithNoStationIsSkippedNotCrashed() {
+    // The decoder permits a row with neither a playola nor a URL station (e.g. a
+    // coming-soon placeholder). Including hidden/coming-soon items must skip such
+    // rows, not trap, while still surfacing the real station beside them.
+    let list = StationList.mockArtistList(items: [
+      APIStationItem(sortOrder: 0, station: nil, urlStation: nil),
+      APIStationItem(
+        sortOrder: 1, station: nil,
+        urlStation: UrlStation.mockWith(id: "real-id", name: "Real FM")),
+    ])
+    @Shared(.stationLists) var stationLists = IdentifiedArrayOf(uniqueElements: [list])
+    let catalog = StationVoiceCatalog()
+    #expect(catalog.suggestedStations().map(\.id) == ["real-id"])
+    #expect(catalog.matches(query: "Real FM").first?.id == "real-id")
   }
 
   @Test

--- a/PlayolaRadio/Models/StationList.swift
+++ b/PlayolaRadio/Models/StationList.swift
@@ -308,6 +308,16 @@ extension APIStationItem {
     fatalError("Station is neither a playola station or a urlStation")
   }
 
+  /// Non-crashing variant of `anyStation`. The decoder permits a row with
+  /// neither a playola nor a URL station (e.g. a coming-soon placeholder), so
+  /// callers that walk over hidden/coming-soon items must skip those rather
+  /// than trap.
+  var anyStationIfPresent: AnyStation? {
+    if let station { return .playola(station) }
+    if let urlStation { return .url(urlStation) }
+    return nil
+  }
+
   func liveSortPriority(_ liveStations: [LiveStationInfo]) -> Int {
     guard let status = liveStations.first(where: { $0.stationId == anyStation.id })?.liveStatus
     else {

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -481,6 +481,21 @@ struct MainContainerTests {
   }
 
   @Test
+  func testRefreshOnForegroundRefreshesSiriShortcutSuggestions() async {
+    @Shared(.stationListsLoaded) var stationListsLoaded = false
+    let didRefresh = LockIsolated(false)
+    let mainContainerModel = withDependencies {
+      $0.api.getStations = { StationList.mocks }
+      $0.pushNotifications.registerForRemoteNotifications = {}
+      $0.siriShortcuts.refreshSuggestions = { didRefresh.setValue(true) }
+    } operation: {
+      MainContainerModel()
+    }
+    await mainContainerModel.refreshOnForeground()
+    #expect(didRefresh.value == true)
+  }
+
+  @Test
   func testRefreshOnForegroundSkipsAiringsWhenNotLoggedIn() async {
     @Shared(.auth) var auth = Auth()
     @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -486,7 +486,6 @@ struct MainContainerTests {
     let didRefresh = LockIsolated(false)
     let mainContainerModel = withDependencies {
       $0.api.getStations = { StationList.mocks }
-      $0.pushNotifications.registerForRemoteNotifications = {}
       $0.siriShortcuts.refreshSuggestions = { didRefresh.setValue(true) }
     } operation: {
       MainContainerModel()

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -109,7 +109,7 @@ release workflow. Names only; values live in CircleCI.
 |---|---|
 | `APP_STORE_CONNECT_API_KEY_ID` | ASC API key identifier. |
 | `APP_STORE_CONNECT_API_ISSUER_ID` | ASC issuer UUID. |
-| `APP_STORE_CONNECT_API_KEY_CONTENT` | Contents of the `.p8` private key used by fastlane to authenticate to App Store Connect. |
+| `APP_STORE_CONNECT_API_KEY_CONTENT` | The `.p8` private key for App Store Connect auth. **Prefer base64** — set it to `base64 -i AuthKey_XXXX.p8 \| tr -d '\n'`. (The raw `.p8` also works, but CircleCI env vars often strip the multi-line PEM's newlines, which corrupts the key and fails the release with OpenSSL `invalid curve name`. The Fastfile auto-detects base64 vs raw via the `-----BEGIN` header.) |
 | `MATCH_PASSWORD` | Passphrase that decrypts the fastlane-match certificate repo. |
 | `MATCH_GIT_PRIVATE_KEY` | SSH key with read access to the `fastlane-match-certs-and-profiles` repo. |
 | `SECRETS_XCCONFIG_B64` | Base64 of `PlayolaRadio/Config/Secrets.xcconfig`. |

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -38,6 +38,26 @@ platform :ios do
     setup_circle_ci if ENV['CI']
   end
 
+  # Resolve the App Store Connect API key, accepting EITHER the raw .p8 PEM or a
+  # base64-encoded .p8 in APP_STORE_CONNECT_API_KEY_CONTENT. base64 is preferred
+  # for CI because a single-line value can't be corrupted by env-var newline
+  # mangling — mangled newlines turn a valid key into OpenSSL "invalid curve
+  # name" at auth time. Falls back to the .p8 file at
+  # APP_STORE_CONNECT_API_KEY_PATH for local runs.
+  private_lane :asc_api_key do
+    key = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] ||
+          (ENV["APP_STORE_CONNECT_API_KEY_PATH"] && File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])) ||
+          UI.user_error!("Set APP_STORE_CONNECT_API_KEY_CONTENT (CI; raw .p8 or base64 of it) or APP_STORE_CONNECT_API_KEY_PATH (local)")
+    app_store_connect_api_key(
+      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
+      issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
+      key_content: key,
+      # A raw PEM always contains the literal "-----BEGIN"; base64 never can
+      # (its alphabet has no dashes), so this disambiguates the two reliably.
+      is_key_content_base64: !key.include?("-----BEGIN")
+    )
+  end
+
   desc "Release STAGING build to TestFlight (Internal Only)"
   lane :release_staging do
     ensure_git_status_clean
@@ -76,11 +96,7 @@ platform :ios do
       include_sources: true
     )
 
-    api_key = app_store_connect_api_key(
-      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
-      issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
-      key_content: File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])
-    )
+    api_key = asc_api_key
 
     upload_to_testflight(
       api_key: api_key,
@@ -148,14 +164,7 @@ platform :ios do
       include_sources: true
     )
 
-    key_content = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] ||
-                  (ENV["APP_STORE_CONNECT_API_KEY_PATH"] && File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])) ||
-                  UI.user_error!("Set APP_STORE_CONNECT_API_KEY_CONTENT (CI) or APP_STORE_CONNECT_API_KEY_PATH (local)")
-    api_key = app_store_connect_api_key(
-      key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
-      issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],
-      key_content: key_content
-    )
+    api_key = asc_api_key
 
     upload_to_testflight(
       api_key: api_key,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -61,7 +61,7 @@ platform :ios do
   desc "Release STAGING build to TestFlight (Internal Only)"
   lane :release_staging do
     ensure_git_status_clean
-    ensure_git_branch(branch: 'develop')
+    ensure_git_branch(branch: 'develop') unless ENV['CI']
 
     match(
       type: "appstore",

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -45,9 +45,9 @@ platform :ios do
   # name" at auth time. Falls back to the .p8 file at
   # APP_STORE_CONNECT_API_KEY_PATH for local runs.
   private_lane :asc_api_key do
-    key = ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] ||
-          (ENV["APP_STORE_CONNECT_API_KEY_PATH"] && File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"])) ||
-          UI.user_error!("Set APP_STORE_CONNECT_API_KEY_CONTENT (CI; raw .p8 or base64 of it) or APP_STORE_CONNECT_API_KEY_PATH (local)")
+    key = (ENV["APP_STORE_CONNECT_API_KEY_CONTENT"] || "").strip
+    key = File.read(ENV["APP_STORE_CONNECT_API_KEY_PATH"]).strip if key.empty? && ENV["APP_STORE_CONNECT_API_KEY_PATH"]
+    UI.user_error!("Set APP_STORE_CONNECT_API_KEY_CONTENT (CI; raw .p8 or base64 of it) or APP_STORE_CONNECT_API_KEY_PATH (local)") if key.empty?
     app_store_connect_api_key(
       key_id: ENV["APP_STORE_CONNECT_API_KEY_ID"],
       issuer_id: ENV["APP_STORE_CONNECT_API_ISSUER_ID"],


### PR DESCRIPTION
## Release 7.2.0 (build 92)

Build-number-only bump. No marketing version change (`MARKETING_VERSION` stays `7.2.0`); `CURRENT_PROJECT_VERSION` `91 → 92`.

### Changes since last release (build 91)
- fix: make Siri play any catalog station, not just visible ones
- fix: set production CFBundleDisplayName so Siri phrases register
- ci: build + upload staging TestFlight on each release tag
- ci: accept base64 App Store Connect key to survive CircleCI newline mangling
- ci: handle empty/whitespace ASC key env var with a clear error

🤖 Generated with [Claude Code](https://claude.com/claude-code)
