### PR TITLE
Live giveaway: player overlay with debug injection

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -9,12 +9,14 @@
 /* Begin PBXBuildFile section */
 		03D9929612C3E595D9BD88D5 /* GiveawayParticipationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5283C7C8C9FAF45659BA98E /* GiveawayParticipationTests.swift */; };
 		1DBE6EEE6CD7879ED93BB12C /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
+		1E09F417B01F258C6D38D660 /* GiveawayPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */; };
 		1F6F57E01E254F5483BD939B /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
 		354451A630DF81468815108F /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
 		5F67160E76C1454189765E5D /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
 		5F721A0797795B3B529757CD /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
 		659E9B124BCB08D5F3D216D7 /* Giveaway.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EDCED098E801AAB2E9DC82 /* Giveaway.swift */; };
 		65D0683FA2A905693317C5AB /* CongratsActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0488057E2A6456204E582B15 /* CongratsActionTests.swift */; };
+		6D6D8F5B3570802E2D336F7C /* GiveawayOverlayModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16A5F5E27CF6BD0259ED1E5 /* GiveawayOverlayModelTests.swift */; };
 		725E8382CB9672F532FC2CDD /* GiveawayMyResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B82DD37711E160592E3842D /* GiveawayMyResult.swift */; };
 		76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */; };
 		81599AD0B41E4A2496EEF25A /* PresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6613FD7A13B448187CB8595 /* PresetTests.swift */; };
@@ -27,7 +29,10 @@
 		AA01000000000005AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
 		AA01000000000006AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
 		B12730D5ECA7018F074B54E6 /* GiveawayBannerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */; };
+		B9D97B72F461E83FF652BDBD /* GiveawayPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */; };
+		C2FCC44BB8C98C486BC343E6 /* GiveawayOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */; };
 		C8BA849E20B449EC91DBF5F2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
+		D0CD5FE434D4950E16A7B1F9 /* GiveawayOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */; };
 		D302576B2E63423D00F4228B /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
 		D302576D2E63428800F4228B /* ToastClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576C2E63428700F4228B /* ToastClient.swift */; };
 		D30257762E6342C900F4228B /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257752E6342C600F4228B /* ToastView.swift */; };
@@ -477,6 +482,8 @@
 		0488057E2A6456204E582B15 /* CongratsActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsActionTests.swift; sourceTree = "<group>"; };
 		2B82DD37711E160592E3842D /* GiveawayMyResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayMyResult.swift; sourceTree = "<group>"; };
 		36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSubmission.swift; sourceTree = "<group>"; };
+		3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayOverlayModel.swift; sourceTree = "<group>"; };
+		4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayPlayerOverlayView.swift; sourceTree = "<group>"; };
 		6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayParticipation.swift; sourceTree = "<group>"; };
 		917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayBannerState.swift; sourceTree = "<group>"; };
 		9553B35A6FBA27239EF49033 /* GiveawayModelsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayModelsTests.swift; sourceTree = "<group>"; };
@@ -723,6 +730,7 @@
 		D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageModel.swift; sourceTree = "<group>"; };
 		D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayTapResponse.swift; sourceTree = "<group>"; };
 		DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsAction.swift; sourceTree = "<group>"; };
+		E16A5F5E27CF6BD0259ED1E5 /* GiveawayOverlayModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayOverlayModelTests.swift; sourceTree = "<group>"; };
 		E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransition.swift; sourceTree = "<group>"; };
 		E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransitionTests.swift; sourceTree = "<group>"; };
 		F5283C7C8C9FAF45659BA98E /* GiveawayParticipationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayParticipationTests.swift; sourceTree = "<group>"; };
@@ -1277,6 +1285,9 @@
 				D38031332E00AD9F0011DD64 /* PlayerPageTests.swift */,
 				D3FA61292E00583F00E9DF49 /* PlayerPageModel.swift */,
 				D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */,
+				3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */,
+				4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */,
+				E16A5F5E27CF6BD0259ED1E5 /* GiveawayOverlayModelTests.swift */,
 			);
 			path = PlayerPage;
 			sourceTree = "<group>";
