### PR TITLE
feat(giveaway): live giveaway win/lose resolution (M2, listener side)

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -16,8 +16,10 @@
 		354451A630DF81468815108F /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
 		36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
 		3E9CF257B133D2AD4734F378 /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
+		54419FC022E2F30E137BEDD6 /* GiveawayWinnerSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */; };
 		5F67160E76C1454189765E5D /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
 		5F721A0797795B3B529757CD /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
+		5FBBC84B39A22DF69240A54E /* GiveawayWinnerSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */; };
 		659E9B124BCB08D5F3D216D7 /* GiveawayEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EDCED098E801AAB2E9DC82 /* GiveawayEvent.swift */; };
 		65D0683FA2A905693317C5AB /* CongratsActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0488057E2A6456204E582B15 /* CongratsActionTests.swift */; };
 		6D6D8F5B3570802E2D336F7C /* GiveawayOverlayModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16A5F5E27CF6BD0259ED1E5 /* GiveawayOverlayModelTests.swift */; };
@@ -507,6 +509,7 @@
 		9E8719F70AFA4992B9037775 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
 		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
 		A6613FD7A13B448187CB8595 /* PresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTests.swift; sourceTree = "<group>"; };
+		AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetView.swift; sourceTree = "<group>"; };
 		BA44EE33EB697E44CEC84351 /* GiveawayWinnerPushTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPushTests.swift; sourceTree = "<group>"; };
 		BC138D8C4809A3F89A5B4985 /* GiveawayWinnerSheetModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetModelTests.swift; sourceTree = "<group>"; };
 		BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetTests.swift; sourceTree = "<group>"; };
@@ -822,6 +825,7 @@
 			children = (
 				0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */,
 				BC138D8C4809A3F89A5B4985 /* GiveawayWinnerSheetModelTests.swift */,
+				AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */,
 			);
 			name = GiveawayWinnerSheet;
 			path = GiveawayWinnerSheet;
@@ -2056,6 +2060,7 @@
 				99112E8696C5C7952F8EBE10 /* GiveawayWinnerSubmissionRequest.swift in Sources */,
 				DDB617A9AA22B4D37A3E3808 /* GiveawayWinnerPush.swift in Sources */,
 				36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */,
+				5FBBC84B39A22DF69240A54E /* GiveawayWinnerSheetView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2241,6 +2246,7 @@
 				C344F2AC7008BF0C48803B71 /* GiveawayWinnerSubmissionRequest.swift in Sources */,
 				F425EEF25FDF6BFE036A49E2 /* GiveawayWinnerPush.swift in Sources */,
 				3E9CF257B133D2AD4734F378 /* GiveawayWinnerSheetModel.swift in Sources */,
+				54419FC022E2F30E137BEDD6 /* GiveawayWinnerSheetView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -14,6 +14,8 @@
 		1E09F417B01F258C6D38D660 /* GiveawayPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */; };
 		1F6F57E01E254F5483BD939B /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
 		354451A630DF81468815108F /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
+		36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
+		3E9CF257B133D2AD4734F378 /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
 		5F67160E76C1454189765E5D /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
 		5F721A0797795B3B529757CD /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
 		659E9B124BCB08D5F3D216D7 /* GiveawayEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EDCED098E801AAB2E9DC82 /* GiveawayEvent.swift */; };
@@ -475,6 +477,7 @@
 		FE110A0000000000000000B5 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
 		FE110A0000000000000000B6 /* WelcomeMessagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */; };
 		FE110AC0DE0000000000B1B1 /* WelcomeMessageEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */; };
+		FE654232793406CA6A2FA1FE /* GiveawayWinnerSheetModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC138D8C4809A3F89A5B4985 /* GiveawayWinnerSheetModelTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -491,6 +494,7 @@
 		02EDCED098E801AAB2E9DC82 /* GiveawayEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayEvent.swift; sourceTree = "<group>"; };
 		0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPush.swift; sourceTree = "<group>"; };
 		0488057E2A6456204E582B15 /* CongratsActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsActionTests.swift; sourceTree = "<group>"; };
+		0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetModel.swift; sourceTree = "<group>"; };
 		1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCoordinator.swift; sourceTree = "<group>"; };
 		2B82DD37711E160592E3842D /* GiveawayMyResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayMyResult.swift; sourceTree = "<group>"; };
 		36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSubmission.swift; sourceTree = "<group>"; };
@@ -504,6 +508,7 @@
 		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
 		A6613FD7A13B448187CB8595 /* PresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTests.swift; sourceTree = "<group>"; };
 		BA44EE33EB697E44CEC84351 /* GiveawayWinnerPushTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPushTests.swift; sourceTree = "<group>"; };
+		BC138D8C4809A3F89A5B4985 /* GiveawayWinnerSheetModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetModelTests.swift; sourceTree = "<group>"; };
 		BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetTests.swift; sourceTree = "<group>"; };
 		BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetStarButton.swift; sourceTree = "<group>"; };
 		BFF0E49DF7714364A04B11B3 /* PresetTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTile.swift; sourceTree = "<group>"; };
@@ -812,6 +817,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		5BCFD236E4802E5BC59860C6 /* GiveawayWinnerSheet */ = {
+			isa = PBXGroup;
+			children = (
+				0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */,
+				BC138D8C4809A3F89A5B4985 /* GiveawayWinnerSheetModelTests.swift */,
+			);
+			name = GiveawayWinnerSheet;
+			path = GiveawayWinnerSheet;
+			sourceTree = "<group>";
+		};
 		5C5534927BB84EF0BB547E65 /* Preset */ = {
 			isa = PBXGroup;
 			children = (
@@ -1026,6 +1041,7 @@
 				D35EFC382F192C76000F64A4 /* SupportPage */,
 				FE110A0000000000000000A0 /* WelcomeMessage */,
 				D3536A062BFA4F49006942D6 /* ContentView.swift */,
+				5BCFD236E4802E5BC59860C6 /* GiveawayWinnerSheet */,
 			);
 			path = Pages;
 			sourceTree = "<group>";
@@ -2039,6 +2055,7 @@
 				A8034ECCAE01C4925AEA0BA4 /* GiveawayCoordinator.swift in Sources */,
 				99112E8696C5C7952F8EBE10 /* GiveawayWinnerSubmissionRequest.swift in Sources */,
 				DDB617A9AA22B4D37A3E3808 /* GiveawayWinnerPush.swift in Sources */,
+				36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2223,6 +2240,7 @@
 				0F528AC0AC6E8A8043556CEC /* GiveawayCoordinator.swift in Sources */,
 				C344F2AC7008BF0C48803B71 /* GiveawayWinnerSubmissionRequest.swift in Sources */,
 				F425EEF25FDF6BFE036A49E2 /* GiveawayWinnerPush.swift in Sources */,
+				3E9CF257B133D2AD4734F378 /* GiveawayWinnerSheetModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2302,6 +2320,7 @@
 				6D6D8F5B3570802E2D336F7C /* GiveawayOverlayModelTests.swift in Sources */,
 				100DEE4C2F7441167117CC58 /* GiveawayCoordinatorTests.swift in Sources */,
 				9B6663109A6517E11DB2D64E /* GiveawayWinnerPushTests.swift in Sources */,
+				FE654232793406CA6A2FA1FE /* GiveawayWinnerSheetModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -23,6 +23,8 @@
 		76C4967DBFE548C0884C2931 /* StationListPresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */; };
 		81599AD0B41E4A2496EEF25A /* PresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6613FD7A13B448187CB8595 /* PresetTests.swift */; };
 		8CECE7D0544EBE95DA92A501 /* GiveawayMyResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B82DD37711E160592E3842D /* GiveawayMyResult.swift */; };
+		99112E8696C5C7952F8EBE10 /* GiveawayWinnerSubmissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7886543EC93B0BA403388A8 /* GiveawayWinnerSubmissionRequest.swift */; };
+		9B6663109A6517E11DB2D64E /* GiveawayWinnerPushTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA44EE33EB697E44CEC84351 /* GiveawayWinnerPushTests.swift */; };
 		A1B2C3D4E5F6A7B8C9D0E1F2 /* StationListPresetComingSoonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */; };
 		A8034ECCAE01C4925AEA0BA4 /* GiveawayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */; };
 		AA01000000000001AAAAAAAA /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
@@ -35,6 +37,7 @@
 		B9D97B72F461E83FF652BDBD /* GiveawayPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */; };
 		BEF7B80875987966A5439482 /* GiveawayFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61840B16734426EAC4079351 /* GiveawayFeature.swift */; };
 		C2FCC44BB8C98C486BC343E6 /* GiveawayOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */; };
+		C344F2AC7008BF0C48803B71 /* GiveawayWinnerSubmissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7886543EC93B0BA403388A8 /* GiveawayWinnerSubmissionRequest.swift */; };
 		C8BA849E20B449EC91DBF5F2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
 		D0CD5FE434D4950E16A7B1F9 /* GiveawayOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */; };
 		D302576B2E63423D00F4228B /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
@@ -453,6 +456,7 @@
 		D3FF74D52FA7CA760052D500 /* CustomDump in Frameworks */ = {isa = PBXBuildFile; productRef = D3FF74D42FA7CA760052D500 /* CustomDump */; };
 		DA5BD241BADE11FCACB9AEA0 /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
 		DBD70D257638FF5934CA78DA /* CongratsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */; };
+		DDB617A9AA22B4D37A3E3808 /* GiveawayWinnerPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */; };
 		E1CA0000000000000000A002 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
 		E1CA0000000000000000A003 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
 		E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */; };
@@ -461,6 +465,7 @@
 		E96C77B08E039DD3EC6916BF /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
 		EDE2B63A1AB34C74CC65C898 /* CongratsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
+		F425EEF25FDF6BFE036A49E2 /* GiveawayWinnerPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */; };
 		F8685D688FF3683E3E6F9F55 /* GiveawayFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61840B16734426EAC4079351 /* GiveawayFeature.swift */; };
 		F94F092AC0FB044790B38A0E /* GiveawayModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9553B35A6FBA27239EF49033 /* GiveawayModelsTests.swift */; };
 		FE02FE02FE02FE02FE02FE02 /* StationListPresetErrorReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE01FE01FE01FE01FE01FE01 /* StationListPresetErrorReportingTests.swift */; };
@@ -484,6 +489,7 @@
 
 /* Begin PBXFileReference section */
 		02EDCED098E801AAB2E9DC82 /* GiveawayEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayEvent.swift; sourceTree = "<group>"; };
+		0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPush.swift; sourceTree = "<group>"; };
 		0488057E2A6456204E582B15 /* CongratsActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsActionTests.swift; sourceTree = "<group>"; };
 		1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCoordinator.swift; sourceTree = "<group>"; };
 		2B82DD37711E160592E3842D /* GiveawayMyResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayMyResult.swift; sourceTree = "<group>"; };
@@ -497,6 +503,7 @@
 		9E8719F70AFA4992B9037775 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
 		A2B3C4D5E6F7A8B9C0D1E2F3 /* StationListPresetComingSoonTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetComingSoonTests.swift; sourceTree = "<group>"; };
 		A6613FD7A13B448187CB8595 /* PresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTests.swift; sourceTree = "<group>"; };
+		BA44EE33EB697E44CEC84351 /* GiveawayWinnerPushTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPushTests.swift; sourceTree = "<group>"; };
 		BFF0E489F7714364A04B11B1 /* StationListPresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPresetTests.swift; sourceTree = "<group>"; };
 		BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetStarButton.swift; sourceTree = "<group>"; };
 		BFF0E49DF7714364A04B11B3 /* PresetTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTile.swift; sourceTree = "<group>"; };
@@ -737,6 +744,7 @@
 		D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageView.swift; sourceTree = "<group>"; };
 		D3FEC80A2EDF646E00A33AE8 /* ChooseStationToBroadcastPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageModel.swift; sourceTree = "<group>"; };
 		D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayTapResponse.swift; sourceTree = "<group>"; };
+		D7886543EC93B0BA403388A8 /* GiveawayWinnerSubmissionRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSubmissionRequest.swift; sourceTree = "<group>"; };
 		DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsAction.swift; sourceTree = "<group>"; };
 		E16A5F5E27CF6BD0259ED1E5 /* GiveawayOverlayModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayOverlayModelTests.swift; sourceTree = "<group>"; };
 		E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransition.swift; sourceTree = "<group>"; };
@@ -944,6 +952,9 @@
 				9553B35A6FBA27239EF49033 /* GiveawayModelsTests.swift */,
 				F5283C7C8C9FAF45659BA98E /* GiveawayParticipationTests.swift */,
 				0488057E2A6456204E582B15 /* CongratsActionTests.swift */,
+				D7886543EC93B0BA403388A8 /* GiveawayWinnerSubmissionRequest.swift */,
+				0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */,
+				BA44EE33EB697E44CEC84351 /* GiveawayWinnerPushTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2026,6 +2037,8 @@
 				1E09F417B01F258C6D38D660 /* GiveawayPlayerOverlayView.swift in Sources */,
 				BEF7B80875987966A5439482 /* GiveawayFeature.swift in Sources */,
 				A8034ECCAE01C4925AEA0BA4 /* GiveawayCoordinator.swift in Sources */,
+				99112E8696C5C7952F8EBE10 /* GiveawayWinnerSubmissionRequest.swift in Sources */,
+				DDB617A9AA22B4D37A3E3808 /* GiveawayWinnerPush.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2208,6 +2221,8 @@
 				B9D97B72F461E83FF652BDBD /* GiveawayPlayerOverlayView.swift in Sources */,
 				F8685D688FF3683E3E6F9F55 /* GiveawayFeature.swift in Sources */,
 				0F528AC0AC6E8A8043556CEC /* GiveawayCoordinator.swift in Sources */,
+				C344F2AC7008BF0C48803B71 /* GiveawayWinnerSubmissionRequest.swift in Sources */,
+				F425EEF25FDF6BFE036A49E2 /* GiveawayWinnerPush.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2286,6 +2301,7 @@
 				65D0683FA2A905693317C5AB /* CongratsActionTests.swift in Sources */,
 				6D6D8F5B3570802E2D336F7C /* GiveawayOverlayModelTests.swift in Sources */,
 				100DEE4C2F7441167117CC58 /* GiveawayCoordinatorTests.swift in Sources */,
