### PR TITLE
Live giveaway contest — PR1: domain models, shared state, and plan

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -7,9 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03D9929612C3E595D9BD88D5 /* GiveawayParticipationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5283C7C8C9FAF45659BA98E /* GiveawayParticipationTests.swift */; };
+		1DBE6EEE6CD7879ED93BB12C /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
 		1F6F57E01E254F5483BD939B /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
+		354451A630DF81468815108F /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
+		5F67160E76C1454189765E5D /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
+		5F721A0797795B3B529757CD /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
+		659E9B124BCB08D5F3D216D7 /* Giveaway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EDCED098E801AAB2E9DC82 /* Giveaway.swift */; };
+		65D0683FA2A905693317C5AB /* CongratsActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0488057E2A6456204E582B15 /* CongratsActionTests.swift */; };
+		725E8382CB9672F532FC2CDD /* GiveawayMyResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B82DD37711E160592E3842D /* GiveawayMyResult.swift */; };
 		76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */; };
 		81599AD0B41E4A2496EEF25A /* PresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6613FD7A13B448187CB8595 /* PresetTests.swift */; };
+		8CECE7D0544EBE95DA92A501 /* GiveawayMyResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B82DD37711E160592E3842D /* GiveawayMyResult.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */; };
 		AA01000000000001AAAAAAAA /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
 		AA01000000000002AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
@@ -17,6 +26,7 @@
 		AA01000000000004AAAAAAAA /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
 		AA01000000000005AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
 		AA01000000000006AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
+		B12730D5ECA7018F074B54E6 /* GiveawayBannerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */; };
 		C8BA849E20B449EC91DBF5F2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
 		D302576B2E63423D00F4228B /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
 		D302576D2E63428800F4228B /* ToastClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576C2E63428700F4228B /* ToastClient.swift */; };
@@ -63,14 +73,8 @@
 		D30F005B2E8592F0007BCC73 /* View+ListInstalledFonts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257BC2DF893BB001BC6F9 /* View+ListInstalledFonts.swift */; };
 		D30F005C2E8592F0007BCC73 /* FontNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */; };
 		D30F005D2E8592F0007BCC73 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673AF2D3DC54F00E4E926 /* CarPlaySceneDelegate.swift */; };
-		E1CA0000000000000000A002 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
 		D30F005E2E8592F0007BCC73 /* CPListItem+InitWithRemoteUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C22D3E871800E4E926 /* CPListItem+InitWithRemoteUrl.swift */; };
 		D30F005F2E8592F0007BCC73 /* MainContainerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744AC2E2FCD8E0042A427 /* MainContainerModel.swift */; };
-		FE110A0000000000000000B2 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
-		FE110A0000000000000000B5 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
-		FE110A0000000000000000B3 /* WelcomeMessagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */; };
-		FE110A0000000000000000B6 /* WelcomeMessagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */; };
-		FE110A0000000000000000B4 /* WelcomeMessagePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */; };
 		D30F00602E8592F0007BCC73 /* ContactPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39591162E39932300720CF8 /* ContactPageModel.swift */; };
 		D30F00612E8592F0007BCC73 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
 		D30F00622E8592F0007BCC73 /* MailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E57D2BFD750700B9E35B /* MailService.swift */; };
@@ -163,7 +167,6 @@
 		D31C43D42D3C783B0021AAE4 /* PlayolaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D31C43D32D3C783B0021AAE4 /* PlayolaPlayer */; };
 		D31CD5232DFBA1F2009B9780 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CD5222DFBA1EC009B9780 /* ViewModel.swift */; };
 		D31CD5272DFBB4DF009B9780 /* MainContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CD5252DFBB47D009B9780 /* MainContainerTests.swift */; };
-		FE110AC0DE0000000000B1B1 /* WelcomeMessageEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */; };
 		D3219C172EDD22150008AFDA /* BroadcastPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3219C162EDD22100008AFDA /* BroadcastPageView.swift */; };
 		D3219C182EDD22150008AFDA /* BroadcastPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3219C162EDD22100008AFDA /* BroadcastPageView.swift */; };
 		D3219C1A2EDD22200008AFDA /* BroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3219C192EDD22180008AFDA /* BroadcastPageModel.swift */; };
@@ -198,7 +201,6 @@
 		D3536A3B2BFA6520006942D6 /* Color+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3536A372BFA6520006942D6 /* Color+Hex.swift */; };
 		D3536A3C2BFA6520006942D6 /* UIImage+Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3536A382BFA6520006942D6 /* UIImage+Cache.swift */; };
 		D35673B02D3DC55900E4E926 /* CarPlaySceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673AF2D3DC54F00E4E926 /* CarPlaySceneDelegate.swift */; };
-		E1CA0000000000000000A003 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
 		D35673B22D3DC59300E4E926 /* RadioStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673B12D3DC59100E4E926 /* RadioStation.swift */; };
 		D35673B72D3DC6EC00E4E926 /* Mixpanel in Frameworks */ = {isa = PBXBuildFile; productRef = D35673B62D3DC6EC00E4E926 /* Mixpanel */; };
 		D35673BA2D3DC9EE00E4E926 /* Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673B92D3DC9ED00E4E926 /* Config.swift */; };
@@ -208,7 +210,6 @@
 		D35905EC2DFCDA140064A9C1 /* StationListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35905EB2DFCDA110064A9C1 /* StationListModel.swift */; };
 		D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */; };
 		D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */; };
-		E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */; };
 		D35EFBEE2F1092A7000F64A4 /* RRuleFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */; };
 		D35EFBF02F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
 		D35EFBF12F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
@@ -347,6 +348,22 @@
 		D3A08A2F2E4E2A35002468E0 /* AnalyticsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */; };
 		D3A08A312E4E2E2A002468E0 /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */; };
 		D3A08A352E4E6F66002468E0 /* NowPlayingUpdaterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A332E4E6F5D002468E0 /* NowPlayingUpdaterTests.swift */; };
+		D3A1B2C001000000000000A4 /* StationVoiceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */; };
+		D3A1B2C001000000000000A5 /* StationVoiceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */; };
+		D3A1B2C001000000000000A6 /* StationVoiceCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */; };
+		D3A1B2C001000000000000B4 /* PlaybackBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */; };
+		D3A1B2C001000000000000B5 /* PlaybackBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */; };
+		D3A1B2C001000000000000C4 /* PlayStationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C2 /* PlayStationAction.swift */; };
+		D3A1B2C001000000000000C5 /* PlayStationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C2 /* PlayStationAction.swift */; };
+		D3A1B2C001000000000000C6 /* PlayStationActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */; };
+		D3A1B2C001000000000000D4 /* RadioStationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000D2 /* RadioStationEntity.swift */; };
+		D3A1B2C001000000000000D5 /* RadioStationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000D2 /* RadioStationEntity.swift */; };
+		D3A1B2C001000000000000E4 /* PlayStationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000E2 /* PlayStationIntent.swift */; };
+		D3A1B2C001000000000000E5 /* PlayStationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000E2 /* PlayStationIntent.swift */; };
+		D3A1B2C001000000000000F4 /* PlayolaShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */; };
+		D3A1B2C001000000000000F5 /* PlayolaShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */; };
+		D3A1B2C001000000000000F6 /* SiriShortcutsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */; };
+		D3A1B2C001000000000000F7 /* SiriShortcutsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */; };
 		D3A2761E2D43C747006055AF /* GoogleSignIn in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761D2D43C747006055AF /* GoogleSignIn */; };
 		D3A276202D43C747006055AF /* GoogleSignInSwift in Frameworks */ = {isa = PBXBuildFile; productRef = D3A2761F2D43C747006055AF /* GoogleSignInSwift */; };
 		D3A276692D49628C006055AF /* UIApplication+keyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A276682D496282006055AF /* UIApplication+keyWindow.swift */; };
@@ -424,25 +441,25 @@
 		D3FEC80B2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */; };
 		D3FEC80C2EDF647600A33AE8 /* ChooseStationToBroadcastPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */; };
 		D3FEC80D2EDF689F00A33AE8 /* ChooseStationToBroadcastPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */; };
-		D3A1B2C001000000000000A4 /* StationVoiceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */; };
-		D3A1B2C001000000000000A5 /* StationVoiceCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */; };
-		D3A1B2C001000000000000A6 /* StationVoiceCatalogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */; };
-		D3A1B2C001000000000000B4 /* PlaybackBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */; };
-		D3A1B2C001000000000000B5 /* PlaybackBootstrap.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */; };
-		D3A1B2C001000000000000C4 /* PlayStationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C2 /* PlayStationAction.swift */; };
-		D3A1B2C001000000000000C5 /* PlayStationAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C2 /* PlayStationAction.swift */; };
-		D3A1B2C001000000000000C6 /* PlayStationActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */; };
-		D3A1B2C001000000000000D4 /* RadioStationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000D2 /* RadioStationEntity.swift */; };
-		D3A1B2C001000000000000D5 /* RadioStationEntity.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000D2 /* RadioStationEntity.swift */; };
-		D3A1B2C001000000000000E4 /* PlayStationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000E2 /* PlayStationIntent.swift */; };
-		D3A1B2C001000000000000E5 /* PlayStationIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000E2 /* PlayStationIntent.swift */; };
-		D3A1B2C001000000000000F4 /* PlayolaShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */; };
-		D3A1B2C001000000000000F5 /* PlayolaShortcuts.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */; };
-		D3A1B2C001000000000000F6 /* SiriShortcutsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */; };
-		D3A1B2C001000000000000F7 /* SiriShortcutsClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */; };
 		D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = D3FF74D42FA7CA760052D500 /* CustomDump */; };
+		DA5BD241BADE11FCACB9AEA0 /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
+		DBD70D257638FF5934CA78DA /* CongratsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */; };
+		E1CA0000000000000000A002 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
+		E1CA0000000000000000A003 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
+		E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */; };
+		E6A2E13F3905B715C7E6FA15 /* Giveaway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EDCED098E801AAB2E9DC82 /* Giveaway.swift */; };
+		E6FA723C089B9E0115951DD1 /* GiveawayBannerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */; };
+		E96C77B08E039DD3EC6916BF /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
+		EDE2B63A1AB34C74CC65C898 /* CongratsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
+		F94F092AC0FB044790B38A0E /* GiveawayModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9553B35A6FBA27239EF49033 /* GiveawayModelsTests.swift */; };
 		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
