### PR TITLE
Fix CarPlay Now Playing being instantly dismissed to station list

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -63,6 +63,7 @@
 		D30F005B2E8592F0007BCC73 /* View+ListInstalledFonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257BC2DF893BB001BC6F9 /* View+ListInstalledFonts.swift */; };
 		D30F005C2E8592F0007BCC73 /* FontNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */; };
 		D30F005D2E8592F0007BCC73 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673AF2D3DC54F00E4E926 /* CarPlaySceneDelegate.swift */; };
+		E1CA0000000000000000A002 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
 		D30F005E2E8592F0007BCC73 /* CPListItem+InitWithRemoteUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C22D3E871800E4E926 /* CPListItem+InitWithRemoteUrl.swift */; };
 		D30F005F2E8592F0007BCC73 /* MainContainerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744AC2E2FCD8E0042A427 /* MainContainerModel.swift */; };
 		FE110A0000000000000000B2 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
@@ -197,6 +198,7 @@
 		D3536A3B2BFA6520006942D6 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3536A372BFA6520006942D6 /* Color+Hex.swift */; };
 		D3536A3C2BFA6520006942D6 /* UIImage+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3536A382BFA6520006942D6 /* UIImage+Cache.swift */; };
 		D35673B02D3DC55900E4E926 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673AF2D3DC54F00E4E926 /* CarPlaySceneDelegate.swift */; };
+		E1CA0000000000000000A003 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
 		D35673B22D3DC59300E4E926 /* RadioStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673B12D3DC59100E4E926 /* RadioStation.swift */; };
 		D35673B72D3DC6EC00E4E926 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = D35673B62D3DC6EC00E4E926 /* Mixpanel */; };
 		D35673BA2D3DC9EE00E4E926 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673B92D3DC9ED00E4E926 /* Config.swift */; };
@@ -206,6 +208,7 @@
 		D35905EC2DFCDA140064A9C1 /* StationListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35905EB2DFCDA110064A9C1 /* StationListModel.swift */; };
 		D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */; };
 		D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */; };
+		E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */; };
 		D35EFBEE2F1092A7000F64A4 /* RRuleFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */; };
 		D35EFBF02F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
 		D35EFBF12F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
@@ -533,6 +536,8 @@
 		D3536A372BFA6520006942D6 /* Color+Hex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
 		D3536A382BFA6520006942D6 /* UIImage+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Cache.swift"; sourceTree = "<group>"; };
 		D35673AF2D3DC54F00E4E926 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
+		E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransition.swift; sourceTree = "<group>"; };
+		E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransitionTests.swift; sourceTree = "<group>"; };
 		D35673B12D3DC59100E4E926 /* RadioStation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioStation.swift; sourceTree = "<group>"; };
 		D35673B92D3DC9ED00E4E926 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		D35673BD2D3DCA1E00E4E926 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
@@ -1061,6 +1066,8 @@
 			children = (
 				D35673C52D3E91B900E4E926 /* MainSceneDelegate.swift */,
 				D35673AF2D3DC54F00E4E926 /* CarPlaySceneDelegate.swift */,
+				E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */,
+				E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */,
 			);
 			path = CarPlay;
 			sourceTree = "<group>";
@@ -1830,6 +1837,7 @@
 				D35EFBF12F1092D7000F64A4 /* RRuleFormatter.swift in Sources */,
 				D30F005C2E8592F0007BCC73 /* FontNames.swift in Sources */,
 				D30F005D2E8592F0007BCC73 /* CarPlaySceneDelegate.swift in Sources */,
+				E1CA0000000000000000A002 /* CarPlayPlaybackTransition.swift in Sources */,
 				D317C0D22EF2027000DBC82E /* VoicetrackStatusResponse.swift in Sources */,
 				D30F005E2E8592F0007BCC73 /* CPListItem+InitWithRemoteUrl.swift in Sources */,
 				D30F005F2E8592F0007BCC73 /* MainContainerModel.swift in Sources */,
@@ -2000,6 +2008,7 @@
 				D35EFBF02F1092D7000F64A4 /* RRuleFormatter.swift in Sources */,
 				D37257CC2DFA3F83001BC6F9 /* FontNames.swift in Sources */,
 				D35673B02D3DC55900E4E926 /* CarPlaySceneDelegate.swift in Sources */,