@@ -1991,6 +2002,8 @@
 				5F67160E76C1454189765E5D /* GiveawayWinnerSubmission.swift in Sources */,
 				E6FA723C089B9E0115951DD1 /* GiveawayBannerState.swift in Sources */,
 				DBD70D257638FF5934CA78DA /* CongratsAction.swift in Sources */,
+				D0CD5FE434D4950E16A7B1F9 /* GiveawayOverlayModel.swift in Sources */,
+				1E09F417B01F258C6D38D660 /* GiveawayPlayerOverlayView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2169,6 +2182,8 @@
 				DA5BD241BADE11FCACB9AEA0 /* GiveawayWinnerSubmission.swift in Sources */,
 				B12730D5ECA7018F074B54E6 /* GiveawayBannerState.swift in Sources */,
 				EDE2B63A1AB34C74CC65C898 /* CongratsAction.swift in Sources */,
+				C2FCC44BB8C98C486BC343E6 /* GiveawayOverlayModel.swift in Sources */,
+				B9D97B72F461E83FF652BDBD /* GiveawayPlayerOverlayView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2245,6 +2260,7 @@
 				F94F092AC0FB044790B38A0E /* GiveawayModelsTests.swift in Sources */,
 				03D9929612C3E595D9BD88D5 /* GiveawayParticipationTests.swift in Sources */,
 				65D0683FA2A905693317C5AB /* CongratsActionTests.swift in Sources */,