+		FE110A0000000000000000B2 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
+		FE110A0000000000000000B3 /* WelcomeMessagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */; };
+		FE110A0000000000000000B4 /* WelcomeMessagePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */; };
+		FE110A0000000000000000B5 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
+		FE110A0000000000000000B6 /* WelcomeMessagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */; };
+		FE110AC0DE0000000000B1B1 /* WelcomeMessageEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -456,6 +473,13 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		02EDCED098E801AAB2E9DC82 /* Giveaway.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Giveaway.swift; sourceTree = "<group>"; };
+		0488057E2A6456204E582B15 /* CongratsActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsActionTests.swift; sourceTree = "<group>"; };
+		2B82DD37711E160592E3842D /* GiveawayMyResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayMyResult.swift; sourceTree = "<group>"; };
+		36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSubmission.swift; sourceTree = "<group>"; };
+		6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayParticipation.swift; sourceTree = "<group>"; };
+		917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayBannerState.swift; sourceTree = "<group>"; };
+		9553B35A6FBA27239EF49033 /* GiveawayModelsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayModelsTests.swift; sourceTree = "<group>"; };
 		9E8719F70AFA4992B9037775 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
 		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
 		A6613FD7A13B448187CB8595 /* PresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTests.swift; sourceTree = "<group>"; };
@@ -505,10 +529,6 @@
 		D31C43A92D3C390C0021AAE4 /* StationPlayerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerMock.swift; sourceTree = "<group>"; };
 		D31CD5222DFBA1EC009B9780 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		D31CD5252DFBB47D009B9780 /* MainContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContainerTests.swift; sourceTree = "<group>"; };
-		FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessageEligibilityTests.swift; sourceTree = "<group>"; };
-		FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageModel.swift; sourceTree = "<group>"; };
-		FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageView.swift; sourceTree = "<group>"; };
-		FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageTests.swift; sourceTree = "<group>"; };
 		D3219C162EDD22100008AFDA /* BroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastPageView.swift; sourceTree = "<group>"; };
 		D3219C192EDD22180008AFDA /* BroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastPageModel.swift; sourceTree = "<group>"; };
 		D3219C1C2EDD22230008AFDA /* BroadcastPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastPageTests.swift; sourceTree = "<group>"; };
@@ -536,8 +556,6 @@
 		D3536A372BFA6520006942D6 /* Color+Hex.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Color+Hex.swift"; sourceTree = "<group>"; };
 		D3536A382BFA6520006942D6 /* UIImage+Cache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIImage+Cache.swift"; sourceTree = "<group>"; };
 		D35673AF2D3DC54F00E4E926 /* CarPlaySceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlaySceneDelegate.swift; sourceTree = "<group>"; };
-		E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransition.swift; sourceTree = "<group>"; };
-		E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransitionTests.swift; sourceTree = "<group>"; };
 		D35673B12D3DC59100E4E926 /* RadioStation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioStation.swift; sourceTree = "<group>"; };
 		D35673B92D3DC9ED00E4E926 /* Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Config.swift; sourceTree = "<group>"; };
 		D35673BD2D3DCA1E00E4E926 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
@@ -640,6 +658,15 @@
 		D3A08A2E2E4E2A31002468E0 /* AnalyticsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClient.swift; sourceTree = "<group>"; };
 		D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEvent.swift; sourceTree = "<group>"; };
 		D3A08A332E4E6F5D002468E0 /* NowPlayingUpdaterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingUpdaterTests.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationVoiceCatalog.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationVoiceCatalogTests.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBootstrap.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000C2 /* PlayStationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationAction.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationActionTests.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000D2 /* RadioStationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioStationEntity.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000E2 /* PlayStationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationIntent.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaShortcuts.swift; sourceTree = "<group>"; };
+		D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiriShortcutsClient.swift; sourceTree = "<group>"; };
 		D3A276682D496282006055AF /* UIApplication+keyWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+keyWindow.swift"; sourceTree = "<group>"; };
 		D3ABC1242F2F2F2F0A2F2F2F /* AnalyticsClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsClientTests.swift; sourceTree = "<group>"; };
 		D3B662692D40103800975D2F /* SignInPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPageView.swift; sourceTree = "<group>"; };
@@ -692,18 +719,18 @@
 		D3FACE010000000000000004 /* ArtistSuggestionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestionTests.swift; sourceTree = "<group>"; };
 		D3FE88832E37EF24009AE7B7 /* PrizeTier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrizeTier.swift; sourceTree = "<group>"; };
 		D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageTests.swift; sourceTree = "<group>"; };
-		D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationVoiceCatalog.swift; sourceTree = "<group>"; };
-		D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationVoiceCatalogTests.swift; sourceTree = "<group>"; };
-		D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackBootstrap.swift; sourceTree = "<group>"; };
-		D3A1B2C001000000000000C2 /* PlayStationAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationAction.swift; sourceTree = "<group>"; };
-		D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationActionTests.swift; sourceTree = "<group>"; };
-		D3A1B2C001000000000000D2 /* RadioStationEntity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RadioStationEntity.swift; sourceTree = "<group>"; };
-		D3A1B2C001000000000000E2 /* PlayStationIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayStationIntent.swift; sourceTree = "<group>"; };
-		D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaShortcuts.swift; sourceTree = "<group>"; };
-		D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiriShortcutsClient.swift; sourceTree = "<group>"; };
 		D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageView.swift; sourceTree = "<group>"; };
 		D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageModel.swift; sourceTree = "<group>"; };
+		D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayTapResponse.swift; sourceTree = "<group>"; };
+		DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsAction.swift; sourceTree = "<group>"; };
+		E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransition.swift; sourceTree = "<group>"; };
+		E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransitionTests.swift; sourceTree = "<group>"; };
+		F5283C7C8C9FAF45659BA98E /* GiveawayParticipationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayParticipationTests.swift; sourceTree = "<group>"; };
 		FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetErrorReportingTests.swift; sourceTree = "<group>"; };
+		FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageModel.swift; sourceTree = "<group>"; };
+		FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageView.swift; sourceTree = "<group>"; };
+		FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageTests.swift; sourceTree = "<group>"; };
+		FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessageEligibilityTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -891,6 +918,16 @@
 				D30C01C42F5C9C8400889E6D /* UserPrize.swift */,
 				D30257A32E63E95200F4228B /* UserSongLike.swift */,
 				D317C0D02EF2027000DBC82E /* VoicetrackStatusResponse.swift */,
+				02EDCED098E801AAB2E9DC82 /* Giveaway.swift */,
+				6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */,
+				2B82DD37711E160592E3842D /* GiveawayMyResult.swift */,
+				D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */,
+				36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */,
+				917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */,
+				DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */,
+				9553B35A6FBA27239EF49033 /* GiveawayModelsTests.swift */,
+				F5283C7C8C9FAF45659BA98E /* GiveawayParticipationTests.swift */,
+				0488057E2A6456204E582B15 /* CongratsActionTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1234,16 +1271,6 @@
 			path = MainContainer;
 			sourceTree = "<group>";
 		};
-		FE110A0000000000000000A0 /* WelcomeMessage */ = {
-			isa = PBXGroup;
-			children = (
-				FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */,
-				FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */,
-				FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */,
-			);
-			path = WelcomeMessage;
-			sourceTree = "<group>";
-		};
 		D37257CE2DFB4358001BC6F9 /* PlayerPage */ = {
 			isa = PBXGroup;
 			children = (
@@ -1325,22 +1352,6 @@
 				D302576E2E63429000F4228B /* Toast */,
 			);
 			path = Core;
-			sourceTree = "<group>";
-		};
-		D3A1B2C001000000000000A1 /* SiriIntents */ = {
-			isa = PBXGroup;
-			children = (
-				D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */,
-				D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */,
-				D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */,
-				D3A1B2C001000000000000C2 /* PlayStationAction.swift */,
-				D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */,
-				D3A1B2C001000000000000D2 /* RadioStationEntity.swift */,
-				D3A1B2C001000000000000E2 /* PlayStationIntent.swift */,
-				D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */,
-				D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */,
-			);
-			path = SiriIntents;
 			sourceTree = "<group>";
 		};
 		D378CCD22E58C38D00497A4A /* Analytics */ = {
@@ -1464,6 +1475,22 @@
 				D35673C72D3EBFB000E4E926 /* NowPlayingUpdater.swift */,
 			);
 			path = NowPlayingUpdater;
+			sourceTree = "<group>";
+		};
+		D3A1B2C001000000000000A1 /* SiriIntents */ = {
+			isa = PBXGroup;
+			children = (
+				D3A1B2C001000000000000A2 /* StationVoiceCatalog.swift */,
+				D3A1B2C001000000000000A3 /* StationVoiceCatalogTests.swift */,
+				D3A1B2C001000000000000B2 /* PlaybackBootstrap.swift */,
+				D3A1B2C001000000000000C2 /* PlayStationAction.swift */,
+				D3A1B2C001000000000000C3 /* PlayStationActionTests.swift */,
+				D3A1B2C001000000000000D2 /* RadioStationEntity.swift */,
+				D3A1B2C001000000000000E2 /* PlayStationIntent.swift */,
+				D3A1B2C001000000000000F2 /* PlayolaShortcuts.swift */,
+				D3A1B2C001000000000000F8 /* SiriShortcutsClient.swift */,
+			);
+			path = SiriIntents;
 			sourceTree = "<group>";
 		};
 		D3B662772D41B10600975D2F /* SignInPage */ = {
@@ -1597,6 +1624,16 @@
 				D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */,
 			);
 			path = ChooseStationToBroadcastPage;