+				E1CA0000000000000000A003 /* CarPlayPlaybackTransition.swift in Sources */,
 				D317C0D12EF2027000DBC82E /* VoicetrackStatusResponse.swift in Sources */,
 				D35673C32D3E872600E4E926 /* CPListItem+InitWithRemoteUrl.swift in Sources */,
 				D3B744AD2E2FCD930042A427 /* MainContainerModel.swift in Sources */,
@@ -2178,6 +2187,7 @@
 				D3B9C7AE2F534D57002D75C2 /* IntroUploadServiceTests.swift in Sources */,
 				D37769FE2F22B70600200ADF /* ChooseStationPageTests.swift in Sources */,
 				D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */,
+				E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */,
 				D395911A2E39933800720CF8 /* ContactPageTests.swift in Sources */,
 				D3B744BC2E312FB60042A427 /* ListeningTrackerTests.swift in Sources */,
 				D3B744A82E2F185F0042A427 /* SmallPlayerTests.swift in Sources */,

--- a/PlayolaRadio/CarPlay/CarPlayPlaybackTransition.swift
+++ b/PlayolaRadio/CarPlay/CarPlayPlaybackTransition.swift
@@ -1,0 +1,41 @@
+//
+//  CarPlayPlaybackTransition.swift
+//  PlayolaRadio
+//
+//  Pure, testable decision logic for which CarPlay template should be shown for
+//  a given playback status. Extracted from CarPlaySceneDelegate so the
+//  push/pop/dismiss decision can be unit tested without a system-provided
+//  CPInterfaceController.
+//
+
+enum CarPlayPlaybackTransition {
+  /// The template change CarPlay should make in response to a playback status.
+  enum Action: Equatable {
+    /// Ensure the Now Playing template is the visible (top) template.
+    case showNowPlaying
+    /// Remove the Now Playing template, returning to the station list.
+    case removeNowPlaying
+    /// Present the "unable to connect" error alert.
+    case showError
+    /// No template change.
+    case none
+  }
+
+  /// Maps a playback status to the template action CarPlay should take.
+  ///
+  /// Critically, `.playing` maps to `.showNowPlaying` (not `.none`). An earlier
+  /// version did nothing on `.playing`, so any spurious `.stopped` that arrived
+  /// after Now Playing was shown dismissed it permanently — the user was stuck
+  /// on the station list. Showing Now Playing on `.playing` makes the
+  /// transition self-healing.
+  static func action(for playbackStatus: StationPlayer.PlaybackStatus) -> Action {
+    switch playbackStatus {
+    case .error:
+      return .showError
+    case .loading, .startingNewStation, .playing:
+      return .showNowPlaying
+    case .stopped:
+      return .removeNowPlaying
+    }
+  }
+}

--- a/PlayolaRadio/CarPlay/CarPlayPlaybackTransition.swift
+++ b/PlayolaRadio/CarPlay/CarPlayPlaybackTransition.swift
@@ -17,7 +17,9 @@ enum CarPlayPlaybackTransition {
     case removeNowPlaying
     /// Present the "unable to connect" error alert.
     case showError
-    /// No template change.
+    /// No template change. `action(for:)` does not emit this today (every
+    /// `PlaybackStatus` maps to a concrete action); it exists so callers have an
+    /// explicit no-op branch and so new statuses can opt out of a template change.
     case none
   }
 