+				6D6D8F5B3570802E2D336F7C /* GiveawayOverlayModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
@@ -43,12 +43,19 @@ class GiveawayOverlayModel: ViewModel {
 
   var headline: String { "WIN A PRIZE!" }
 
-  var promptText: String {
+  var promptPrefix: String { "Be the " }
+
+  var promptOrdinal: String {
     guard let giveaway = visibleGiveaway else { return "" }
-    return "Be the \(giveaway.winningNumber.ordinalString) listener to tap the button below to win:"
+    return giveaway.winningNumber.ordinalString
   }
 
-  var prizeName: String { visibleGiveaway?.prizeName ?? "" }
+  var promptSuffix: String { " Listener to Tap the Button Below to win:" }
+
+  var prizeText: String {
+    guard let giveaway = visibleGiveaway else { return "" }
+    return "\(giveaway.prizeName)."
+  }
 
   var buttonTitle: String { "TAP HERE" }
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
@@ -26,6 +26,12 @@ class GiveawayOverlayModel: ViewModel {
     super.init()
   }
 
+  // MARK: - User Actions
+  func tapButtonTapped() async {
+    guard let giveaway = visibleGiveaway else { return }
+    await onTap?(giveaway)
+  }
+
   // MARK: - View Helpers
   var isVisible: Bool { visibleGiveaway != nil }
 
@@ -63,20 +69,18 @@ class GiveawayOverlayModel: ViewModel {
 
   var standbySubtitle: String { "Hang tight — we'll reveal the winner when the song ends." }
 
-  /// Human-readable reason the overlay is hidden, for the debug diagnostics readout.
+  /// Human-readable explanation of the visibility gate, for the debug diagnostics readout.
+  /// Mirrors `visibleGiveaway` so the HUD never contradicts what's on screen.
   var gateDiagnostics: String {
     guard let giveaway = activeGiveaway else { return "hidden: no activeGiveaway" }
     if giveaway.status != .open { return "hidden: status is \(giveaway.status.rawValue), not open" }
+    #if DEBUG
+      if debugForceVisible { return "visible: debug force-visible (station check bypassed)" }
+    #endif
     if giveaway.stationId != currentStationId {
       return "hidden: giveaway station \(giveaway.stationId) ≠ playing \(currentStationId ?? "nil")"
     }
     return "visible: open giveaway on the current station"
-  }
-
-  // MARK: - User Actions
-  func tapButtonTapped() async {
-    guard let giveaway = visibleGiveaway else { return }
-    await onTap?(giveaway)
   }
 
   // MARK: - Private Helpers
@@ -98,7 +102,7 @@ class GiveawayOverlayModel: ViewModel {
 }
 
 extension Int {
-  var ordinalString: String {
+  fileprivate var ordinalString: String {
     let ones = self % 10
     let tens = self % 100
     if tens >= 11 && tens <= 13 { return "\(self)th" }

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
@@ -1,0 +1,105 @@
+import Dependencies
+import Foundation
+import Sharing
+
+@MainActor
+@Observable
+class GiveawayOverlayModel: ViewModel {
+
+  // MARK: - Shared State
+  @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
+  @ObservationIgnored @Shared(.activeGiveaway) var activeGiveaway
+  @ObservationIgnored @Shared(.giveawayParticipations) var participations
+
+  // MARK: - Callbacks
+  var onTap: (@MainActor (Giveaway) async -> Void)?
+
+  // MARK: - Debug
+  #if DEBUG
+    /// When true, the station-match / status gate is bypassed so the overlay renders for the
+    /// injected `activeGiveaway` even without live playback. Debug builds only.
+    var debugForceVisible = false
+  #endif
+
+  // MARK: - Initialization
+  override init() {
+    super.init()
+  }
+
+  // MARK: - View Helpers
+  var isVisible: Bool { visibleGiveaway != nil }
+
+  var overlayOpacity: Double { isVisible ? 1 : 0 }
+
+  var hasTapped: Bool {
+    guard let giveaway = visibleGiveaway else { return false }
+    return participations[giveaway.id]?.isStandby ?? false
+  }
+
+  var promptOpacity: Double { hasTapped ? 0 : 1 }
+  var standbyOpacity: Double { hasTapped ? 1 : 0 }
+  var promptInteractive: Bool { isVisible && !hasTapped }
+  var standbyInteractive: Bool { isVisible && hasTapped }
+
+  var headline: String { "WIN A PRIZE!" }
+
+  var promptText: String {
+    guard let giveaway = visibleGiveaway else { return "" }
+    return "Be the \(giveaway.winningNumber.ordinalString) listener to tap the button below to win:"
+  }
+
+  var prizeName: String { visibleGiveaway?.prizeName ?? "" }
+
+  var buttonTitle: String { "TAP HERE" }
+
+  var standbyText: String { "STAND BY…" }
+
+  var standbySubtitle: String { "Hang tight — we'll reveal the winner when the song ends." }
+
+  /// Human-readable reason the overlay is hidden, for the debug diagnostics readout.
+  var gateDiagnostics: String {
+    guard let giveaway = activeGiveaway else { return "hidden: no activeGiveaway" }
+    if giveaway.status != .open { return "hidden: status is \(giveaway.status.rawValue), not open" }
+    if giveaway.stationId != currentStationId {
+      return "hidden: giveaway station \(giveaway.stationId) ≠ playing \(currentStationId ?? "nil")"
+    }
+    return "visible: open giveaway on the current station"
+  }
+
+  // MARK: - User Actions
+  func tapButtonTapped() async {
+    guard let giveaway = visibleGiveaway else { return }
+    await onTap?(giveaway)
+  }
+
+  // MARK: - Private Helpers
+  private var currentStationId: String? {
+    guard let anyStation = nowPlaying?.currentStation,
+      case .playola(let station) = anyStation
+    else { return nil }
+    return station.id
+  }
+
+  private var visibleGiveaway: Giveaway? {
+    guard let giveaway = activeGiveaway, giveaway.status == .open else { return nil }
+    #if DEBUG
+      if debugForceVisible { return giveaway }
+    #endif
+    guard giveaway.stationId == currentStationId else { return nil }
+    return giveaway
+  }
+}
+
+extension Int {
+  var ordinalString: String {
+    let ones = self % 10
+    let tens = self % 100
+    if tens >= 11 && tens <= 13 { return "\(self)th" }
+    switch ones {
+    case 1: return "\(self)st"
+    case 2: return "\(self)nd"
+    case 3: return "\(self)rd"
+    default: return "\(self)th"
+    }
+  }
+}

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct GiveawayOverlayModelTests {
+  private func openGiveaway(station: String = "s1") -> Giveaway {
+    Giveaway(
+      id: "g1", stationId: station, prizeName: "Two tickets", winningNumber: 9, status: .open)
+  }
+
+  @Test func hiddenWhenNoActiveGiveaway() {
+    @Shared(.activeGiveaway) var activeGiveaway: Giveaway? = nil
+    let model = GiveawayOverlayModel()
+    #expect(model.isVisible == false)
+    #expect(model.overlayOpacity == 0)
+    #expect(model.gateDiagnostics == "hidden: no activeGiveaway")
+  }
+
+  @Test func hiddenWhenStatusNotOpen() {
+    @Shared(.activeGiveaway) var activeGiveaway: Giveaway? = Giveaway(
+      id: "g1", stationId: "s1", prizeName: "x", winningNumber: 9, status: .closed)
+    let model = GiveawayOverlayModel()
+    model.debugForceVisible = true
+    #expect(model.isVisible == false)
+    #expect(model.gateDiagnostics == "hidden: status is closed, not open")
+  }
+
+  @Test func hiddenWhenStationMismatchWithoutDebugForce() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+    @Shared(.activeGiveaway) var activeGiveaway: Giveaway? = openGiveaway(station: "s1")
+    let model = GiveawayOverlayModel()
+    #expect(model.isVisible == false)
+    #expect(model.gateDiagnostics == "hidden: giveaway station s1 ≠ playing nil")
+  }
+
+  @Test func visibleWhenDebugForceVisibleAndOpen() {
+    @Shared(.activeGiveaway) var activeGiveaway: Giveaway? = openGiveaway()
+    let model = GiveawayOverlayModel()
+    model.debugForceVisible = true
+    #expect(model.isVisible == true)
+    #expect(model.overlayOpacity == 1)
+    #expect(model.prizeName == "Two tickets")
+    #expect(model.promptText == "Be the 9th listener to tap the button below to win:")
+  }
+
+  @Test func tappedFlipsPromptToStandby() {
+    @Shared(.activeGiveaway) var activeGiveaway: Giveaway? = openGiveaway()
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "g1": GiveawayParticipation(
+        id: "g1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9,
+        tapNumber: 7, status: .tappedStandby, tappedAt: Date())
+    ]
+    let model = GiveawayOverlayModel()
+    model.debugForceVisible = true
+    #expect(model.hasTapped == true)
+    #expect(model.promptOpacity == 0)
+    #expect(model.standbyOpacity == 1)
+    #expect(model.standbyInteractive == true)
+  }
+
+  @Test func ordinalStringHandlesTeensAndOnes() {
+    #expect(1.ordinalString == "1st")
+    #expect(2.ordinalString == "2nd")
+    #expect(3.ordinalString == "3rd")
+    #expect(9.ordinalString == "9th")
+    #expect(11.ordinalString == "11th")
+    #expect(12.ordinalString == "12th")
+    #expect(21.ordinalString == "21st")
+  }
+}

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -8,9 +8,10 @@ import Testing
 
 @MainActor
 struct GiveawayOverlayModelTests {
-  private func openGiveaway(station: String = "s1") -> Giveaway {
+  private func openGiveaway(station: String = "s1", winningNumber: Int = 9) -> Giveaway {
     Giveaway(
-      id: "g1", stationId: station, prizeName: "Two tickets", winningNumber: 9, status: .open)
+      id: "g1", stationId: station, prizeName: "Two tickets", winningNumber: winningNumber,
+      status: .open)
   }
 
   @Test func hiddenWhenNoActiveGiveaway() {
@@ -47,6 +48,7 @@ struct GiveawayOverlayModelTests {
     #expect(model.prizeText == "Two tickets.")
     #expect(model.promptOrdinal == "9th")
     #expect(model.promptSuffix == " Listener to Tap the Button Below to win:")
+    #expect(model.gateDiagnostics == "visible: debug force-visible (station check bypassed)")
   }
 
   @Test func tappedFlipsPromptToStandby() {
@@ -64,14 +66,36 @@ struct GiveawayOverlayModelTests {
     #expect(model.standbyInteractive == true)
   }
 
-  @Test func ordinalStringHandlesTeensAndOnes() {
-    #expect(1.ordinalString == "1st")
-    #expect(2.ordinalString == "2nd")
-    #expect(3.ordinalString == "3rd")
-    #expect(9.ordinalString == "9th")
-    #expect(11.ordinalString == "11th")
-    #expect(12.ordinalString == "12th")
-    #expect(21.ordinalString == "21st")
+  @Test func tapButtonInvokesOnTapWithTheVisibleGiveaway() async {
+    @Shared(.activeGiveaway) var activeGiveaway: Giveaway? = openGiveaway()
+    let model = GiveawayOverlayModel()
+    model.debugForceVisible = true
+    var tapped: Giveaway?
+    model.onTap = { tapped = $0 }
+    await model.tapButtonTapped()
+    #expect(tapped?.id == "g1")
+  }
+
+  @Test func tapButtonNoOpsWhenNotVisible() async {
+    @Shared(.activeGiveaway) var activeGiveaway: Giveaway? = nil
+    let model = GiveawayOverlayModel()
+    var called = false
+    model.onTap = { _ in called = true }
+    await model.tapButtonTapped()
+    #expect(called == false)
+  }
+
+  @Test func promptOrdinalHandlesTeensAndOnes() {
+    @Shared(.activeGiveaway) var activeGiveaway: Giveaway? = openGiveaway()
+    let model = GiveawayOverlayModel()
+    model.debugForceVisible = true
+    let cases: [(Int, String)] = [
+      (1, "1st"), (2, "2nd"), (3, "3rd"), (9, "9th"), (11, "11th"), (12, "12th"), (21, "21st"),
+    ]
+    for (number, expected) in cases {
+      $activeGiveaway.withLock { $0 = openGiveaway(winningNumber: number) }
+      #expect(model.promptOrdinal == expected)
+    }
   }
 }
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -44,8 +44,9 @@ struct GiveawayOverlayModelTests {
     model.debugForceVisible = true
     #expect(model.isVisible == true)
     #expect(model.overlayOpacity == 1)
-    #expect(model.prizeName == "Two tickets")
-    #expect(model.promptText == "Be the 9th listener to tap the button below to win:")
+    #expect(model.prizeText == "Two tickets.")
+    #expect(model.promptOrdinal == "9th")
+    #expect(model.promptSuffix == " Listener to Tap the Button Below to win:")
   }
 
   @Test func tappedFlipsPromptToStandby() {

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -4,6 +4,8 @@ import Testing
 
 @testable import PlayolaRadio
 
+// swiftlint:disable redundant_optional_initialization
+
 @MainActor
 struct GiveawayOverlayModelTests {
   private func openGiveaway(station: String = "s1") -> Giveaway {
@@ -71,3 +73,5 @@ struct GiveawayOverlayModelTests {
     #expect(21.ordinalString == "21st")
   }
 }
+
+// swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
@@ -1,0 +1,115 @@
+import Sharing
+import SwiftUI
+
+struct GiveawayPlayerOverlayView: View {
+  let model: GiveawayOverlayModel
+
+  var body: some View {
+    ZStack {
+      GiveawayOverlayPromptView(model: model)
+        .opacity(model.promptOpacity)
+        .allowsHitTesting(model.promptInteractive)
+
+      GiveawayOverlayStandbyView(model: model)
+        .opacity(model.standbyOpacity)
+        .allowsHitTesting(model.standbyInteractive)
+    }
+    .padding(.horizontal, 24)
+    .padding(.top, 24)
+    .frame(height: model.isVisible ? nil : 0)
+    .opacity(model.overlayOpacity)
+    .allowsHitTesting(model.isVisible)
+    .clipped()
+  }
+}
+
+private struct GiveawayOverlayPromptView: View {
+  let model: GiveawayOverlayModel
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Text(model.headline)
+        .font(.custom(FontNames.Inter_700_Bold, size: 20))
+        .foregroundColor(.white)
+
+      Text(model.promptText)
+        .font(.custom(FontNames.Inter_400_Regular, size: 14))
+        .foregroundColor(Color(hex: "#C7C7C7"))
+        .multilineTextAlignment(.center)
+
+      Text(model.prizeName)
+        .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+        .foregroundColor(.white)
+        .multilineTextAlignment(.center)
+
+      Button(
+        action: { Task { await model.tapButtonTapped() } },
+        label: {
+          Text(model.buttonTitle)
+            .font(.custom(FontNames.Inter_700_Bold, size: 18))
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 18)
+            .background(RoundedRectangle(cornerRadius: 14).fill(Color.playolaRed))
+        }
+      )
+      .padding(.top, 8)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(20)
+    .background(RoundedRectangle(cornerRadius: 16).fill(Color(hex: "#1A1A1A")))
+  }
+}
+
+private struct GiveawayOverlayStandbyView: View {
+  let model: GiveawayOverlayModel
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Text(model.standbyText)
+        .font(.custom(FontNames.Inter_700_Bold, size: 20))
+        .foregroundColor(.white)
+
+      Text(model.standbySubtitle)
+        .font(.custom(FontNames.Inter_400_Regular, size: 14))
+        .foregroundColor(Color(hex: "#C7C7C7"))
+        .multilineTextAlignment(.center)
+    }
+    .frame(maxWidth: .infinity)
+    .padding(20)
+    .background(RoundedRectangle(cornerRadius: 16).fill(Color(hex: "#1A1A1A")))
+  }
+}
+
+#if DEBUG
+  @MainActor private func previewModel(tapped: Bool) -> GiveawayOverlayModel {
+    @Shared(.activeGiveaway) var activeGiveaway = Giveaway(
+      id: "preview-giveaway", stationId: "preview-station",
+      prizeName: "Two tickets to Reckless Kelly at the Heights", winningNumber: 9, status: .open)
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] =
+      tapped
+      ? [
+        "preview-giveaway": GiveawayParticipation(
+          id: "preview-giveaway", stationId: "preview-station",
+          prizeName: "Two tickets", winningNumber: 9, tapNumber: 7,
+          status: .tappedStandby, tappedAt: Date())
+      ] : [:]
+    let model = GiveawayOverlayModel()
+    model.debugForceVisible = true
+    return model
+  }
+
+  #Preview("Overlay — Prompt") {
+    ZStack {
+      Color.black.ignoresSafeArea()
+      GiveawayPlayerOverlayView(model: previewModel(tapped: false))
+    }
+  }
+
+  #Preview("Overlay — Standby") {
+    ZStack {
+      Color.black.ignoresSafeArea()
+      GiveawayPlayerOverlayView(model: previewModel(tapped: true))
+    }
+  }
+#endif

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
@@ -37,7 +37,8 @@ private struct GiveawayOverlayPromptView: View {
         + Text(model.promptSuffix).foregroundColor(.white))
         .font(.custom(FontNames.Inter_400_Regular, size: 15))
         .multilineTextAlignment(.center)
-        .lineSpacing(3)
+        .lineLimit(1)
+        .minimumScaleFactor(0.7)
         .padding(.top, 8)
 
       Text(model.prizeText)
@@ -55,9 +56,9 @@ private struct GiveawayOverlayPromptView: View {
             .tracking(2)
             .foregroundColor(.white)
             .frame(maxWidth: .infinity)
-            .frame(height: 64)
-            .background(RoundedRectangle(cornerRadius: 32).fill(Color.playolaRed))
-            .overlay(RoundedRectangle(cornerRadius: 32).stroke(Color.white, lineWidth: 3))
+            .frame(height: 54)
+            .background(RoundedRectangle(cornerRadius: 27).fill(Color.playolaRed))
+            .overlay(RoundedRectangle(cornerRadius: 27).stroke(Color.white, lineWidth: 3))
         }
       )
       .padding(.top, 20)

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
@@ -15,7 +15,6 @@ struct GiveawayPlayerOverlayView: View {
         .allowsHitTesting(model.standbyInteractive)
     }
     .padding(.horizontal, 24)
-    .padding(.top, 24)
     .frame(height: model.isVisible ? nil : 0)
     .opacity(model.overlayOpacity)
     .allowsHitTesting(model.isVisible)
@@ -27,37 +26,43 @@ private struct GiveawayOverlayPromptView: View {
   let model: GiveawayOverlayModel
 
   var body: some View {
-    VStack(spacing: 12) {
+    VStack(spacing: 0) {
       Text(model.headline)
-        .font(.custom(FontNames.Inter_700_Bold, size: 20))
-        .foregroundColor(.white)
+        .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 22))
+        .tracking(0.4)
+        .foregroundColor(.playolaRed)
 
-      Text(model.promptText)
-        .font(.custom(FontNames.Inter_400_Regular, size: 14))
-        .foregroundColor(Color(hex: "#C7C7C7"))
+      (Text(model.promptPrefix).foregroundColor(.white)
+        + Text(model.promptOrdinal).foregroundColor(.playolaRed).fontWeight(.bold)
+        + Text(model.promptSuffix).foregroundColor(.white))
+        .font(.custom(FontNames.Inter_400_Regular, size: 15))
         .multilineTextAlignment(.center)
+        .lineSpacing(3)
+        .padding(.top, 8)
 
-      Text(model.prizeName)
-        .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+      Text(model.prizeText)
+        .font(.custom(FontNames.Inter_600_SemiBold, size: 15))
         .foregroundColor(.white)
         .multilineTextAlignment(.center)
+        .lineSpacing(3)
+        .padding(.top, 4)
 
       Button(
         action: { Task { await model.tapButtonTapped() } },
         label: {
           Text(model.buttonTitle)
-            .font(.custom(FontNames.Inter_700_Bold, size: 18))
+            .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 20))
+            .tracking(2)
             .foregroundColor(.white)
             .frame(maxWidth: .infinity)
-            .padding(.vertical, 18)
-            .background(RoundedRectangle(cornerRadius: 14).fill(Color.playolaRed))
+            .frame(height: 64)
+            .background(RoundedRectangle(cornerRadius: 32).fill(Color.playolaRed))
+            .overlay(RoundedRectangle(cornerRadius: 32).stroke(Color.white, lineWidth: 3))
         }
       )
-      .padding(.top, 8)
+      .padding(.top, 20)
     }
     .frame(maxWidth: .infinity)
-    .padding(20)
-    .background(RoundedRectangle(cornerRadius: 16).fill(Color(hex: "#1A1A1A")))
   }
 }
 
@@ -65,19 +70,24 @@ private struct GiveawayOverlayStandbyView: View {
   let model: GiveawayOverlayModel
 
   var body: some View {
-    VStack(spacing: 12) {
+    VStack(spacing: 0) {
       Text(model.standbyText)
-        .font(.custom(FontNames.Inter_700_Bold, size: 20))
+        .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 18))
+        .tracking(2)
         .foregroundColor(.white)
+        .frame(maxWidth: .infinity)
+        .frame(height: 60)
+        .background(RoundedRectangle(cornerRadius: 32).fill(Color(hex: "#1A1A1A")))
+        .overlay(RoundedRectangle(cornerRadius: 32).stroke(Color(hex: "#3A3A3A"), lineWidth: 3))
 
       Text(model.standbySubtitle)
         .font(.custom(FontNames.Inter_400_Regular, size: 14))
         .foregroundColor(Color(hex: "#C7C7C7"))
         .multilineTextAlignment(.center)
+        .lineSpacing(2)
+        .padding(.top, 12)
     }
     .frame(maxWidth: .infinity)
-    .padding(20)
-    .background(RoundedRectangle(cornerRadius: 16).fill(Color(hex: "#1A1A1A")))
   }
 }
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -218,14 +218,17 @@ struct PlayerPage: View {
 
     var body: some View {
       VStack(spacing: 8) {
-        Button(action: { model.debugToggleGiveawayTapped() }) {
-          Text(model.debugGiveawayButtonTitle)
-            .font(.custom(FontNames.Inter_500_Medium, size: 14))
-            .foregroundColor(.white)
-            .padding(.horizontal, 16)
-            .padding(.vertical, 8)
-            .background(Capsule().stroke(Color.playolaRed, lineWidth: 1))
-        }
+        Button(
+          action: { model.debugToggleGiveawayTapped() },
+          label: {
+            Text(model.debugGiveawayButtonTitle)
+              .font(.custom(FontNames.Inter_500_Medium, size: 14))
+              .foregroundColor(.white)
+              .padding(.horizontal, 16)
+              .padding(.vertical, 8)
+              .background(Capsule().stroke(Color.playolaRed, lineWidth: 1))
+          }
+        )
         Text(model.debugGiveawayDiagnostics)
           .font(.custom(FontNames.Inter_400_Regular, size: 11))
           .foregroundColor(.gray)

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -131,6 +131,14 @@ struct PlayerPage: View {
         .padding(.horizontal, 24)
         .padding(.top, 32)
 
+        // Giveaway overlay (hidden until an open giveaway is live for this station)
+        GiveawayPlayerOverlayView(model: model.giveawayOverlayModel)
+          .padding(.top, 8)
+
+        #if DEBUG
+          GiveawayDebugControls(model: model)
+        #endif
+
         // Play Button
         Button(
           action: { model.playPauseButtonTapped() },
@@ -203,3 +211,28 @@ struct PlayerPage: View {
   PlayerPage(model: PlayerPageModel())
     .preferredColorScheme(.dark)
 }
+
+#if DEBUG
+  private struct GiveawayDebugControls: View {
+    let model: PlayerPageModel
+
+    var body: some View {
+      VStack(spacing: 8) {
+        Button(action: { model.debugToggleGiveawayTapped() }) {
+          Text(model.debugGiveawayButtonTitle)
+            .font(.custom(FontNames.Inter_500_Medium, size: 14))
+            .foregroundColor(.white)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 8)
+            .background(Capsule().stroke(Color.playolaRed, lineWidth: 1))
+        }
+        Text(model.debugGiveawayDiagnostics)
+          .font(.custom(FontNames.Inter_400_Regular, size: 11))
+          .foregroundColor(.gray)
+          .multilineTextAlignment(.center)
+          .padding(.horizontal, 24)
+      }
+      .padding(.top, 16)
+    }
+  }
+#endif

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -185,9 +185,55 @@ class PlayerPageModel: ViewModel {
 
   @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
+  // MARK: - Giveaway
+  let giveawayOverlayModel = GiveawayOverlayModel()
+  @ObservationIgnored @Shared(.activeGiveaway) var activeGiveaway
+  @ObservationIgnored @Shared(.giveawayParticipations) var giveawayParticipations
+
   init(onDismiss: (() -> Void)? = nil) {
     self.onDismiss = onDismiss
+    super.init()
+    #if DEBUG
+      giveawayOverlayModel.onTap = { [weak self] giveaway in
+        self?.debugMarkStandby(giveaway)
+      }
+    #endif
   }
+
+  #if DEBUG
+    var debugGiveawayButtonTitle: String {
+      activeGiveaway != nil ? "🐞 Clear giveaway" : "🐞 Inject giveaway"
+    }
+
+    var debugGiveawayDiagnostics: String { giveawayOverlayModel.gateDiagnostics }
+
+    /// Inject / clear a fake open giveaway so the overlay can be QA'd without a live contest.
+    func debugToggleGiveawayTapped() {
+      if activeGiveaway != nil {
+        $activeGiveaway.withLock { $0 = nil }
+        $giveawayParticipations.withLock { $0["debug-giveaway"] = nil }
+        giveawayOverlayModel.debugForceVisible = false
+      } else {
+        $activeGiveaway.withLock {
+          $0 = Giveaway(
+            id: "debug-giveaway", stationId: "debug-station",
+            prizeName: "Two tickets to Reckless Kelly at the Heights",
+            prizeDescription: "Friday night, doors at 8.", winningNumber: 9, status: .open)
+        }
+        giveawayOverlayModel.debugForceVisible = true
+      }
+    }
+
+    private func debugMarkStandby(_ giveaway: Giveaway) {
+      $giveawayParticipations.withLock {
+        $0[giveaway.id] = GiveawayParticipation(
+          id: giveaway.id, stationId: giveaway.stationId, prizeName: giveaway.prizeName,
+          prizeDescription: giveaway.prizeDescription, prizeImageUrl: giveaway.prizeImageUrl,
+          winningNumber: giveaway.winningNumber, tapNumber: 7, status: .tappedStandby,
+          tappedAt: Date())
+      }
+    }
+  #endif
 
   func playPauseButtonTapped() {
     stationPlayer.stop()


### PR DESCRIPTION
Second PR of the live giveaway feature (after #332's models/state) — the first **visible** surface. Adds `GiveawayOverlayModel` + `GiveawayPlayerOverlayView`, mounted in `PlayerPage` and driven by `@Shared(.activeGiveaway)`, with all conditionals as model-computed values so the view has no control flow. Styling matches the lovable-ios `TapperGiveawayOverlay` mockup exactly (coral `#EF6962` Space Grotesk headline, inline coral ordinal, white-bordered TAP HERE pill, STAND BY… pill). A DEBUG-only inject toggle + gate-diagnostics readout on the player make the overlay QA-able without a live contest, and there are previews + gate-logic tests.

**Deployable / inert in release:** the `#if DEBUG` controls compile out and nothing wires the live `/active` data path yet, so in a release build `activeGiveaway` is always nil and the overlay stays hidden (height 0) — no user-visible change. The live polling that populates it (behind a feature flag) is a follow-up PR.

> Note: the Conductor PR template attached a stale "Release 5.5.0" title/changelog unrelated to this branch; replaced with an accurate title/description. Easy to amend if a different one was intended.