+			sourceTree = "<group>";
+		};
+		FE110A0000000000000000A0 /* WelcomeMessage */ = {
+			isa = PBXGroup;
+			children = (
+				FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */,
+				FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */,
+				FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */,
+			);
+			path = WelcomeMessage;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -1947,6 +1984,13 @@
 				AA01000000000001AAAAAAAA /* PresetStarButton.swift in Sources */,
 				AA01000000000002AAAAAAAA /* PresetTile.swift in Sources */,
 				AA01000000000003AAAAAAAA /* PresetsCarousel.swift in Sources */,
+				659E9B124BCB08D5F3D216D7 /* Giveaway.swift in Sources */,
+				E96C77B08E039DD3EC6916BF /* GiveawayParticipation.swift in Sources */,
+				725E8382CB9672F532FC2CDD /* GiveawayMyResult.swift in Sources */,
+				5F721A0797795B3B529757CD /* GiveawayTapResponse.swift in Sources */,
+				5F67160E76C1454189765E5D /* GiveawayWinnerSubmission.swift in Sources */,
+				E6FA723C089B9E0115951DD1 /* GiveawayBannerState.swift in Sources */,
+				DBD70D257638FF5934CA78DA /* CongratsAction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2118,6 +2162,13 @@
 				AA01000000000004AAAAAAAA /* PresetStarButton.swift in Sources */,
 				AA01000000000005AAAAAAAA /* PresetTile.swift in Sources */,
 				AA01000000000006AAAAAAAA /* PresetsCarousel.swift in Sources */,
+				E6A2E13F3905B715C7E6FA15 /* Giveaway.swift in Sources */,
+				354451A630DF81468815108F /* GiveawayParticipation.swift in Sources */,
+				8CECE7D0544EBE95DA92A501 /* GiveawayMyResult.swift in Sources */,
+				1DBE6EEE6CD7879ED93BB12C /* GiveawayTapResponse.swift in Sources */,
+				DA5BD241BADE11FCACB9AEA0 /* GiveawayWinnerSubmission.swift in Sources */,
+				B12730D5ECA7018F074B54E6 /* GiveawayBannerState.swift in Sources */,
+				EDE2B63A1AB34C74CC65C898 /* CongratsAction.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2191,6 +2242,9 @@
 				D395911A2E39933800720CF8 /* ContactPageTests.swift in Sources */,
 				D3B744BC2E312FB60042A427 /* ListeningTrackerTests.swift in Sources */,
 				D3B744A82E2F185F0042A427 /* SmallPlayerTests.swift in Sources */,
+				F94F092AC0FB044790B38A0E /* GiveawayModelsTests.swift in Sources */,
+				03D9929612C3E595D9BD88D5 /* GiveawayParticipationTests.swift in Sources */,
+				65D0683FA2A905693317C5AB /* CongratsActionTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2199,11 +2253,11 @@
 /* Begin PBXTargetDependency section */
 		D30F00332E8592F0007BCC73 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = D384837A2E242DB5008676BB /* SwiftLintBuildToolPlugin */;
+			productRef = D384837A2E242DB5008676BB /* plugin:SwiftLintBuildToolPlugin */;
 		};
 		D351296B2E2546E400209795 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = D351296A2E2546E400209795 /* SwiftLintBuildToolPlugin */;
+			productRef = D351296A2E2546E400209795 /* plugin:SwiftLintBuildToolPlugin */;
 		};
 		D3536A132BFA4F4A006942D6 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2212,7 +2266,7 @@
 		};
 		D384837B2E242DB5008676BB /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			productRef = D384837A2E242DB5008676BB /* SwiftLintBuildToolPlugin */;
+			productRef = D384837A2E242DB5008676BB /* plugin:SwiftLintBuildToolPlugin */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2488,7 +2542,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PlayolaRadio/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Playola";
+				INFOPLIST_KEY_CFBundleDisplayName = Playola;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Playola uses the microphone to let you record voicetracks or audio messages.";
@@ -2534,7 +2588,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PlayolaRadio/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Playola";
+				INFOPLIST_KEY_CFBundleDisplayName = Playola;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Playola uses the microphone to let you record voicetracks or audio messages.";
@@ -2682,7 +2736,7 @@
 				ENABLE_USER_SCRIPT_SANDBOXING = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = PlayolaRadio/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = "Playola";
+				INFOPLIST_KEY_CFBundleDisplayName = Playola;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Playola uses the microphone to let you record voicetracks or audio messages.";
@@ -2782,8 +2836,6 @@
 				kind = upToNextMajorVersion;
 				minimumVersion = 9.10.0;
 			};
-			traits = (
-			);
 		};
 		D30F00382E8592F0007BCC73 /* XCRemoteSwiftPackageReference "PlayolaPlayer" */ = {
 			isa = XCRemoteSwiftPackageReference;
@@ -3011,7 +3063,7 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = PlayolaPlayer;
 		};
-		D351296A2E2546E400209795 /* SwiftLintBuildToolPlugin */ = {
+		D351296A2E2546E400209795 /* plugin:SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D38483792E242D61008676BB /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";
@@ -3021,7 +3073,7 @@
 			package = D35673B52D3DC6EC00E4E926 /* XCRemoteSwiftPackageReference "mixpanel-swift" */;
 			productName = Mixpanel;
 		};