--- a/PlayolaRadio/CarPlay/CarPlayPlaybackTransitionTests.swift
+++ b/PlayolaRadio/CarPlay/CarPlayPlaybackTransitionTests.swift
@@ -1,0 +1,57 @@
+//
+//  CarPlayPlaybackTransitionTests.swift
+//  PlayolaRadio
+//
+
+import CustomDump
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct CarPlayPlaybackTransitionTests {
+
+  // Regression for the CarPlay "Now Playing is instantly dismissed" bug: while
+  // a station is playing, CarPlay must keep showing Now Playing. The previous
+  // implementation did nothing on `.playing`, so once any stray `.stopped`
+  // dismissed Now Playing it was never restored and the user stayed on the list.
+  @Test
+  func testPlayingShowsNowPlaying() {
+    expectNoDifference(
+      CarPlayPlaybackTransition.action(for: .playing(.mock)),
+      .showNowPlaying
+    )
+  }
+
+  @Test
+  func testLoadingShowsNowPlaying() {
+    expectNoDifference(
+      CarPlayPlaybackTransition.action(for: .loading(.mock)),
+      .showNowPlaying
+    )
+  }
+
+  @Test
+  func testStartingNewStationShowsNowPlaying() {
+    expectNoDifference(
+      CarPlayPlaybackTransition.action(for: .startingNewStation(.mock)),
+      .showNowPlaying
+    )
+  }
+
+  @Test
+  func testStoppedRemovesNowPlaying() {
+    expectNoDifference(
+      CarPlayPlaybackTransition.action(for: .stopped),
+      .removeNowPlaying
+    )
+  }
+
+  @Test
+  func testErrorShowsError() {
+    expectNoDifference(
+      CarPlayPlaybackTransition.action(for: .error),
+      .showError
+    )
+  }
+}

--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -104,7 +104,20 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
       tabBarTemplate?.delegate = self
 
       guard let tabBarTemplate = tabBarTemplate else { return }
-      self.interfaceController?.setRootTemplate(tabBarTemplate, animated: true, completion: nil)
+      self.interfaceController?.setRootTemplate(tabBarTemplate, animated: true) {
+        [weak self] _, _ in
+        guard let self else { return }
+        // If CarPlay connects while audio is already playing/loading, show Now
+        // Playing immediately. The $state observer's first emission arrives during
+        // init (before this controller exists) and is then deduplicated, so
+        // without this replay the user would be stuck on the station list until
+        // the next real status transition.
+        if CarPlayPlaybackTransition.action(for: self.stationPlayer.state.playbackStatus)
+          == .showNowPlaying
+        {
+          self.handleStationLoading()
+        }
+      }
     }
   }
 