+				9B6663109A6517E11DB2D64E /* GiveawayWinnerPushTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -774,6 +774,15 @@ extension APIClient: DependencyKey {
       tapGiveawayEvent: { jwtToken, eventId in
         try await authenticatedPost(path: "/v1/giveaway-events/\(eventId)/tap", token: jwtToken)
       },
+      giveawayEventMyResult: { jwtToken, eventId in
+        try await authenticatedGet(
+          path: "/v1/giveaway-events/\(eventId)/my-result", token: jwtToken)
+      },
+      submitGiveawayWinnerDetails: { jwtToken, eventId, body in
+        try await authenticatedPostVoid(
+          path: "/v1/giveaway-events/\(eventId)/winner-submission",
+          token: jwtToken, parameters: body.asParameters)
+      },
       getSupportConversation: { jwtToken in
         try await authenticatedGet(path: "/v1/conversations/support", token: jwtToken)
       },

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -772,7 +772,19 @@ extension APIClient: DependencyKey {
           path: "/v1/stations/\(stationId)/giveaway-events/active", token: jwtToken)
       },
       tapGiveawayEvent: { jwtToken, eventId in
-        try await authenticatedPost(path: "/v1/giveaway-events/\(eventId)/tap", token: jwtToken)
+        do {
+          return try await authenticatedPost(
+            path: "/v1/giveaway-events/\(eventId)/tap", token: jwtToken)
+        } catch let error as AFError {
+          // 400 = the contest isn't open yet (an expected race when a device's clock is slightly
+          // fast). Translate to a domain error so callers never inspect HTTP status codes.
+          if case .responseValidationFailed(reason: .unacceptableStatusCode(let code)) = error,
+            code == 400
+          {
+            throw GiveawayTapError.notOpenYet
+          }
+          throw error
+        }
       },
       giveawayEventMyResult: { jwtToken, eventId in
         try await authenticatedGet(

--- a/PlayolaRadio/Core/API/APIClient.swift
+++ b/PlayolaRadio/Core/API/APIClient.swift
@@ -559,6 +559,18 @@ struct APIClient: Sendable {
       _, _ in .mock
     }
 
+  /// The viewer's authoritative final outcome for an event. Reconciles a due close on demand, so
+  /// the last-tapper promotion is reflected without waiting for the worker. 404 if the event is gone.
+  var giveawayEventMyResult:
+    @Sendable (_ jwtToken: String, _ eventId: String) async throws -> GiveawayMyResult = { _, _ in
+      .mock
+    }
+
+  /// Submits (upserts) the winner's mailing details for an event. Winner-only on the server.
+  var submitGiveawayWinnerDetails:
+    @Sendable (_ jwtToken: String, _ eventId: String, _ body: GiveawayWinnerSubmissionRequest)
+      async throws -> Void = { _, _, _ in }
+
   /// Gets the user's support conversation (may be nil if none exists)
   /// - Parameter jwtToken: The JWT token for authentication
   /// - Returns: SupportConversationResponse containing the conversation (nullable) and unread count

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
@@ -32,6 +32,10 @@ final class GiveawayCoordinator {
   @ObservationIgnored private var generation = 0
 
   static let feedPollInterval: Duration = .seconds(30)
+  /// How far back a `.resolvedLost` participation is still re-checked for a last-tapper promotion on
+  /// foreground. A contest closes minutes after a tap, so a few hours is generous without unbounded
+  /// polling of stale losses.
+  static let lossReconcileWindow: TimeInterval = 6 * 60 * 60
 
   // MARK: - Lifecycle
 
@@ -66,6 +70,7 @@ final class GiveawayCoordinator {
   func pollNow() async {
     guard GiveawayFeature.isLiveDataEnabled else { return }
     await reconcile()
+    await reconcileRecentResolvedLosses()
   }
 
   // MARK: - Reconcile
@@ -143,6 +148,9 @@ final class GiveawayCoordinator {
       ? .resolvedWon(submissionCompleted: false)
       : .resolvedLost(toastShown: false)
     $participations.withLock {
+      // A push or backstop may have crowned this event while the POST was in flight; never let a
+      // (losing) tap response downgrade an already-recorded win.
+      if case .resolvedWon = $0[event.id]?.status { return }
       $0[event.id] = GiveawayParticipation(
         id: event.id, stationId: event.stationId, prizeName: event.prizeName,
         prizeDescription: event.prizeDescription, prizeImageUrl: event.prizeImageUrl,
@@ -204,10 +212,30 @@ final class GiveawayCoordinator {
     guard let result = try? await api.giveawayEventMyResult(jwt, eventId) else { return }
     guard result.isResolved, result.isWinner else { return }
     $participations.withLock {
+      // Re-check inside the lock: a push or a claim may have changed the state during the GET, and we
+      // must not reset a now-won/claimed participation back to an unsubmitted win.
+      guard case .resolvedLost = $0[eventId]?.status else { return }
       $0[eventId]?.status = .resolvedWon(submissionCompleted: false)
       if let tapNumber = result.tapNumber { $0[eventId]?.tapNumber = tapNumber }
     }
     log("backstop: \(eventId) promoted loss→win")
+  }
+
+  /// Foreground safety net for the promoted last-tapper when the live close-detection path didn't run
+  /// (app was killed, the station changed, or `activeGiveaway` was already cleared). Re-checks each
+  /// recent `.resolvedLost` once. Bounded by `lossReconcileWindow` so old losses aren't polled forever.
+  func reconcileRecentResolvedLosses() async {
+    guard let jwt = auth.jwt else { return }
+    let losses = participations.values.filter {
+      if case .resolvedLost = $0.status { return true }
+      return false
+    }
+    guard !losses.isEmpty else { return }
+    let cutoff = now.addingTimeInterval(-Self.lossReconcileWindow)
+    let recentLossIds = losses.compactMap { $0.tappedAt >= cutoff ? $0.id : nil }
+    for eventId in recentLossIds {
+      await reconcileResolvedLoss(jwt: jwt, eventId: eventId)
+    }
   }
 
   /// Among a station's events, pick the relevant one: an open one (reveal now), otherwise the

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
@@ -115,8 +115,9 @@ final class GiveawayCoordinator {
   // MARK: - Tap
 
   /// Tap into a giveaway. Persists a standby participation (keyed by the per-airing event id) the
-  /// instant the POST returns, so the reveal survives an app kill. One tap per event.
-  func tap(event: GiveawayEvent) async {
+  /// instant the POST returns, so the reveal survives an app kill. One tap per event. Stays silent
+  /// on the expected `.notOpenYet` race; rethrows any genuine failure for the caller to surface.
+  func tap(event: GiveawayEvent) async throws {
     guard let jwt = auth.jwt else { return }
     guard participations[event.id] == nil, !inFlightTapIds.contains(event.id) else { return }
     inFlightTapIds.insert(event.id)
@@ -124,8 +125,11 @@ final class GiveawayCoordinator {
     do {
       let response = try await api.tapGiveawayEvent(jwt, event.id)
       persistStandby(event: event, tapNumber: response.tapNumber)
+    } catch GiveawayTapError.notOpenYet {
+      log("tap: not-open-yet for \(event.id) — silent (expected race)")
     } catch {
-      // 400 (not open yet) / network: no participation written; the user can tap again.
+      log("tap: unexpected failure for \(event.id) — \(error)")
+      throw error
     }
   }
 

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
@@ -114,9 +114,10 @@ final class GiveawayCoordinator {
 
   // MARK: - Tap
 
-  /// Tap into a giveaway. Persists a standby participation (keyed by the per-airing event id) the
-  /// instant the POST returns, so the reveal survives an app kill. One tap per event. Stays silent
-  /// on the expected `.notOpenYet` race; rethrows any genuine failure for the caller to surface.
+  /// Tap into a giveaway. The tap response carries the authoritative `isWinner`, so the outcome is
+  /// resolved and persisted (keyed by the per-airing event id) the instant the POST returns — no
+  /// wait for the contest to close. The durable write survives an app kill. One tap per event.
+  /// Stays silent on the expected `.notOpenYet` race; rethrows any genuine failure for the caller.
   func tap(event: GiveawayEvent) async throws {
     guard let jwt = auth.jwt else { return }
     guard participations[event.id] == nil, !inFlightTapIds.contains(event.id) else { return }
@@ -124,7 +125,7 @@ final class GiveawayCoordinator {
     defer { inFlightTapIds.remove(event.id) }
     do {
       let response = try await api.tapGiveawayEvent(jwt, event.id)
-      persistStandby(event: event, tapNumber: response.tapNumber)
+      persistOutcome(event: event, response: response)
     } catch GiveawayTapError.notOpenYet {
       log("tap: not-open-yet for \(event.id) — silent (expected race)")
     } catch {
@@ -133,12 +134,19 @@ final class GiveawayCoordinator {
     }
   }
 
-  private func persistStandby(event: GiveawayEvent, tapNumber: Int) {
+  /// Resolve the tap immediately from the server's authoritative response. A non-winning tap is only
+  /// *provisionally* lost — the last-tapper promotion at close can still flip it to a win (recovered
+  /// by the poll-while-open backstop and the winner push).
+  private func persistOutcome(event: GiveawayEvent, response: GiveawayTapResponse) {
+    let status: GiveawayParticipationStatus =
+      response.isWinner
+      ? .resolvedWon(submissionCompleted: false)
+      : .resolvedLost(toastShown: false)
     $participations.withLock {
       $0[event.id] = GiveawayParticipation(
         id: event.id, stationId: event.stationId, prizeName: event.prizeName,
         prizeDescription: event.prizeDescription, prizeImageUrl: event.prizeImageUrl,
-        winningNumber: event.winningNumber, tapNumber: tapNumber, status: .tappedStandby,
+        winningNumber: event.winningNumber, tapNumber: response.tapNumber, status: status,
         tappedAt: now)
     }
   }

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
@@ -184,15 +184,30 @@ final class GiveawayCoordinator {
 
   /// A published event has dropped out of the feed. Confirm via the authoritative GET: keep it if
   /// it's still open (a transient feed gap at the open transition), clear it once it has closed.
-  /// A transient GET failure keeps it (the next poll retries). (A canceled event that 404s is
-  /// cleared by the result-poll reveal step — a later PR.)
+  /// A transient GET failure keeps it (the next poll retries). On close, run the loss backstop so a
+  /// last-tapper promotion is caught for the in-app user without waiting on the push.
   func clearActiveIfNoLongerOpen(jwt: String, event: GiveawayEvent, stationId: String) async {
     guard let fresh = try? await api.giveawayEvent(jwt, event.id) else { return }
     guard currentPlayolaStationId == stationId else { return }
     if fresh.status != .open {
       $activeGiveaway.withLock { $0 = nil }
       log("active event \(event.id) is now \(fresh.status.rawValue) → cleared")
+      await reconcileResolvedLoss(jwt: jwt, eventId: event.id)
     }
+  }
+
+  /// Backstop for the last-tapper promotion: when a contest the user provisionally lost has closed,
+  /// re-check `my-result` once and flip `.resolvedLost → .resolvedWon` if the server promoted them.
+  /// No-op on a still-open contest, a confirmed loss, or a transient failure.
+  func reconcileResolvedLoss(jwt: String, eventId: String) async {
+    guard case .resolvedLost = participations[eventId]?.status else { return }
+    guard let result = try? await api.giveawayEventMyResult(jwt, eventId) else { return }
+    guard result.isResolved, result.isWinner else { return }
+    $participations.withLock {
+      $0[eventId]?.status = .resolvedWon(submissionCompleted: false)
+      if let tapNumber = result.tapNumber { $0[eventId]?.tapNumber = tapNumber }
+    }
+    log("backstop: \(eventId) promoted loss→win")
   }
 
   /// Among a station's events, pick the relevant one: an open one (reveal now), otherwise the

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift
@@ -325,8 +325,22 @@ final class GiveawayCoordinator {
       log("arm: \(eventId) stale after sleep (gen/station changed) — skipping")
       return
     }
-    await revealEvent(jwt: jwt, eventId: eventId, expectedStationId: stationId)
+    // Reveal the button the instant we reach opensAt, straight from the event we already hold — no
+    // confirming GET, whose round-trip would push the button several seconds past opensAt. The tap
+    // opens the contest on-demand server-side, and the next feed poll converges authoritative state.
+    revealFromHeldEvent(event, expectedStationId: stationId)
     armedEventId = nil
+  }
+
+  /// Publish a giveaway we already hold (flipped to `.open`) so the overlay shows the tap button with
+  /// no network round-trip.
+  func revealFromHeldEvent(_ event: GiveawayEvent, expectedStationId: String) {
+    guard currentPlayolaStationId == expectedStationId else {
+      log("reveal: station changed before publish — skipping \(event.id)")
+      return
+    }
+    $activeGiveaway.withLock { $0 = event.openedCopy() }
+    log("REVEALED \(event.id) from held event (no refresh)")
   }
 
   private func cancelArmedReveal() {

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
@@ -190,7 +190,7 @@ struct GiveawayCoordinatorTests {
       winningNumber: 9, status: .open, giveawayId: "gv1")
   }
 
-  @Test func tapPersistsStandbyParticipationOnSuccess() async {
+  @Test func tapPersistsResolvedLossOnNonWinningTap() async {
     let tappedAt = Date(timeIntervalSince1970: 1000)
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
@@ -202,12 +202,33 @@ struct GiveawayCoordinatorTests {
     } operation: {
       try? await GiveawayCoordinator().tap(event: openEvent())
     }
-    // Keyed by the per-airing event id, carrying the prize details and the server tap number.
+    // Resolved immediately from the tap response, keyed by the per-airing event id.
     expectNoDifference(
       participations["e1"],
       GiveawayParticipation(
         id: "e1", stationId: "s1", prizeName: "Two tickets", prizeDescription: "Front row",
-        winningNumber: 9, tapNumber: 7, status: .tappedStandby, tappedAt: tappedAt))
+        winningNumber: 9, tapNumber: 7, status: .resolvedLost(toastShown: false),
+        tappedAt: tappedAt))
+  }
+
+  @Test func tapPersistsResolvedWonOnWinningTap() async {
+    let tappedAt = Date(timeIntervalSince1970: 1000)
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+    await withDependencies {
+      $0.date = .constant(tappedAt)
+      $0.api.tapGiveawayEvent = { _, _ in
+        GiveawayTapResponse(tapNumber: 9, isWinner: true, status: .open)
+      }
+    } operation: {
+      try? await GiveawayCoordinator().tap(event: openEvent())
+    }
+    expectNoDifference(
+      participations["e1"],
+      GiveawayParticipation(
+        id: "e1", stationId: "s1", prizeName: "Two tickets", prizeDescription: "Front row",
+        winningNumber: 9, tapNumber: 9, status: .resolvedWon(submissionCompleted: false),
+        tappedAt: tappedAt))
   }
 
   @Test func tapWithoutJWTIsNoOp() async {

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
@@ -200,7 +200,7 @@ struct GiveawayCoordinatorTests {
         GiveawayTapResponse(tapNumber: 7, isWinner: false, status: .open)
       }
     } operation: {
-      await GiveawayCoordinator().tap(event: openEvent())
+      try? await GiveawayCoordinator().tap(event: openEvent())
     }
     // Keyed by the per-airing event id, carrying the prize details and the server tap number.
     expectNoDifference(
@@ -214,7 +214,7 @@ struct GiveawayCoordinatorTests {
     @Shared(.auth) var auth = Auth()
     @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
     // The default tap stub would persist a participation if the JWT guard failed to short-circuit.
-    await GiveawayCoordinator().tap(event: openEvent())
+    try? await GiveawayCoordinator().tap(event: openEvent())
     #expect(participations["e1"] == nil)
   }
 
@@ -229,18 +229,32 @@ struct GiveawayCoordinatorTests {
     await withDependencies {
       $0.api.tapGiveawayEvent = { _, _ in .mock }
     } operation: {
-      await GiveawayCoordinator().tap(event: openEvent())
+      try? await GiveawayCoordinator().tap(event: openEvent())
     }
     #expect(participations["e1"]?.tapNumber == 99)
   }
 
-  @Test func tapDoesNotPersistOnError() async {
+  @Test func tapStaysSilentAndDoesNotPersistOnNotOpenYet() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+    // A 400 race is surfaced by the API as `.notOpenYet`; tap swallows it silently (no rethrow).
     await withDependencies {
-      $0.api.tapGiveawayEvent = { _, _ in throw BoomError() }
+      $0.api.tapGiveawayEvent = { _, _ in throw GiveawayTapError.notOpenYet }
     } operation: {
-      await GiveawayCoordinator().tap(event: openEvent())
+      try? await GiveawayCoordinator().tap(event: openEvent())
+    }
+    #expect(participations["e1"] == nil)
+  }
+
+  @Test func tapRethrowsUnexpectedErrorAndDoesNotPersist() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+    await #expect(throws: BoomError.self) {
+      try await withDependencies {
+        $0.api.tapGiveawayEvent = { _, _ in throw BoomError() }
+      } operation: {
+        try await GiveawayCoordinator().tap(event: openEvent())
+      }
     }
     #expect(participations["e1"] == nil)
   }

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
@@ -182,6 +182,31 @@ struct GiveawayCoordinatorTests {
     #expect(activeGiveaway == nil)
   }
 
+  @Test func revealFromHeldEventPublishesOpenWithoutAGet() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    let scheduled = GiveawayEvent(
+      id: "e1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9, status: .scheduled)
+
+    GiveawayCoordinator().revealFromHeldEvent(scheduled, expectedStationId: "s1")
+
+    // Published straight from the held event, flipped to .open. The id is "e1" (not the detail GET's
+    // ".mock"/"event-1"), proving the reveal did NOT make a network round-trip.
+    #expect(activeGiveaway?.id == "e1")
+    #expect(activeGiveaway?.status == .open)
+  }
+
+  @Test func revealFromHeldEventSkipsWhenStationChanged() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "other")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    let scheduled = GiveawayEvent(
+      id: "e1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9, status: .scheduled)
+
+    GiveawayCoordinator().revealFromHeldEvent(scheduled, expectedStationId: "s1")
+
+    #expect(activeGiveaway == nil)
+  }
+
   // MARK: - tap
 
   private func openEvent(id: String = "e1") -> GiveawayEvent {

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
@@ -338,6 +338,34 @@ struct GiveawayCoordinatorTests {
       participations["e1"]?.status
         == GiveawayParticipationStatus.resolvedLost(toastShown: true))
   }
+
+  @Test func foregroundReconcileFlipsRecentLossButSkipsStale() async {
+    let nowDate = Date(timeIntervalSince1970: 1_000_000)
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "recent": GiveawayParticipation(
+        id: "recent", stationId: "s1", prizeName: "P", winningNumber: 9, tapNumber: 5,
+        status: .resolvedLost(toastShown: true), tappedAt: nowDate.addingTimeInterval(-60)),
+      "stale": GiveawayParticipation(
+        id: "stale", stationId: "s1", prizeName: "P", winningNumber: 9, tapNumber: 5,
+        status: .resolvedLost(toastShown: true),
+        tappedAt: nowDate.addingTimeInterval(-7 * 60 * 60)),
+    ]
+    await withDependencies {
+      $0.date = .constant(nowDate)
+      $0.api.giveawayEventMyResult = { _, _ in
+        GiveawayMyResult(tapNumber: 5, isWinner: true, status: .closed, winningNumber: 9)
+      }
+    } operation: {
+      await GiveawayCoordinator().reconcileRecentResolvedLosses()
+    }
+    #expect(
+      participations["recent"]?.status
+        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
+    #expect(
+      participations["stale"]?.status
+        == GiveawayParticipationStatus.resolvedLost(toastShown: true))
+  }
 }
 
 // swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
@@ -279,6 +279,65 @@ struct GiveawayCoordinatorTests {
     }
     #expect(participations["e1"] == nil)
   }
+
+  // MARK: - Loss Backstop
+
+  private func lostParticipation() -> GiveawayParticipation {
+    GiveawayParticipation(
+      id: "e1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9, tapNumber: 5,
+      status: .resolvedLost(toastShown: true), tappedAt: Date(timeIntervalSince1970: 100))
+  }
+
+  @Test func backstopFlipsLossToWinWhenPromoted() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e1": lostParticipation()
+    ]
+    await withDependencies {
+      $0.api.giveawayEventMyResult = { _, _ in
+        GiveawayMyResult(tapNumber: 5, isWinner: true, status: .closed, winningNumber: 9)
+      }
+    } operation: {
+      await GiveawayCoordinator().reconcileResolvedLoss(jwt: "jwt", eventId: "e1")
+    }
+    #expect(
+      participations["e1"]?.status
+        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
+  }
+
+  @Test func backstopLeavesLossWhenStillLost() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e1": lostParticipation()
+    ]
+    await withDependencies {
+      $0.api.giveawayEventMyResult = { _, _ in
+        GiveawayMyResult(tapNumber: 5, isWinner: false, status: .closed, winningNumber: 9)
+      }
+    } operation: {
+      await GiveawayCoordinator().reconcileResolvedLoss(jwt: "jwt", eventId: "e1")
+    }
+    #expect(
+      participations["e1"]?.status
+        == GiveawayParticipationStatus.resolvedLost(toastShown: true))
+  }
+
+  @Test func backstopIgnoresStillOpenResult() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e1": lostParticipation()
+    ]
+    await withDependencies {
+      $0.api.giveawayEventMyResult = { _, _ in
+        GiveawayMyResult(tapNumber: 5, isWinner: false, status: .open, winningNumber: 9)
+      }
+    } operation: {
+      await GiveawayCoordinator().reconcileResolvedLoss(jwt: "jwt", eventId: "e1")
+    }
+    #expect(
+      participations["e1"]?.status
+        == GiveawayParticipationStatus.resolvedLost(toastShown: true))
+  }
 }
 
 // swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -8,6 +8,7 @@
 import Dependencies
 import DependenciesMacros
 import Foundation
+import IssueReporting
 import Sharing
 import UIKit
 import UserNotifications
@@ -212,22 +213,32 @@ extension PushNotificationsClient: DependencyKey {
       await stationPlayer.play(station: station)
     },
     handleGiveawayWinnerPush: { userInfo in
-      guard let push = GiveawayWinnerPush(userInfo: userInfo) else { return }
+      guard let push = GiveawayWinnerPush(userInfo: userInfo) else {
+        // A malformed winner push is the one rescue path for a missed promotion — never drop it
+        // silently. (A non-giveaway payload routed here by mistake is not worth reporting.)
+        if userInfo["type"] as? String == "giveaway_winner" {
+          reportIssue("Dropped malformed giveaway_winner push: \(userInfo)")
+        }
+        return
+      }
+      // Honor the server's claim flag: an already-claimed prize (other device) resolves straight to a
+      // completed win, so the arbiter never prompts the form for it.
+      let submissionCompleted = push.submissionCompleted ?? false
       @Shared(.giveawayParticipations) var participations
       let participationsShared = $participations
       await MainActor.run {
         participationsShared.withLock { dict in
-          // Already fully claimed, or already a (possibly pending) win → leave untouched so we never
-          // clobber a `winnerSheetPresentedAt` stamp or re-open a completed claim.
+          // Already a (possibly pending or claimed) win → leave untouched so we never clobber a
+          // `winnerSheetPresentedAt` stamp or re-open a completed claim.
           if case .resolvedWon = dict[push.eventId]?.status { return }
           if dict[push.eventId] != nil {
-            dict[push.eventId]?.status = .resolvedWon(submissionCompleted: false)
+            dict[push.eventId]?.status = .resolvedWon(submissionCompleted: submissionCompleted)
           } else {
             dict[push.eventId] = GiveawayParticipation(
               id: push.eventId, stationId: push.stationId ?? "", prizeName: push.prizeName,
               prizeDescription: push.prizeDescription, prizeImageUrl: push.prizeImageUrl,
               winningNumber: push.winningNumber, tapNumber: push.tapNumber,
-              status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+              status: .resolvedWon(submissionCompleted: submissionCompleted), tappedAt: Date())
           }
         }
       }

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -83,6 +83,11 @@ struct PushNotificationsClient: Sendable {
   /// - Parameter userInfo: The notification payload
   var handleNotificationTap: @Sendable (_ userInfo: [String: any Sendable]) async -> Void
 
+  /// Handle the targeted "you won" giveaway push. Flips (or creates) the winning participation in
+  /// durable shared state; the MainContainer arbiter presents the winner sheet. Idempotent.
+  /// - Parameter userInfo: The notification payload
+  var handleGiveawayWinnerPush: @Sendable (_ userInfo: [String: any Sendable]) async -> Void
+
   /// Set the app icon badge count
   /// - Parameter count: The badge count to display
   var setBadgeCount: @Sendable (_ count: Int) async -> Void
@@ -205,6 +210,27 @@ extension PushNotificationsClient: DependencyKey {
 
       @Dependency(\.stationPlayer) var stationPlayer
       await stationPlayer.play(station: station)
+    },
+    handleGiveawayWinnerPush: { userInfo in
+      guard let push = GiveawayWinnerPush(userInfo: userInfo) else { return }
+      @Shared(.giveawayParticipations) var participations
+      let participationsShared = $participations
+      await MainActor.run {
+        participationsShared.withLock { dict in
+          // Already fully claimed, or already a (possibly pending) win → leave untouched so we never
+          // clobber a `winnerSheetPresentedAt` stamp or re-open a completed claim.
+          if case .resolvedWon = dict[push.eventId]?.status { return }
+          if dict[push.eventId] != nil {
+            dict[push.eventId]?.status = .resolvedWon(submissionCompleted: false)
+          } else {
+            dict[push.eventId] = GiveawayParticipation(
+              id: push.eventId, stationId: push.stationId ?? "", prizeName: push.prizeName,
+              prizeDescription: push.prizeDescription, prizeImageUrl: push.prizeImageUrl,
+              winningNumber: push.winningNumber, tapNumber: push.tapNumber,
+              status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+          }
+        }
+      }
     },
     setBadgeCount: { count in
       try? await UNUserNotificationCenter.current().setBadgeCount(count)

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -226,4 +226,58 @@ struct PushNotificationsTests {
 
     #expect(refreshNotificationPosted.value)
   }
+
+  // MARK: - handleGiveawayWinnerPush
+
+  private func winnerPayload() -> [String: any Sendable] {
+    [
+      "type": "giveaway_winner", "eventId": "e", "stationId": "s", "prizeName": "Two tickets",
+      "winningNumber": 9, "tapNumber": 5, "reason": "last_tapper_fallback",
+    ]
+  }
+
+  @Test func winnerPushFlipsLossToWon() async {
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e": GiveawayParticipation(
+        id: "e", stationId: "s", prizeName: "Two tickets", winningNumber: 9, tapNumber: 5,
+        status: .resolvedLost(toastShown: true), tappedAt: Date())
+    ]
+    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())
+    #expect(
+      participations["e"]?.status
+        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
+  }
+
+  @Test func winnerPushIsIdempotentWhenAlreadyWon() async {
+    let presentedAt = Date(timeIntervalSince1970: 42)
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e": GiveawayParticipation(
+        id: "e", stationId: "s", prizeName: "Two tickets", winningNumber: 9, tapNumber: 5,
+        status: .resolvedWon(submissionCompleted: true), tappedAt: Date(),
+        winnerSheetPresentedAt: presentedAt)
+    ]
+    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())
+    // Untouched: a completed claim must not be reset, and the presentation stamp must survive.
+    #expect(
+      participations["e"]?.status
+        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: true))
+    #expect(participations["e"]?.winnerSheetPresentedAt == presentedAt)
+  }
+
+  @Test func winnerPushCreatesParticipationOnReinstall() async {
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())
+    #expect(
+      participations["e"]?.status
+        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
+    #expect(participations["e"]?.tapNumber == 5)
+  }
+
+  @Test func nonGiveawayPushIsIgnored() async {
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush([
+      "type": "giveaway_closed", "eventId": "e",
+    ])
+    #expect(participations.isEmpty)
+  }
 }

--- a/PlayolaRadio/Models/GiveawayEvent.swift
+++ b/PlayolaRadio/Models/GiveawayEvent.swift
@@ -94,6 +94,16 @@ struct GiveawayEvent: Decodable, Sendable, Identifiable, Equatable {
     self.viewer = viewer
   }
 
+  /// A copy flipped to `.open`, used to reveal the tap button instantly from data already in hand
+  /// (the armed event) without waiting on a confirming network round-trip.
+  func openedCopy() -> GiveawayEvent {
+    GiveawayEvent(
+      id: id, stationId: stationId, prizeName: prizeName, prizeDescription: prizeDescription,
+      prizeImageUrl: prizeImageUrl, winningNumber: winningNumber, status: .open,
+      airingId: airingId, giveawayId: giveawayId, opensAt: opensAt, serverTime: serverTime,
+      viewer: viewer)
+  }
+
   static var mock: GiveawayEvent {
     GiveawayEvent(
       id: "event-1", stationId: "station-1",

--- a/PlayolaRadio/Models/GiveawayModelsTests.swift
+++ b/PlayolaRadio/Models/GiveawayModelsTests.swift
@@ -89,26 +89,46 @@ struct GiveawayModelsTests {
   }
 
   @Test func decodesWinnerSubmission() throws {
+    // The server keys submissions by eventId (NOT giveawayId).
     let json = Data(
       """
-      { "id": "sub1", "giveawayId": "g1", "userId": "u1", "fullName": "Brian Keane",
+      { "id": "sub1", "eventId": "e1", "userId": "u1", "fullName": "Brian Keane",
         "addressLine1": "123 Main", "city": "Austin", "postalCode": "78701",
         "country": "US", "willingToRecord": true, "fulfillmentStatus": "pending",
         "submittedAt": "2026-06-13T19:00:00.000Z" }
       """.utf8)
     let submission = try decoder().decode(GiveawayWinnerSubmission.self, from: json)
     #expect(submission.id == "sub1")
+    #expect(submission.eventId == "e1")
+    #expect(submission.fullName == "Brian Keane")
     #expect(submission.willingToRecord == true)
+    #expect(submission.fulfillmentStatus == .pending)
+  }
+
+  @Test func decodesEmailOnlyWinnerSubmission() throws {
+    // The email-only flow: the 201 carries eventId + preferredEmail and NO mailing-address fields.
+    // The optional address fields must decode to nil rather than throwing keyNotFound.
+    let json = Data(
+      """
+      { "id": "sub1", "eventId": "e1", "userId": "u1", "preferredEmail": "winner@example.com",
+        "fulfillmentStatus": "pending", "submittedAt": "2026-06-13T19:00:00.000Z" }
+      """.utf8)
+    let submission = try decoder().decode(GiveawayWinnerSubmission.self, from: json)
+    #expect(submission.eventId == "e1")
+    #expect(submission.preferredEmail == "winner@example.com")
+    #expect(submission.fullName == nil)
+    #expect(submission.addressLine1 == nil)
+    #expect(submission.city == nil)
+    #expect(submission.postalCode == nil)
+    #expect(submission.willingToRecord == false)
     #expect(submission.fulfillmentStatus == .pending)
   }
 
   @Test func decodesUnknownFulfillmentStatusAsUnknown() throws {
     let json = Data(
       """
-      { "id": "sub1", "giveawayId": "g1", "userId": "u1", "fullName": "X",
-        "addressLine1": "1", "city": "Austin", "postalCode": "78701",
-        "country": "US", "willingToRecord": false, "fulfillmentStatus": "shipped",
-        "submittedAt": "2026-06-13T19:00:00.000Z" }
+      { "id": "sub1", "eventId": "e1", "userId": "u1", "preferredEmail": "x@example.com",
+        "fulfillmentStatus": "shipped", "submittedAt": "2026-06-13T19:00:00.000Z" }
       """.utf8)
     let submission = try decoder().decode(GiveawayWinnerSubmission.self, from: json)
     #expect(submission.fulfillmentStatus == .unknown)

--- a/PlayolaRadio/Models/GiveawayParticipation.swift
+++ b/PlayolaRadio/Models/GiveawayParticipation.swift
@@ -33,6 +33,14 @@ struct GiveawayParticipation: Codable, Equatable, Sendable, Identifiable {
     }
   }
 
+  /// True when the user won without hitting the winning number — the last-tapper promotion at close.
+  /// A regular Nth-tapper winner always has `tapNumber == winningNumber`, so this isolates the
+  /// "surprise upgrade" path that the winner sheet headline acknowledges.
+  var wasPromotedWin: Bool {
+    guard case .resolvedWon = status else { return false }
+    return tapNumber != winningNumber
+  }
+
   static var mock: GiveawayParticipation {
     GiveawayParticipation(
       id: "giveaway-1", stationId: "station-1",

--- a/PlayolaRadio/Models/GiveawayParticipationTests.swift
+++ b/PlayolaRadio/Models/GiveawayParticipationTests.swift
@@ -35,4 +35,24 @@ struct GiveawayParticipationTests {
     participation.status = .canceled
     #expect(participation.isFullyHandled)
   }
+
+  @Test func wasPromotedWinTrueWhenWonBelowWinningNumber() {
+    var participation = GiveawayParticipation(
+      id: "g1", stationId: "s1", prizeName: "Tickets", winningNumber: 9,
+      tapNumber: 5, status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+    #expect(participation.wasPromotedWin)
+
+    participation.tapNumber = 9
+    #expect(!participation.wasPromotedWin)
+  }
+
+  @Test func wasPromotedWinFalseWhenNotWon() {
+    var participation = GiveawayParticipation(
+      id: "g1", stationId: "s1", prizeName: "Tickets", winningNumber: 9,
+      tapNumber: 5, status: .resolvedLost(toastShown: false), tappedAt: Date())
+    #expect(!participation.wasPromotedWin)
+
+    participation.status = .tappedStandby
+    #expect(!participation.wasPromotedWin)
+  }
 }

--- a/PlayolaRadio/Models/GiveawayTapResponse.swift
+++ b/PlayolaRadio/Models/GiveawayTapResponse.swift
@@ -9,3 +9,10 @@ struct GiveawayTapResponse: Decodable, Sendable, Equatable {
     GiveawayTapResponse(tapNumber: 5, isWinner: false, status: .open)
   }
 }
+
+/// Domain errors for a tap, translated from the transport layer inside `APIClient` so callers never
+/// touch HTTP/Alamofire details. `.notOpenYet` is the expected 400 race at the open moment (callers
+/// stay silent); any other failure propagates as-is for the caller to surface.
+enum GiveawayTapError: Error, Equatable {
+  case notOpenYet
+}

--- a/PlayolaRadio/Models/GiveawayWinnerPush.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPush.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// The targeted "you won" push the server sends to a resolved winner's devices at close (covers the
+/// last-tapper promotion and reinstall / second-device cases). Parsed from an APNs userInfo payload.
+struct GiveawayWinnerPush: Equatable, Sendable {
+  let eventId: String
+  let stationId: String?
+  let giveawayId: String?
+  let prizeName: String
+  let prizeDescription: String?
+  let prizeImageUrl: URL?
+  let winningNumber: Int
+  let tapNumber: Int
+  let winnerUserId: String?
+  let reason: String?
+  let submissionCompleted: Bool?
+  let canSubmitMailingInfo: Bool?
+
+  init?(userInfo: [String: any Sendable]) {
+    guard userInfo["type"] as? String == "giveaway_winner",
+      let eventId = userInfo["eventId"] as? String,
+      let prizeName = userInfo["prizeName"] as? String,
+      let winningNumber = userInfo["winningNumber"] as? Int,
+      let tapNumber = userInfo["tapNumber"] as? Int
+    else { return nil }
+    self.eventId = eventId
+    self.stationId = userInfo["stationId"] as? String
+    self.giveawayId = userInfo["giveawayId"] as? String
+    self.prizeName = prizeName
+    self.prizeDescription = userInfo["prizeDescription"] as? String
+    self.prizeImageUrl = (userInfo["prizeImageUrl"] as? String).flatMap(URL.init(string:))
+    self.winningNumber = winningNumber
+    self.tapNumber = tapNumber
+    self.winnerUserId = userInfo["winnerUserId"] as? String
+    self.reason = userInfo["reason"] as? String
+    self.submissionCompleted = userInfo["submissionCompleted"] as? Bool
+    self.canSubmitMailingInfo = userInfo["canSubmitMailingInfo"] as? Bool
+  }
+}

--- a/PlayolaRadio/Models/GiveawayWinnerPushTests.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPushTests.swift
@@ -26,15 +26,8 @@ struct GiveawayWinnerPushTests {
     #expect(GiveawayWinnerPush(userInfo: ["type": "giveaway_winner", "eventId": "evt-1"]) == nil)
   }
 
-  @Test func submissionRequestParametersDropEmptyOptionals() {
-    let request = GiveawayWinnerSubmissionRequest(
-      fullName: "Jo", addressLine1: "1 Main", city: "Austin", state: "TX",
-      postalCode: "78701", addressLine2: nil, country: "US", comment: nil)
-    expectNoDifference(
-      request.asParameters,
-      [
-        "fullName": "Jo", "addressLine1": "1 Main", "city": "Austin",
-        "state": "TX", "postalCode": "78701", "country": "US",
-      ])
+  @Test func submissionRequestParametersAreEmailOnly() {
+    let request = GiveawayWinnerSubmissionRequest(preferredEmail: "winner@example.com")
+    expectNoDifference(request.asParameters, ["preferredEmail": "winner@example.com"])
   }
 }

--- a/PlayolaRadio/Models/GiveawayWinnerPushTests.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPushTests.swift
@@ -1,0 +1,40 @@
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct GiveawayWinnerPushTests {
+  @Test func parsesValidWinnerPush() {
+    let push = GiveawayWinnerPush(userInfo: [
+      "type": "giveaway_winner", "eventId": "evt-1", "stationId": "stn-1",
+      "prizeName": "Two tickets", "winningNumber": 9, "tapNumber": 5,
+      "reason": "last_tapper_fallback", "canSubmitMailingInfo": true,
+    ])
+    expectNoDifference(push?.eventId, "evt-1")
+    expectNoDifference(push?.tapNumber, 5)
+    expectNoDifference(push?.reason, "last_tapper_fallback")
+    expectNoDifference(push?.canSubmitMailingInfo, true)
+  }
+
+  @Test func rejectsWrongType() {
+    #expect(GiveawayWinnerPush(userInfo: ["type": "giveaway_closed", "eventId": "evt-1"]) == nil)
+  }
+
+  @Test func rejectsMissingRequiredFields() {
+    #expect(GiveawayWinnerPush(userInfo: ["type": "giveaway_winner", "eventId": "evt-1"]) == nil)
+  }
+
+  @Test func submissionRequestParametersDropEmptyOptionals() {
+    let request = GiveawayWinnerSubmissionRequest(
+      fullName: "Jo", addressLine1: "1 Main", city: "Austin", state: "TX",
+      postalCode: "78701", addressLine2: nil, country: "US", comment: nil)
+    expectNoDifference(
+      request.asParameters,
+      [
+        "fullName": "Jo", "addressLine1": "1 Main", "city": "Austin",
+        "state": "TX", "postalCode": "78701", "country": "US",
+      ])
+  }
+}

--- a/PlayolaRadio/Models/GiveawayWinnerSubmission.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerSubmission.swift
@@ -11,39 +11,44 @@ enum FulfillmentStatus: String, Codable, Sendable, Equatable {
   }
 }
 
+/// A winner's submission for a per-airing giveaway event. The server keys it by `eventId` (NOT
+/// `giveawayId`). Mailing-address fields are optional: the iOS app now collects only a confirmed
+/// `preferredEmail` and arranges delivery over email, so a fresh submission carries no address.
 struct GiveawayWinnerSubmission: Decodable, Sendable, Identifiable, Equatable {
   let id: String
-  let giveawayId: String
+  let eventId: String
   let userId: String
-  let fullName: String
-  let addressLine1: String
+  let preferredEmail: String?
+  let fullName: String?
+  let addressLine1: String?
   let addressLine2: String?
-  let city: String
+  let city: String?
   let state: String?
-  let postalCode: String
-  let country: String
+  let postalCode: String?
+  let country: String?
   let comment: String?
   let willingToRecord: Bool
   let fulfillmentStatus: FulfillmentStatus
   let submittedAt: Date
 
   enum CodingKeys: String, CodingKey {
-    case id, giveawayId, userId, fullName, addressLine1, addressLine2, city, state
+    case id, eventId, userId, preferredEmail, fullName, addressLine1, addressLine2, city, state
     case postalCode, country, comment, willingToRecord, fulfillmentStatus, submittedAt
   }
 
   init(from decoder: Decoder) throws {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     id = try container.decode(String.self, forKey: .id)
-    giveawayId = try container.decode(String.self, forKey: .giveawayId)
+    eventId = try container.decode(String.self, forKey: .eventId)
     userId = try container.decode(String.self, forKey: .userId)
-    fullName = try container.decode(String.self, forKey: .fullName)
-    addressLine1 = try container.decode(String.self, forKey: .addressLine1)
+    preferredEmail = try container.decodeIfPresent(String.self, forKey: .preferredEmail)
+    fullName = try container.decodeIfPresent(String.self, forKey: .fullName)
+    addressLine1 = try container.decodeIfPresent(String.self, forKey: .addressLine1)
     addressLine2 = try container.decodeIfPresent(String.self, forKey: .addressLine2)
-    city = try container.decode(String.self, forKey: .city)
+    city = try container.decodeIfPresent(String.self, forKey: .city)
     state = try container.decodeIfPresent(String.self, forKey: .state)
-    postalCode = try container.decode(String.self, forKey: .postalCode)
-    country = try container.decode(String.self, forKey: .country)
+    postalCode = try container.decodeIfPresent(String.self, forKey: .postalCode)
+    country = try container.decodeIfPresent(String.self, forKey: .country)
     comment = try container.decodeIfPresent(String.self, forKey: .comment)
     willingToRecord = try container.decodeIfPresent(Bool.self, forKey: .willingToRecord) ?? false
     fulfillmentStatus = try container.decode(FulfillmentStatus.self, forKey: .fulfillmentStatus)
@@ -52,23 +57,25 @@ struct GiveawayWinnerSubmission: Decodable, Sendable, Identifiable, Equatable {
 
   init(
     id: String,
-    giveawayId: String,
+    eventId: String,
     userId: String,
-    fullName: String,
-    addressLine1: String,
+    preferredEmail: String? = nil,
+    fullName: String? = nil,
+    addressLine1: String? = nil,
     addressLine2: String? = nil,
-    city: String,
+    city: String? = nil,
     state: String? = nil,
-    postalCode: String,
-    country: String,
+    postalCode: String? = nil,
+    country: String? = nil,
     comment: String? = nil,
     willingToRecord: Bool,
     fulfillmentStatus: FulfillmentStatus,
     submittedAt: Date
   ) {
     self.id = id
-    self.giveawayId = giveawayId
+    self.eventId = eventId
     self.userId = userId
+    self.preferredEmail = preferredEmail
     self.fullName = fullName
     self.addressLine1 = addressLine1
     self.addressLine2 = addressLine2
@@ -85,13 +92,9 @@ struct GiveawayWinnerSubmission: Decodable, Sendable, Identifiable, Equatable {
   static var mock: GiveawayWinnerSubmission {
     GiveawayWinnerSubmission(
       id: "sub-1",
-      giveawayId: "giveaway-1",
+      eventId: "event-1",
       userId: "user-1",
-      fullName: "Brian Keane",
-      addressLine1: "123 Main St",
-      city: "Austin",
-      postalCode: "78701",
-      country: "US",
+      preferredEmail: "winner@example.com",
       willingToRecord: false,
       fulfillmentStatus: .pending,
       submittedAt: Date(timeIntervalSince1970: 1_781_722_800))

--- a/PlayolaRadio/Models/GiveawayWinnerSubmissionRequest.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerSubmissionRequest.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+struct GiveawayWinnerSubmissionRequest: Encodable, Equatable, Sendable {
+  var fullName: String
+  var addressLine1: String
+  var city: String
+  var state: String
+  var postalCode: String
+  var addressLine2: String?
+  var country: String = "US"
+  var comment: String?
+
+  var asParameters: [String: String] {
+    var parameters: [String: String] = [
+      "fullName": fullName,
+      "addressLine1": addressLine1,
+      "city": city,
+      "state": state,
+      "postalCode": postalCode,
+      "country": country,
+    ]
+    if let addressLine2, !addressLine2.isEmpty { parameters["addressLine2"] = addressLine2 }
+    if let comment, !comment.isEmpty { parameters["comment"] = comment }
+    return parameters
+  }
+}

--- a/PlayolaRadio/Models/GiveawayWinnerSubmissionRequest.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerSubmissionRequest.swift
@@ -1,26 +1,11 @@
 import Foundation
 
+/// The winner confirms how to reach them; the team arranges prize delivery over email. The full
+/// mailing address is intentionally NOT collected in-app (too much friction at the "you won" moment).
 struct GiveawayWinnerSubmissionRequest: Encodable, Equatable, Sendable {
-  var fullName: String
-  var addressLine1: String
-  var city: String
-  var state: String
-  var postalCode: String
-  var addressLine2: String?
-  var country: String = "US"
-  var comment: String?
+  var preferredEmail: String
 
   var asParameters: [String: String] {
-    var parameters: [String: String] = [
-      "fullName": fullName,
-      "addressLine1": addressLine1,
-      "city": city,
-      "state": state,
-      "postalCode": postalCode,
-      "country": country,
-    ]
-    if let addressLine2, !addressLine2.isEmpty { parameters["addressLine2"] = addressLine2 }
-    if let comment, !comment.isEmpty { parameters["comment"] = comment }
-    return parameters
+    ["preferredEmail": preferredEmail]
   }
 }

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -170,14 +170,19 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
     withCompletionHandler completionHandler: @escaping () -> Void
   ) {
     let userInfo = response.notification.request.content.userInfo.sendablePayload()
-    Task {
-      if userInfo["type"] as? String == "giveaway_winner" {
+    if userInfo["type"] as? String == "giveaway_winner" {
+      // Defer completion until the participation mutation persists, so the system doesn't suspend
+      // mid-write and drop the win.
+      Task {
         await pushNotifications.handleGiveawayWinnerPush(userInfo)
-      } else {
+        completionHandler()
+      }
+    } else {
+      Task {
         await pushNotifications.handleNotificationTap(userInfo)
       }
+      completionHandler()
     }
-    completionHandler()
   }
 }
 

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -105,6 +105,12 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
         userInfo: info
       )
       completionHandler(.newData)
+    } else if userInfo["type"] as? String == "giveaway_winner" {
+      let payload = userInfo.sendablePayload()
+      Task {
+        await pushNotifications.handleGiveawayWinnerPush(payload)
+        completionHandler(.newData)
+      }
     } else {
       completionHandler(.noData)
     }
@@ -121,6 +127,16 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
     print("📬 Notification received in foreground: \(notification.request.content.title)")
 
     if userInfo["type"] as? String == "schedule_updated" {
+      completionHandler([])
+      return
+    }
+
+    if userInfo["type"] as? String == "giveaway_winner" {
+      let payload = userInfo.sendablePayload()
+      Task {
+        await pushNotifications.handleGiveawayWinnerPush(payload)
+      }
+      // The arbiter presents the winner sheet in-app; no redundant OS banner.
       completionHandler([])
       return
     }
@@ -155,7 +171,11 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
   ) {
     let userInfo = response.notification.request.content.userInfo.sendablePayload()
     Task {
-      await pushNotifications.handleNotificationTap(userInfo)
+      if userInfo["type"] as? String == "giveaway_winner" {
+        await pushNotifications.handleGiveawayWinnerPush(userInfo)
+      } else {
+        await pushNotifications.handleNotificationTap(userInfo)
+      }
     }
     completionHandler()
   }

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
@@ -16,14 +16,15 @@ class GiveawayWinnerSheetModel: ViewModel {
 
   // MARK: - Initialization
   private let participation: GiveawayParticipation
-  private let fromPush: Bool
+  private let verifyEligibility: Bool
   private let onClose: () -> Void
 
   init(
-    participation: GiveawayParticipation, fromPush: Bool = false, onClose: @escaping () -> Void
+    participation: GiveawayParticipation, verifyEligibility: Bool = true,
+    onClose: @escaping () -> Void
   ) {
     self.participation = participation
-    self.fromPush = fromPush
+    self.verifyEligibility = verifyEligibility
     self.onClose = onClose
     super.init()
   }
@@ -91,10 +92,11 @@ class GiveawayWinnerSheetModel: ViewModel {
 
   // MARK: - User Actions
 
-  /// For a sheet opened from a push / unknown provenance, confirm the prize is still claimable before
-  /// showing the form — otherwise we'd prompt to claim a prize already claimed on another device.
+  /// Confirm the prize is still claimable before showing the form — otherwise we'd prompt to claim a
+  /// prize already claimed on another device (push / reinstall). Disabled only where the caller has
+  /// already proven local provenance.
   func task() async {
-    guard fromPush, let jwt = auth.jwt else { return }
+    guard verifyEligibility, let jwt = auth.jwt else { return }
     guard let event = try? await api.giveawayEvent(jwt, participation.id) else { return }
     if event.viewer?.canSubmitMailingInfo == false {
       markSubmissionCompleted()

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
@@ -1,0 +1,115 @@
+import Dependencies
+import Foundation
+import Observation
+import Sharing
+
+@MainActor
+@Observable
+class GiveawayWinnerSheetModel: ViewModel {
+
+  // MARK: - Dependencies
+  @ObservationIgnored @Dependency(\.api) var api
+
+  // MARK: - Shared State
+  @ObservationIgnored @Shared(.auth) var auth
+  @ObservationIgnored @Shared(.giveawayParticipations) var participations
+
+  // MARK: - Initialization
+  private let participation: GiveawayParticipation
+  private let fromPush: Bool
+  private let onClose: () -> Void
+
+  init(
+    participation: GiveawayParticipation, fromPush: Bool = false, onClose: @escaping () -> Void
+  ) {
+    self.participation = participation
+    self.fromPush = fromPush
+    self.onClose = onClose
+    super.init()
+  }
+
+  // MARK: - Properties
+  var fullName = ""
+  var addressLine1 = ""
+  var addressLine2 = ""
+  var city = ""
+  var state = ""
+  var postalCode = ""
+  var comment = ""
+  var isSubmitting = false
+  var submitErrorMessage: String?
+  var showsClaimedConfirmation = false
+
+  // MARK: - View Helpers
+  var headline: String {
+    participation.wasPromotedWin
+      ? "Good news — you got bumped up to the winner!"
+      : "You won! You're Listener #\(participation.tapNumber)"
+  }
+
+  var prizeName: String { participation.prizeName }
+  var prizeDescription: String? { participation.prizeDescription }
+  var prizeImageUrl: URL? { participation.prizeImageUrl }
+
+  var claimButtonTitle: String { isSubmitting ? "Submitting…" : "Claim Prize" }
+  var claimedTitle: String { "You're all set" }
+  var claimedSubtitle: String { "We'll be in touch." }
+
+  var canSubmit: Bool {
+    !isSubmitting
+      && !fullName.trimmed.isEmpty
+      && !addressLine1.trimmed.isEmpty
+      && !city.trimmed.isEmpty
+      && !state.trimmed.isEmpty
+      && !postalCode.trimmed.isEmpty
+  }
+
+  // MARK: - User Actions
+
+  /// For a sheet opened from a push / unknown provenance, confirm the prize is still claimable before
+  /// showing the form — otherwise we'd prompt to claim a prize already claimed on another device.
+  func task() async {
+    guard fromPush, let jwt = auth.jwt else { return }
+    guard let event = try? await api.giveawayEvent(jwt, participation.id) else { return }
+    if event.viewer?.canSubmitMailingInfo == false {
+      markSubmissionCompleted()
+      showsClaimedConfirmation = true
+    }
+  }
+
+  func claimButtonTapped() async {
+    guard canSubmit, let jwt = auth.jwt else { return }
+    isSubmitting = true
+    submitErrorMessage = nil
+    defer { isSubmitting = false }
+    let request = GiveawayWinnerSubmissionRequest(
+      fullName: fullName.trimmed, addressLine1: addressLine1.trimmed, city: city.trimmed,
+      state: state.trimmed, postalCode: postalCode.trimmed,
+      addressLine2: addressLine2.trimmed.isEmpty ? nil : addressLine2.trimmed,
+      comment: comment.trimmed.isEmpty ? nil : comment.trimmed)
+    do {
+      try await api.submitGiveawayWinnerDetails(jwt, participation.id, request)
+      markSubmissionCompleted()
+      onClose()
+    } catch {
+      submitErrorMessage = "Something went wrong submitting your info. Please try again."
+    }
+  }
+
+  func closeButtonTapped() {
+    onClose()
+  }
+
+  // MARK: - Private Helpers
+  private func markSubmissionCompleted() {
+    $participations.withLock {
+      if $0[participation.id] != nil {
+        $0[participation.id]?.status = .resolvedWon(submissionCompleted: true)
+      }
+    }
+  }
+}
+
+extension String {
+  fileprivate var trimmed: String { trimmingCharacters(in: .whitespacesAndNewlines) }
+}

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
@@ -49,11 +49,36 @@ class GiveawayWinnerSheetModel: ViewModel {
 
   var prizeName: String { participation.prizeName }
   var prizeDescription: String? { participation.prizeDescription }
+  var prizeDescriptionText: String { participation.prizeDescription ?? "" }
   var prizeImageUrl: URL? { participation.prizeImageUrl }
+
+  var formInteractive: Bool { !showsClaimedConfirmation }
+  var claimedInteractive: Bool { showsClaimedConfirmation }
 
   var claimButtonTitle: String { isSubmitting ? "Submitting…" : "Claim Prize" }
   var claimedTitle: String { "You're all set" }
   var claimedSubtitle: String { "We'll be in touch." }
+  var closeButtonTitle: String { "Done" }
+
+  // Opacity-driven view swaps (the view stays control-flow-free).
+  var formOpacity: Double { showsClaimedConfirmation ? 0 : 1 }
+  var claimedOpacity: Double { showsClaimedConfirmation ? 1 : 0 }
+  var submitErrorText: String { submitErrorMessage ?? "" }
+  var submitErrorOpacity: Double { submitErrorMessage == nil ? 0 : 1 }
+  var claimButtonDisabled: Bool { !canSubmit }
+  var claimButtonOpacity: Double { canSubmit ? 1 : 0.5 }
+
+  // Field labels / placeholders (all copy lives on the model).
+  var fullNameLabel: String { "Full name" }
+  var addressLine1Label: String { "Street address" }
+  var addressLine1Placeholder: String { "123 Main St" }
+  var addressLine2Label: String { "Apt / suite (optional)" }
+  var cityLabel: String { "City" }
+  var cityPlaceholder: String { "Austin" }
+  var stateLabel: String { "State" }
+  var statePlaceholder: String { "TX" }
+  var postalCodeLabel: String { "ZIP" }
+  var postalCodePlaceholder: String { "78701" }
 
   var canSubmit: Bool {
     !isSubmitting

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
@@ -2,6 +2,7 @@ import Dependencies
 import Foundation
 import Observation
 import Sharing
+import SwiftUI
 
 @MainActor
 @Observable
@@ -38,8 +39,51 @@ class GiveawayWinnerSheetModel: ViewModel {
   var postalCode = ""
   var comment = ""
   var isSubmitting = false
-  var submitErrorMessage: String?
   var showsClaimedConfirmation = false
+  var presentedAlert: PlayolaAlert?
+
+  // MARK: - User Actions
+
+  /// Confirm the prize is still claimable before showing the form — otherwise we'd prompt to claim a
+  /// prize already claimed on another device (push / reinstall). Disabled only where the caller has
+  /// already proven local provenance. Fails open: if the check can't complete, show the form (a
+  /// re-submit upserts server-side, so it's harmless).
+  func task() async {
+    guard verifyEligibility, let jwt = auth.jwt else { return }
+    do {
+      let event = try await api.giveawayEvent(jwt, participation.id)
+      if event.viewer?.canSubmitMailingInfo == false {
+        markSubmissionCompleted()
+        showsClaimedConfirmation = true
+      }
+    } catch {
+      // Fail open — leave the form available.
+    }
+  }
+
+  func claimButtonTapped() async {
+    guard canSubmit, let jwt = auth.jwt else { return }
+    isSubmitting = true
+    presentedAlert = nil
+    defer { isSubmitting = false }
+    let request = GiveawayWinnerSubmissionRequest(
+      fullName: fullName.trimmed, addressLine1: addressLine1.trimmed, city: city.trimmed,
+      state: state.trimmed, postalCode: postalCode.trimmed,
+      addressLine2: addressLine2.trimmed.isEmpty ? nil : addressLine2.trimmed,
+      comment: comment.trimmed.isEmpty ? nil : comment.trimmed)
+    do {
+      try await api.submitGiveawayWinnerDetails(jwt, participation.id, request)
+      markSubmissionCompleted()
+      onClose()
+    } catch {
+      // Keep the sheet open with the form intact so the user can retry (the server upserts).
+      presentedAlert = .giveawaySubmissionFailed
+    }
+  }
+
+  func closeButtonTapped() {
+    onClose()
+  }
 
   // MARK: - View Helpers
   var headline: String {
@@ -57,6 +101,7 @@ class GiveawayWinnerSheetModel: ViewModel {
   var claimedInteractive: Bool { showsClaimedConfirmation }
 
   var claimButtonTitle: String { isSubmitting ? "Submitting…" : "Claim Prize" }
+  var claimedEmoji: String { "🎉" }
   var claimedTitle: String { "You're all set" }
   var claimedSubtitle: String { "We'll be in touch." }
   var closeButtonTitle: String { "Done" }
@@ -64,8 +109,6 @@ class GiveawayWinnerSheetModel: ViewModel {
   // Opacity-driven view swaps (the view stays control-flow-free).
   var formOpacity: Double { showsClaimedConfirmation ? 0 : 1 }
   var claimedOpacity: Double { showsClaimedConfirmation ? 1 : 0 }
-  var submitErrorText: String { submitErrorMessage ?? "" }
-  var submitErrorOpacity: Double { submitErrorMessage == nil ? 0 : 1 }
   var claimButtonDisabled: Bool { !canSubmit }
   var claimButtonOpacity: Double { canSubmit ? 1 : 0.5 }
 
@@ -90,43 +133,6 @@ class GiveawayWinnerSheetModel: ViewModel {
       && !postalCode.trimmed.isEmpty
   }
 
-  // MARK: - User Actions
-
-  /// Confirm the prize is still claimable before showing the form — otherwise we'd prompt to claim a
-  /// prize already claimed on another device (push / reinstall). Disabled only where the caller has
-  /// already proven local provenance.
-  func task() async {
-    guard verifyEligibility, let jwt = auth.jwt else { return }
-    guard let event = try? await api.giveawayEvent(jwt, participation.id) else { return }
-    if event.viewer?.canSubmitMailingInfo == false {
-      markSubmissionCompleted()
-      showsClaimedConfirmation = true
-    }
-  }
-
-  func claimButtonTapped() async {
-    guard canSubmit, let jwt = auth.jwt else { return }
-    isSubmitting = true
-    submitErrorMessage = nil
-    defer { isSubmitting = false }
-    let request = GiveawayWinnerSubmissionRequest(
-      fullName: fullName.trimmed, addressLine1: addressLine1.trimmed, city: city.trimmed,
-      state: state.trimmed, postalCode: postalCode.trimmed,
-      addressLine2: addressLine2.trimmed.isEmpty ? nil : addressLine2.trimmed,
-      comment: comment.trimmed.isEmpty ? nil : comment.trimmed)
-    do {
-      try await api.submitGiveawayWinnerDetails(jwt, participation.id, request)
-      markSubmissionCompleted()
-      onClose()
-    } catch {
-      submitErrorMessage = "Something went wrong submitting your info. Please try again."
-    }
-  }
-
-  func closeButtonTapped() {
-    onClose()
-  }
-
   // MARK: - Private Helpers
   private func markSubmissionCompleted() {
     $participations.withLock {
@@ -134,6 +140,16 @@ class GiveawayWinnerSheetModel: ViewModel {
         $0[participation.id]?.status = .resolvedWon(submissionCompleted: true)
       }
     }
+  }
+}
+
+extension PlayolaAlert {
+  static var giveawaySubmissionFailed: PlayolaAlert {
+    PlayolaAlert(
+      title: "Submission Failed",
+      message:
+        "Something went wrong submitting your info. Please check your connection and try again.",
+      dismissButton: .cancel(Text("OK")))
   }
 }
 

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
@@ -28,16 +28,11 @@ class GiveawayWinnerSheetModel: ViewModel {
     self.verifyEligibility = verifyEligibility
     self.onClose = onClose
     super.init()
+    self.email = auth.currentUser?.verifiedEmail ?? auth.currentUser?.email ?? ""
   }
 
   // MARK: - Properties
-  var fullName = ""
-  var addressLine1 = ""
-  var addressLine2 = ""
-  var city = ""
-  var state = ""
-  var postalCode = ""
-  var comment = ""
+  var email = ""
   var isSubmitting = false
   var showsClaimedConfirmation = false
   var presentedAlert: PlayolaAlert?
@@ -66,17 +61,13 @@ class GiveawayWinnerSheetModel: ViewModel {
     isSubmitting = true
     presentedAlert = nil
     defer { isSubmitting = false }
-    let request = GiveawayWinnerSubmissionRequest(
-      fullName: fullName.trimmed, addressLine1: addressLine1.trimmed, city: city.trimmed,
-      state: state.trimmed, postalCode: postalCode.trimmed,
-      addressLine2: addressLine2.trimmed.isEmpty ? nil : addressLine2.trimmed,
-      comment: comment.trimmed.isEmpty ? nil : comment.trimmed)
+    let request = GiveawayWinnerSubmissionRequest(preferredEmail: email.trimmed)
     do {
       try await api.submitGiveawayWinnerDetails(jwt, participation.id, request)
       markSubmissionCompleted()
       onClose()
     } catch {
-      // Keep the sheet open with the form intact so the user can retry (the server upserts).
+      // Keep the sheet open with the field intact so the user can retry (the server upserts).
       presentedAlert = .giveawaySubmissionFailed
     }
   }
@@ -97,13 +88,20 @@ class GiveawayWinnerSheetModel: ViewModel {
   var prizeDescriptionText: String { participation.prizeDescription ?? "" }
   var prizeImageUrl: URL? { participation.prizeImageUrl }
 
+  var deliveryExplanation: String {
+    "Confirm your email and we'll be in touch to arrange your prize."
+  }
+
+  var emailLabel: String { "Email" }
+  var emailPlaceholder: String { "you@example.com" }
+
   var formInteractive: Bool { !showsClaimedConfirmation }
   var claimedInteractive: Bool { showsClaimedConfirmation }
 
   var claimButtonTitle: String { isSubmitting ? "Submitting…" : "Claim Prize" }
   var claimedEmoji: String { "🎉" }
   var claimedTitle: String { "You're all set" }
-  var claimedSubtitle: String { "We'll be in touch." }
+  var claimedSubtitle: String { "Check your email — we'll be in touch about your prize." }
   var closeButtonTitle: String { "Done" }
 
   // Opacity-driven view swaps (the view stays control-flow-free).
@@ -112,25 +110,10 @@ class GiveawayWinnerSheetModel: ViewModel {
   var claimButtonDisabled: Bool { !canSubmit }
   var claimButtonOpacity: Double { canSubmit ? 1 : 0.5 }
 
-  // Field labels / placeholders (all copy lives on the model).
-  var fullNameLabel: String { "Full name" }
-  var addressLine1Label: String { "Street address" }
-  var addressLine1Placeholder: String { "123 Main St" }
-  var addressLine2Label: String { "Apt / suite (optional)" }
-  var cityLabel: String { "City" }
-  var cityPlaceholder: String { "Austin" }
-  var stateLabel: String { "State" }
-  var statePlaceholder: String { "TX" }
-  var postalCodeLabel: String { "ZIP" }
-  var postalCodePlaceholder: String { "78701" }
-
   var canSubmit: Bool {
-    !isSubmitting
-      && !fullName.trimmed.isEmpty
-      && !addressLine1.trimmed.isEmpty
-      && !city.trimmed.isEmpty
-      && !state.trimmed.isEmpty
-      && !postalCode.trimmed.isEmpty
+    guard !isSubmitting else { return false }
+    let trimmed = email.trimmed
+    return trimmed.contains("@") && !trimmed.hasPrefix("@") && !trimmed.hasSuffix("@")
   }
 
   // MARK: - Private Helpers
@@ -148,7 +131,7 @@ extension PlayolaAlert {
     PlayolaAlert(
       title: "Submission Failed",
       message:
-        "Something went wrong submitting your info. Please check your connection and try again.",
+        "Something went wrong confirming your email. Please check your connection and try again.",
       dismissButton: .cancel(Text("OK")))
   }
 }

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
@@ -16,11 +16,7 @@ struct GiveawayWinnerSheetModelTests {
   }
 
   private func fill(_ model: GiveawayWinnerSheetModel) {
-    model.fullName = "Jo"
-    model.addressLine1 = "1 Main"
-    model.city = "Austin"
-    model.state = "TX"
-    model.postalCode = "78701"
+    model.email = "winner@example.com"
   }
 
   @Test func headlineForNthTapperWin() {
@@ -34,11 +30,21 @@ struct GiveawayWinnerSheetModelTests {
     #expect(model.headline == "Good news — you got bumped up to the winner!")
   }
 
-  @Test func canSubmitRequiresRequiredFields() {
+  @Test func canSubmitRequiresValidEmail() {
+    @Shared(.auth) var auth = Auth(currentUser: nil, jwt: nil)
     let model = GiveawayWinnerSheetModel(participation: wonParticipation(), onClose: {})
-    #expect(model.canSubmit == false)
-    fill(model)
+    #expect(model.canSubmit == false)  // empty email
+    model.email = "not-an-email"
+    #expect(model.canSubmit == false)  // no @
+    model.email = "winner@example.com"
     #expect(model.canSubmit == true)
+  }
+
+  @Test func prefillsEmailFromAccount() {
+    @Shared(.auth) var auth = Auth(
+      currentUser: LoggedInUser(id: "u1", firstName: "Me", email: "me@playola.fm"), jwt: nil)
+    let model = GiveawayWinnerSheetModel(participation: wonParticipation(), onClose: {})
+    #expect(model.email == "me@playola.fm")
   }
 
   @Test func claimSuccessMarksSubmissionCompletedAndCloses() async {

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
@@ -1,0 +1,109 @@
+import Dependencies
+import Foundation
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct GiveawayWinnerSheetModelTests {
+  private func wonParticipation(tapNumber: Int = 9, winningNumber: Int = 9)
+    -> GiveawayParticipation
+  {
+    GiveawayParticipation(
+      id: "e", stationId: "s", prizeName: "Two tickets", winningNumber: winningNumber,
+      tapNumber: tapNumber, status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+  }
+
+  private func fill(_ model: GiveawayWinnerSheetModel) {
+    model.fullName = "Jo"
+    model.addressLine1 = "1 Main"
+    model.city = "Austin"
+    model.state = "TX"
+    model.postalCode = "78701"
+  }
+
+  @Test func headlineForNthTapperWin() {
+    let model = GiveawayWinnerSheetModel(participation: wonParticipation(tapNumber: 9), onClose: {})
+    #expect(model.headline == "You won! You're Listener #9")
+  }
+
+  @Test func headlineForPromotedWin() {
+    let model = GiveawayWinnerSheetModel(
+      participation: wonParticipation(tapNumber: 5, winningNumber: 9), onClose: {})
+    #expect(model.headline == "Good news — you got bumped up to the winner!")
+  }
+
+  @Test func canSubmitRequiresRequiredFields() {
+    let model = GiveawayWinnerSheetModel(participation: wonParticipation(), onClose: {})
+    #expect(model.canSubmit == false)
+    fill(model)
+    #expect(model.canSubmit == true)
+  }
+
+  @Test func claimSuccessMarksSubmissionCompletedAndCloses() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e": wonParticipation()
+    ]
+    var closed = false
+    await withDependencies {
+      $0.api.submitGiveawayWinnerDetails = { _, _, _ in }
+    } operation: {
+      let model = GiveawayWinnerSheetModel(
+        participation: participations["e"]!, onClose: { closed = true })
+      fill(model)
+      await model.claimButtonTapped()
+    }
+    #expect(
+      participations["e"]?.status
+        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: true))
+    #expect(closed == true)
+  }
+
+  @Test func claimFailureKeepsSheetOpenWithError() async {
+    struct Boom: Error {}
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e": wonParticipation()
+    ]
+    var closed = false
+    let errorMessage: String? = await withDependencies {
+      $0.api.submitGiveawayWinnerDetails = { _, _, _ in throw Boom() }
+    } operation: {
+      let model = GiveawayWinnerSheetModel(
+        participation: participations["e"]!, onClose: { closed = true })
+      fill(model)
+      await model.claimButtonTapped()
+      return model.submitErrorMessage
+    }
+    #expect(closed == false)
+    #expect(errorMessage != nil)
+    #expect(
+      participations["e"]?.status
+        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
+  }
+
+  @Test func pushProvenanceAlreadyClaimedShowsConfirmation() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e": wonParticipation(tapNumber: 5, winningNumber: 9)
+    ]
+    let showsConfirmation: Bool = await withDependencies {
+      $0.api.giveawayEvent = { _, _ in
+        GiveawayEvent(
+          id: "e", stationId: "s", prizeName: "Two tickets", winningNumber: 9, status: .closed,
+          viewer: GiveawayEventViewer(hasTapped: true, isWinner: true, canSubmitMailingInfo: false))
+      }
+    } operation: {
+      let model = GiveawayWinnerSheetModel(
+        participation: participations["e"]!, fromPush: true, onClose: {})
+      await model.task()
+      return model.showsClaimedConfirmation
+    }
+    #expect(showsConfirmation == true)
+    #expect(
+      participations["e"]?.status
+        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: true))
+  }
+}

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
@@ -97,7 +97,7 @@ struct GiveawayWinnerSheetModelTests {
       }
     } operation: {
       let model = GiveawayWinnerSheetModel(
-        participation: participations["e"]!, fromPush: true, onClose: {})
+        participation: participations["e"]!, onClose: {})
       await model.task()
       return model.showsClaimedConfirmation
     }

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
@@ -68,17 +68,17 @@ struct GiveawayWinnerSheetModelTests {
       "e": wonParticipation()
     ]
     var closed = false
-    let errorMessage: String? = await withDependencies {
+    let presentedAlert: PlayolaAlert? = await withDependencies {
       $0.api.submitGiveawayWinnerDetails = { _, _, _ in throw Boom() }
     } operation: {
       let model = GiveawayWinnerSheetModel(
         participation: participations["e"]!, onClose: { closed = true })
       fill(model)
       await model.claimButtonTapped()
-      return model.submitErrorMessage
+      return model.presentedAlert
     }
     #expect(closed == false)
-    #expect(errorMessage != nil)
+    #expect(presentedAlert != nil)
     #expect(
       participations["e"]?.status
         == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
@@ -69,14 +69,17 @@ private struct GiveawayWinnerFormView: View {
         }
         .padding(.top, 8)
 
-        Button(action: { Task { await model.claimButtonTapped() } }) {
-          Text(model.claimButtonTitle)
-            .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
-            .foregroundColor(.white)
-            .frame(maxWidth: .infinity)
-            .frame(height: 54)
-            .background(RoundedRectangle(cornerRadius: 14).fill(Color.playolaRed))
-        }
+        Button(
+          action: { Task { await model.claimButtonTapped() } },
+          label: {
+            Text(model.claimButtonTitle)
+              .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+              .foregroundColor(.white)
+              .frame(maxWidth: .infinity)
+              .frame(height: 54)
+              .background(RoundedRectangle(cornerRadius: 14).fill(Color.playolaRed))
+          }
+        )
         .disabled(model.claimButtonDisabled)
         .opacity(model.claimButtonOpacity)
       }
@@ -120,14 +123,17 @@ private struct GiveawayWinnerClaimedView: View {
         .font(.custom(FontNames.Inter_400_Regular, size: 14))
         .foregroundColor(Color(hex: "#C7C7C7"))
 
-      Button(action: { model.closeButtonTapped() }) {
-        Text(model.closeButtonTitle)
-          .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
-          .foregroundColor(.white)
-          .frame(maxWidth: .infinity)
-          .frame(height: 54)
-          .background(RoundedRectangle(cornerRadius: 14).fill(Color.playolaRed))
-      }
+      Button(
+        action: { model.closeButtonTapped() },
+        label: {
+          Text(model.closeButtonTitle)
+            .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 54)
+            .background(RoundedRectangle(cornerRadius: 14).fill(Color.playolaRed))
+        }
+      )
       .padding(.top, 24)
       .padding(.horizontal, 24)
     }

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
@@ -16,6 +16,7 @@ struct GiveawayWinnerSheetView: View {
         .opacity(model.claimedOpacity)
         .allowsHitTesting(model.claimedInteractive)
     }
+    .playolaAlert($model.presentedAlert)
     .task { await model.task() }
   }
 }
@@ -68,12 +69,6 @@ private struct GiveawayWinnerFormView: View {
         }
         .padding(.top, 8)
 
-        Text(model.submitErrorText)
-          .font(.custom(FontNames.Inter_400_Regular, size: 13))
-          .foregroundColor(.playolaRed)
-          .multilineTextAlignment(.center)
-          .opacity(model.submitErrorOpacity)
-
         Button(action: { Task { await model.claimButtonTapped() } }) {
           Text(model.claimButtonTitle)
             .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
@@ -116,7 +111,7 @@ private struct GiveawayWinnerClaimedView: View {
 
   var body: some View {
     VStack(spacing: 12) {
-      Text("🎉")
+      Text(model.claimedEmoji)
         .font(.system(size: 48))
       Text(model.claimedTitle)
         .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 24))

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
@@ -49,24 +49,16 @@ private struct GiveawayWinnerFormView: View {
           .foregroundColor(Color(hex: "#C7C7C7"))
           .multilineTextAlignment(.center)
 
-        VStack(spacing: 12) {
-          GiveawayWinnerField(
-            label: model.fullNameLabel, placeholder: "", text: $model.fullName)
-          GiveawayWinnerField(
-            label: model.addressLine1Label, placeholder: model.addressLine1Placeholder,
-            text: $model.addressLine1)
-          GiveawayWinnerField(
-            label: model.addressLine2Label, placeholder: "", text: $model.addressLine2)
-          GiveawayWinnerField(
-            label: model.cityLabel, placeholder: model.cityPlaceholder, text: $model.city)
-          HStack(spacing: 12) {
-            GiveawayWinnerField(
-              label: model.stateLabel, placeholder: model.statePlaceholder, text: $model.state)
-            GiveawayWinnerField(
-              label: model.postalCodeLabel, placeholder: model.postalCodePlaceholder,
-              text: $model.postalCode)
-          }
-        }
+        Text(model.deliveryExplanation)
+          .font(.custom(FontNames.Inter_400_Regular, size: 14))
+          .foregroundColor(Color(hex: "#C7C7C7"))
+          .multilineTextAlignment(.center)
+          .padding(.top, 4)
+
+        GiveawayWinnerField(
+          label: model.emailLabel, placeholder: model.emailPlaceholder, text: $model.email,
+          keyboardType: .emailAddress, autocapitalization: .never
+        )
         .padding(.top, 8)
 
         Button(
@@ -93,6 +85,8 @@ private struct GiveawayWinnerField: View {
   let label: String
   let placeholder: String
   @Binding var text: String
+  var keyboardType: UIKeyboardType = .default
+  var autocapitalization: TextInputAutocapitalization = .sentences
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
@@ -102,6 +96,9 @@ private struct GiveawayWinnerField: View {
       TextField(placeholder, text: $text)
         .font(.custom(FontNames.Inter_400_Regular, size: 16))
         .foregroundColor(.white)
+        .keyboardType(keyboardType)
+        .textInputAutocapitalization(autocapitalization)
+        .autocorrectionDisabled(keyboardType == .emailAddress)
         .padding(.horizontal, 16)
         .frame(height: 48)
         .background(RoundedRectangle(cornerRadius: 8).fill(Color(hex: "#1A1A1A")))

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
@@ -1,0 +1,163 @@
+import SDWebImageSwiftUI
+import SwiftUI
+
+struct GiveawayWinnerSheetView: View {
+  @Bindable var model: GiveawayWinnerSheetModel
+
+  var body: some View {
+    ZStack {
+      Color.black.ignoresSafeArea()
+
+      GiveawayWinnerFormView(model: model)
+        .opacity(model.formOpacity)
+        .allowsHitTesting(model.formInteractive)
+
+      GiveawayWinnerClaimedView(model: model)
+        .opacity(model.claimedOpacity)
+        .allowsHitTesting(model.claimedInteractive)
+    }
+    .task { await model.task() }
+  }
+}
+
+private struct GiveawayWinnerFormView: View {
+  @Bindable var model: GiveawayWinnerSheetModel
+
+  var body: some View {
+    ScrollView {
+      VStack(spacing: 16) {
+        WebImage(url: model.prizeImageUrl)
+          .resizable()
+          .scaledToFill()
+          .frame(width: 160, height: 160)
+          .clipShape(RoundedRectangle(cornerRadius: 14))
+          .padding(.top, 24)
+
+        Text(model.headline)
+          .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 26))
+          .foregroundColor(.white)
+          .multilineTextAlignment(.center)
+
+        Text(model.prizeName)
+          .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+          .foregroundColor(.white)
+          .multilineTextAlignment(.center)
+
+        Text(model.prizeDescriptionText)
+          .font(.custom(FontNames.Inter_400_Regular, size: 14))
+          .foregroundColor(Color(hex: "#C7C7C7"))
+          .multilineTextAlignment(.center)
+
+        VStack(spacing: 12) {
+          GiveawayWinnerField(
+            label: model.fullNameLabel, placeholder: "", text: $model.fullName)
+          GiveawayWinnerField(
+            label: model.addressLine1Label, placeholder: model.addressLine1Placeholder,
+            text: $model.addressLine1)
+          GiveawayWinnerField(
+            label: model.addressLine2Label, placeholder: "", text: $model.addressLine2)
+          GiveawayWinnerField(
+            label: model.cityLabel, placeholder: model.cityPlaceholder, text: $model.city)
+          HStack(spacing: 12) {
+            GiveawayWinnerField(
+              label: model.stateLabel, placeholder: model.statePlaceholder, text: $model.state)
+            GiveawayWinnerField(
+              label: model.postalCodeLabel, placeholder: model.postalCodePlaceholder,
+              text: $model.postalCode)
+          }
+        }
+        .padding(.top, 8)
+
+        Text(model.submitErrorText)
+          .font(.custom(FontNames.Inter_400_Regular, size: 13))
+          .foregroundColor(.playolaRed)
+          .multilineTextAlignment(.center)
+          .opacity(model.submitErrorOpacity)
+
+        Button(action: { Task { await model.claimButtonTapped() } }) {
+          Text(model.claimButtonTitle)
+            .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 54)
+            .background(RoundedRectangle(cornerRadius: 14).fill(Color.playolaRed))
+        }
+        .disabled(model.claimButtonDisabled)
+        .opacity(model.claimButtonOpacity)
+      }
+      .padding(.horizontal, 24)
+      .padding(.bottom, 40)
+    }
+  }
+}
+
+private struct GiveawayWinnerField: View {
+  let label: String
+  let placeholder: String
+  @Binding var text: String
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text(label)
+        .font(.custom(FontNames.Inter_600_SemiBold, size: 12))
+        .foregroundColor(Color(hex: "#868686"))
+      TextField(placeholder, text: $text)
+        .font(.custom(FontNames.Inter_400_Regular, size: 16))
+        .foregroundColor(.white)
+        .padding(.horizontal, 16)
+        .frame(height: 48)
+        .background(RoundedRectangle(cornerRadius: 8).fill(Color(hex: "#1A1A1A")))
+    }
+  }
+}
+
+private struct GiveawayWinnerClaimedView: View {
+  let model: GiveawayWinnerSheetModel
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Text("🎉")
+        .font(.system(size: 48))
+      Text(model.claimedTitle)
+        .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 24))
+        .foregroundColor(.white)
+      Text(model.claimedSubtitle)
+        .font(.custom(FontNames.Inter_400_Regular, size: 14))
+        .foregroundColor(Color(hex: "#C7C7C7"))
+
+      Button(action: { model.closeButtonTapped() }) {
+        Text(model.closeButtonTitle)
+          .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+          .foregroundColor(.white)
+          .frame(maxWidth: .infinity)
+          .frame(height: 54)
+          .background(RoundedRectangle(cornerRadius: 14).fill(Color.playolaRed))
+      }
+      .padding(.top, 24)
+      .padding(.horizontal, 24)
+    }
+    .padding(.horizontal, 24)
+  }
+}
+
+#if DEBUG
+  #Preview("Winner — Nth tapper") {
+    GiveawayWinnerSheetView(
+      model: GiveawayWinnerSheetModel(
+        participation: GiveawayParticipation(
+          id: "e", stationId: "s", prizeName: "Two tickets to Reckless Kelly at the Heights",
+          prizeDescription: "Friday night, doors at 8.", winningNumber: 9, tapNumber: 9,
+          status: .resolvedWon(submissionCompleted: false), tappedAt: Date()),
+        onClose: {}))
+  }
+
+  #Preview("Winner — promoted") {
+    GiveawayWinnerSheetView(
+      model: GiveawayWinnerSheetModel(
+        participation: GiveawayParticipation(
+          id: "e", stationId: "s", prizeName: "Two tickets to Reckless Kelly at the Heights",
+          prizeDescription: "Friday night, doors at 8.", winningNumber: 9, tapNumber: 5,
+          status: .resolvedWon(submissionCompleted: false), tappedAt: Date()),
+        onClose: {}))
+  }
+#endif

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -48,7 +48,8 @@ struct MainContainer: View {
       item: Binding(
         get: {
           switch model.mainContainerNavigationCoordinator.presentedSheet {
-          case .player, .feedbackSheet, .share, .redeemPrize, .artistSuggestion, .welcomeMessage:
+          case .player, .feedbackSheet, .share, .redeemPrize, .artistSuggestion, .welcomeMessage,
+            .giveawayWinner:
             return model.mainContainerNavigationCoordinator.presentedSheet
           default:
             return nil

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -75,6 +75,8 @@ struct MainContainer: View {
             StationSuggestionPageView(model: artistSuggestionModel)
           case .welcomeMessage(let welcomeModel):
             WelcomeMessagePageView(model: welcomeModel)
+          case .giveawayWinner(let winnerModel):
+            GiveawayWinnerSheetView(model: winnerModel)
           default:
             EmptyView()
           }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -337,17 +337,24 @@ class MainContainerModel: ViewModel {
 
   private func presentPendingGiveawayWinnerIfNeeded() {
     if case .giveawayWinner = mainContainerNavigationCoordinator.presentedSheet { return }
+    // Gate on the unclaimed prize, NOT on whether we've presented before: a winner who dismisses the
+    // sheet without submitting (or backgrounds before claiming) must get it back on the next
+    // foreground. The early-return above prevents a re-present loop while the sheet is up.
     let pending = giveawayParticipations.values
       .filter {
         guard case .resolvedWon(let submissionCompleted) = $0.status else { return false }
-        return !submissionCompleted && $0.winnerSheetPresentedAt == nil
+        return !submissionCompleted
       }
       .sorted { $0.tappedAt < $1.tappedAt }
     guard let winner = pending.first else { return }
     let model = GiveawayWinnerSheetModel(
       participation: winner,
       onClose: { [weak self] in self?.dismissGiveawayWinnerSheet() })
-    $giveawayParticipations.withLock { $0[winner.id]?.winnerSheetPresentedAt = now }
+    $giveawayParticipations.withLock {
+      if $0[winner.id]?.winnerSheetPresentedAt == nil {
+        $0[winner.id]?.winnerSheetPresentedAt = now
+      }
+    }
     mainContainerNavigationCoordinator.presentedSheet = .giveawayWinner(model)
   }
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -20,6 +20,7 @@ class MainContainerModel: ViewModel {
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.toast) var toast
+  @ObservationIgnored @Dependency(\.date.now) var now
   @ObservationIgnored @Dependency(\.pushNotifications) var pushNotifications
   @ObservationIgnored @Dependency(\.siriShortcuts) var siriShortcuts
   @ObservationIgnored @Dependency(\.appRating) var appRating
@@ -36,6 +37,7 @@ class MainContainerModel: ViewModel {
   @ObservationIgnored @Shared(.unreadSupportCount) var unreadSupportCount
   @ObservationIgnored @Shared(.isBroadcaster) var isBroadcaster
   @ObservationIgnored @Shared(.appVersionRequirements) var appVersionRequirements
+  @ObservationIgnored @Shared(.giveawayParticipations) var giveawayParticipations
 
   enum ActiveTab {
     // Listening mode tabs
@@ -134,8 +136,20 @@ class MainContainerModel: ViewModel {
 
     liveStationsPoller.startPolling()
     giveawayCoordinator.start()
+    observeGiveawayResolutions()
 
     await fetchBroadcasterStatus()
+  }
+
+  /// Re-run the resolution arbiter whenever a participation resolves (tap, backstop, or push). The
+  /// `.publisher` fires in `willSet`, so defer to a `Task` — by the time it runs the durable write
+  /// has completed and `giveawayParticipations` reflects the new value (not the stale one).
+  private func observeGiveawayResolutions() {
+    $giveawayParticipations.publisher
+      .sink { [weak self] _ in
+        Task { await self?.processGiveawayResolutions() }
+      }
+      .store(in: &cancellables)
   }
 
   func refreshOnForeground() async {
@@ -153,6 +167,7 @@ class MainContainerModel: ViewModel {
     await loadAirings()
     await fetchUnreadSupportCount()
     await giveawayCoordinator.pollNow()
+    await processGiveawayResolutions()
   }
 
   private func applyStationLists(_ lists: IdentifiedArrayOf<StationList>) {
@@ -307,6 +322,53 @@ class MainContainerModel: ViewModel {
       self?.presentedAlert = .giveawayTapFailed
     }
     return model
+  }
+
+  // MARK: - Giveaway Resolution Presentation
+
+  /// The single app-wide consumer of resolved giveaway participations. The coordinator and push
+  /// handler only mutate `@Shared(.giveawayParticipations)`; this turns those durable facts into a
+  /// winner sheet (once per win) or a one-time consolation toast. Idempotent — safe to call on every
+  /// dict change and on foreground.
+  func processGiveawayResolutions() async {
+    presentPendingGiveawayWinnerIfNeeded()
+    await fireGiveawayLossToastIfNeeded()
+  }
+
+  private func presentPendingGiveawayWinnerIfNeeded() {
+    if case .giveawayWinner = mainContainerNavigationCoordinator.presentedSheet { return }
+    let pending = giveawayParticipations.values
+      .filter {
+        guard case .resolvedWon(let submissionCompleted) = $0.status else { return false }
+        return !submissionCompleted && $0.winnerSheetPresentedAt == nil
+      }
+      .sorted { $0.tappedAt < $1.tappedAt }
+    guard let winner = pending.first else { return }
+    let model = GiveawayWinnerSheetModel(
+      participation: winner,
+      onClose: { [weak self] in self?.dismissGiveawayWinnerSheet() })
+    $giveawayParticipations.withLock { $0[winner.id]?.winnerSheetPresentedAt = now }
+    mainContainerNavigationCoordinator.presentedSheet = .giveawayWinner(model)
+  }
+
+  private func fireGiveawayLossToastIfNeeded() async {
+    let pending = giveawayParticipations.values
+      .filter {
+        guard case .resolvedLost(let toastShown) = $0.status else { return false }
+        return !toastShown
+      }
+      .sorted { $0.tappedAt < $1.tappedAt }
+    guard let loss = pending.first else { return }
+    $giveawayParticipations.withLock { $0[loss.id]?.status = .resolvedLost(toastShown: true) }
+    await toast.show(
+      PlayolaToast(
+        message: "You were listener #\(loss.tapNumber) — good luck next time!", buttonTitle: ""))
+  }
+
+  private func dismissGiveawayWinnerSheet() {
+    if case .giveawayWinner = mainContainerNavigationCoordinator.presentedSheet {
+      mainContainerNavigationCoordinator.presentedSheet = nil
+    }
   }
 
   // Test method for showing toasts

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -137,6 +137,10 @@ class MainContainerModel: ViewModel {
     liveStationsPoller.startPolling()
     giveawayCoordinator.start()
     observeGiveawayResolutions()
+    // The publisher only emits on future changes, and the initial `.active` scene phase may not fire
+    // `refreshOnForeground()`, so drain any participation resolved before this point (a prior launch,
+    // or a winner push handled before the observer installed).
+    await processGiveawayResolutions()
 
     await fetchBroadcasterStatus()
   }
@@ -364,11 +368,9 @@ class MainContainerModel: ViewModel {
   }
 
   private func fireGiveawayLossToastIfNeeded() async {
-    // The toast is the FALLBACK for a loss the user didn't see in the player. While the player is up,
-    // the in-player reveal is the surface and marks the loss shown, so skip the toast (and don't mark
-    // it) — if the reveal never actually appears, `toastShown` stays false and a later foreground
-    // (player closed) fires the toast.
-    if case .player = mainContainerNavigationCoordinator.presentedSheet { return }
+    // The one-time toast is the GUARANTEED loss feedback ("toast everywhere"); the in-player reveal
+    // is a bonus while the player is open. Firing it unconditionally means a loser never misses
+    // feedback even if the reveal collapses at song-end.
     let pending = giveawayParticipations.values
       .filter {
         guard case .resolvedLost(let toastShown) = $0.status else { return false }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -336,7 +336,12 @@ class MainContainerModel: ViewModel {
   }
 
   private func presentPendingGiveawayWinnerIfNeeded() {
-    if case .giveawayWinner = mainContainerNavigationCoordinator.presentedSheet { return }
+    // Only take over an empty stage or the player (the immediate-win context). Never clobber another
+    // modal flow (feedback, redeem, welcome, …); those defer the win to the next foreground.
+    switch mainContainerNavigationCoordinator.presentedSheet {
+    case .none, .player: break
+    default: return
+    }
     // Gate on the unclaimed prize, NOT on whether we've presented before: a winner who dismisses the
     // sheet without submitting (or backgrounds before claiming) must get it back on the next
     // foreground. The early-return above prevents a re-present loop while the sheet is up.
@@ -359,6 +364,11 @@ class MainContainerModel: ViewModel {
   }
 
   private func fireGiveawayLossToastIfNeeded() async {
+    // The toast is the FALLBACK for a loss the user didn't see in the player. While the player is up,
+    // the in-player reveal is the surface and marks the loss shown, so skip the toast (and don't mark
+    // it) — if the reveal never actually appears, `toastShown` stays false and a later foreground
+    // (player closed) fires the toast.
+    if case .player = mainContainerNavigationCoordinator.presentedSheet { return }
     let pending = giveawayParticipations.values
       .filter {
         guard case .resolvedLost(let toastShown) = $0.status else { return false }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -301,7 +301,10 @@ class MainContainerModel: ViewModel {
       self?.mainContainerNavigationCoordinator.presentedSheet = nil
     })
     model.giveawayOverlayModel.onTap = { [weak self] event in
-      await self?.giveawayCoordinator.tap(event: event)
+      try await self?.giveawayCoordinator.tap(event: event)
+    }
+    model.giveawayOverlayModel.onError = { [weak self] _ in
+      self?.presentedAlert = .giveawayTapFailed
     }
     return model
   }
@@ -370,6 +373,14 @@ extension PlayolaAlert {
       title: "Thank You for the Feedback!",
       message:
         "Thank you so much. Someone will get back to you soon.",
+      dismissButton: .cancel(Text("OK"))
+    )
+  }
+
+  static var giveawayTapFailed: PlayolaAlert {
+    PlayolaAlert(
+      title: "Tap Didn't Go Through",
+      message: "Something went wrong tapping in. Please check your connection and try again.",
       dismissButton: .cancel(Text("OK"))
     )
   }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -1063,6 +1063,31 @@ struct MainContainerTests {
     await model.processGiveawayResolutions()
     #expect(shown.value.count == 1)
   }
+
+  @Test func processGiveawayResolutionsRepresentsUnclaimedWinnerAfterDismissal() async {
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+    navCoordinator.presentedSheet = nil
+    // Winner was already presented once (stamp set) but dismissed without submitting — must NOT be
+    // stranded. With no sheet currently up, the next pass re-presents it.
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e": GiveawayParticipation(
+        id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+        status: .resolvedWon(submissionCompleted: false),
+        tappedAt: Date(timeIntervalSince1970: 100),
+        winnerSheetPresentedAt: Date(timeIntervalSince1970: 50))
+    ]
+    let model = MainContainerModel()
+
+    await model.processGiveawayResolutions()
+
+    if case .giveawayWinner = navCoordinator.presentedSheet {
+      // Test passes
+    } else {
+      Issue.record("Expected an unclaimed winner to be re-presented")
+    }
+    // The original stamp is preserved (we record first-presentation, not every present).
+    #expect(participations["e"]?.winnerSheetPresentedAt == Date(timeIntervalSince1970: 50))
+  }
 }
 
 // Drain the fire-and-forget Task in MainContainerModel.showFeedbackSheet()

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -1134,7 +1134,7 @@ struct MainContainerTests {
     }
   }
 
-  @Test func processGiveawayResolutionsSkipsLossToastWhilePlayerIsOpen() async {
+  @Test func processGiveawayResolutionsFiresLossToastEvenWhilePlayerIsOpen() async {
     await withMainSerialExecutor {
       @Shared(.mainContainerNavigationCoordinator) var navCoordinator
       navCoordinator.presentedSheet = .player(PlayerPageModel(onDismiss: {}))
@@ -1155,10 +1155,10 @@ struct MainContainerTests {
 
       await model.processGiveawayResolutions()
 
-      // The in-player reveal owns the loss while the player is up — no toast, and not marked shown.
-      #expect(shown.value.isEmpty)
+      // The one-time toast is guaranteed feedback even with the player up (the reveal is a bonus).
+      #expect(shown.value.count == 1)
       #expect(
-        participations["e"]?.status == GiveawayParticipationStatus.resolvedLost(toastShown: false))
+        participations["e"]?.status == GiveawayParticipationStatus.resolvedLost(toastShown: true))
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -1006,6 +1006,63 @@ struct MainContainerTests {
     #expect(mainContainerModel.broadcastPageModel?.stationId == "station-456")
     #expect(!(mainContainerModel.broadcastPageModel === originalModel))
   }
+
+  // MARK: - Giveaway Resolution Arbiter Tests
+
+  @Test func processGiveawayResolutionsPresentsWinnerSheetOnce() async {
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+    navCoordinator.presentedSheet = nil
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e": GiveawayParticipation(
+        id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+        status: .resolvedWon(submissionCompleted: false),
+        tappedAt: Date(timeIntervalSince1970: 100))
+    ]
+    let model = withDependencies {
+      $0.date = .constant(Date(timeIntervalSince1970: 555))
+    } operation: {
+      MainContainerModel()
+    }
+
+    await model.processGiveawayResolutions()
+
+    #expect(participations["e"]?.winnerSheetPresentedAt == Date(timeIntervalSince1970: 555))
+    if case .giveawayWinner = navCoordinator.presentedSheet {
+      // Test passes
+    } else {
+      Issue.record("Expected giveaway winner sheet to be presented")
+    }
+
+    // Idempotent: a second pass must not re-present or re-stamp.
+    await model.processGiveawayResolutions()
+    #expect(participations["e"]?.winnerSheetPresentedAt == Date(timeIntervalSince1970: 555))
+  }
+
+  @Test func processGiveawayResolutionsFiresLoserToastOnce() async {
+    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+    navCoordinator.presentedSheet = nil
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e": GiveawayParticipation(
+        id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+        status: .resolvedLost(toastShown: false), tappedAt: Date(timeIntervalSince1970: 100))
+    ]
+    let shown = LockIsolated<[PlayolaToast]>([])
+    let model = withDependencies {
+      $0.toast.show = { toast in shown.withValue { $0.append(toast) } }
+    } operation: {
+      MainContainerModel()
+    }
+
+    await model.processGiveawayResolutions()
+
+    #expect(
+      participations["e"]?.status == GiveawayParticipationStatus.resolvedLost(toastShown: true))
+    #expect(shown.value.count == 1)
+
+    // Idempotent: already-shown loss does not re-toast.
+    await model.processGiveawayResolutions()
+    #expect(shown.value.count == 1)
+  }
 }
 
 // Drain the fire-and-forget Task in MainContainerModel.showFeedbackSheet()

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -1009,84 +1009,157 @@ struct MainContainerTests {
 
   // MARK: - Giveaway Resolution Arbiter Tests
 
+  // These exercise the app-wide arbiter, which awaits while mutating the file-backed
+  // `@Shared(.giveawayParticipations)`. `withMainSerialExecutor` serializes async execution so a
+  // parallel test's write to the same shared key can't clobber the participation mid-`await` (see
+  // .claude/TESTING.md).
   @Test func processGiveawayResolutionsPresentsWinnerSheetOnce() async {
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
-    navCoordinator.presentedSheet = nil
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e": GiveawayParticipation(
-        id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
-        status: .resolvedWon(submissionCompleted: false),
-        tappedAt: Date(timeIntervalSince1970: 100))
-    ]
-    let model = withDependencies {
-      $0.date = .constant(Date(timeIntervalSince1970: 555))
-    } operation: {
-      MainContainerModel()
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = nil
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock {
+        $0 = [
+          "e": GiveawayParticipation(
+            id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+            status: .resolvedWon(submissionCompleted: false),
+            tappedAt: Date(timeIntervalSince1970: 100))
+        ]
+      }
+      let model = withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 555))
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+
+      #expect(participations["e"]?.winnerSheetPresentedAt == Date(timeIntervalSince1970: 555))
+      if case .giveawayWinner = navCoordinator.presentedSheet {
+        // Test passes
+      } else {
+        Issue.record("Expected giveaway winner sheet to be presented")
+      }
+
+      // Idempotent: a second pass must not re-present or re-stamp.
+      await model.processGiveawayResolutions()
+      #expect(participations["e"]?.winnerSheetPresentedAt == Date(timeIntervalSince1970: 555))
     }
-
-    await model.processGiveawayResolutions()
-
-    #expect(participations["e"]?.winnerSheetPresentedAt == Date(timeIntervalSince1970: 555))
-    if case .giveawayWinner = navCoordinator.presentedSheet {
-      // Test passes
-    } else {
-      Issue.record("Expected giveaway winner sheet to be presented")
-    }
-
-    // Idempotent: a second pass must not re-present or re-stamp.
-    await model.processGiveawayResolutions()
-    #expect(participations["e"]?.winnerSheetPresentedAt == Date(timeIntervalSince1970: 555))
   }
 
   @Test func processGiveawayResolutionsFiresLoserToastOnce() async {
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
-    navCoordinator.presentedSheet = nil
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e": GiveawayParticipation(
-        id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
-        status: .resolvedLost(toastShown: false), tappedAt: Date(timeIntervalSince1970: 100))
-    ]
-    let shown = LockIsolated<[PlayolaToast]>([])
-    let model = withDependencies {
-      $0.toast.show = { toast in shown.withValue { $0.append(toast) } }
-    } operation: {
-      MainContainerModel()
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = nil
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock {
+        $0 = [
+          "e": GiveawayParticipation(
+            id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+            status: .resolvedLost(toastShown: false), tappedAt: Date(timeIntervalSince1970: 100))
+        ]
+      }
+      let shown = LockIsolated<[PlayolaToast]>([])
+      let model = withDependencies {
+        $0.toast.show = { toast in shown.withValue { $0.append(toast) } }
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+
+      #expect(
+        participations["e"]?.status == GiveawayParticipationStatus.resolvedLost(toastShown: true))
+      #expect(shown.value.count == 1)
+
+      // Idempotent: already-shown loss does not re-toast.
+      await model.processGiveawayResolutions()
+      #expect(shown.value.count == 1)
     }
-
-    await model.processGiveawayResolutions()
-
-    #expect(
-      participations["e"]?.status == GiveawayParticipationStatus.resolvedLost(toastShown: true))
-    #expect(shown.value.count == 1)
-
-    // Idempotent: already-shown loss does not re-toast.
-    await model.processGiveawayResolutions()
-    #expect(shown.value.count == 1)
   }
 
   @Test func processGiveawayResolutionsRepresentsUnclaimedWinnerAfterDismissal() async {
-    @Shared(.mainContainerNavigationCoordinator) var navCoordinator
-    navCoordinator.presentedSheet = nil
-    // Winner was already presented once (stamp set) but dismissed without submitting — must NOT be
-    // stranded. With no sheet currently up, the next pass re-presents it.
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e": GiveawayParticipation(
-        id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
-        status: .resolvedWon(submissionCompleted: false),
-        tappedAt: Date(timeIntervalSince1970: 100),
-        winnerSheetPresentedAt: Date(timeIntervalSince1970: 50))
-    ]
-    let model = MainContainerModel()
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = nil
+      // Winner was already presented once (stamp set) but dismissed without submitting — must NOT be
+      // stranded. With no sheet currently up, the next pass re-presents it.
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock {
+        $0 = [
+          "e": GiveawayParticipation(
+            id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+            status: .resolvedWon(submissionCompleted: false),
+            tappedAt: Date(timeIntervalSince1970: 100),
+            winnerSheetPresentedAt: Date(timeIntervalSince1970: 50))
+        ]
+      }
+      let model = MainContainerModel()
 
-    await model.processGiveawayResolutions()
+      await model.processGiveawayResolutions()
 
-    if case .giveawayWinner = navCoordinator.presentedSheet {
-      // Test passes
-    } else {
-      Issue.record("Expected an unclaimed winner to be re-presented")
+      if case .giveawayWinner = navCoordinator.presentedSheet {
+        // Test passes
+      } else {
+        Issue.record("Expected an unclaimed winner to be re-presented")
+      }
+      // The original stamp is preserved (we record first-presentation, not every present).
+      #expect(participations["e"]?.winnerSheetPresentedAt == Date(timeIntervalSince1970: 50))
     }
-    // The original stamp is preserved (we record first-presentation, not every present).
-    #expect(participations["e"]?.winnerSheetPresentedAt == Date(timeIntervalSince1970: 50))
+  }
+
+  @Test func processGiveawayResolutionsDoesNotClobberAnotherSheet() async {
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = .share(ShareSheetModel(items: ["x"]))
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock {
+        $0 = [
+          "e": GiveawayParticipation(
+            id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+            status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+        ]
+      }
+      let model = MainContainerModel()
+
+      await model.processGiveawayResolutions()
+
+      // The unrelated share sheet must be left intact; the win waits for the next foreground.
+      if case .share = navCoordinator.presentedSheet {
+        // Test passes
+      } else {
+        Issue.record("Expected the share sheet to be left untouched")
+      }
+      #expect(participations["e"]?.winnerSheetPresentedAt == nil)
+    }
+  }
+
+  @Test func processGiveawayResolutionsSkipsLossToastWhilePlayerIsOpen() async {
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = .player(PlayerPageModel(onDismiss: {}))
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock {
+        $0 = [
+          "e": GiveawayParticipation(
+            id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+            status: .resolvedLost(toastShown: false), tappedAt: Date())
+        ]
+      }
+      let shown = LockIsolated<[PlayolaToast]>([])
+      let model = withDependencies {
+        $0.toast.show = { toast in shown.withValue { $0.append(toast) } }
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+
+      // The in-player reveal owns the loss while the player is up — no toast, and not marked shown.
+      #expect(shown.value.isEmpty)
+      #expect(
+        participations["e"]?.status == GiveawayParticipationStatus.resolvedLost(toastShown: false))
+    }
   }
 }
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
@@ -31,21 +31,34 @@ class GiveawayOverlayModel: ViewModel {
   }
 
   // MARK: - View Helpers
-  var isVisible: Bool { visibleGiveaway != nil }
+
+  /// The open giveaway is on screen at all only while there is prompt or loser-reveal content to
+  /// show. A winner's overlay collapses (the app-wide winner sheet takes over).
+  var isVisible: Bool { showsPrompt || showsLoserReveal }
 
   var overlayOpacity: Double { isVisible ? 1 : 0 }
 
-  var hasTapped: Bool {
-    guard let giveaway = visibleGiveaway else { return false }
-    // Keyed by the per-airing event id (giveaway.id), NOT giveawayId: each airing is its own
-    // contest, so a tap on a prior airing must not pre-mark this one. The tap flow keys the same.
-    return participations[giveaway.id]?.isStandby ?? false
+  /// The user's participation for the on-screen event (keyed by the per-airing event id, NOT
+  /// giveawayId — each airing is its own contest).
+  private var participation: GiveawayParticipation? {
+    guard let giveaway = visibleGiveaway else { return nil }
+    return participations[giveaway.id]
   }
 
-  var promptOpacity: Double { hasTapped ? 0 : 1 }
-  var standbyOpacity: Double { hasTapped ? 1 : 0 }
-  var promptInteractive: Bool { isVisible && !hasTapped }
-  var standbyInteractive: Bool { isVisible && hasTapped }
+  /// Show the tap prompt until the user has tapped this event.
+  var showsPrompt: Bool { visibleGiveaway != nil && participation == nil }
+
+  /// Show the consolation reveal once the tap resolved as a (provisional) loss. The win path is an
+  /// app-wide sheet, so the overlay shows nothing for a winner.
+  var showsLoserReveal: Bool {
+    guard visibleGiveaway != nil, case .resolvedLost = participation?.status else { return false }
+    return true
+  }
+
+  var promptOpacity: Double { showsPrompt ? 1 : 0 }
+  var loserRevealOpacity: Double { showsLoserReveal ? 1 : 0 }
+  var promptInteractive: Bool { showsPrompt }
+  var loserRevealInteractive: Bool { showsLoserReveal }
 
   var headline: String { "WIN A PRIZE!" }
 
@@ -65,9 +78,22 @@ class GiveawayOverlayModel: ViewModel {
 
   var buttonTitle: String { "TAP HERE" }
 
-  var standbyText: String { "STAND BY…" }
+  var loserRevealHeadline: String {
+    guard let participation else { return "" }
+    return "You were listener #\(participation.tapNumber) — good luck next time!"
+  }
 
-  var standbySubtitle: String { "Hang tight — we'll reveal the winner when the song ends." }
+  /// The loser reveal counts as the loss having been surfaced: mark the toast as shown so the
+  /// app-wide fallback toast does not also fire. If the app dies before the reveal appears,
+  /// `toastShown` stays false and the arbiter fires the toast on the next launch.
+  func loserRevealAppeared() {
+    guard let giveaway = visibleGiveaway else { return }
+    $participations.withLock {
+      if case .resolvedLost = $0[giveaway.id]?.status {
+        $0[giveaway.id]?.status = .resolvedLost(toastShown: true)
+      }
+    }
+  }
 
   /// Human-readable explanation of the visibility gate, for the debug diagnostics readout.
   /// Mirrors `visibleGiveaway` so the HUD never contradicts what's on screen.

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
@@ -12,7 +12,8 @@ class GiveawayOverlayModel: ViewModel {
   @ObservationIgnored @Shared(.giveawayParticipations) var participations
 
   // MARK: - Callbacks
-  var onTap: (@MainActor (GiveawayEvent) async -> Void)?
+  var onTap: (@MainActor (GiveawayEvent) async throws -> Void)?
+  var onError: (@MainActor (any Error) async -> Void)?
 
   // MARK: - Initialization
   override init() {
@@ -22,7 +23,11 @@ class GiveawayOverlayModel: ViewModel {
   // MARK: - User Actions
   func tapButtonTapped() async {
     guard let giveaway = visibleGiveaway else { return }
-    await onTap?(giveaway)
+    do {
+      try await onTap?(giveaway)
+    } catch {
+      await onError?(error)
+    }
   }
 
   // MARK: - View Helpers

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
@@ -83,18 +83,6 @@ class GiveawayOverlayModel: ViewModel {
     return "You were listener #\(participation.tapNumber) — good luck next time!"
   }
 
-  /// The loser reveal counts as the loss having been surfaced: mark the toast as shown so the
-  /// app-wide fallback toast does not also fire. If the app dies before the reveal appears,
-  /// `toastShown` stays false and the arbiter fires the toast on the next launch.
-  func loserRevealAppeared() {
-    guard let giveaway = visibleGiveaway else { return }
-    $participations.withLock {
-      if case .resolvedLost = $0[giveaway.id]?.status {
-        $0[giveaway.id]?.status = .resolvedLost(toastShown: true)
-      }
-    }
-  }
-
   /// Human-readable explanation of the visibility gate, for the debug diagnostics readout.
   /// Mirrors `visibleGiveaway` so the HUD never contradicts what's on screen.
   var gateDiagnostics: String {

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -93,6 +93,18 @@ struct GiveawayOverlayModelTests {
     #expect(called == false)
   }
 
+  @Test func tapButtonRoutesThrownErrorToOnError() async {
+    struct Boom: Error {}
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
+    let model = GiveawayOverlayModel()
+    var capturedError: (any Error)?
+    model.onTap = { _ in throw Boom() }
+    model.onError = { capturedError = $0 }
+    await model.tapButtonTapped()
+    #expect(capturedError is Boom)
+  }
+
   @Test func promptOrdinalHandlesTeensAndOnes() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -57,21 +57,51 @@ struct GiveawayOverlayModelTests {
     #expect(model.gateDiagnostics == "visible: open giveaway on the current station")
   }
 
-  @Test func tappedFlipsPromptToStandby() {
+  @Test func resolvedLossShowsLoserRevealAndHidesPrompt() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
     // Keyed by the event id ("g1"), which differs from the event's giveawayId ("gv1") — so this
-    // fails if hasTapped ever re-keys by giveawayId.
+    // fails if the overlay ever re-keys by giveawayId.
     @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
       "g1": GiveawayParticipation(
         id: "g1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9,
-        tapNumber: 7, status: .tappedStandby, tappedAt: Date())
+        tapNumber: 7, status: .resolvedLost(toastShown: false), tappedAt: Date())
     ]
     let model = GiveawayOverlayModel()
-    #expect(model.hasTapped == true)
+    #expect(model.showsLoserReveal == true)
+    #expect(model.showsPrompt == false)
     #expect(model.promptOpacity == 0)
-    #expect(model.standbyOpacity == 1)
-    #expect(model.standbyInteractive == true)
+    #expect(model.loserRevealOpacity == 1)
+    #expect(model.loserRevealInteractive == true)
+    #expect(model.loserRevealHeadline == "You were listener #7 — good luck next time!")
+  }
+
+  @Test func resolvedWinCollapsesTheOverlay() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "g1": GiveawayParticipation(
+        id: "g1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9,
+        tapNumber: 9, status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+    ]
+    let model = GiveawayOverlayModel()
+    #expect(model.showsLoserReveal == false)
+    #expect(model.showsPrompt == false)
+    #expect(model.isVisible == false)
+  }
+
+  @Test func loserRevealAppearedMarksToastShown() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "g1": GiveawayParticipation(
+        id: "g1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9,
+        tapNumber: 7, status: .resolvedLost(toastShown: false), tappedAt: Date())
+    ]
+    let model = GiveawayOverlayModel()
+    model.loserRevealAppeared()
+    #expect(
+      participations["g1"]?.status == GiveawayParticipationStatus.resolvedLost(toastShown: true))
   }
 
   @Test func tapButtonInvokesOnTapWithTheVisibleGiveaway() async {

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -90,20 +90,6 @@ struct GiveawayOverlayModelTests {
     #expect(model.isVisible == false)
   }
 
-  @Test func loserRevealAppearedMarksToastShown() {
-    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
-    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "g1": GiveawayParticipation(
-        id: "g1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9,
-        tapNumber: 7, status: .resolvedLost(toastShown: false), tappedAt: Date())
-    ]
-    let model = GiveawayOverlayModel()
-    model.loserRevealAppeared()
-    #expect(
-      participations["g1"]?.status == GiveawayParticipationStatus.resolvedLost(toastShown: true))
-  }
-
   @Test func tapButtonInvokesOnTapWithTheVisibleGiveaway() async {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
@@ -10,9 +10,9 @@ struct GiveawayPlayerOverlayView: View {
         .opacity(model.promptOpacity)
         .allowsHitTesting(model.promptInteractive)
 
-      GiveawayOverlayStandbyView(model: model)
-        .opacity(model.standbyOpacity)
-        .allowsHitTesting(model.standbyInteractive)
+      GiveawayOverlayLoserRevealView(model: model)
+        .opacity(model.loserRevealOpacity)
+        .allowsHitTesting(model.loserRevealInteractive)
     }
     .padding(.horizontal, 24)
     .frame(height: model.isVisible ? nil : 0)
@@ -67,45 +67,42 @@ private struct GiveawayOverlayPromptView: View {
   }
 }
 
-private struct GiveawayOverlayStandbyView: View {
+private struct GiveawayOverlayLoserRevealView: View {
   let model: GiveawayOverlayModel
 
   var body: some View {
     VStack(spacing: 0) {
-      Text(model.standbyText)
-        .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 18))
-        .tracking(2)
+      Image(systemName: "gift")
+        .font(.system(size: 56, weight: .regular))
         .foregroundColor(.white)
-        .frame(maxWidth: .infinity)
-        .frame(height: 60)
-        .background(RoundedRectangle(cornerRadius: 32).fill(Color(hex: "#1A1A1A")))
-        .overlay(RoundedRectangle(cornerRadius: 32).stroke(Color(hex: "#3A3A3A"), lineWidth: 3))
+        .opacity(0.4)
 
-      Text(model.standbySubtitle)
-        .font(.custom(FontNames.Inter_400_Regular, size: 14))
-        .foregroundColor(Color(hex: "#C7C7C7"))
+      Text(model.loserRevealHeadline)
+        .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 20))
+        .foregroundColor(.white)
         .multilineTextAlignment(.center)
-        .lineSpacing(2)
-        .padding(.top, 12)
+        .lineSpacing(3)
+        .padding(.top, 16)
     }
     .frame(maxWidth: .infinity)
+    .onAppear { model.loserRevealAppeared() }
   }
 }
 
 #if DEBUG
-  @MainActor private func previewModel(tapped: Bool) -> GiveawayOverlayModel {
+  @MainActor private func previewModel(lost: Bool) -> GiveawayOverlayModel {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = NowPlaying.mockWith(
       station: AnyStation.mockPlayola(id: "preview-station"))
     @Shared(.activeGiveaway) var activeGiveaway = GiveawayEvent(
       id: "preview-giveaway", stationId: "preview-station",
       prizeName: "Two tickets to Reckless Kelly at the Heights", winningNumber: 9, status: .open)
     @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] =
-      tapped
+      lost
       ? [
         "preview-giveaway": GiveawayParticipation(
           id: "preview-giveaway", stationId: "preview-station",
           prizeName: "Two tickets", winningNumber: 9, tapNumber: 7,
-          status: .tappedStandby, tappedAt: Date())
+          status: .resolvedLost(toastShown: false), tappedAt: Date())
       ] : [:]
     return GiveawayOverlayModel()
   }
@@ -113,14 +110,14 @@ private struct GiveawayOverlayStandbyView: View {
   #Preview("Overlay — Prompt") {
     ZStack {
       Color.black.ignoresSafeArea()
-      GiveawayPlayerOverlayView(model: previewModel(tapped: false))
+      GiveawayPlayerOverlayView(model: previewModel(lost: false))
     }
   }
 
-  #Preview("Overlay — Standby") {
+  #Preview("Overlay — Loser reveal") {
     ZStack {
       Color.black.ignoresSafeArea()
-      GiveawayPlayerOverlayView(model: previewModel(tapped: true))
+      GiveawayPlayerOverlayView(model: previewModel(lost: true))
     }
   }
 #endif

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
@@ -85,7 +85,6 @@ private struct GiveawayOverlayLoserRevealView: View {
         .padding(.top, 16)
     }
     .frame(maxWidth: .infinity)
-    .onAppear { model.loserRevealAppeared() }
   }
 }
 

--- a/PlayolaRadio/Views/Reusable Components/PlayolaSheet.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaSheet.swift
@@ -31,4 +31,5 @@ enum PlayolaSheet: Hashable, Identifiable, Equatable {
   case redeemPrize(RedeemPrizeSheetModel)
   case artistSuggestion(StationSuggestionPageModel)
   case welcomeMessage(WelcomeMessagePageModel)
+  case giveawayWinner(GiveawayWinnerSheetModel)
 }

--- a/docs/superpowers/plans/2026-06-23-live-giveaway-resolution.md
+++ b/docs/superpowers/plans/2026-06-23-live-giveaway-resolution.md
@@ -21,6 +21,12 @@
 
 **Spec:** `docs/superpowers/specs/2026-06-23-live-giveaway-resolution-design.md`
 
+### Execution corrections (apply to every task)
+
+- **Tests use Swift Testing**, not XCTest: `import Testing`, `@MainActor struct XTests { @Test func … }`, `#expect(...)`, and `expectNoDifference` from CustomDump. Add cases to the existing test structs where present.
+- **No CasePaths dependency** (not linked in the project). Use plain `if case` pattern matching instead of `@CasePathable`/`.is(\.case)`/`.modify`. `wasPromotedWin` and the backstop's loss-check are written with `if case`.
+- Auth mock is `@Shared(.auth) var auth = Auth(jwt: "jwt")`. Build the coordinator/model **inside** the `withDependencies { … } operation:` block so `@Dependency(\.api)` resolves the override.
+
 ---
 
 ## Stage 1 — Foundations (models + API), no behavior change

--- a/docs/superpowers/plans/2026-06-23-live-giveaway-resolution.md
+++ b/docs/superpowers/plans/2026-06-23-live-giveaway-resolution.md
@@ -1,0 +1,973 @@
+# Live Giveaway Win/Lose Resolution (M2) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Before writing Swift, invoke the applicable `pfw-*` skills (pfw-observable-models, pfw-dependencies, pfw-sharing, pfw-modern-swiftui, pfw-testing, pfw-custom-dump, pfw-case-paths).
+
+**Goal:** When a listener taps a live giveaway, reveal win/lose immediately from the tap response, let a winner submit mailing info, and recover the rare last-tapper-promotion via a bounded backstop + a targeted server push.
+
+**Architecture:** The tap response (`isWinner`) drives an immediate outcome written to the durable `@Shared(.giveawayParticipations)` dict. The coordinator and push handler only *mutate* that dict; `MainContainerModel` is the sole presenter (winner sheet, loser-toast fallback). A foreground feed-reconcile backstop does one `my-result` check when a tapped contest closes, flipping loss→win if the server promoted the user.
+
+**Tech Stack:** SwiftUI, `@Observable` MV models, swift-dependencies (`@DependencyClient`), swift-sharing (`@Shared`), swift-case-paths, swift-custom-dump, XCTest (`@MainActor`).
+
+## Global Constraints
+
+- All runtime behavior gated on `GiveawayFeature.isLiveDataEnabled` (`Config.shared.environment != .production`). `develop` stays deployable; prod stays dark.
+- Participations keyed by the **per-airing event id** (`GiveawayEvent.id`), never `giveawayId`. Never cache a station→eventId map.
+- Server-decoded status enums keep the `unknown` fallback; app-owned state enums (`GiveawayParticipationStatus`) stay strict.
+- New `.swift` files must be hand-registered in `project.pbxproj` (explicit refs). Exclude `DEVELOPMENT_TEAM`/reordering churn from the PR.
+- Every `@DependencyClient` property needs an explicit default/`testValue`.
+- Page/overlay **views contain zero control flow** (no `if`/`switch`/ternary) — push conditionals into the model or a no-op subview via opacity/`allowsHitTesting`.
+- Tests: `@MainActor`, colocated, camelCase names, no `Task.sleep`, `expectNoDifference`/`expectDifference` (not raw `#expect(a == b)`).
+- Server "you won" push is a **named dependency** implemented in the server worktree, NOT here. iOS builds against the §7 contract in the spec.
+
+**Spec:** `docs/superpowers/specs/2026-06-23-live-giveaway-resolution-design.md`
+
+---
+
+## Stage 1 — Foundations (models + API), no behavior change
+
+### Task 1: CasePathable status + upgrade-win helper
+
+**Files:**
+- Modify: `PlayolaRadio/Models/GiveawayParticipation.swift`
+- Test: `PlayolaRadio/Models/GiveawayParticipationTests.swift`
+
+**Interfaces:**
+- Produces: `GiveawayParticipationStatus` is `@CasePathable @dynamicMemberLookup`; `GiveawayParticipation.wasPromotedWin: Bool` (true when resolvedWon with `tapNumber != winningNumber` — the last-tapper surprise upgrade).
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import CasePaths
+import CustomDump
+import XCTest
+
+@testable import PlayolaRadio
+
+@MainActor
+final class GiveawayParticipationTests: XCTestCase {
+  func testWasPromotedWinTrueWhenWonBelowWinningNumber() {
+    var p = GiveawayParticipation.mock
+    p.winningNumber = 9
+    p.tapNumber = 5
+    p.status = .resolvedWon(submissionCompleted: false)
+    XCTAssertTrue(p.wasPromotedWin)
+  }
+
+  func testWasPromotedWinFalseForNthTapperWin() {
+    var p = GiveawayParticipation.mock
+    p.winningNumber = 9
+    p.tapNumber = 9
+    p.status = .resolvedWon(submissionCompleted: false)
+    XCTAssertFalse(p.wasPromotedWin)
+  }
+
+  func testWasPromotedWinFalseWhenLost() {
+    var p = GiveawayParticipation.mock
+    p.winningNumber = 9
+    p.tapNumber = 5
+    p.status = .resolvedLost(toastShown: false)
+    XCTAssertFalse(p.wasPromotedWin)
+  }
+}
+```
+
+- [ ] **Step 2: Run, verify fail** (`wasPromotedWin` undefined). Use Xcode MCP / `xcodebuild test` (§ Running tests).
+
+- [ ] **Step 3: Implement**
+
+In `GiveawayParticipation.swift`, annotate the enum and add the helper:
+
+```swift
+import CasePaths
+import Foundation
+
+@CasePathable
+@dynamicMemberLookup
+enum GiveawayParticipationStatus: Codable, Equatable, Sendable {
+  case tappedStandby
+  case resolvedWon(submissionCompleted: Bool)
+  case resolvedLost(toastShown: Bool)
+  case canceled
+}
+```
+
+Add to `GiveawayParticipation`:
+
+```swift
+var wasPromotedWin: Bool {
+  status.is(\.resolvedWon) && tapNumber != winningNumber
+}
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(giveaway): case-pathable status + promoted-win helper"`
+
+---
+
+### Task 2: Winner-submission request + winner-push payload models
+
+**Files:**
+- Create: `PlayolaRadio/Models/GiveawayWinnerSubmissionRequest.swift`
+- Create: `PlayolaRadio/Models/GiveawayWinnerPush.swift`
+- Test: `PlayolaRadio/Models/GiveawayWinnerPushTests.swift`
+- Register both new files in `project.pbxproj`.
+
+**Interfaces:**
+- Produces:
+  - `GiveawayWinnerSubmissionRequest` — `Encodable, Equatable, Sendable` with `fullName, addressLine1, city, state, postalCode` (required) and `addressLine2: String?, country: String, comment: String?` (`country` defaults `"US"`). Provides `asParameters: [String: String]` (drops nil/empty optionals).
+  - `GiveawayWinnerPush` — value parsed from an APNs `[String: any Sendable]` payload via `init?(userInfo:)`. Fields: `eventId, stationId, giveawayId?, prizeName, prizeDescription?, prizeImageUrl: URL?, winningNumber, tapNumber, winnerUserId?, reason: String?, submissionCompleted: Bool?, canSubmitMailingInfo: Bool?`. `init?` returns nil unless `type == "giveaway_winner"` and `eventId`/`prizeName`/`winningNumber`/`tapNumber` are present.
+
+- [ ] **Step 1: Write the failing test**
+
+```swift
+import CustomDump
+import XCTest
+
+@testable import PlayolaRadio
+
+@MainActor
+final class GiveawayWinnerPushTests: XCTestCase {
+  func testParsesValidWinnerPush() {
+    let push = GiveawayWinnerPush(userInfo: [
+      "type": "giveaway_winner", "eventId": "evt-1", "stationId": "stn-1",
+      "prizeName": "Two tickets", "winningNumber": 9, "tapNumber": 5,
+      "reason": "last_tapper_fallback", "canSubmitMailingInfo": true,
+    ])
+    expectNoDifference(push?.eventId, "evt-1")
+    expectNoDifference(push?.tapNumber, 5)
+    expectNoDifference(push?.reason, "last_tapper_fallback")
+    expectNoDifference(push?.canSubmitMailingInfo, true)
+  }
+
+  func testRejectsWrongType() {
+    XCTAssertNil(GiveawayWinnerPush(userInfo: ["type": "giveaway_closed", "eventId": "evt-1"]))
+  }
+
+  func testRejectsMissingRequiredFields() {
+    XCTAssertNil(GiveawayWinnerPush(userInfo: ["type": "giveaway_winner", "eventId": "evt-1"]))
+  }
+
+  func testSubmissionRequestParametersDropEmptyOptionals() {
+    let req = GiveawayWinnerSubmissionRequest(
+      fullName: "Jo", addressLine1: "1 Main", city: "Austin", state: "TX",
+      postalCode: "78701", addressLine2: nil, country: "US", comment: nil)
+    expectNoDifference(req.asParameters, [
+      "fullName": "Jo", "addressLine1": "1 Main", "city": "Austin",
+      "state": "TX", "postalCode": "78701", "country": "US",
+    ])
+  }
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** `GiveawayWinnerSubmissionRequest.swift`:
+
+```swift
+import Foundation
+
+struct GiveawayWinnerSubmissionRequest: Encodable, Equatable, Sendable {
+  var fullName: String
+  var addressLine1: String
+  var city: String
+  var state: String
+  var postalCode: String
+  var addressLine2: String?
+  var country: String = "US"
+  var comment: String?
+
+  var asParameters: [String: String] {
+    var p: [String: String] = [
+      "fullName": fullName, "addressLine1": addressLine1, "city": city,
+      "state": state, "postalCode": postalCode, "country": country,
+    ]
+    if let addressLine2, !addressLine2.isEmpty { p["addressLine2"] = addressLine2 }
+    if let comment, !comment.isEmpty { p["comment"] = comment }
+    return p
+  }
+}
+```
+
+`GiveawayWinnerPush.swift`:
+
+```swift
+import Foundation
+
+struct GiveawayWinnerPush: Equatable, Sendable {
+  let eventId: String
+  let stationId: String?
+  let giveawayId: String?
+  let prizeName: String
+  let prizeDescription: String?
+  let prizeImageUrl: URL?
+  let winningNumber: Int
+  let tapNumber: Int
+  let winnerUserId: String?
+  let reason: String?
+  let submissionCompleted: Bool?
+  let canSubmitMailingInfo: Bool?
+
+  init?(userInfo: [String: any Sendable]) {
+    guard userInfo["type"] as? String == "giveaway_winner",
+      let eventId = userInfo["eventId"] as? String,
+      let prizeName = userInfo["prizeName"] as? String,
+      let winningNumber = userInfo["winningNumber"] as? Int,
+      let tapNumber = userInfo["tapNumber"] as? Int
+    else { return nil }
+    self.eventId = eventId
+    self.stationId = userInfo["stationId"] as? String
+    self.giveawayId = userInfo["giveawayId"] as? String
+    self.prizeName = prizeName
+    self.prizeDescription = userInfo["prizeDescription"] as? String
+    self.prizeImageUrl = (userInfo["prizeImageUrl"] as? String).flatMap(URL.init(string:))
+    self.winningNumber = winningNumber
+    self.tapNumber = tapNumber
+    self.winnerUserId = userInfo["winnerUserId"] as? String
+    self.reason = userInfo["reason"] as? String
+    self.submissionCompleted = userInfo["submissionCompleted"] as? Bool
+    self.canSubmitMailingInfo = userInfo["canSubmitMailingInfo"] as? Bool
+  }
+}
+```
+
+- [ ] **Step 4: Register both files in `project.pbxproj`; run, verify pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(giveaway): winner-submission request + winner-push payload models"`
+
+---
+
+### Task 3: APIClient — my-result + winner-submission
+
+**Files:**
+- Modify: `PlayolaRadio/Core/API/APIClient.swift` (after the giveaway block ~line 560)
+- Modify: `PlayolaRadio/Core/API/APIClient+Live.swift` (after `tapGiveawayEvent` ~line 776)
+- Test: `PlayolaRadio/Core/API/APIClientGiveawayResolutionTests.swift` (verify defaults; optional)
+
+**Interfaces:**
+- Produces on `APIClient`:
+  - `giveawayEventMyResult: @Sendable (_ jwt: String, _ eventId: String) async throws -> GiveawayMyResult` (default `{ _,_ in .mock }`)
+  - `submitGiveawayWinnerDetails: @Sendable (_ jwt: String, _ eventId: String, _ body: GiveawayWinnerSubmissionRequest) async throws -> Void` (default `{ _,_,_ in }`)
+
+- [ ] **Step 1: Add the client properties** in `APIClient.swift` Giveaway section:
+
+```swift
+/// Authoritative final outcome for the current viewer. Reconciles a due close on demand.
+var giveawayEventMyResult:
+  @Sendable (_ jwtToken: String, _ eventId: String) async throws -> GiveawayMyResult = { _, _ in
+    .mock
+  }
+
+/// Submits (upserts) the winner's mailing details. Winner-only on the server.
+var submitGiveawayWinnerDetails:
+  @Sendable (_ jwtToken: String, _ eventId: String, _ body: GiveawayWinnerSubmissionRequest)
+    async throws -> Void = { _, _, _ in }
+```
+
+- [ ] **Step 2: Add live impls** in `APIClient+Live.swift`:
+
+```swift
+giveawayEventMyResult: { jwtToken, eventId in
+  try await authenticatedGet(
+    path: "/v1/giveaway-events/\(eventId)/my-result", token: jwtToken)
+},
+submitGiveawayWinnerDetails: { jwtToken, eventId, body in
+  try await authenticatedPostVoid(
+    path: "/v1/giveaway-events/\(eventId)/winner-submission",
+    token: jwtToken, parameters: body.asParameters)
+},
+```
+
+- [ ] **Step 3: Build.** No new test strictly required (covered via coordinator/sheet tests downstream). Confirm it compiles.
+
+- [ ] **Step 4: Commit** — `git commit -m "feat(api): giveaway my-result + winner-submission endpoints"`
+
+---
+
+## Stage 2 — Task 0: tap() failure path
+
+### Task 4: `onError` on overlay + throwing tap classification
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift`
+- Modify: `PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift`
+- Modify: `PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift` (`makePlayerModel`)
+- Create: `PlayolaRadio/Core/Giveaways/GiveawayTapError.swift`
+- Test: `PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift`, `PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `enum GiveawayTapError: Error, Equatable { case unexpected }`
+  - `GiveawayOverlayModel.onTap: (@MainActor (GiveawayEvent) async throws -> Void)?` (now throwing)
+  - `GiveawayOverlayModel.onError: (@MainActor (any Error) async -> Void)?`
+  - `GiveawayCoordinator.tap(event:)` throws `GiveawayTapError.unexpected` on network/5xx; silent on 400/success.
+
+- [ ] **Step 1: Failing overlay test** — `onTap` throwing routes to `onError`:
+
+```swift
+func testTapButtonRoutesThrownErrorToOnError() async {
+  @Shared(.nowPlaying) var nowPlaying: NowPlaying? = NowPlaying.mockWith(
+    station: AnyStation.mockPlayola(id: "station-1"))
+  @Shared(.activeGiveaway) var activeGiveaway = GiveawayEvent(
+    id: "evt-1", stationId: "station-1", prizeName: "Prize", winningNumber: 9, status: .open)
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+
+  let model = GiveawayOverlayModel()
+  var capturedError: (any Error)?
+  model.onTap = { _ in throw GiveawayTapError.unexpected }
+  model.onError = { capturedError = $0 }
+
+  await model.tapButtonTapped()
+
+  XCTAssertEqual(capturedError as? GiveawayTapError, .unexpected)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement.** `GiveawayTapError.swift`:
+
+```swift
+enum GiveawayTapError: Error, Equatable {
+  case unexpected
+}
+```
+
+In `GiveawayOverlayModel.swift`:
+
+```swift
+var onTap: (@MainActor (GiveawayEvent) async throws -> Void)?
+var onError: (@MainActor (any Error) async -> Void)?
+
+func tapButtonTapped() async {
+  guard let giveaway = visibleGiveaway else { return }
+  do {
+    try await onTap?(giveaway)
+  } catch {
+    await onError?(error)
+  }
+}
+```
+
+In `GiveawayCoordinator.tap`, classify (the project's `APIError` carries `statusCode`; 400 = expected race → silent; everything else genuine → throw):
+
+```swift
+func tap(event: GiveawayEvent) async throws {
+  guard let jwt = auth.jwt else { return }
+  guard participations[event.id] == nil, !inFlightTapIds.contains(event.id) else { return }
+  inFlightTapIds.insert(event.id)
+  defer { inFlightTapIds.remove(event.id) }
+  do {
+    let response = try await api.tapGiveawayEvent(jwt, event.id)
+    persistOutcome(event: event, response: response)
+  } catch let error as APIError where error.statusCode == 400 {
+    log("tap: 400 not-open-yet for \(event.id) — silent")
+  } catch {
+    log("tap: unexpected failure for \(event.id) — \(error)")
+    throw GiveawayTapError.unexpected
+  }
+}
+```
+
+> `persistOutcome` is implemented in Task 5; for this task keep the existing `persistStandby` call and only add the throwing classification, then swap to `persistOutcome` in Task 5. (Verify `APIError` exposes `statusCode`; if it is an enum, match the not-open case instead — read `APIClient+Live.swift:114`/`452`.)
+
+Wire in `MainContainerModel.makePlayerModel()`:
+
+```swift
+model.giveawayOverlayModel.onTap = { [weak self] event in
+  try await self?.giveawayCoordinator.tap(event: event)
+}
+model.giveawayOverlayModel.onError = { [weak self] _ in
+  self?.giveawayCoordinator.presentTapErrorAlert()
+}
+```
+
+Add to `GiveawayCoordinator` (or surface via a `@Shared` alert the player observes — choose the existing alert pattern; here we route through MainContainer's `presentedAlert`). Concretely, have `onError` set MainContainer state:
+
+```swift
+model.giveawayOverlayModel.onError = { [weak self] _ in
+  self?.presentGiveawayTapErrorAlert()
+}
+```
+
+and in `MainContainerModel`:
+
+```swift
+func presentGiveawayTapErrorAlert() {
+  presentedAlert = PlayolaAlert(
+    title: "Tap didn't go through",
+    message: "Something went wrong. Please try again.",
+    dismissButton: .default(Text("OK")))
+}
+```
+
+(Match the actual `PlayolaAlert` initializer in `PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift` and whatever alert surface `MainContainerModel` already presents.)
+
+- [ ] **Step 4: Coordinator test** — 400 stays silent (no throw, no participation); 5xx throws:
+
+```swift
+func testTapSilentOn400NotOpen() async throws {
+  @Shared(.auth) var auth = Auth.mockLoggedIn
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+  let coordinator = withDependencies {
+    $0.api.tapGiveawayEvent = { _, _ in throw APIError.badRequest }  // 400 equivalent
+  } operation: { GiveawayCoordinator() }
+
+  try await coordinator.tap(event: .mock)  // does not throw
+
+  expectNoDifference(participations, [:])
+}
+
+func testTapThrowsOnUnexpectedFailure() async {
+  @Shared(.auth) var auth = Auth.mockLoggedIn
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+  let coordinator = withDependencies {
+    $0.api.tapGiveawayEvent = { _, _ in throw APIError.serverError }  // 5xx equivalent
+  } operation: { GiveawayCoordinator() }
+
+  do { try await coordinator.tap(event: .mock); XCTFail("expected throw") }
+  catch { XCTAssertEqual(error as? GiveawayTapError, .unexpected) }
+}
+```
+
+(Use the real `APIError` cases/initializers — adjust `.badRequest`/`.serverError` to match the enum.)
+
+- [ ] **Step 5: Run all, verify pass. Commit** — `git commit -m "feat(giveaway): surface unexpected tap failures via onError alert"`
+
+---
+
+## Stage 3 — Immediate reveal
+
+### Task 5: tap persists resolved outcome from the tap response
+
+**Files:**
+- Modify: `PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift` (replace `persistStandby` with `persistOutcome`)
+- Test: `PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift`
+
+**Interfaces:**
+- Produces: `GiveawayCoordinator.persistOutcome(event:response:)` writes `.resolvedWon(submissionCompleted: false)` when `response.isWinner`, else `.resolvedLost(toastShown: false)`, carrying `tapNumber` from the response.
+
+- [ ] **Step 1: Failing tests**
+
+```swift
+func testTapWinPersistsResolvedWon() async throws {
+  @Shared(.auth) var auth = Auth.mockLoggedIn
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+  @Dependency(\.date.now) var now
+  let event = GiveawayEvent(
+    id: "evt-1", stationId: "stn-1", prizeName: "Tickets", winningNumber: 9, status: .open)
+  let coordinator = withDependencies {
+    $0.api.tapGiveawayEvent = { _, _ in GiveawayTapResponse(tapNumber: 9, isWinner: true, status: .open) }
+  } operation: { GiveawayCoordinator() }
+
+  try await coordinator.tap(event: event)
+
+  expectNoDifference(participations["evt-1"]?.status, .resolvedWon(submissionCompleted: false))
+  expectNoDifference(participations["evt-1"]?.tapNumber, 9)
+}
+
+func testTapLossPersistsResolvedLost() async throws {
+  @Shared(.auth) var auth = Auth.mockLoggedIn
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+  let event = GiveawayEvent(
+    id: "evt-1", stationId: "stn-1", prizeName: "Tickets", winningNumber: 9, status: .open)
+  let coordinator = withDependencies {
+    $0.api.tapGiveawayEvent = { _, _ in GiveawayTapResponse(tapNumber: 5, isWinner: false, status: .open) }
+  } operation: { GiveawayCoordinator() }
+
+  try await coordinator.tap(event: event)
+
+  expectNoDifference(participations["evt-1"]?.status, .resolvedLost(toastShown: false))
+  expectNoDifference(participations["evt-1"]?.tapNumber, 5)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** — replace `persistStandby` with:
+
+```swift
+private func persistOutcome(event: GiveawayEvent, response: GiveawayTapResponse) {
+  let status: GiveawayParticipationStatus =
+    response.isWinner
+    ? .resolvedWon(submissionCompleted: false)
+    : .resolvedLost(toastShown: false)
+  $participations.withLock {
+    $0[event.id] = GiveawayParticipation(
+      id: event.id, stationId: event.stationId, prizeName: event.prizeName,
+      prizeDescription: event.prizeDescription, prizeImageUrl: event.prizeImageUrl,
+      winningNumber: event.winningNumber, tapNumber: response.tapNumber,
+      status: status, tappedAt: now)
+  }
+}
+```
+
+Update `tap` to call `persistOutcome(event: event, response: response)`.
+
+- [ ] **Step 4: Update the M1 standby-persist test** (`hasTapped`/standby assertions) that now expect a resolved status. Run, verify pass.
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(giveaway): resolve win/lose immediately from tap response"`
+
+---
+
+### Task 6: In-player loser reveal (overlay model + view)
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift`
+- Modify: `PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift`
+- Test: `PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift`
+
+**Interfaces:**
+- Consumes: `GiveawayParticipation.wasPromotedWin`, the participations dict, `activeGiveaway`.
+- Produces on `GiveawayOverlayModel`: `showsLoserReveal: Bool`, `loserRevealHeadline: String` ("You were listener #N — good luck next time!"), `loserRevealOpacity`/interactive flags; min-display handled by a `revealedLossEventId` + `@Dependency(\.continuousClock)` hold so it survives `activeGiveaway` clearing for ≥10s.
+
+**Design:** The loser reveal shows when the participation for the active (or just-active) event is `.resolvedLost`. Because `activeGiveaway` clears at close, the model latches the lost event id when it first sees the loss and keeps the reveal up for a minimum hold (10s), then clears on station change / player dismiss. Keep the view free of control flow (opacity + `allowsHitTesting`, like the existing prompt/standby split).
+
+- [ ] **Step 1: Failing tests**
+
+```swift
+func testShowsLoserRevealForResolvedLostOnCurrentStation() {
+  @Shared(.nowPlaying) var nowPlaying: NowPlaying? = NowPlaying.mockWith(
+    station: AnyStation.mockPlayola(id: "stn-1"))
+  @Shared(.activeGiveaway) var activeGiveaway = GiveawayEvent(
+    id: "evt-1", stationId: "stn-1", prizeName: "P", winningNumber: 9, status: .open)
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "evt-1": GiveawayParticipation(
+      id: "evt-1", stationId: "stn-1", prizeName: "P", winningNumber: 9, tapNumber: 5,
+      status: .resolvedLost(toastShown: false), tappedAt: Date())
+  ]
+  let model = GiveawayOverlayModel()
+  XCTAssertTrue(model.showsLoserReveal)
+  expectNoDifference(model.loserRevealHeadline, "You were listener #5 — good luck next time!")
+}
+
+func testNoLoserRevealForWin() {
+  @Shared(.nowPlaying) var nowPlaying: NowPlaying? = NowPlaying.mockWith(
+    station: AnyStation.mockPlayola(id: "stn-1"))
+  @Shared(.activeGiveaway) var activeGiveaway = GiveawayEvent(
+    id: "evt-1", stationId: "stn-1", prizeName: "P", winningNumber: 9, status: .open)
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "evt-1": GiveawayParticipation(
+      id: "evt-1", stationId: "stn-1", prizeName: "P", winningNumber: 9, tapNumber: 9,
+      status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+  ]
+  let model = GiveawayOverlayModel()
+  XCTAssertFalse(model.showsLoserReveal)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** the model helpers (derive the lost participation for the active event / now-playing station; compute headline from `tapNumber`). Add the min-hold latch (latch `revealedLossEventId` + a `clock.sleep(for: .seconds(10))` task that clears it; clear immediately on station change). Replace the standby subview with a `GiveawayOverlayLoserView` driven by `loserRevealOpacity` / `showsLoserReveal`. Keep all copy on the model.
+
+- [ ] **Step 4: Update the `#Preview`s** to add a "Loser reveal" preview. Run, verify pass + visually check the preview.
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(giveaway): in-player loser reveal with minimum display hold"`
+
+---
+
+## Stage 4 — Winner sheet
+
+### Task 7: `GiveawayWinnerSheetModel`
+
+**Files:**
+- Create: `PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift`
+- Test: `PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift`
+- Register in `project.pbxproj`.
+
+**Interfaces:**
+- Consumes: `api.submitGiveawayWinnerDetails`, `api.giveawayEvent`, `@Shared(.auth)`, `@Shared(.giveawayParticipations)`.
+- Produces: `@MainActor @Observable final class GiveawayWinnerSheetModel: ViewModel, Identifiable` with:
+  - `init(participation: GiveawayParticipation, fromPush: Bool = false, onClose: @escaping () -> Void)`
+  - form fields `fullName/addressLine1/city/state/postalCode/addressLine2/comment`
+  - `headline: String` ("You won! You're Listener #N" or, when `participation.wasPromotedWin`, "Good news — you got bumped up to the winner!")
+  - `prizeName/prizeDescription/prizeImageUrl`, `canSubmit: Bool`, `isSubmitting`, `submitErrorMessage: String?`, `showsClaimedConfirmation: Bool`
+  - `task() async` (eligibility check when `fromPush`), `claimButtonTapped() async`, `closeButtonTapped()`
+
+- [ ] **Step 1: Failing tests**
+
+```swift
+func testHeadlineForNthTapperWin() {
+  let p = GiveawayParticipation(
+    id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+    status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+  let model = GiveawayWinnerSheetModel(participation: p, onClose: {})
+  expectNoDifference(model.headline, "You won! You're Listener #9")
+}
+
+func testHeadlineForPromotedWin() {
+  let p = GiveawayParticipation(
+    id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+    status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+  let model = GiveawayWinnerSheetModel(participation: p, onClose: {})
+  expectNoDifference(model.headline, "Good news — you got bumped up to the winner!")
+}
+
+func testCanSubmitRequiresRequiredFields() {
+  let model = GiveawayWinnerSheetModel(participation: .mock, onClose: {})
+  XCTAssertFalse(model.canSubmit)
+  model.fullName = "Jo"; model.addressLine1 = "1 Main"; model.city = "Austin"
+  model.state = "TX"; model.postalCode = "78701"
+  XCTAssertTrue(model.canSubmit)
+}
+
+func testClaimSuccessMarksSubmissionCompletedAndCloses() async {
+  @Shared(.auth) var auth = Auth.mockLoggedIn
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "e": GiveawayParticipation(
+      id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+      status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+  ]
+  var closed = false
+  let model = withDependencies {
+    $0.api.submitGiveawayWinnerDetails = { _, _, _ in }
+  } operation: {
+    GiveawayWinnerSheetModel(participation: participations["e"]!, onClose: { closed = true })
+  }
+  model.fullName = "Jo"; model.addressLine1 = "1 Main"; model.city = "Austin"
+  model.state = "TX"; model.postalCode = "78701"
+
+  await model.claimButtonTapped()
+
+  expectNoDifference(participations["e"]?.status, .resolvedWon(submissionCompleted: true))
+  XCTAssertTrue(closed)
+}
+
+func testClaimFailureKeepsSheetOpenWithError() async {
+  @Shared(.auth) var auth = Auth.mockLoggedIn
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "e": GiveawayParticipation(
+      id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+      status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+  ]
+  var closed = false
+  let model = withDependencies {
+    $0.api.submitGiveawayWinnerDetails = { _, _, _ in throw APIError.serverError }
+  } operation: {
+    GiveawayWinnerSheetModel(participation: participations["e"]!, onClose: { closed = true })
+  }
+  model.fullName = "Jo"; model.addressLine1 = "1 Main"; model.city = "Austin"
+  model.state = "TX"; model.postalCode = "78701"
+
+  await model.claimButtonTapped()
+
+  XCTAssertFalse(closed)
+  XCTAssertNotNil(model.submitErrorMessage)
+  expectNoDifference(participations["e"]?.status, .resolvedWon(submissionCompleted: false))
+}
+
+func testPushProvenanceAlreadyClaimedShowsConfirmation() async {
+  @Shared(.auth) var auth = Auth.mockLoggedIn
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+  let p = GiveawayParticipation(
+    id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+    status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+  let model = withDependencies {
+    $0.api.giveawayEvent = { _, _ in
+      GiveawayEvent(
+        id: "e", stationId: "s", prizeName: "P", winningNumber: 9, status: .closed,
+        viewer: GiveawayEventViewer(hasTapped: true, isWinner: true, canSubmitMailingInfo: false))
+    }
+  } operation: {
+    GiveawayWinnerSheetModel(participation: p, fromPush: true, onClose: {})
+  }
+
+  await model.task()
+
+  XCTAssertTrue(model.showsClaimedConfirmation)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** following `pfw-observable-models` (no comments, `@ObservationIgnored @Dependency`/`@Shared`, action-named methods). `task()` GETs `api.giveawayEvent` when `fromPush`; if `viewer?.canSubmitMailingInfo == false` set `showsClaimedConfirmation = true` and mark `.resolvedWon(submissionCompleted: true)`. `claimButtonTapped()` builds `GiveawayWinnerSubmissionRequest`, calls `api.submitGiveawayWinnerDetails`; on success `$participations.withLock` set `.resolvedWon(submissionCompleted: true)` then `onClose()`; on failure set `submitErrorMessage`. Use `withErrorReporting`/`reportIssue` per `pfw-issue-reporting` for the unexpected failure log.
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(giveaway): winner sheet model (claim, eligibility, upgrade copy)"`
+
+---
+
+### Task 8: Winner sheet view + `PlayolaSheet` case
+
+**Files:**
+- Create: `PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift`
+- Modify: `PlayolaRadio/Views/Reusable Components/PlayolaSheet.swift` (add case)
+- Modify: wherever `PlayolaSheet` is switched to a view (the sheet host) to render the new case.
+- Register the new view in `project.pbxproj`.
+
+**Interfaces:**
+- Consumes: `GiveawayWinnerSheetModel`.
+- Produces: `case giveawayWinner(GiveawayWinnerSheetModel)` on `PlayolaSheet`; `GiveawayWinnerSheetView(model:)`.
+
+- [ ] **Step 1:** Add the enum case (since `GiveawayWinnerSheetModel` is an `@Observable` class, conform it `Equatable`/`Hashable` by object identity per `pfw-observable-models`, matching how other model-bearing cases hash):
+
+```swift
+case giveawayWinner(GiveawayWinnerSheetModel)
+```
+
+- [ ] **Step 2:** Build the view from the lovable `TapperWinnerScreen` (confetti, prize image via `WebImage` not `AsyncImage`, form fields, "Claim Prize", submitted/claimed states). **Zero control flow in the view** — drive the submitted/claimed/error states through opacity/disabled bindings off the model. Bindings via dynamic-member lookup, never `Binding(get:set:)`.
+
+- [ ] **Step 3:** Render the case in the sheet host switch; add a `#Preview` for win and promoted-win.
+
+- [ ] **Step 4:** Build, verify previews render. (No new unit test — model is covered in Task 7.)
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(giveaway): winner sheet view + PlayolaSheet case"`
+
+---
+
+## Stage 5 — Presentation arbiter
+
+### Task 9: MainContainer presents winner sheet + loser-toast fallback
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift`
+- Test: `PlayolaRadio/Views/Pages/MainContainer/MainContainerModelTests.swift` (or existing)
+
+**Interfaces:**
+- Consumes: `@Shared(.giveawayParticipations)`, `@Dependency(\.toast)`, the nav coordinator, `GiveawayWinnerSheetModel`.
+- Produces: `MainContainerModel.processGiveawayResolutions()` — presents the oldest pending winner (resolvedWon, `winnerSheetPresentedAt == nil`) when no blocking sheet is up, marking `winnerSheetPresentedAt = now` in the same `withLock`; fires a one-time toast for the oldest pending loss (resolvedLost, `toastShown == false`) and flips `toastShown = true`. Observes the dict (Combine `$participations.publisher` or `Observations`) and on app foreground.
+
+- [ ] **Step 1: Failing tests**
+
+```swift
+func testPresentsWinnerSheetOncePerWin() {
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "e": GiveawayParticipation(
+      id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+      status: .resolvedWon(submissionCompleted: false), tappedAt: Date(), winnerSheetPresentedAt: nil)
+  ]
+  let model = MainContainerModel()
+
+  model.processGiveawayResolutions()
+
+  XCTAssertNotNil(participations["e"]?.winnerSheetPresentedAt)
+  // sheet is the winner case
+  guard case .giveawayWinner = model.mainContainerNavigationCoordinator.presentedSheet else {
+    return XCTFail("expected winner sheet")
+  }
+
+  let presentedAt = participations["e"]?.winnerSheetPresentedAt
+  model.processGiveawayResolutions()  // idempotent
+  expectNoDifference(participations["e"]?.winnerSheetPresentedAt, presentedAt)
+}
+
+func testFiresLoserToastOnce() async {
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "e": GiveawayParticipation(
+      id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+      status: .resolvedLost(toastShown: false), tappedAt: Date())
+  ]
+  var shownToasts: [PlayolaToast] = []
+  let model = withDependencies {
+    $0.toast = ToastClient(show: { shownToasts.append($0) }, /* … */ )
+  } operation: { MainContainerModel() }
+
+  model.processGiveawayResolutions()
+
+  expectNoDifference(participations["e"]?.status, .resolvedLost(toastShown: true))
+  expectNoDifference(shownToasts.count, 1)
+}
+```
+
+(Adjust `ToastClient` override to its real shape; assert `presentedSheet` via the nav coordinator the project uses.)
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** `processGiveawayResolutions()` — filter pending winners (sorted by `tappedAt`), guard `presentedSheet == nil` (or only the player is up), build `GiveawayWinnerSheetModel(participation:onClose:)`, set `winnerSheetPresentedAt = now` in the same `withLock`, present `.giveawayWinner(model)`. Then pending losses → `toast.show(...)`, flip `toastShown`. Subscribe in `start()`/the existing observation setup, and call from the foreground hook (next to `giveawayCoordinator.pollNow()`).
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(giveaway): MainContainer arbiter presents winner sheet + loser toast"`
+
+---
+
+## Stage 6 — Correctness backstop + push
+
+### Task 10: Poll-while-open backstop (flip loss→win on close)
+
+**Files:**
+- Modify: `PlayolaRadio/Core/Giveaways/GiveawayCoordinator.swift` (extend close-detection in `clearActiveIfNoLongerOpen` / reconcile)
+- Test: `PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift`
+
+**Interfaces:**
+- Consumes: `api.giveawayEventMyResult`.
+- Produces: `GiveawayCoordinator.reconcileResolvedLoss(jwt:eventId:)` — when a tapped contest closes and the local participation is `.resolvedLost`, GET `my-result`; if `isWinner` and `status` resolved, flip to `.resolvedWon(submissionCompleted: false)` (carry `tapNumber` from the result). No-op on still-open / loser / throw.
+
+- [ ] **Step 1: Failing tests**
+
+```swift
+func testBackstopFlipsLossToWinWhenPromoted() async {
+  @Shared(.auth) var auth = Auth.mockLoggedIn
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "e": GiveawayParticipation(
+      id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+      status: .resolvedLost(toastShown: false), tappedAt: Date())
+  ]
+  let coordinator = withDependencies {
+    $0.api.giveawayEventMyResult = { _, _ in
+      GiveawayMyResult(tapNumber: 5, isWinner: true, status: .closed, winningNumber: 9)
+    }
+  } operation: { GiveawayCoordinator() }
+
+  await coordinator.reconcileResolvedLoss(jwt: "jwt", eventId: "e")
+
+  expectNoDifference(participations["e"]?.status, .resolvedWon(submissionCompleted: false))
+}
+
+func testBackstopLeavesLossWhenStillLost() async {
+  @Shared(.auth) var auth = Auth.mockLoggedIn
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "e": GiveawayParticipation(
+      id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+      status: .resolvedLost(toastShown: false), tappedAt: Date())
+  ]
+  let coordinator = withDependencies {
+    $0.api.giveawayEventMyResult = { _, _ in
+      GiveawayMyResult(tapNumber: 5, isWinner: false, status: .closed, winningNumber: 9)
+    }
+  } operation: { GiveawayCoordinator() }
+
+  await coordinator.reconcileResolvedLoss(jwt: "jwt", eventId: "e")
+
+  expectNoDifference(participations["e"]?.status, .resolvedLost(toastShown: false))
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement**
+
+```swift
+func reconcileResolvedLoss(jwt: String, eventId: String) async {
+  guard participations[eventId]?.status.is(\.resolvedLost) == true else { return }
+  guard let result = try? await api.giveawayEventMyResult(jwt, eventId) else { return }
+  guard result.isResolved, result.isWinner else { return }
+  $participations.withLock {
+    $0[eventId]?.status = .resolvedWon(submissionCompleted: false)
+    if let tap = result.tapNumber { $0[eventId]?.tapNumber = tap }
+  }
+  log("backstop: \(eventId) promoted loss→win")
+}
+```
+
+Hook it where the feed reconcile detects an active tapped event closing (inside/after `clearActiveIfNoLongerOpen` when `fresh.status != .open`, for the local participation). Iterate any `.resolvedLost` participations whose event left the feed for the current station.
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(giveaway): foreground backstop flips promoted loss to win"`
+
+---
+
+### Task 11: Winner push handler + delegate wiring
+
+**Files:**
+- Modify: `PlayolaRadio/Core/PushNotifications/PushNotifications.swift` (add `handleGiveawayWinnerPush`)
+- Modify: `PlayolaRadio/PlayolaRadioApp.swift` (`didReceiveRemoteNotification`, `willPresent`, `didReceive`)
+- Test: `PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift`
+
+**Interfaces:**
+- Consumes: `GiveawayWinnerPush`, `@Shared(.giveawayParticipations)`.
+- Produces: `PushNotificationsClient.handleGiveawayWinnerPush: @Sendable (_ userInfo: [String: any Sendable]) async -> Void` — parse; find/create participation by `eventId`; idempotent flip to `.resolvedWon(submissionCompleted: false)` unless already won-and-presented or already submitted. Presentation is left to the MainContainer arbiter (which observes the dict).
+
+- [ ] **Step 1: Failing tests**
+
+```swift
+func testWinnerPushFlipsLossToWon() async {
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "e": GiveawayParticipation(
+      id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+      status: .resolvedLost(toastShown: true), tappedAt: Date())
+  ]
+  let client = PushNotificationsClient.liveValue
+  await client.handleGiveawayWinnerPush([
+    "type": "giveaway_winner", "eventId": "e", "stationId": "s", "prizeName": "P",
+    "winningNumber": 9, "tapNumber": 5, "reason": "last_tapper_fallback",
+  ])
+  expectNoDifference(participations["e"]?.status, .resolvedWon(submissionCompleted: false))
+}
+
+func testWinnerPushIdempotentWhenAlreadySubmitted() async {
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+    "e": GiveawayParticipation(
+      id: "e", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 5,
+      status: .resolvedWon(submissionCompleted: true), tappedAt: Date())
+  ]
+  let client = PushNotificationsClient.liveValue
+  await client.handleGiveawayWinnerPush([
+    "type": "giveaway_winner", "eventId": "e", "stationId": "s", "prizeName": "P",
+    "winningNumber": 9, "tapNumber": 5,
+  ])
+  expectNoDifference(participations["e"]?.status, .resolvedWon(submissionCompleted: true))
+}
+
+func testWinnerPushCreatesParticipationOnReinstall() async {
+  @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+  let client = PushNotificationsClient.liveValue
+  await client.handleGiveawayWinnerPush([
+    "type": "giveaway_winner", "eventId": "e", "stationId": "s", "prizeName": "P",
+    "winningNumber": 9, "tapNumber": 5,
+  ])
+  expectNoDifference(participations["e"]?.status, .resolvedWon(submissionCompleted: false))
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** `handleGiveawayWinnerPush` in the live client:
+
+```swift
+handleGiveawayWinnerPush: { userInfo in
+  guard let push = GiveawayWinnerPush(userInfo: userInfo) else { return }
+  @Shared(.giveawayParticipations) var participations
+  let participationsShared = $participations
+  await MainActor.run {
+    participationsShared.withLock { dict in
+      if case .resolvedWon(submissionCompleted: true) = dict[push.eventId]?.status { return }
+      if let existing = dict[push.eventId] {
+        var updated = existing
+        if case .resolvedWon = existing.status {} else {
+          updated.status = .resolvedWon(submissionCompleted: false)
+        }
+        dict[push.eventId] = updated
+      } else {
+        dict[push.eventId] = GiveawayParticipation(
+          id: push.eventId, stationId: push.stationId ?? "", prizeName: push.prizeName,
+          prizeDescription: push.prizeDescription, prizeImageUrl: push.prizeImageUrl,
+          winningNumber: push.winningNumber, tapNumber: push.tapNumber,
+          status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+      }
+    }
+  }
+}
+```
+
+Add the property to the `@DependencyClient` struct (with the implicit default). Wire the three delegate entry points in `PlayolaRadioApp.swift` to call it for `type == "giveaway_winner"`:
+- `didReceiveRemoteNotification` (background/silent): call, `completionHandler(.newData)`.
+- `willPresent` (foreground): call; `completionHandler([])` for a silent data push (the arbiter presents the sheet) or `[.banner, .sound]` if product wants the banner too.
+- `didReceive` (tap): call (the arbiter then presents).
+
+> The `MainActor.run` + `withLock` + `Date()` here mirror the existing `handleSupportNotificationBadge` pattern. Replace `Date()` with the injected clock if this is refactored into a model later.
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit** — `git commit -m "feat(giveaway): winner push handler flips state for arbiter to present"`
+
+---
+
+## Final verification
+
+- [ ] Run the full giveaway test suite via `xcodebuild test` with `-skipPackagePluginValidation -skipMacroValidation` and a concrete simulator id (see memory `project_xcodebuild_test_cli_flags`). Not just build.
+- [ ] Simulator smoke (staging / `isLiveDataEnabled`): tap → win sheet; tap → loser reveal; (with a stub/dev push) loss→win flip presents the sheet.
+- [ ] Codex review (pass/fail gate) + Codex challenge (adversarial) on the final diff; fix findings.
+- [ ] PR against `develop`. Body notes the server-push dependency (§7) and that the feature is gated dark in prod.
+- [ ] Confirm `project.pbxproj` diff contains only the new file refs (no `DEVELOPMENT_TEAM`/reorder churn).
+
+---
+
+## Self-review notes (spec coverage)
+
+- Immediate reveal → Task 5. Loser reveal + min hold → Task 6. Winner sheet (form, eligibility, upgrade copy, retry) → Tasks 7-8. Arbiter (sole presenter, dedupe, toast fallback) → Task 9. Backstop → Task 10. Push handler → Task 11. Task 0 onError → Task 4. APIClient additions → Task 3. Models (CasePathable, request/push) → Tasks 1-2.
+- Server "you won" push = external dependency (spec §7); not a task here.
+- Out of scope (spec §10): congrats recording / record-video toggle, cross-station banner, stale GC.
+- Open implementation confirmations flagged inline: real `APIError` shape for the 400-vs-5xx classification (Task 4), the exact `ToastClient`/`PlayolaAlert`/nav-coordinator APIs (Tasks 4, 9), and the `PlayolaSheet` host switch site (Task 8).

--- a/docs/superpowers/specs/2026-06-23-live-giveaway-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-23-live-giveaway-resolution-design.md
@@ -1,0 +1,245 @@
+# Live Giveaway — Milestone 2: Win/Lose Resolution (listener side)
+
+**Date:** 2026-06-23
+**Branch:** `briankeane/richmond-v1` → PRs target `develop`
+**Status:** Design — awaiting approval
+**Gate:** all runtime behavior behind `GiveawayFeature.isLiveDataEnabled` (dark in prod, live in staging). `develop` stays deployable.
+
+Builds on Milestone 1 (PR #336: reveal engine + tap). See memory `project_giveaway_milestones`,
+`project_giveaway_event_contract`, `project_server_enums_unknown_fallback`.
+
+---
+
+## 1. Goal
+
+When a listener taps into a giveaway, show them whether they won or lost, and let a winner submit
+mailing info to claim the prize.
+
+The headline decision (made during design): **reveal the outcome immediately from the tap response**,
+not after a wait. This collapses most of the resolution machinery — there is no standby-then-reveal
+poll loop. A small bounded backstop + a server push handle the one edge case where an immediate
+"you lost" can later become a win.
+
+---
+
+## 2. Server contract (confirmed from source, branch `briankeane/giveaway-event-runtime`)
+
+Do not guess field names (we got burned in M1 by id-vs-eventId). These are read from the server source.
+
+### Two ways the server picks a winner
+1. **At tap time** (`giveawayEvents.lib.ts`): `isWinner = !event.winnerUserId && tapNumber === winningNumber`.
+   If you hit the winning number and no winner exists yet, the server crowns you **on that tap** and
+   sets `winnerUserId`. The tap response carries this authoritative `isWinner`.
+2. **At close** (`reconcileGiveawayClose`): *"keep an Nth-tap winner; else promote the last (highest)
+   tapper; zero taps → no winner."* The last-tapper promotion is the only outcome a tapper cannot know
+   at tap time.
+
+### Endpoints
+- `POST /v1/giveaway-events/:eventId/tap` → `{ tapNumber: Int, isWinner: Bool, status }`
+  (already wired as `api.tapGiveawayEvent`; response type `GiveawayTapResponse` already exists).
+- `GET /v1/giveaway-events/:eventId/my-result` → `{ tapNumber: Int?, isWinner: Bool, status, winningNumber: Int }`
+  — exactly the existing `GiveawayMyResult`. Reconciles a due close on demand. 404 if event missing.
+  **Not yet in `APIClient` — we add it.**
+- `POST /v1/giveaway-events/:eventId/winner-submission` — body required `fullName, addressLine1, city,
+  postalCode`; optional `addressLine2, state, country (default "US"), comment`. 201. Winner-only (403
+  otherwise). Upserts on `(eventId)`. **Not yet in `APIClient` — we add it.**
+- `GET /v1/giveaway-events/:eventId` → full event + `viewer { hasTapped, isWinner, canSubmitMailingInfo,
+  tapNumber }` (`viewer.tapNumber` only set once closed). Reconciles on demand. Already wired as
+  `api.giveawayEvent`. Used by the winner sheet to check claim eligibility for push/reinstall cases.
+
+### Notifications today (and the gap)
+- `giveaway_opened` / `giveaway_closed` → broadcast to ALL users. `giveaway_closed` is "see if you won"
+  (not personalized).
+- `winner_pending_owner` → **owner only** (the "record a congrats" nudge).
+- **There is no targeted per-listener "you won" push.** This milestone defines one as a dependency
+  (§7) for the server worktree that owns giveaway code to implement.
+
+---
+
+## 3. Reveal model — immediate
+
+`tap()` POSTs and inspects the response:
+
+- **`isWinner == true`** → persist `.resolvedWon(submissionCompleted: false)`; the arbiter presents the
+  app-wide winner sheet immediately. Correct and final (server set `winnerUserId` on this tap).
+- **`isWinner == false`** → persist `.resolvedLost(toastShown: false)`; the player shows the in-player
+  loser reveal immediately. Because the tap button only lives in the player, a losing tapper is always
+  looking at the player, so the reveal is the primary loser surface; the one-time toast is the **durable
+  fallback** (app died before the reveal was seen → toast on next foreground).
+- **400 (not open yet)** → silent (expected race at the open moment; user can tap again).
+- **network / 5xx** → surface via the new `onError` callback → `PlayolaAlert` (Task 0, §6).
+
+`.tappedStandby` is no longer a persisted "waiting" state. It survives only as a transient in-flight /
+loading marker on the button while the POST is in flight. The "STAND BY… we'll reveal when the song
+ends" copy is removed.
+
+`resolvedLost` means **currently lost, not mathematically final** until the contest closes (last-tapper
+promotion can still flip it). The backstop (§5) and push (§7) upgrade it if that happens.
+
+---
+
+## 4. Components & responsibilities
+
+Single source of truth = `@Shared(.giveawayParticipations)` (durable file-backed `[String:
+GiveawayParticipation]`, keyed by per-airing event id). Coordinator/push **mutate** it; MainContainer
+**presents** from it. The overlay never presents app-wide UI.
+
+### 4.1 `GiveawayCoordinator`
+- `tap(event:)` (modified): POST, classify errors, on success persist `.resolvedWon`/`.resolvedLost`
+  immediately (replacing the M1 `.tappedStandby` persist). Surface genuine failures to `onError`.
+- **Poll-while-open backstop** (modified reconcile): the feed reconcile already runs every 30s while
+  foregrounded and already detects when an active event closes (`handleNoFeedEvent` →
+  `clearActiveIfNoLongerOpen` does a detail GET). Extend that close-detection: when a contest the user
+  holds a `.resolvedLost` participation for has closed, do **one** `my-result` call and flip
+  `.resolvedLost → .resolvedWon(submissionCompleted:false)` if the server promoted them. Bounded to
+  contest length; no new loop or cadence.
+- Coordinator only mutates durable state. No sheet/toast decisions.
+
+### 4.2 `MainContainerModel` — presentation arbiter (sole presenter)
+- Observes the participations dict. Derives pending effects:
+  - **Winner pending**: `status == .resolvedWon(submissionCompleted: false)` && `winnerSheetPresentedAt
+    == nil`. If no blocking sheet is up, mark `winnerSheetPresentedAt = now` **synchronously** with
+    installing the sheet (same MainActor transaction), present the winner sheet. Serialize multiple,
+    oldest-first by `tappedAt`. Durable dict ⇒ survives app kill ⇒ presents on next launch if not yet
+    presented.
+  - **Loser toast fallback**: `status == .resolvedLost(toastShown: false)` and the in-player reveal did
+    not show it → fire one-time toast, set `toastShown = true`.
+- eventId is the idempotency key; `winnerSheetPresentedAt` dedupes re-entry.
+
+### 4.3 In-player loser reveal (player overlay)
+- New reveal view replacing the standby view. Driven by the just-resolved participation for the
+  now-playing station.
+- **Minimum display duration (~8–12s)** then clears on navigation / station change / player dismissal —
+  not tied solely to `activeGiveaway` lifetime (which clears at song-end and would otherwise yank the
+  reveal mid-look).
+- Copy from the lovable design (`briankeane/tapper-giveaway` `TapperLoserScreen`): dimmed gift,
+  "You were listener #N — good luck next time!". All strings live on the model.
+
+### 4.4 Push handler (new — iOS has zero giveaway push handling today)
+- On the targeted winner push: find/create participation by `eventId`.
+  - If already `.resolvedWon(submissionCompleted: true)` → ignore.
+  - If `.resolvedWon(submissionCompleted: false)` && `winnerSheetPresentedAt != nil` → do not re-present.
+  - Else flip to `.resolvedWon(submissionCompleted: false)` and let the **arbiter** present (handler does
+    NOT present directly — it only mutates durable state).
+- Push fires for **all** winners (covers reinstall / second device); eventId-deduped. Prefer a
+  data/silent push so a common winner who already saw the sheet does not get a redundant banner.
+
+### 4.5 Winner sheet (`GiveawayWinnerSheetModel` + view; new `PlayolaSheet` case)
+- Form: `fullName, addressLine1, city, state, postalCode` required; `addressLine2, country, comment`
+  optional. No "willing to record a video" toggle (deferred to the congrats milestone; server has no
+  field for it).
+- **Provenance check**: if the participation was created from a push or has unknown provenance, GET the
+  event detail first; if `viewer.canSubmitMailingInfo == false` (already claimed on another device),
+  mark `.resolvedWon(submissionCompleted: true)` and show a "claimed" confirmation instead of the form.
+- Submit → POST winner-submission. Success → `submissionCompleted = true`, dismiss. Failure → keep the
+  sheet open with a retry error (server upserts, so retry is safe). Do not loop-re-present.
+- Visuals from `TapperWinnerScreen` (confetti, prize image, "You won! You're Listener #N", prize
+  name/desc, form, "Claim Prize", then "You're all set / We'll be in touch").
+
+### 4.6 `APIClient` additions
+- `giveawayEventMyResult: (jwt, eventId) async throws -> GiveawayMyResult`
+  → `authenticatedGet("/v1/giveaway-events/\(eventId)/my-result")`.
+- `submitGiveawayWinnerDetails: (jwt, eventId, GiveawayWinnerSubmissionRequest) async throws -> …`
+  → POST `/v1/giveaway-events/\(eventId)/winner-submission`. Body fields are all strings, so this fits
+  the existing `authenticatedPost(parameters: [String: String])` (or add a typed `Encodable` body —
+  decide in implementation). Provide an explicit `testValue`/default (memory
+  `project_swift_dependencies_testvalue`).
+
+---
+
+## 5. Correctness backstop (layered)
+
+A promoted last-tapper winner must never be permanently stranded as "lost". Three layers, fast → safe:
+
+1. **Immediate** — tap response (winner path; instant).
+2. **Poll-while-open** (§4.1) — the foreground feed reconcile, on detecting a tapped contest closed,
+   does one `my-result` check and flips if promoted. Covers the user who stays in-app through close.
+3. **Targeted push** (§4.4, §7) — covers backgrounded / reinstall / second-device. Lossy by nature
+   (APNs), which is exactly why layer 2 exists: push is the accelerant, not the correctness guarantee.
+
+---
+
+## 6. Task 0 — tap() failure path (carried over from M1 P1 review)
+
+- Add `onError: (@MainActor (Error) async -> Void)?` to `GiveawayOverlayModel`, parallel to `onTap`.
+- `tapButtonTapped()` routes a thrown error from the tap path to `onError`.
+- `coordinator.tap` throws a typed error on genuine failure (network / 5xx); stays silent on 400
+  (not-open-yet) and on success.
+- `MainContainerModel.makePlayerModel()` wires `onError` to present a `PlayolaAlert`.
+- Alert **only** on genuinely-unexpected failures; never on the expected 400 race.
+
+---
+
+## 7. Dependency: server "you won" push (contract for the server team)
+
+Implemented in the server worktree that owns giveaway code (NOT in this iOS effort — avoids colliding
+with the active `giveaways-event-contract-migration` / `giveaway-dashboard-events` / `giveaway-contract`
+worktrees). iOS ships gated and goes fully live once this lands.
+
+Fire a targeted push to the resolved winner's device ARNs at close, for **every** winner.
+
+**Payload contract:**
+```json
+{
+  "type": "giveaway_winner",
+  "eventId": "evt_…",          // REQUIRED — idempotency key
+  "stationId": "stn_…",
+  "giveawayId": "gw_…",
+  "prizeName": "…",
+  "winningNumber": 9,
+  "tapNumber": 5,
+  "winnerUserId": "usr_…",
+  "status": "closed",
+  "occurredAt": "2026-06-23T18:30:00Z",
+  "reason": "tap_win | last_tapper_fallback",
+  "schemaVersion": 1,
+  // recommended (lets the sheet skip the eligibility GET):
+  "prizeDescription": "…",
+  "prizeImageUrl": "https://…",
+  "submissionCompleted": false,
+  "canSubmitMailingInfo": true
+}
+```
+If `submissionCompleted` / `canSubmitMailingInfo` are omitted, iOS GETs the detail before showing the
+form for push-created participations. Prefer a data/silent push when feasible.
+
+---
+
+## 8. State model (mostly exists — confirm, don't reinvent)
+
+- `GiveawayParticipationStatus`: `.tappedStandby` (now transient-only), `.resolvedWon(submissionCompleted:
+  Bool)`, `.resolvedLost(toastShown: Bool)`, `.canceled`. **No new cases needed.**
+- `GiveawayParticipation`: `id, stationId, prize…, winningNumber, tapNumber, status, tappedAt,
+  winnerSheetPresentedAt`. Sufficient. (No `resolvedAt`/stale fields — no long-lived poll loop to bound.)
+- `GiveawayMyResult`: matches `my-result`. Reused as the backstop decode type.
+- New `GiveawayWinnerSubmissionRequest` (Encodable) for the POST body.
+- New `GiveawayWinnerPush` payload decode type for the push handler.
+
+---
+
+## 9. Testing (XCTest, `@MainActor`, colocated; see CLAUDE.md + pfw-testing)
+
+- **Coordinator.tap**: win → persists `.resolvedWon`; loss → persists `.resolvedLost`; 400 → no
+  participation + no error; network/5xx → `onError` fired, no participation. (`expectNoDifference`.)
+- **Backstop**: reconcile detects a `.resolvedLost` event closed → my-result winner → flips to
+  `.resolvedWon`; my-result still loser → stays lost; my-result throws → unchanged.
+- **Arbiter**: resolvedWon pending → presents once, sets `winnerSheetPresentedAt`; second observation →
+  no re-present; multiple wins → oldest-first; resolvedLost → toast once, sets `toastShown`; blocking
+  sheet up → defers.
+- **Push handler**: flips loss→won + lets arbiter present; duplicate push → idempotent; already-submitted
+  → no form; no local participation → constructs from payload.
+- **Winner sheet**: valid form enables submit; submit success → `submissionCompleted=true` + dismiss;
+  submit failure → sheet stays open + error; push-provenance with `canSubmitMailingInfo=false` → claimed
+  state, no form.
+- **Overlay**: `onError` invoked when `onTap` throws; loser reveal min-duration; strings present.
+- No `Task.sleep` in tests (use the `continuousClock` dependency / synchronous doubles).
+
+---
+
+## 10. Out of scope (named, not silently dropped)
+
+- Server push implementation (dependency §7).
+- Artist congrats recording flow + the "willing to record a video" opt-in.
+- Cross-station invite banner.
+- Stale-participation GC / 24h TTL (no long-lived poll loop exists to require it).
+```

--- a/docs/superpowers/specs/2026-06-23-live-giveaway-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-23-live-giveaway-resolution-design.md
@@ -135,6 +135,10 @@ GiveawayParticipation]`, keyed by per-airing event id). Coordinator/push **mutat
   sheet open with a retry error (server upserts, so retry is safe). Do not loop-re-present.
 - Visuals from `TapperWinnerScreen` (confetti, prize image, "You won! You're Listener #N", prize
   name/desc, form, "Claim Prize", then "You're all set / We'll be in touch").
+- **Surprise-upgrade copy**: when the sheet is reached by flipping a `.resolvedLost` participation to
+  won (the promoted last-tapper — local provenance was a loss, or push `reason == "last_tapper_fallback"`),
+  the headline acknowledges the upgrade (e.g. "Good news — you got bumped up to the winner!") instead of
+  the plain "You won!". The model exposes the right headline; the view just renders it.
 
 ### 4.6 `APIClient` additions
 - `giveawayEventMyResult: (jwt, eventId) async throws -> GiveawayMyResult`

--- a/docs/superpowers/specs/2026-06-23-live-giveaway-resolution-design.md
+++ b/docs/superpowers/specs/2026-06-23-live-giveaway-resolution-design.md
@@ -40,9 +40,14 @@ Do not guess field names (we got burned in M1 by id-vs-eventId). These are read 
 - `GET /v1/giveaway-events/:eventId/my-result` → `{ tapNumber: Int?, isWinner: Bool, status, winningNumber: Int }`
   — exactly the existing `GiveawayMyResult`. Reconciles a due close on demand. 404 if event missing.
   **Not yet in `APIClient` — we add it.**
-- `POST /v1/giveaway-events/:eventId/winner-submission` — body required `fullName, addressLine1, city,
-  postalCode`; optional `addressLine2, state, country (default "US"), comment`. 201. Winner-only (403
-  otherwise). Upserts on `(eventId)`. **Not yet in `APIClient` — we add it.**
+- `POST /v1/giveaway-events/:eventId/winner-submission` — **email-only (revised 2026-06-24):** iOS
+  sends `{ "preferredEmail": "<confirmed>" }`. 201. Winner-only (403 otherwise). Upserts on `(eventId)`.
+  **Server dependency:** the endpoint currently *requires* `fullName/addressLine1/city/postalCode` —
+  it must be relaxed to accept email-only + store `preferredEmail` (it may still accept the legacy
+  address fields from other clients). Delivery is arranged manually over email for v1. The original
+  address-form contract is retained below for history.
+  - *(legacy)* required `fullName, addressLine1, city, postalCode`; optional `addressLine2, state,
+    country (default "US"), comment`.
 - `GET /v1/giveaway-events/:eventId` → full event + `viewer { hasTapped, isWinner, canSubmitMailingInfo,
   tapNumber }` (`viewer.tapNumber` only set once closed). Reconciles on demand. Already wired as
   `api.giveawayEvent`. Used by the winner sheet to check claim eligibility for push/reinstall cases.
@@ -125,16 +130,19 @@ GiveawayParticipation]`, keyed by per-airing event id). Coordinator/push **mutat
   data/silent push so a common winner who already saw the sheet does not get a redundant banner.
 
 ### 4.5 Winner sheet (`GiveawayWinnerSheetModel` + view; new `PlayolaSheet` case)