-		D384837A2E242DB5008676BB /* SwiftLintBuildToolPlugin */ = {
+		D384837A2E242DB5008676BB /* plugin:SwiftLintBuildToolPlugin */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D38483792E242D61008676BB /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
 			productName = "plugin:SwiftLintBuildToolPlugin";

--- a/PlayolaRadio/Models/CongratsAction.swift
+++ b/PlayolaRadio/Models/CongratsAction.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum CongratsActionState: Codable, Equatable, Sendable {
+  case pending
+  case uploaded(audioBlockId: String)
+  case submitted
+  case alreadyClosed
+}
+
+struct CongratsAction: Codable, Equatable, Sendable, Identifiable {
+  let giveawayId: String
+  let stationId: String
+  var state: CongratsActionState
+  var startedAt: Date
+
+  var id: String { giveawayId }
+
+  var audioBlockId: String? {
+    if case .uploaded(let audioBlockId) = state { return audioBlockId }
+    return nil
+  }
+
+  var isTerminal: Bool {
+    switch state {
+    case .submitted, .alreadyClosed: return true
+    case .pending, .uploaded: return false
+    }
+  }
+
+  static var mock: CongratsAction {
+    CongratsAction(
+      giveawayId: "giveaway-1", stationId: "station-1", state: .pending,
+      startedAt: Date(timeIntervalSince1970: 1_781_722_800))
+  }
+}

--- a/PlayolaRadio/Models/CongratsActionTests.swift
+++ b/PlayolaRadio/Models/CongratsActionTests.swift
@@ -1,0 +1,37 @@
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct CongratsActionTests {
+  @Test func codableRoundTrips() throws {
+    let action = CongratsAction(
+      giveawayId: "g1", stationId: "s1", state: .uploaded(audioBlockId: "ab1"),
+      startedAt: Date(timeIntervalSince1970: 1_000_000))
+    let data = try JSONEncoder().encode(action)
+    let back = try JSONDecoder().decode(CongratsAction.self, from: data)
+    expectNoDifference(back, action)
+  }
+
+  @Test func audioBlockIdOnlyPresentWhenUploaded() {
+    var action = CongratsAction.mock
+    #expect(action.audioBlockId == nil)
+    action.state = .uploaded(audioBlockId: "ab1")
+    #expect(action.audioBlockId == "ab1")
+    action.state = .submitted
+    #expect(action.audioBlockId == nil)
+  }
+
+  @Test func isTerminalForSubmittedAndAlreadyClosed() {
+    var action = CongratsAction.mock
+    #expect(!action.isTerminal)
+    action.state = .uploaded(audioBlockId: "ab1")
+    #expect(!action.isTerminal)
+    action.state = .submitted
+    #expect(action.isTerminal)
+    action.state = .alreadyClosed
+    #expect(action.isTerminal)
+  }
+}

--- a/PlayolaRadio/Models/Giveaway.swift
+++ b/PlayolaRadio/Models/Giveaway.swift
@@ -5,6 +5,12 @@ enum GiveawayStatus: String, Codable, Sendable, Equatable {
   case open
   case closed
   case canceled
+  case unknown
+
+  init(from decoder: Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = GiveawayStatus(rawValue: raw) ?? .unknown
+  }
 }
 
 struct Giveaway: Decodable, Sendable, Identifiable, Equatable {

--- a/PlayolaRadio/Models/Giveaway.swift
+++ b/PlayolaRadio/Models/Giveaway.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+enum GiveawayStatus: String, Codable, Sendable, Equatable {
+  case scheduled
+  case open
+  case closed
+  case canceled
+}
+
+struct Giveaway: Decodable, Sendable, Identifiable, Equatable {
+  let id: String
+  let stationId: String
+  let prizeName: String
+  let prizeDescription: String?
+  let prizeImageUrl: URL?
+  let winningNumber: Int
+  let status: GiveawayStatus
+  let winnerUserId: String?
+  let openedAt: Date?
+  let closedAt: Date?
+  let createdAt: Date
+  let updatedAt: Date
+
+  enum CodingKeys: String, CodingKey {
+    case id, stationId, prizeName, prizeDescription, prizeImageUrl, winningNumber
+    case status, winnerUserId, openedAt, closedAt, createdAt, updatedAt
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    stationId = try container.decode(String.self, forKey: .stationId)
+    prizeName = try container.decode(String.self, forKey: .prizeName)
+    prizeDescription = try container.decodeIfPresent(String.self, forKey: .prizeDescription)
+    if let raw = try container.decodeIfPresent(String.self, forKey: .prizeImageUrl) {
+      prizeImageUrl = URL(string: raw)
+    } else {
+      prizeImageUrl = nil
+    }
+    winningNumber = try container.decode(Int.self, forKey: .winningNumber)
+    status = try container.decode(GiveawayStatus.self, forKey: .status)
+    winnerUserId = try container.decodeIfPresent(String.self, forKey: .winnerUserId)
+    openedAt = try container.decodeIfPresent(Date.self, forKey: .openedAt)
+    closedAt = try container.decodeIfPresent(Date.self, forKey: .closedAt)
+    createdAt = try container.decode(Date.self, forKey: .createdAt)
+    updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+  }
+
+  init(
+    id: String, stationId: String, prizeName: String, prizeDescription: String? = nil,
+    prizeImageUrl: URL? = nil, winningNumber: Int, status: GiveawayStatus,
+    winnerUserId: String? = nil, openedAt: Date? = nil, closedAt: Date? = nil,
+    createdAt: Date = Date(), updatedAt: Date = Date()
+  ) {
+    self.id = id
+    self.stationId = stationId
+    self.prizeName = prizeName
+    self.prizeDescription = prizeDescription
+    self.prizeImageUrl = prizeImageUrl
+    self.winningNumber = winningNumber
+    self.status = status
+    self.winnerUserId = winnerUserId
+    self.openedAt = openedAt
+    self.closedAt = closedAt
+    self.createdAt = createdAt
+    self.updatedAt = updatedAt
+  }
+
+  static var mock: Giveaway {
+    Giveaway(
+      id: "giveaway-1", stationId: "station-1",
+      prizeName: "Two tickets to Reckless Kelly at the Heights",
+      prizeDescription: "Friday night, doors at 8.",
+      prizeImageUrl: URL(string: "https://example.com/prize.png"),
+      winningNumber: 9, status: .open)
+  }
+}

--- a/PlayolaRadio/Models/GiveawayBannerState.swift
+++ b/PlayolaRadio/Models/GiveawayBannerState.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+struct GiveawayBannerState: Codable, Equatable, Sendable, Identifiable {
+  let giveawayId: String
+  let stationId: String
+
+  var id: String { giveawayId }
+}

--- a/PlayolaRadio/Models/GiveawayModelsTests.swift
+++ b/PlayolaRadio/Models/GiveawayModelsTests.swift
@@ -56,6 +56,18 @@ struct GiveawayModelsTests {
     let submission = try decoder().decode(GiveawayWinnerSubmission.self, from: json)
     #expect(submission.id == "sub1")
     #expect(submission.willingToRecord == true)
-    #expect(submission.fulfillmentStatus == "pending")
+    #expect(submission.fulfillmentStatus == .pending)
+  }
+
+  @Test func decodesUnknownFulfillmentStatusAsUnknown() throws {
+    let json = Data(
+      """
+      { "id": "sub1", "giveawayId": "g1", "userId": "u1", "fullName": "X",
+        "addressLine1": "1", "city": "Austin", "postalCode": "78701",
+        "country": "US", "willingToRecord": false, "fulfillmentStatus": "shipped",
+        "submittedAt": "2026-06-13T19:00:00.000Z" }
+      """.utf8)
+    let submission = try decoder().decode(GiveawayWinnerSubmission.self, from: json)
+    #expect(submission.fulfillmentStatus == .unknown)
   }
 }

--- a/PlayolaRadio/Models/GiveawayModelsTests.swift
+++ b/PlayolaRadio/Models/GiveawayModelsTests.swift
@@ -28,6 +28,27 @@ struct GiveawayModelsTests {
     #expect(giveaway.prizeImageUrl == URL(string: "https://x.test/p.png"))
   }
 
+  @Test func decodesUnknownGiveawayStatusAsUnknownRatherThanThrowing() throws {
+    let json = Data(
+      """
+      {
+        "id": "g1", "stationId": "s1", "prizeName": "Two tickets",
+        "winningNumber": 9, "status": "paused", "winnerUserId": null,
+        "createdAt": "2026-06-13T17:00:00.000Z", "updatedAt": "2026-06-13T18:00:00.000Z"
+      }
+      """.utf8)
+    let giveaway = try decoder().decode(Giveaway.self, from: json)
+    #expect(giveaway.status == .unknown)
+  }
+
+  @Test func decodesUnknownMyResultStatusAsUnknown() throws {
+    let json = Data(
+      #"{ "tapNumber": null, "isWinner": false, "status": "expired", "winningNumber": 9 }"#.utf8)
+    let result = try decoder().decode(GiveawayMyResult.self, from: json)
+    #expect(result.status == .unknown)
+    #expect(result.isResolved == false)
+  }
+
   @Test func decodesTapResponse() throws {
     let json = Data(#"{ "tapNumber": 14, "isWinner": false, "status": "open" }"#.utf8)
     let response = try decoder().decode(GiveawayTapResponse.self, from: json)

--- a/PlayolaRadio/Models/GiveawayModelsTests.swift
+++ b/PlayolaRadio/Models/GiveawayModelsTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import PlayolaPlayer
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct GiveawayModelsTests {
+  private func decoder() -> JSONDecoder { JSONDecoderWithIsoFull() }
+
+  @Test func decodesActiveGiveawayWithWinningNumberAndNoTapCount() throws {
+    let json = Data(
+      """
+      {
+        "id": "g1", "stationId": "s1", "prizeName": "Two tickets",
+        "prizeDescription": "Friday night", "prizeImageUrl": "https://x.test/p.png",
+        "winningNumber": 9, "status": "open", "winnerUserId": null,
+        "openedAt": "2026-06-13T18:00:00.000Z", "closedAt": null,
+        "createdAt": "2026-06-13T17:00:00.000Z", "updatedAt": "2026-06-13T18:00:00.000Z"
+      }
+      """.utf8)
+    let giveaway = try decoder().decode(Giveaway.self, from: json)
+    #expect(giveaway.id == "g1")
+    #expect(giveaway.stationId == "s1")
+    #expect(giveaway.prizeName == "Two tickets")
+    #expect(giveaway.winningNumber == 9)
+    #expect(giveaway.status == .open)
+    #expect(giveaway.prizeImageUrl == URL(string: "https://x.test/p.png"))
+  }
+
+  @Test func decodesTapResponse() throws {
+    let json = Data(#"{ "tapNumber": 14, "isWinner": false, "status": "open" }"#.utf8)
+    let response = try decoder().decode(GiveawayTapResponse.self, from: json)
+    #expect(response.tapNumber == 14)
+    #expect(response.isWinner == false)
+    #expect(response.status == .open)
+  }
+
+  @Test func decodesMyResultWithNullTapNumber() throws {
+    let json = Data(
+      #"{ "tapNumber": null, "isWinner": false, "status": "closed", "winningNumber": 9 }"#.utf8)
+    let result = try decoder().decode(GiveawayMyResult.self, from: json)
+    #expect(result.tapNumber == nil)
+    #expect(result.status == .closed)
+    #expect(result.winningNumber == 9)
+  }
+
+  @Test func decodesWinnerSubmission() throws {
+    let json = Data(
+      """
+      { "id": "sub1", "giveawayId": "g1", "userId": "u1", "fullName": "Brian Keane",
+        "addressLine1": "123 Main", "city": "Austin", "postalCode": "78701",
+        "country": "US", "willingToRecord": true, "fulfillmentStatus": "pending",
+        "submittedAt": "2026-06-13T19:00:00.000Z" }
+      """.utf8)
+    let submission = try decoder().decode(GiveawayWinnerSubmission.self, from: json)
+    #expect(submission.id == "sub1")
+    #expect(submission.willingToRecord == true)
+    #expect(submission.fulfillmentStatus == "pending")
+  }
+}

--- a/PlayolaRadio/Models/GiveawayMyResult.swift
+++ b/PlayolaRadio/Models/GiveawayMyResult.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+struct GiveawayMyResult: Decodable, Sendable, Equatable {
+  let tapNumber: Int?
+  let isWinner: Bool
+  let status: GiveawayStatus
+  let winningNumber: Int
+
+  init(tapNumber: Int?, isWinner: Bool, status: GiveawayStatus, winningNumber: Int) {
+    self.tapNumber = tapNumber
+    self.isWinner = isWinner
+    self.status = status
+    self.winningNumber = winningNumber
+  }
+
+  var isResolved: Bool { status == .closed || status == .canceled }
+
+  static var mock: GiveawayMyResult {
+    GiveawayMyResult(tapNumber: 9, isWinner: true, status: .closed, winningNumber: 9)
+  }
+}

--- a/PlayolaRadio/Models/GiveawayParticipation.swift
+++ b/PlayolaRadio/Models/GiveawayParticipation.swift
@@ -1,9 +1,9 @@
 import Foundation
 
 enum GiveawayParticipationStatus: Codable, Equatable, Sendable {
-  case tappedStandby(tapNumber: Int)
-  case resolvedWon(tapNumber: Int, submissionCompleted: Bool)
-  case resolvedLost(tapNumber: Int, toastShown: Bool)
+  case tappedStandby
+  case resolvedWon(submissionCompleted: Bool)
+  case resolvedLost(toastShown: Bool)
   case canceled
 }
 
@@ -27,9 +27,17 @@ struct GiveawayParticipation: Codable, Equatable, Sendable, Identifiable {
   var isFullyHandled: Bool {
     switch status {
     case .tappedStandby: return false
-    case .resolvedWon(_, let submissionCompleted): return submissionCompleted
-    case .resolvedLost(_, let toastShown): return toastShown
+    case .resolvedWon(let submissionCompleted): return submissionCompleted
+    case .resolvedLost(let toastShown): return toastShown
     case .canceled: return true
     }
+  }
+
+  static var mock: GiveawayParticipation {
+    GiveawayParticipation(
+      id: "giveaway-1", stationId: "station-1",
+      prizeName: "Two tickets to Reckless Kelly at the Heights",
+      winningNumber: 9, tapNumber: 7, status: .tappedStandby,
+      tappedAt: Date(timeIntervalSince1970: 1_781_722_800))
   }
 }

--- a/PlayolaRadio/Models/GiveawayParticipation.swift
+++ b/PlayolaRadio/Models/GiveawayParticipation.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+enum GiveawayParticipationStatus: Codable, Equatable, Sendable {
+  case tappedStandby(tapNumber: Int)
+  case resolvedWon(tapNumber: Int, submissionCompleted: Bool)
+  case resolvedLost(tapNumber: Int, toastShown: Bool)
+  case canceled
+}
+
+struct GiveawayParticipation: Codable, Equatable, Sendable, Identifiable {
+  let id: String
+  let stationId: String
+  let prizeName: String
+  var prizeDescription: String?
+  var prizeImageUrl: URL?
+  let winningNumber: Int
+  var tapNumber: Int
+  var status: GiveawayParticipationStatus
+  var tappedAt: Date
+  var winnerSheetPresentedAt: Date?
+
+  var isStandby: Bool {
+    if case .tappedStandby = status { return true }
+    return false
+  }
+
+  var isFullyHandled: Bool {
+    switch status {
+    case .tappedStandby: return false
+    case .resolvedWon(_, let submissionCompleted): return submissionCompleted
+    case .resolvedLost(_, let toastShown): return toastShown
+    case .canceled: return true
+    }
+  }
+}

--- a/PlayolaRadio/Models/GiveawayParticipationTests.swift
+++ b/PlayolaRadio/Models/GiveawayParticipationTests.swift
@@ -9,7 +9,7 @@ struct GiveawayParticipationTests {
   @Test func codableRoundTrips() throws {
     let participation = GiveawayParticipation(
       id: "g1", stationId: "s1", prizeName: "Tickets", winningNumber: 9,
-      tapNumber: 5, status: .tappedStandby(tapNumber: 5),
+      tapNumber: 5, status: .tappedStandby,
       tappedAt: Date(timeIntervalSince1970: 1_000_000))
     let data = try JSONEncoder().encode(participation)
     let back = try JSONDecoder().decode(GiveawayParticipation.self, from: data)
@@ -19,17 +19,17 @@ struct GiveawayParticipationTests {
   @Test func terminalStatesAreHandledFlags() {
     var participation = GiveawayParticipation(
       id: "g1", stationId: "s1", prizeName: "Tickets", winningNumber: 9,
-      tapNumber: 5, status: .tappedStandby(tapNumber: 5), tappedAt: Date())
+      tapNumber: 5, status: .tappedStandby, tappedAt: Date())
     #expect(!participation.isFullyHandled)
 
-    participation.status = .resolvedLost(tapNumber: 5, toastShown: false)
+    participation.status = .resolvedLost(toastShown: false)
     #expect(!participation.isFullyHandled)
-    participation.status = .resolvedLost(tapNumber: 5, toastShown: true)
+    participation.status = .resolvedLost(toastShown: true)
     #expect(participation.isFullyHandled)
 
-    participation.status = .resolvedWon(tapNumber: 5, submissionCompleted: false)
+    participation.status = .resolvedWon(submissionCompleted: false)
     #expect(!participation.isFullyHandled)
-    participation.status = .resolvedWon(tapNumber: 5, submissionCompleted: true)
+    participation.status = .resolvedWon(submissionCompleted: true)
     #expect(participation.isFullyHandled)
 
     participation.status = .canceled

--- a/PlayolaRadio/Models/GiveawayParticipationTests.swift
+++ b/PlayolaRadio/Models/GiveawayParticipationTests.swift
@@ -1,0 +1,38 @@
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct GiveawayParticipationTests {
+  @Test func codableRoundTrips() throws {
+    let participation = GiveawayParticipation(
+      id: "g1", stationId: "s1", prizeName: "Tickets", winningNumber: 9,
+      tapNumber: 5, status: .tappedStandby(tapNumber: 5),
+      tappedAt: Date(timeIntervalSince1970: 1_000_000))
+    let data = try JSONEncoder().encode(participation)
+    let back = try JSONDecoder().decode(GiveawayParticipation.self, from: data)
+    expectNoDifference(back, participation)
+  }
+
+  @Test func terminalStatesAreHandledFlags() {
+    var participation = GiveawayParticipation(
+      id: "g1", stationId: "s1", prizeName: "Tickets", winningNumber: 9,
+      tapNumber: 5, status: .tappedStandby(tapNumber: 5), tappedAt: Date())
+    #expect(!participation.isFullyHandled)
+
+    participation.status = .resolvedLost(tapNumber: 5, toastShown: false)
+    #expect(!participation.isFullyHandled)
+    participation.status = .resolvedLost(tapNumber: 5, toastShown: true)
+    #expect(participation.isFullyHandled)
+
+    participation.status = .resolvedWon(tapNumber: 5, submissionCompleted: false)
+    #expect(!participation.isFullyHandled)
+    participation.status = .resolvedWon(tapNumber: 5, submissionCompleted: true)
+    #expect(participation.isFullyHandled)
+
+    participation.status = .canceled
+    #expect(participation.isFullyHandled)
+  }
+}

--- a/PlayolaRadio/Models/GiveawayTapResponse.swift
+++ b/PlayolaRadio/Models/GiveawayTapResponse.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+struct GiveawayTapResponse: Decodable, Sendable, Equatable {
+  let tapNumber: Int
+  let isWinner: Bool
+  let status: GiveawayStatus
+
+  static var mock: GiveawayTapResponse {
+    GiveawayTapResponse(tapNumber: 5, isWinner: false, status: .open)
+  }
+}

--- a/PlayolaRadio/Models/GiveawayWinnerSubmission.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerSubmission.swift
@@ -1,0 +1,88 @@
+import Foundation
+
+struct GiveawayWinnerSubmission: Decodable, Sendable, Identifiable, Equatable {
+  let id: String
+  let giveawayId: String
+  let userId: String
+  let fullName: String
+  let addressLine1: String
+  let addressLine2: String?
+  let city: String
+  let state: String?
+  let postalCode: String
+  let country: String
+  let comment: String?
+  let willingToRecord: Bool
+  let fulfillmentStatus: String
+  let submittedAt: Date
+
+  enum CodingKeys: String, CodingKey {
+    case id, giveawayId, userId, fullName, addressLine1, addressLine2, city, state
+    case postalCode, country, comment, willingToRecord, fulfillmentStatus, submittedAt
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    giveawayId = try container.decode(String.self, forKey: .giveawayId)
+    userId = try container.decode(String.self, forKey: .userId)
+    fullName = try container.decode(String.self, forKey: .fullName)
+    addressLine1 = try container.decode(String.self, forKey: .addressLine1)
+    addressLine2 = try container.decodeIfPresent(String.self, forKey: .addressLine2)
+    city = try container.decode(String.self, forKey: .city)
+    state = try container.decodeIfPresent(String.self, forKey: .state)
+    postalCode = try container.decode(String.self, forKey: .postalCode)
+    country = try container.decode(String.self, forKey: .country)
+    comment = try container.decodeIfPresent(String.self, forKey: .comment)
+    willingToRecord = try container.decodeIfPresent(Bool.self, forKey: .willingToRecord) ?? false
+    fulfillmentStatus = try container.decode(String.self, forKey: .fulfillmentStatus)
+    submittedAt = try container.decode(Date.self, forKey: .submittedAt)
+  }
+
+  init(
+    id: String,
+    giveawayId: String,
+    userId: String,
+    fullName: String,
+    addressLine1: String,
+    addressLine2: String? = nil,
+    city: String,
+    state: String? = nil,
+    postalCode: String,
+    country: String,
+    comment: String? = nil,
+    willingToRecord: Bool,
+    fulfillmentStatus: String,
+    submittedAt: Date
+  ) {
+    self.id = id
+    self.giveawayId = giveawayId
+    self.userId = userId
+    self.fullName = fullName
+    self.addressLine1 = addressLine1
+    self.addressLine2 = addressLine2
+    self.city = city
+    self.state = state
+    self.postalCode = postalCode
+    self.country = country
+    self.comment = comment
+    self.willingToRecord = willingToRecord
+    self.fulfillmentStatus = fulfillmentStatus
+    self.submittedAt = submittedAt
+  }
+
+  static var mock: GiveawayWinnerSubmission {
+    GiveawayWinnerSubmission(
+      id: "sub-1",
+      giveawayId: "giveaway-1",
+      userId: "user-1",
+      fullName: "Brian Keane",
+      addressLine1: "123 Main St",
+      city: "Austin",
+      postalCode: "78701",
+      country: "US",
+      willingToRecord: false,
+      fulfillmentStatus: "pending",
+      submittedAt: Date(timeIntervalSince1970: 1_781_722_800))
+  }
+}

--- a/PlayolaRadio/Models/GiveawayWinnerSubmission.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerSubmission.swift
@@ -1,5 +1,16 @@
 import Foundation
 
+enum FulfillmentStatus: String, Codable, Sendable, Equatable {
+  case pending
+  case fulfilled
+  case unknown
+
+  init(from decoder: Decoder) throws {
+    let raw = try decoder.singleValueContainer().decode(String.self)
+    self = FulfillmentStatus(rawValue: raw) ?? .unknown
+  }
+}
+
 struct GiveawayWinnerSubmission: Decodable, Sendable, Identifiable, Equatable {
   let id: String
   let giveawayId: String
@@ -13,7 +24,7 @@ struct GiveawayWinnerSubmission: Decodable, Sendable, Identifiable, Equatable {
   let country: String
   let comment: String?
   let willingToRecord: Bool
-  let fulfillmentStatus: String
+  let fulfillmentStatus: FulfillmentStatus
   let submittedAt: Date
 
   enum CodingKeys: String, CodingKey {
@@ -35,7 +46,7 @@ struct GiveawayWinnerSubmission: Decodable, Sendable, Identifiable, Equatable {
     country = try container.decode(String.self, forKey: .country)
     comment = try container.decodeIfPresent(String.self, forKey: .comment)
     willingToRecord = try container.decodeIfPresent(Bool.self, forKey: .willingToRecord) ?? false
-    fulfillmentStatus = try container.decode(String.self, forKey: .fulfillmentStatus)
+    fulfillmentStatus = try container.decode(FulfillmentStatus.self, forKey: .fulfillmentStatus)
     submittedAt = try container.decode(Date.self, forKey: .submittedAt)
   }
 
@@ -52,7 +63,7 @@ struct GiveawayWinnerSubmission: Decodable, Sendable, Identifiable, Equatable {
     country: String,
     comment: String? = nil,
     willingToRecord: Bool,
-    fulfillmentStatus: String,
+    fulfillmentStatus: FulfillmentStatus,
     submittedAt: Date
   ) {
     self.id = id
@@ -82,7 +93,7 @@ struct GiveawayWinnerSubmission: Decodable, Sendable, Identifiable, Equatable {
       postalCode: "78701",
       country: "US",
       willingToRecord: false,
-      fulfillmentStatus: "pending",
+      fulfillmentStatus: .pending,
       submittedAt: Date(timeIntervalSince1970: 1_781_722_800))
   }
 }

--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -199,6 +199,11 @@ class AuthService: @unchecked Sendable {
     @Shared(.isBroadcaster) var isBroadcaster
     @Shared(.welcomeMessageEligible) var welcomeMessageEligible
     @Shared(.welcomeMessageShownThisSession) var welcomeMessageShownThisSession
+    @Shared(.activeGiveaway) var activeGiveaway
+    @Shared(.giveawayBanner) var giveawayBanner
+    @Shared(.giveawayParticipations) var giveawayParticipations
+    @Shared(.dismissedGiveawayBannerIds) var dismissedGiveawayBannerIds
+    @Shared(.pendingCongratsAction) var pendingCongratsAction
 
     let jwt = auth.jwt
     let deviceId = registeredDeviceId
@@ -218,6 +223,11 @@ class AuthService: @unchecked Sendable {
     $isBroadcaster.withLock { $0 = false }
     $welcomeMessageEligible.withLock { $0 = false }
     $welcomeMessageShownThisSession.withLock { $0 = false }
+    $activeGiveaway.withLock { $0 = nil }
+    $giveawayBanner.withLock { $0 = nil }
+    $giveawayParticipations.withLock { $0 = [:] }
+    $dismissedGiveawayBannerIds.withLock { $0 = [] }
+    $pendingCongratsAction.withLock { $0 = nil }
 
     UserDefaults.standard.removeObject(forKey: "analytics_session_paused_at")
   }

--- a/PlayolaRadio/State/SharedUserDefaults.swift
+++ b/PlayolaRadio/State/SharedUserDefaults.swift
@@ -116,6 +116,53 @@ extension SharedKey where Self == InMemoryKey<[LiveStationInfo]>.Default {
   }
 }
 
+// MARK: - Giveaways
+
+extension SharedKey where Self == InMemoryKey<Giveaway?>.Default {
+  /// The open giveaway for the currently-playing station. Drives the player overlay.
+  static var activeGiveaway: Self {
+    Self[.inMemory("activeGiveaway"), default: nil]
+  }
+}
+
+extension SharedKey where Self == InMemoryKey<GiveawayBannerState?>.Default {
+  /// The app-wide "Tap In" invite banner.
+  static var giveawayBanner: Self {
+    Self[.inMemory("giveawayBanner"), default: nil]
+  }
+}
+
+extension SharedKey where Self == FileStorageKey<[String: GiveawayParticipation]>.Default {
+  /// Durable per-giveaway participation (keyed by giveawayId) so the reveal survives an app kill.
+  /// Cleared on sign-out so one account never sees another's state.
+  static var giveawayParticipations: Self {
+    Self[
+      .fileStorage(.documentsDirectory.appending(component: "giveaway-participations.json")),
+      default: [:]
+    ]
+  }
+}
+
+extension SharedKey where Self == FileStorageKey<Set<String>>.Default {
+  /// Giveaway ids whose banner the user dismissed (per giveaway, not per station).
+  static var dismissedGiveawayBannerIds: Self {
+    Self[
+      .fileStorage(.documentsDirectory.appending(component: "dismissed-giveaway-banners.json")),
+      default: []
+    ]
+  }
+}
+
+extension SharedKey where Self == FileStorageKey<CongratsAction?>.Default {
+  /// Durable artist congrats progress; survives a kill and holds the uploaded audioBlockId for retry.
+  static var pendingCongratsAction: Self {
+    Self[
+      .fileStorage(.documentsDirectory.appending(component: "pending-congrats-action.json")),
+      default: nil
+    ]
+  }
+}
+
 // MARK: - Push Notifications
 
 extension SharedKey where Self == AppStorageKey<String?>.Default {

--- a/docs/superpowers/plans/2026-06-18-live-giveaway-contest-plan.md
+++ b/docs/superpowers/plans/2026-06-18-live-giveaway-contest-plan.md
@@ -1,0 +1,116 @@
+# Live Giveaway Contest — Implementation Plan
+
+**Design:** `docs/superpowers/specs/2026-06-18-live-giveaway-contest-design.md`
+**Branch:** `briankeane/live-giveaway-contest` · **PRs target:** `develop`
+
+Rule for every PR: it ends with **something visible in the running simulator**, verified by hand
+(not just green units). Each PR is independently shippable. TDD per the project workflow; invoke the
+relevant `pfw-*` skills before writing Swift; register new files in `project.pbxproj`.
+
+---
+
+## PR 1: Models + debug surfaces + previews (the anti-invisibility foundation)
+**Goal:** Every giveaway surface renders in the simulator on demand, with no live server data.
+**Deliverables:**
+- Codable models: `Giveaway`, `GiveawayTapResponse`, `GiveawayMyResult`, `GiveawayWinnerSubmission`,
+  `GiveawayParticipation` (+ status enum), `GiveawayBannerState`, `CongratsAction`. Each with `.mock`.
+- New `@Shared` keys (`State/SharedUserDefaults.swift`); participations + pendingCongrats user-scoped.
+- Static (not-yet-wired) views: `GiveawayBannerView`, `GiveawayPlayerOverlayView` (+ `GiveawayOverlayModel`),
+  `GiveawayWinnerSheetView` (+ model), `CongratsRecordingPageView` (+ model) — bound to model strings only.
+- `GiveawayDebug` (`#if DEBUG`): force-inject a fake open giveaway / banner / each participation state;
+  a gate-diagnostics readout. Reachable from a debug menu.
+- `#Preview` for every surface and state.
+**Success (see it):** From the debug menu, inject a fake giveaway → overlay shows on the player;
+inject banner → banner shows; open winner/loser/artist screens in every state via previews + injection.
+**Tests:** model decode/encode + mocks; winner-submission field mapping (required/optional, country
+default "US"); participation status transitions.
+**Status:** In Progress —
+- ✅ Models (`Giveaway`, `GiveawayParticipation`, `GiveawayMyResult`, `GiveawayTapResponse`,
+  `GiveawayWinnerSubmission`, `GiveawayBannerState`, `CongratsAction`) + 5 `@Shared` keys, registered
+  in pbxproj, compiling; 9 tests green (`GiveawayModelsTests`, `GiveawayParticipationTests`,
+  `CongratsActionTests`).
+- ⬜ Static views (banner / overlay / winner sheet / congrats recording) bound to model strings.
+- ⬜ `GiveawayDebug` force-injection + gate-diagnostics readout + debug-menu entry.
+- ⬜ `#Preview` for every surface/state; **runtime-verify in simulator**.
+
+## PR 2: Listener open overlay via `/active`
+**Goal:** The real overlay appears when tuned to a station with a live open giveaway.
+**Deliverables:** APIClient `activeGiveaway` + `giveaway`; `GiveawayCoordinator` skeleton (Inputs→`apply()`→Effects)
+with the active-station poll only; owned/started by `MainContainerModel`; overlay reads `.activeGiveaway`
+gated on `status==open` && station match && `.playola`. Gate diagnostics wired to real values.
+**Success (see it):** With a mocked/staging open giveaway, overlay appears; switching stations clears it;
+diagnostics explain a closed gate. **A 401/network error does NOT clear the overlay.**
+**Tests:** poll sets/clears `.activeGiveaway`; wrong-station / nil-station / not-`.playola` → hidden;
+fetch failure keeps last state; immediate poll on foreground + station change; `start()` idempotent.
+**Status:** Not Started
+
+## PR 3: Tap + participation persistence
+**Goal:** Tapping enters the contest and survives an app kill.
+**Deliverables:** APIClient `tapGiveaway`; `coordinator.tap(giveaway:)` with in-flight double-tap guard;
+persist `GiveawayParticipation` (`tappedStandby`) **immediately after the POST returns, before UI**;
+overlay flips to "You're in" (tapNumber hidden).
+**Success (see it):** Tap → "You're in"; kill & relaunch → still "You're in" (not a fresh TAP button).
+**Tests:** tap persists before UI; double-tap → one POST; 400-not-open handled; relaunch restores standby.
+**Status:** Not Started
+
+## PR 4: Result poll + reveal (winner sheet / loser toast)
+**Goal:** The contest resolves and reveals correctly, once.
+**Deliverables:** APIClient `giveawayMyResult` + `submitGiveawayWinner`; pending-result poll (5s→15s)
+keyed by giveawayId, app-wide; resolve via `my-result` (closed/canceled rules); winner sheet queued
+behind the single `presentedSheet` slot (`pendingWinnerPresentation`); loser toast once; winner sheet
+form → `POST /winner-submission` → confirmation; prune terminal rows.
+**Success (see it):** Force a closed-winner → sheet (even if another sheet was up, it waits then shows);
+force closed-loser → toast once; canceled → neutral; submit form → confirmation; relaunch re-presents
+an unshown winner sheet.
+**Tests:** resolve→won queued/presented; resolve→lost toast exactly once; never stop polling on
+`isWinner==false` while not closed; canceled suppresses reveal; submission idempotent; markers guard
+duplicate presentation.
+**Status:** Not Started
+
+## PR 5: Push integration (listener)
+**Goal:** Pushes accelerate the experience; GET still confirms.
+**Deliverables:** `PushNotifications` handles `giveaway_opened` (seed banner, confirm via `/active`),
+`giveaway_closed` (accelerate result poll); ignore `giveaway_show_started` (v1). Banner tap plays the
+station + opens player; dismiss remembered per giveaway. Out-of-app push tap plays station (reuse).
+**Success (see it):** Simulated `giveaway_opened` → banner; tap → plays station + overlay; dismiss
+sticks; simulated `giveaway_closed` → faster reveal.
+**Tests:** opened seeds banner then `/active` confirms/clears; closed accelerates poll; banner dismissal
+per-giveaway (not per-station); non-current-station push doesn't overwrite current overlay.
+**Status:** Not Started
+
+## PR 6: Artist congrats — flow shell
+**Goal:** An owner can get from the winner-pending push to a recording screen showing winner + prize.
+**Deliverables:** ownership detection (`fetchUserStations`); `giveaway_winner_pending` push tap →
+persist `CongratsAction` → present `CongratsRecordingPageModel`; screen fetches `GET /giveaways/:id`
+on open for prize (+ winner name if available); `PlayolaSheet.congratsRecording`; record→review UI via
+`AudioRecorderClient` (no upload yet). Cold-launch + warm paths; owner-while-listening doesn't collide
+with listener overlay/sheet.
+**Success (see it):** Simulated winner-pending push (as owner) → recording screen with prize/winner;
+record + review playback works.
+**Tests:** ownership gate; cold-launch intent persisted then resolved; sheet-slot arbitration vs winner
+sheet; non-owner ignores the push.
+**Status:** Not Started
+
+## PR 7: Artist upload + `POST /congrats`
+**Goal:** The recorded congrats uploads and is submitted, with correct retry.
+**Deliverables:** APIClient `postGiveawayCongrats`; `CongratsUploadService` = `VoicetrackUploadService`
+(steps 1–4) → store `audioBlockId` in `CongratsAction` → step 5 `POST /congrats`. Retry **only step 5**
+on failure; already-closed 4xx → terminal "already closed," no re-record; 401/403 stop; 5xx/network
+retryable; success terminal.
+**Success (see it):** Record → upload progress → done; kill mid-flow and relaunch → resumes/retries
+step 5 without re-recording; already-closed path shows the terminal message.
+**Tests:** upload success then `/congrats` failure → retry step 5 only (audioBlockId preserved);
+already-closed → terminal; auth error stops; pending action persists across relaunch.
+**Status:** Not Started
+
+---
+
+## Cross-cutting
+- After each PR: run the full XCTest suite via `xcodebuild test` (compile ≠ pass), `make format`,
+  `make lint`; then **launch the app in the simulator and confirm the PR's surface by hand**.
+- Adversarial Codex review (`/codex review` then `/codex challenge`) on each PR's diff before opening it.
+- Keep pbxproj device-team/reorder churn out of feature PRs.
+
+## Open item (non-blocking for PRs 1–5)
+Confirm `GET /v1/giveaways/:id` returns the **winner's name** for the station owner (prize is already on
+the giveaway). If not, request an owner-facing winner-detail field before PR 6.

--- a/docs/superpowers/specs/2026-06-18-live-giveaway-contest-design.md
+++ b/docs/superpowers/specs/2026-06-18-live-giveaway-contest-design.md
@@ -1,0 +1,259 @@
+# Live Giveaway Contest — Design (iOS)
+
+**Date:** 2026-06-18
+**Branch:** `briankeane/live-giveaway-contest`
+**Scope:** FULL feature — listener side **and** artist congrats recording. This **replaces** the
+abandoned `briankeane/prizes-flow` work (listener-only, ~4800 lines, unit-tested but at runtime
+**none of its UI ever appeared**). We are not basing on or merging that branch.
+
+## Problem
+
+A station runs a live giveaway during a broadcast. Mechanic: "be the Nth person to tap." The
+target (`winningNumber`) is **public**. A listener taps once, gets their own tap number, and learns
+win/lose only when the giveaway resolves (server closes it — either the artist's congrats voicetrack
+airs, or a timeout). Winners fill a shipping form; losers get a quiet "try again." Separately, when a
+winner is determined the **station owner (artist)** gets a push and can record an optional congrats
+voicetrack; if it airs, that closes the contest.
+
+## Why the prior attempt failed, and the prime directive of this rebuild
+
+The prior implementation was fully unit-tested yet **invisible at runtime** — banner, overlay, and
+winner sheet never appeared. Root-cause theory (Codex-reviewed):
+
+1. The feature is **100% server-data-driven**. `GET …/giveaways/active` returns `null` until a
+   giveaway is `open`, and pushes only fire during a live contest. With no live giveaway, every
+   surface correctly renders nothing — and there was **no way to make it appear on demand**, so it
+   was undebuggable.
+2. Secondary: silent gate failures (the overlay's `isVisible` requires `status==open` AND
+   `activeGiveaway.stationId == nowPlaying.currentStation.id` AND a `.playola` station — one wrong
+   comparison and it stays height 0), and error paths that **normalize every fetch failure (401 /
+   network) to "no giveaway"**, clearing the UI forever.
+
+**Prime directive:** *Make every surface visible on demand, with diagnostics, before wiring live
+data.* The first PR delivers debug fake-injection + a gate-diagnostics readout + `#Preview`s for
+every state. Each subsequent PR ends with something you can **see in the simulator**. Unit tests did
+not save the prior attempt; runtime verification per PR is mandatory.
+
+`@ObservationIgnored @Shared(.key)` in an `@Observable` model is the correct, sanctioned pattern —
+`@Shared` manages its own observation and drives SwiftUI updates. (This was *not* the bug.)
+
+## Server contract
+
+### Listener (all Bearer JWT; IDs are UUID strings; timestamps ISO-8601 UTC)
+
+| Endpoint | Returns / Body | Notes |
+|---|---|---|
+| `GET /v1/stations/:stationId/giveaways/active` | open `Giveaway` (incl. `winningNumber`, **no** `tapCount`) or `null` | Source of truth for "is a giveaway live & open on this station." Cheap; designed to poll. Returns `null` for `scheduled` (pre-open). |
+| `GET /v1/giveaways/:giveawayId` | full `Giveaway` — `status ∈ {scheduled, open, closed, canceled}`, `winnerUserId?`, `viewer:{ hasTapped, isWinner, canSubmitMailingInfo, tapNumber? }` | Authoritative detail/status. `viewer.tapNumber` is `null` until `closed`. 404 if missing/canceled. Used for overlay confirm + artist screen. |
+| `POST /v1/giveaways/:giveawayId/tap` (no body) | `{ tapNumber, isWinner, status }` | Idempotent (repeat tap → same `tapNumber`). `400` if not open. **Ignore `isWinner`** (not final — last-tapper fallback). |
+| `GET /v1/giveaways/:giveawayId/my-result` | `{ tapNumber?, isWinner, status, winningNumber }` | **AUTHORITATIVE** final outcome (incl. last-tapper fallback). `tapNumber` null if never tapped. **Resolve the reveal from this.** |
+| `POST /v1/giveaways/:giveawayId/winner-submission` | body below → `201` | Idempotent. `403` if caller isn't the winner. |
+
+Winner-submission body — **required:** `fullName`, `addressLine1`, `city`, `postalCode`.
+**Optional:** `addressLine2`, `state`, `comment`, `country` (default `"US"`), `willingToRecord` (bool).
+
+### Artist congrats (reuses the existing voicetrack pipeline + ONE new endpoint)
+
+1. `POST /v1/stations/:stationId/voicetrack-presigned-url { originalFilename }` → `{ presignedUrl, s3Key }`
+2. `PUT` recorded audio (M4A) to `presignedUrl` (S3)
+3. poll `GET /v1/stations/:stationId/voicetrack-status/:s3Key` until `ready` (LUFS normalize)
+4. `POST /v1/stations/:stationId/voicetracks { durationMS, s3Key }` → `AudioBlock` (⇒ `audioBlockId`)
+5. **NEW:** `POST /v1/giveaways/:giveawayId/congrats { audioBlockId }`
+
+Steps 1–4 already exist as `VoicetrackUploadService` (`AudioRecorderClient` → convert WAV→M4A →
+presign → S3 PUT → poll → create). Only step 5 is new client-side. Recording is **optional**; if the
+artist never records, the server closes on a timeout.
+
+### Push types (envelope `{ aps, type, stationId, giveawayId }`; `aps.alert.title` = curator name)
+
+| `type` | Audience | When | iOS action |
+|---|---|---|---|
+| `giveaway_show_started` | all | show starts | **v1: ignore** (no `/active` confirmation possible pre-open; see Decision 1). |
+| `giveaway_opened` | all | button opens | Seed app-wide banner (unconfirmed announcement); next `/active` confirms still-open. |
+| `giveaway_closed` | all | contest closes | Accelerate the pending-result poll for that giveaway. |
+| `giveaway_winner_pending` | **owner only** | winner determined | Present the artist congrats entry; the screen fetches `GET /giveaways/:id` on open (no winner name in the payload — privacy). |
+
+Pushes are **accelerants**; always confirm via a GET before changing UI.
+
+## Decisions (locked)
+
+1. **No pre-open banner in v1.** Banner appears only once `status==open` (confirmable via `/active`).
+   `giveaway_show_started` is ignored for v1 (avoids stale-banner logic). Revisit a "coming up"
+   teaser later.
+2. **Incremental, runtime-verified PRs** (see plan) — listener first, artist last.
+3. **Winner name is NOT in the push.** The artist screen fetches `GET /giveaways/:id` on open.
+   *Open item (does not block PRs 1–5):* confirm that GET returns the **winner's name** for the
+   owner (prize is already on the giveaway). If not, request an owner-facing winner-detail field.
+
+## Architecture
+
+### Ownership & lifecycle
+
+A `GiveawayCoordinator` (`@MainActor @Observable`) is owned by `MainContainerModel` (the existing
+app-lifetime owner of pollers, push handling, toasts, and global sheets). Started from
+`MainContainer.viewAppeared()`; paused/resumed on scene-phase changes. The coordinator is **not** in
+`@Shared`; it writes small value structs into `@Shared` that the UI reads. `APIClient` gets plain
+endpoint methods only — no polling/UI state in the client. Inject `@Dependency(\.continuousClock)`
+from day one (resolution timing is core behavior under test).
+
+### Shape: Inputs → `apply()` → Effects (avoid a god reducer)
+
+The coordinator funnels every **input** through one state-recompute path so `@Shared` outputs can't
+get half-updated:
+
+- **Inputs:** push event · active-poll result · result-poll result · tap response · now-playing
+  station change · auth change · app phase change.
+- **`apply()`** recomputes ALL outputs together: `.activeGiveaway`, `.giveawayBanner`, the relevant
+  `.giveawayParticipations` row, and any sheet/toast *intent*.
+- **Effects** (kept separate from the recompute): polling tasks, API calls, `StationPlayer.play`,
+  sheet presentation, toast.
+
+Lifecycle correctness (explicit, tested):
+
+- `start()` idempotent; `stop()` cancels tasks deterministically.
+- Foreground → immediate poll of `/active` (current station) + `my-result` (each unresolved
+  participation). Now-playing station change → immediate `/active` poll for the new station (don't
+  wait 15s).
+- Broadcast push for a **non-current** station → banner/invite intent only; **never** overwrite the
+  current overlay's `activeGiveaway`.
+- Sign-out → clear in-memory giveaway/banner; participations are **user-scoped** so one account never
+  sees another's winner state.
+- **Never normalize a 401 / network error to "no giveaway."** Distinguish "authoritatively null"
+  from "fetch failed" — on failure, keep last-known state and retry (after re-auth for 401). No task
+  pileup if a call exceeds the interval.
+
+### Two poll loops, one funnel
+
+1. **Active-station poll** → `GET /stations/:id/giveaways/active` for the currently-playing
+   `.playola` station only. ~15s while playing; immediate on foreground & station change. Open →
+   `.activeGiveaway` set → overlay shows. Authoritative `null` → clear. Also catches a missed push.
+2. **Pending-result poll** → `GET /giveaways/:id/my-result` for every persisted unresolved
+   participation, **app-wide, keyed by `giveawayId`** (independent of current station). ~5s for the
+   first minute after tap, then ~15s; immediate on launch/foreground; accelerated by
+   `giveaway_closed`. Resolve → winner sheet / loser toast.
+
+### Reveal logic (canonical = `my-result`)
+
+After a successful tap, persist `tappedStandby`, then poll `my-result`:
+`open|scheduled` → keep polling · `closed` → persist final `tapNumber/isWinner`, reveal once
+(winner sheet **or** loser toast) · `canceled` → persist canceled, stop, neutral (suppress
+win/lose). **Never** stop polling merely because `isWinner==false` while `status != closed`. Never
+trust the tap response's `isWinner`. `GET /giveaways/:id viewer{}` is for overlay/cold-launch sync,
+**not** the reveal authority.
+
+### Shared state (new keys in `State/SharedUserDefaults.swift`)
+
+| Key | Storage | Type | Drives |
+|---|---|---|---|
+| `.activeGiveaway` | in-memory | `Giveaway?` | Player overlay (open giveaway for current station). |
+| `.giveawayBanner` | in-memory | `GiveawayBannerState?` | App-wide "Tap In" banner. |
+| `.giveawayParticipations` | file storage (user-scoped) | `[String: GiveawayParticipation]` keyed by `giveawayId` | Durable "I tapped X"; survives restart. |
+| `.dismissedGiveawayBannerIds` | file storage | `Set<String>` | Remember banner dismissals (per-giveaway, not per-station). |
+| `.pendingCongratsAction` | file storage (user-scoped) | `CongratsAction?` | Durable artist congrats progress (survives kill; holds `audioBlockId` for retry). |
+
+### Per-user participation phase (persisted per giveaway)
+
+```swift
+enum GiveawayParticipationStatus: Codable, Equatable, Sendable {
+  case tappedStandby(tapNumber: Int)
+  case resolvedWon(tapNumber: Int, submissionCompleted: Bool)
+  case resolvedLost(tapNumber: Int, toastShown: Bool)
+  case canceled
+}
+```
+
+A row is written **only after the user taps**, **immediately after the tap POST returns** (before any
+UI update) so a crash can't lose the reveal. A row is **pruned** once terminal & fully handled
+(`resolvedWon` + submission complete, `resolvedLost` + toast shown, or `canceled`).
+
+### The five surfaces
+
+- **App-wide banner** — in `MainContainer`, above the toast / small-player region. Shown when
+  `.giveawayBanner` is set and the id isn't dismissed. Tap → play that station + open player.
+  Dismiss (X) → add id to `.dismissedGiveawayBannerIds`.
+- **Player overlay** — `GiveawayPlayerOverlayView` injected into `PlayerPage`, reading
+  `.activeGiveaway` for the current station. Untapped: "Be the **Nth** tapper to win" + prize + TAP.
+  After tap: "You're in." `PlayerPageModel` does **not** poll — it calls
+  `coordinator.tap(giveaway:)` and reads shared state.
+- **Winner sheet** — new `PlayolaSheet.giveawayWinner(GiveawayWinnerSheetModel)`, app-wide. "You won!
+  You're #N", prize, shipping form (required: fullName/addressLine1/city/postalCode; optional:
+  state/addressLine2/comment/country default "US"/`willingToRecord`) → `POST /winner-submission` →
+  confirmation. **Queued** behind the nav coordinator's single `presentedSheet` slot; if a sheet is
+  up, store `pendingWinnerPresentation` and present when the slot frees. Persist
+  `winnerSheetPresentedAt` only **after** actually presented (so relaunch can re-present).
+- **Loser toast** — existing toast dependency, shown exactly once (guarded).
+- **Artist congrats** — new `PlayolaSheet.congratsRecording(CongratsRecordingPageModel)` (mirrors
+  `RecordIntroPageModel`: record → review → auto-upload via `VoicetrackUploadService` → `POST
+  /congrats`). Entry from the `giveaway_winner_pending` push tap and an in-app foreground entry point
+  for owners. The screen fetches `GET /giveaways/:id` on open for prize/winner.
+
+### Artist congrats correctness
+
+Persist a `CongratsAction { giveawayId, stationId, state, audioBlockId? }` so progress survives a
+kill. Cold-launch push tap may arrive before auth/nav exist → persist intent, resolve after launch.
+Confirm ownership via `fetchUserStations` (server also enforces). Store `audioBlockId` **before**
+`POST /congrats`; on step-5 failure **retry only step 5** (don't re-record). If `/congrats` 4xx's
+because the contest already closed (timeout beat the artist) → "Giveaway already closed," terminal,
+no re-record. 401/403 → stop until auth changes; 5xx/network → keep retryable. (Assume `/congrats`
+is idempotent per giveaway — confirm server-side.)
+
+### Debug / verifiability (PR1 — the prime directive)
+
+- `#Preview` for every surface and every state (banner, overlay untapped/standby, winner sheet
+  form/confirmation, loser, artist record/review/uploading/done).
+- Debug-only **force-inject**: set a fake open `Giveaway` into `.activeGiveaway`, push a fake banner,
+  simulate each push type and each result transition — togglable from a debug menu.
+- Debug-only **gate diagnostics** readout: last push, last `/active` status code, current station id,
+  `activeGiveaway` id/station/status, and **the reason the overlay gate is closed**
+  (e.g. "station mismatch: playing A, giveaway B").
+
+## New files
+
+- `Models/Giveaway.swift`, `Models/GiveawayTapResponse.swift`, `Models/GiveawayMyResult.swift`,
+  `Models/GiveawayWinnerSubmission.swift`, `Models/GiveawayParticipation.swift`,
+  `Models/GiveawayBannerState.swift`, `Models/CongratsAction.swift`
+- `Core/Giveaways/GiveawayCoordinator.swift`
+- `Core/Giveaways/GiveawayDebug.swift` (debug fake-injection + diagnostics; `#if DEBUG`)
+- `Views/Reusable Components/GiveawayBannerView.swift`
+- `Views/Pages/PlayerPage/GiveawayOverlayModel.swift` + `GiveawayPlayerOverlayView.swift`
+- `Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift` + `…View.swift`
+- `Views/Pages/CongratsRecording/CongratsRecordingPageModel.swift` + `…View.swift`
+- `Core/Giveaways/CongratsUploadService.swift` (thin wrapper over `VoicetrackUploadService` + step 5)
+- Colocated tests for each model/coordinator.
+
+## Touched files
+
+- `Core/API/APIClient.swift` + `APIClient+Live.swift` — `activeGiveaway`, `giveaway`, `tapGiveaway`,
+  `giveawayMyResult`, `submitGiveawayWinner`, `postGiveawayCongrats`.
+- `State/SharedUserDefaults.swift` — new keys.
+- `Views/Reusable Components/PlayolaSheet.swift` — `.giveawayWinner`, `.congratsRecording`.
+- `Core/Navigation/MainContainerNavigationCoordinator.swift` — `pendingWinnerPresentation` queue.
+- `Views/Pages/MainContainer/MainContainerModel.swift` + `MainContainer.swift` — own/start
+  coordinator, render banner, host sheets.
+- `Views/Pages/PlayerPage/PlayerPageModel.swift` + `PlayerPage.swift` — inject overlay, wire `tap`.
+- `Core/PushNotifications/PushNotifications.swift` — `giveaway_opened`, `giveaway_closed`,
+  `giveaway_winner_pending`; ignore `giveaway_show_started` (v1).
+
+## Conventions
+
+Models hold ALL text/logic/state; views are visuals only with **zero control flow** (push
+conditional rendering into the model or a no-op component). All models + tests `@MainActor`. New
+`.swift` files must be hand-registered in `project.pbxproj` (explicit refs). Tests: XCTest,
+`@Shared` declared locally per test, controlled `continuousClock`, mocked `APIClient`,
+`expectNoDifference`/`expectDifference` (not raw `==`). pfw skills invoked before writing Swift.
+
+## Testing focus
+
+tap → standby → delayed `my-result` resolve → winner sheet queued/presented; tap → lost → loser
+toast **once**; relaunch with persisted standby → re-poll → reveal; winner sheet **waits** while a
+sheet occupies the slot; banner dismissal remembered (per giveaway, not station); `/active` null
+clears overlay but a **401/network does NOT**; wrong-station / nil-station / not-`.playola` overlay
+gate stays hidden (and diagnostics explain why); congrats: upload success then `/congrats` failure →
+retry step 5 only; `/congrats` already-closed → terminal; sign-out clears state.
+
+## Risks
+
+Single `presentedSheet` slot (mitigated by queue) · persist-before-die on tap · key by `giveawayId`
+not station · banner push is an announcement not durable truth · auth expiration must fail gracefully
+and retry · duplicate presentation guarded by `winnerSheetPresentedAt`/`loserToastShownAt` · **the
+invisibility trap** — every gate must be diagnosable and every surface force-renderable.

--- a/docs/superpowers/specs/2026-06-18-live-giveaway-contest-design.md
+++ b/docs/superpowers/specs/2026-06-18-live-giveaway-contest-design.md
@@ -37,6 +37,14 @@ not save the prior attempt; runtime verification per PR is mandatory.
 `@ObservationIgnored @Shared(.key)` in an `@Observable` model is the correct, sanctioned pattern —
 `@Shared` manages its own observation and drives SwiftUI updates. (This was *not* the bug.)
 
+**Server-decoded status enums tolerate unknown values.** `GiveawayStatus` and `FulfillmentStatus`
+are decoded straight from server JSON and use an `unknown` fallback (`init(from:)` → `rawValue ?? .unknown`)
+so one unrecognized value can't make a whole `Giveaway`/`GiveawayMyResult`/`GiveawayTapResponse` decode
+throw — which the poll loop would swallow, silently hiding the UI (the exact failure mode above).
+Consumers (PR2+) must handle `.unknown` explicitly; treat it as non-open and non-terminal (the
+`opensAt+10min` fallback timer backstops a giveaway stuck in `.unknown`). The *local* state enums
+`GiveawayParticipationStatus` / `CongratsActionState` are ours to control and stay strict.
+
 ## Server contract
 
 ### Listener (all Bearer JWT; IDs are UUID strings; timestamps ISO-8601 UTC)

--- a/scripts/add-file-to-xcodeproj.rb
+++ b/scripts/add-file-to-xcodeproj.rb
@@ -1,0 +1,49 @@
+#!/usr/bin/env ruby
+# Usage:
+#   ruby Scripts/add-file-to-xcodeproj.rb <relative/path/File.swift> app
+#   ruby Scripts/add-file-to-xcodeproj.rb <relative/path/FileTests.swift> test
+#
+# Adds a source file to the two app targets, or a test file to the test target.
+# Groups are created/matched WITHOUT mutating any existing group's source tree
+# (a previous version reset source trees and corrupted existing model paths).
+require 'xcodeproj'
+
+path = ARGV[0]
+kind = ARGV[1] || 'app'
+abort "usage: add-file-to-xcodeproj.rb <relative/path.swift> [app|test]" unless path
+
+root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+project_path = File.join(root, 'PlayolaRadio.xcodeproj')
+project = Xcodeproj::Project.open(project_path)
+
+abs = File.join(root, path)
+abort "file does not exist on disk: #{abs}" unless File.exist?(abs)
+
+# Walk the directory segments from the project main group, matching existing
+# groups by name and creating missing ones as group-relative children. Never
+# call set_source_tree on a group we did not just create.
+group = project.main_group
+File.dirname(path).split('/').each do |segment|
+  next if segment == '.'
+  existing = group.children.find { |c| c.isa == 'PBXGroup' && c.display_name == segment }
+  group = existing || group.new_group(segment, segment)
+end
+
+file_ref = group.files.find { |f| f.display_name == File.basename(path) }
+file_ref ||= group.new_reference(abs)
+
+# Defensive check: the reference must resolve to the real on-disk file.
+unless File.expand_path(file_ref.real_path.to_s) == File.expand_path(abs)
+  abort "refusing to save: #{File.basename(path)} resolves to #{file_ref.real_path} not #{abs}"
+end
+
+target_names = kind == 'test' ? ['PlayolaRadioTests'] : ['PlayolaRadio', 'PlayolaRadio Staging']
+target_names.each do |name|
+  target = project.targets.find { |t| t.name == name }
+  raise "target #{name} not found" unless target
+  already = target.source_build_phase.files.any? { |bf| bf.file_ref == file_ref }
+  target.add_file_references([file_ref]) unless already
+end
+
+project.save
+puts "registered #{path} -> #{target_names.join(', ')}"


### PR DESCRIPTION
First PR of the live giveaway contest rebuild, which replaces the abandoned `prizes-flow` work (that implementation was fully unit-tested but never appeared at runtime — the prime directive of this rebuild is making every surface verifiable on demand). This PR is the foundation only: the listener + artist giveaway domain models (`Giveaway`, `GiveawayParticipation`, `GiveawayMyResult`, `GiveawayTapResponse`, `GiveawayWinnerSubmission`, `GiveawayBannerState`, `CongratsAction`), five new `@Shared` keys, the full design spec + phased plan under `docs/superpowers/`, and a pbxproj registration helper. No UI is wired yet — the next PR adds the debug-injectable surfaces (banner/overlay/winner sheet/congrats) so the whole feature can be QA'd on a device without a live contest. Everything compiles and 9 new unit tests pass; the pbxproj also carries reordering churn from the registration helper. Known/tracked for PR2 (flagged by Codex review): the new persisted keys aren't cleared on sign-out yet — they're inert (no consumer reads them in this PR), and the coordinator owns auth-change/sign-out clearing in PR2.