### PR TITLE
ci: skip SwiftLint plugin validation in staging archive

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -74,6 +74,7 @@ platform :ios do
       scheme: "PlayolaRadio-Staging",
       export_method: "app-store",
       output_directory: "./build",
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation",
       export_options: {
         method: "app-store",
         # sentry-cocoa's SwiftPM `Sentry` product links statically (its symbols


### PR DESCRIPTION
## Fix staging TestFlight archive failure

The `release_staging` `build_app` was missing the `xcargs: "-skipPackagePluginValidation -skipMacroValidation"` that `release_production` already passes. Without it, CI archiving fails at:

```
Validate plug-in "SwiftLintBuildToolPlugin" in package "swiftlintplugins"
** ARCHIVE FAILED **
```

This is exactly what broke the staging upload on tag `v7.2.0-b92` — production uploaded fine (it has the flag), staging did not.

### Change
One line: add the same `xcargs` to the staging `build_app`, bringing the staging lane to parity with production (which already has `xcargs`, `uploadSymbols: false`, and the shared `asc_api_key` helper).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