-- Form: `fullName, addressLine1, city, state, postalCode` required; `addressLine2, country, comment`
-  optional. No "willing to record a video" toggle (deferred to the congrats milestone; server has no
-  field for it).
+- **Email-only (revised 2026-06-24).** A full mailing-address form is too much friction at the "you
+  won" moment, and the server already knows the winner (`winnerUserId` → `User`). So the sheet collects
+  just a **confirmed email**: prize image + headline + a single email field (pre-filled from
+  `auth.currentUser.verifiedEmail ?? .email`, editable) + Claim. The team arranges delivery over email.
+  No address fields, no "record a video" toggle.
+- Submit → `POST winner-submission` with `{ "preferredEmail": "<confirmed>" }`. Success →
+  `submissionCompleted = true`, dismiss. Failure → keep the sheet open, show a `PlayolaAlert` (matches
+  `RedeemPrizeSheet`), let the user retry (server upserts). Do not loop-re-present.
 - **Provenance check**: if the participation was created from a push or has unknown provenance, GET the
   event detail first; if `viewer.canSubmitMailingInfo == false` (already claimed on another device),
   mark `.resolvedWon(submissionCompleted: true)` and show a "claimed" confirmation instead of the form.
-- Submit → POST winner-submission. Success → `submissionCompleted = true`, dismiss. Failure → keep the
-  sheet open with a retry error (server upserts, so retry is safe). Do not loop-re-present.
 - Visuals from `TapperWinnerScreen` (confetti, prize image, "You won! You're Listener #N", prize
-  name/desc, form, "Claim Prize", then "You're all set / We'll be in touch").
+  name/desc, email field, "Claim Prize", then "You're all set — check your email").
 - **Surprise-upgrade copy**: when the sheet is reached by flipping a `.resolvedLost` participation to
   won (the promoted last-tapper — local provenance was a loss, or push `reason == "last_tapper_fallback"`),
   the headline acknowledges the upgrade (e.g. "Good news — you got bumped up to the winner!") instead of