@@ -181,19 +194,29 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
   }
 
   private func observePlaybackErrors() {
+    // Only react to actual playback-status transitions. `state` republishes on
+    // artwork/metadata updates without a status change; without `removeDuplicates`
+    // every such update would re-run the template logic and (because `.playing`
+    // shows Now Playing) yank the user back to Now Playing while they are browsing
+    // the station list mid-playback.
     stationPlayer.$state
-      .sink { [weak self] state in
+      .map(\.playbackStatus)
+      .removeDuplicates()
+      .sink { [weak self] playbackStatus in
         guard let self = self else { return }
 
-        switch state.playbackStatus {
-        case .error:
-          self.handlePlaybackError()
-        case .loading, .startingNewStation:
+        // `.playing` shows Now Playing too (not a no-op): if a stray `.stopped`
+        // ever dismissed it, the next transition into `.playing` restores it
+        // instead of leaving the user stuck on the station list.
+        switch CarPlayPlaybackTransition.action(for: playbackStatus) {
+        case .showNowPlaying:
           self.handleStationLoading()
-        case .playing:
-          break
-        case .stopped:
+        case .removeNowPlaying:
           self.handleStationStopped()
+        case .showError:
+          self.handlePlaybackError()
+        case .none:
+          break
         }
       }
       .store(in: &observers)

--- a/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
+++ b/PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift
@@ -107,16 +107,12 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
       self.interfaceController?.setRootTemplate(tabBarTemplate, animated: true) {
         [weak self] _, _ in
         guard let self else { return }
-        // If CarPlay connects while audio is already playing/loading, show Now
-        // Playing immediately. The $state observer's first emission arrives during
-        // init (before this controller exists) and is then deduplicated, so
-        // without this replay the user would be stuck on the station list until
-        // the next real status transition.
-        if CarPlayPlaybackTransition.action(for: self.stationPlayer.state.playbackStatus)
-          == .showNowPlaying
-        {
-          self.handleStationLoading()
-        }
+        // Replay the current playback status now that the controller exists. The
+        // $state observer's first emission arrives during init (before this
+        // controller exists) and is then deduplicated, so without this replay a
+        // session already playing/loading/erroring when CarPlay connects would be
+        // stuck on the station list until the next real status transition.
+        self.applyPlaybackTransition(for: self.stationPlayer.state.playbackStatus)
       }
     }
   }
@@ -203,23 +199,29 @@ class CarPlaySceneDelegate: UIResponder, CPTemplateApplicationSceneDelegate {
       .map(\.playbackStatus)
       .removeDuplicates()
       .sink { [weak self] playbackStatus in
-        guard let self = self else { return }
-
-        // `.playing` shows Now Playing too (not a no-op): if a stray `.stopped`
-        // ever dismissed it, the next transition into `.playing` restores it
-        // instead of leaving the user stuck on the station list.
-        switch CarPlayPlaybackTransition.action(for: playbackStatus) {
-        case .showNowPlaying:
-          self.handleStationLoading()
-        case .removeNowPlaying:
-          self.handleStationStopped()
-        case .showError:
-          self.handlePlaybackError()
-        case .none:
-          break
-        }
+        self?.applyPlaybackTransition(for: playbackStatus)
       }
       .store(in: &observers)
+  }
+
+  /// Translates a playback status into the corresponding CarPlay template change.
+  /// Shared by the live `$state` observer and the `didConnect` replay so both
+  /// paths run through the same (unit-tested) `CarPlayPlaybackTransition` logic.
+  ///
+  /// `.playing` shows Now Playing too (not a no-op): if a stray `.stopped` ever
+  /// dismissed it, the next transition into `.playing` restores it instead of
+  /// leaving the user stuck on the station list.
+  private func applyPlaybackTransition(for playbackStatus: StationPlayer.PlaybackStatus) {
+    switch CarPlayPlaybackTransition.action(for: playbackStatus) {
+    case .showNowPlaying:
+      handleStationLoading()
+    case .removeNowPlaying:
+      handleStationStopped()
+    case .showError:
+      handlePlaybackError()
+    case .none:
+      break
+    }
   }
 
   private func handleStationLoading() {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -368,6 +368,10 @@ class NowPlayingUpdater {
   func processPlayolaStationPlayerState(
     _ playolaState: PlayolaStationPlayer.State?
   ) {
+    // Backend ownership: while a URL station is active, ignore all Playola events
+    // (stale `.idle`/`.error`/`.loading`/`.playing`) so they cannot clobber the
+    // shared now-playing state. Mirrors StationPlayer.processPlayolaStationPlayerState.
+    if case .url = stationPlayer.currentStation { return }
     switch playolaState {
     case .idle:
       $nowPlaying.withLock {
@@ -423,9 +427,14 @@ class NowPlayingUpdater {
     }
   }
 
-  private func processUrlStreamStateChanged(
+  func processUrlStreamStateChanged(
     _ urlStreamPlayerState: URLStreamPlayer.State
   ) {
+    // Backend ownership: while a Playola station is active, ignore all URL events
+    // (a late `.urlNotSet` from the `reset()` every Playola play performs, or a
+    // stale `.readyToPlay`/`.error`) so they cannot clobber the shared now-playing
+    // state. Mirrors StationPlayer.processUrlStreamStateChanged.
+    if case .playola = stationPlayer.currentStation { return }
     switch urlStreamPlayerState.playerStatus {
     case .loading:
       guard let currentStation = stationPlayer.currentStation else { return }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 8/14/25.
 //
 
+import CustomDump
 import Dependencies
 import Foundation
 import MediaPlayer
@@ -73,6 +74,71 @@ struct NowPlayingUpdaterTests {
     updater.processPlayolaStationPlayerState(.error(.networkError("boom")))
 
     #expect(nowPlaying?.playbackStatus == .error)
+  }
+
+  // MARK: - Backend Ownership Regression Tests
+
+  // Same CarPlay/lock-screen "instantly dismissed" regression as in
+  // StationPlayer, but for the shared `nowPlaying` state NowPlayingUpdater
+  // publishes. NowPlayingUpdater independently observes both audio backends, so
+  // the spurious cross-backend `.stopped` must be guarded here too.
+
+  @Test
+  func testUrlStreamUrlNotSetDoesNotClobberActivePlayolaNowPlaying() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    let playolaStation = AnyStation.mockPlayola()
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer()
+      stationPlayer.state = StationPlayer.State(playbackStatus: .loading(playolaStation))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    // Establish a real Playola baseline (last writer wins over init echoes).
+    updater.processPlayolaStationPlayerState(.loading(0.5))
+    // A late URL-backend `.urlNotSet` (FRadioPlayer's response to reset() during
+    // the Playola play) must not clobber shared state back to .stopped.
+    updater.processUrlStreamStateChanged(
+      URLStreamPlayer.State(
+        playbackState: .stopped,
+        playerStatus: .urlNotSet,
+        currentStation: nil,
+        nowPlaying: nil
+      )
+    )
+
+    expectNoDifference(nowPlaying?.playbackStatus, .loading(playolaStation, 0.5))
+  }
+
+  @Test
+  func testPlayolaIdleDoesNotClobberActiveUrlNowPlaying() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    let urlStation = AnyStation.mockUrl()
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer()
+      stationPlayer.state = StationPlayer.State(playbackStatus: .playing(urlStation))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    // Establish a real URL baseline.
+    updater.processUrlStreamStateChanged(
+      URLStreamPlayer.State(
+        playbackState: .playing,
+        playerStatus: .readyToPlay,
+        currentStation: nil,
+        nowPlaying: nil
+      )
+    )
+    // A stray Playola `.idle` (emitted by stop() while switching) must not
+    // clobber the active URL station back to .stopped.
+    updater.processPlayolaStationPlayerState(.idle)
+
+    expectNoDifference(nowPlaying?.playbackStatus, .playing(urlStation))
   }
 
   @Test

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -204,6 +204,13 @@ class StationPlayer: ObservableObject {
   func processPlayolaStationPlayerState(
     _ playolaState: PlayolaStationPlayer.State?
   ) {
+    // Backend ownership: the Playola backend only owns global playback state
+    // while a Playola station is active (or nothing is). While a URL station is
+    // active, ignore all Playola events — a late/stale `.idle` (emitted by
+    // `stop()` while switching), `.error`, `.loading`, or `.playing` would
+    // otherwise clobber the active URL station. Real stops are driven by
+    // `stop()`, which sets `.stopped` explicitly.
+    if case .url = currentStation { return }
     switch playolaState {
     case .idle:
       state = .init(
@@ -251,6 +258,14 @@ class StationPlayer: ObservableObject {
   private func processUrlStreamStateChanged(
     _ urlStreamPlayerState: URLStreamPlayer.State
   ) {
+    // Backend ownership: the URL backend only owns global playback state while a
+    // URL station is active (or nothing is). While a Playola station is active,
+    // ignore all URL events — a late `.urlNotSet` (FRadioPlayer's response to the
+    // `urlStreamPlayer.reset()` that every Playola play performs), or a stale
+    // `.readyToPlay`/`.error`, would otherwise clobber the active Playola station
+    // (e.g. dismissing CarPlay's Now Playing, or mislabeling it with URL
+    // metadata). Real stops are driven by `stop()`, which sets `.stopped`.
+    if case .playola = currentStation { return }
     switch urlStreamPlayerState.playerStatus {
     case .loading:
       guard let currentStation else {

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -65,6 +65,94 @@ struct StationPlayerTests {
     expectNoDifference(nowPlaying?.playbackStatus, .loading(.mock))
   }
 
+  // MARK: - Backend Ownership Regression Tests
+
+  // Regression for the CarPlay "Now Playing is instantly dismissed" bug.
+  //
+  // Playing a Playola station calls `urlStreamPlayer.reset()`, which makes
+  // FRadioPlayer report `.urlNotSet` asynchronously. That URL-backend event used
+  // to clobber the active Playola station's state back to `.stopped`, which
+  // CarPlay observed and reacted to by popping Now Playing back to the list.
+  // The URL backend must not drive global state while a Playola station is active.
+
+  @Test
+  func testUrlStreamUrlNotSetDoesNotClobberLoadingPlayolaStation() {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let playolaStation = AnyStation.mockPlayola()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .loading(playolaStation))
+
+    urlStreamPlayer.state = URLStreamPlayer.State(
+      playbackState: .stopped,
+      playerStatus: .urlNotSet,
+      currentStation: nil,
+      nowPlaying: nil
+    )
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .loading(playolaStation))
+  }
+
+  @Test
+  func testUrlStreamUrlNotSetDoesNotClobberPlayingPlayolaStation() {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let playolaStation = AnyStation.mockPlayola()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .playing(playolaStation))
+
+    urlStreamPlayer.state = URLStreamPlayer.State(
+      playbackState: .stopped,
+      playerStatus: .urlNotSet,
+      currentStation: nil,
+      nowPlaying: nil
+    )
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .playing(playolaStation))
+  }
+
+  // Mirror of the above: the Playola backend must not clobber an active URL
+  // station. `stop()` emits Playola `.idle` while switching stations, so a URL
+  // station's playback could be wiped the same way.
+  @Test
+  func testPlayolaIdleDoesNotClobberActiveUrlStation() {
+    let stationPlayer = StationPlayer()
+    let urlStation = AnyStation.mockUrl()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .playing(urlStation))
+
+    stationPlayer.processPlayolaStationPlayerState(.idle)
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .playing(urlStation))
+  }
+
+  // Ownership also covers non-`.stopped` terminal events: an inactive backend's
+  // late `.error` must not error out the active station.
+  @Test
+  func testUrlStreamErrorDoesNotClobberActivePlayolaStation() {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let playolaStation = AnyStation.mockPlayola()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .playing(playolaStation))
+
+    urlStreamPlayer.state = URLStreamPlayer.State(
+      playbackState: .stopped,
+      playerStatus: .error,
+      currentStation: nil,
+      nowPlaying: nil
+    )
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .playing(playolaStation))
+  }
+
+  @Test
+  func testPlayolaErrorDoesNotClobberActiveUrlStation() {
+    let stationPlayer = StationPlayer()
+    let urlStation = AnyStation.mockUrl()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .playing(urlStation))
+
+    stationPlayer.processPlayolaStationPlayerState(.error(.networkError("boom")))
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .playing(urlStation))
+  }
+
   // MARK: - seekNext Tests
 
   @Test

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -109,6 +109,26 @@ struct StationPlayerTests {
     expectNoDifference(stationPlayer.state.playbackStatus, .playing(playolaStation))
   }
 
+  // Covers the brief `.startingNewStation` window between `stop()` and
+  // `.loading` during a Playola play — the guard must hold here too, so a future
+  // refactor of `currentStation` can't silently reintroduce the clobber.
+  @Test
+  func testUrlStreamUrlNotSetDoesNotClobberStartingNewPlayolaStation() {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let playolaStation = AnyStation.mockPlayola()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .startingNewStation(playolaStation))
+
+    urlStreamPlayer.state = URLStreamPlayer.State(
+      playbackState: .stopped,
+      playerStatus: .urlNotSet,
+      currentStation: nil,
+      nowPlaying: nil
+    )
+
+    expectNoDifference(stationPlayer.state.playbackStatus, .startingNewStation(playolaStation))
+  }
+
   // Mirror of the above: the Playola backend must not clobber an active URL
   // station. `stop()` emits Playola `.idle` while switching stations, so a URL
   // station's playback could be wiped the same way.


### PR DESCRIPTION
CarPlay pushed Now Playing then instantly popped it back to the station list, so users couldn't see what was playing. Root cause: `StationPlayer` let either audio backend drive global playback state regardless of which station was active — every Playola play calls `urlStreamPlayer.reset()`, after which FRadioPlayer async-reports `.urlNotSet` → `.stopped`, wiping the active Playola station, which CarPlay dismissed and never restored (since `.playing` was a no-op). This adds backend-ownership guards in `StationPlayer` and `NowPlayingUpdater`, a pure `CarPlayPlaybackTransition` decision function so `.playing` shows Now Playing (gated on `playbackStatus` transitions so artwork/metadata updates don't yank the user off the list mid-browse), and a `didConnect` replay so connecting while already playing shows Now Playing. Regression tests cover all three layers; the full suite (1045 tests) and SwiftLint pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)