### PR DESCRIPTION
## Live Giveaway — Milestone 2: win/lose resolution (listener side)

Builds directly on M1 (PR #336, the reveal + tap engine). The tap-button/prompt path is unchanged; this adds everything that happens **after** a tap. Entirely behind `GiveawayFeature.isLiveDataEnabled` (live in staging, dark in prod) — `develop` stays deployable.

Spec + plan: `docs/superpowers/specs/2026-06-23-live-giveaway-resolution-design.md`, `docs/superpowers/plans/2026-06-23-live-giveaway-resolution.md`.

### What it does
- **Immediate reveal** — the outcome comes straight from the tap response's authoritative `isWinner`. Win → app-wide winner sheet now; loss → in-player "You were listener #N" reveal now + a one-time toast. No standby wait, no resolution poll loop. (This replaces M1's "STAND BY…" screen — the one user-visible change vs M1.)
- **Winner sheet** — mailing form (name/address/city/state/zip), submits to `POST /winner-submission`, verifies claim eligibility on open (so it never prompts for an already-claimed prize), and shows "you got bumped up" copy for a promoted last-tapper.
- **App-wide arbiter** (`MainContainerModel`) is the *single* presenter: the durable `@Shared(.giveawayParticipations)` dict is the source of truth; the coordinator and push handler only mutate it. Winner sheet presents once per unclaimed win (re-presents if dismissed without claiming, never clobbers another modal); loss toast fires once.
- **Correctness backstop** — the only gap (the server promotes the last tapper at close on a low-turnout airing) is closed three ways: the foreground feed reconcile rechecks `my-result` on close, a bounded foreground recheck of recent losses (dropped-push safety net), and the targeted winner push.
- **Task 0** — tap failures surface via `onError` → `PlayolaAlert` (silent on the expected 400 "not open yet"; the HTTP→domain-error translation lives behind the `APIClient`, not the coordinator).

### Server dependency (not in this PR)
The targeted **`giveaway_winner` push** to the winner's devices does not exist yet — it's specified in spec §7 and must be implemented in the server worktree that owns giveaway code. iOS ships gated and goes fully live once it lands; the foreground backstop means in-app correctness doesn't wait for it.

### Review
Architecture driven through Codex (consult), then Codex **review** + **challenge** + re-review on the diff. Fixes landed for: the winner-sheet binding (was unreachable), stranded unclaimed winners, TOCTOU races in the participation writes, arbiter clobbering other sheets, lossy-push backstop, push idempotency/logging, and launch-time draining of pre-existing results. 96 giveaway/container/push tests pass (deflaked with `withMainSerialExecutor` + explicit `withLock`).

### Known limitation
The in-player loser reveal is tied to the open event, so it can collapse at song-end; the guaranteed one-time toast is the durable loss feedback, so no feedback is missed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
