### PR TITLE
feat(giveaway): M3 — artist congrats recording (owner side)

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		03D9929612C3E595D9BD88D5 /* GiveawayParticipationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5283C7C8C9FAF45659BA98E /* GiveawayParticipationTests.swift */; };
 		0F528AC0AC6E8A8043556CEC /* GiveawayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */; };
 		100DEE4C2F7441167117CC58 /* GiveawayCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F408E712B42EAED9BE68 /* GiveawayCoordinatorTests.swift */; };
+		1D674687C98A493790039AA2 /* GiveawayCongratsSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1493664DBC23415D4EE04C91 /* GiveawayCongratsSheetView.swift */; };
 		1DBE6EEE6CD7879ED93BB12C /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
 		1E09F417B01F258C6D38D660 /* GiveawayPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */; };
 		1F6F57E01E254F5483BD939B /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
@@ -48,6 +49,7 @@
 		C2FCC44BB8C98C486BC343E6 /* GiveawayOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */; };
 		C344F2AC7008BF0C48803B71 /* GiveawayWinnerSubmissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7886543EC93B0BA403388A8 /* GiveawayWinnerSubmissionRequest.swift */; };
 		C8BA849E20B449EC91DBF5F2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
+		C8DC13568BBCD5F8E6845644 /* GiveawayCongratsSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1493664DBC23415D4EE04C91 /* GiveawayCongratsSheetView.swift */; };
 		D0CD5FE434D4950E16A7B1F9 /* GiveawayOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */; };
 		D302576B2E63423D00F4228B /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
 		D302576D2E63428800F4228B /* ToastClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576C2E63428700F4228B /* ToastClient.swift */; };
@@ -504,6 +506,7 @@
 		0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPush.swift; sourceTree = "<group>"; };
 		0488057E2A6456204E582B15 /* CongratsActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsActionTests.swift; sourceTree = "<group>"; };
 		0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetModel.swift; sourceTree = "<group>"; };
+		1493664DBC23415D4EE04C91 /* GiveawayCongratsSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCongratsSheetView.swift; sourceTree = "<group>"; };
 		1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCoordinator.swift; sourceTree = "<group>"; };
 		2261DEC52F41A8CC973B73FF /* GiveawayCongratsSheetModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCongratsSheetModelTests.swift; sourceTree = "<group>"; };
 		2B82DD37711E160592E3842D /* GiveawayMyResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayMyResult.swift; sourceTree = "<group>"; };
@@ -837,6 +840,7 @@
 			children = (
 				51C95B740988B02A7A472F8C /* GiveawayCongratsSheetModel.swift */,
 				2261DEC52F41A8CC973B73FF /* GiveawayCongratsSheetModelTests.swift */,
+				1493664DBC23415D4EE04C91 /* GiveawayCongratsSheetView.swift */,
 			);
 			name = GiveawayCongratsSheet;
 			path = GiveawayCongratsSheet;
@@ -2089,6 +2093,7 @@
 				5FBBC84B39A22DF69240A54E /* GiveawayWinnerSheetView.swift in Sources */,
 				51CBBA46B5E06C646C37BD3A /* GiveawayWinnerPendingPush.swift in Sources */,
 				EDC6A1FF8A6499631C7E1C1A /* GiveawayCongratsSheetModel.swift in Sources */,
+				1D674687C98A493790039AA2 /* GiveawayCongratsSheetView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2277,6 +2282,7 @@
 				54419FC022E2F30E137BEDD6 /* GiveawayWinnerSheetView.swift in Sources */,
 				2ADE71F9A72B59B6B6C727B5 /* GiveawayWinnerPendingPush.swift in Sources */,
 				B196C20AFDE46B1A6FBA8194 /* GiveawayCongratsSheetModel.swift in Sources */,
+				C8DC13568BBCD5F8E6845644 /* GiveawayCongratsSheetView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -18,6 +18,7 @@
 		36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
 		37BCC67C3543B124A9EDB4C8 /* GiveawayWinnerPendingPushTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3809555E7296131D612667B9 /* GiveawayWinnerPendingPushTests.swift */; };
 		3E9CF257B133D2AD4734F378 /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
+		45C15A64DBFAC157AF8EBA65 /* GiveawayCongratsSheetModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2261DEC52F41A8CC973B73FF /* GiveawayCongratsSheetModelTests.swift */; };
 		51CBBA46B5E06C646C37BD3A /* GiveawayWinnerPendingPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */; };
 		54419FC022E2F30E137BEDD6 /* GiveawayWinnerSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */; };
 		5F67160E76C1454189765E5D /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
@@ -41,6 +42,7 @@
 		AA01000000000005AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
 		AA01000000000006AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
 		B12730D5ECA7018F074B54E6 /* GiveawayBannerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */; };
+		B196C20AFDE46B1A6FBA8194 /* GiveawayCongratsSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C95B740988B02A7A472F8C /* GiveawayCongratsSheetModel.swift */; };
 		B9D97B72F461E83FF652BDBD /* GiveawayPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */; };
 		BEF7B80875987966A5439482 /* GiveawayFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61840B16734426EAC4079351 /* GiveawayFeature.swift */; };
 		C2FCC44BB8C98C486BC343E6 /* GiveawayOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */; };
@@ -470,6 +472,7 @@
 		E6A2E13F3905B715C7E6FA15 /* GiveawayEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EDCED098E801AAB2E9DC82 /* GiveawayEvent.swift */; };
 		E6FA723C089B9E0115951DD1 /* GiveawayBannerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */; };
 		E96C77B08E039DD3EC6916BF /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
+		EDC6A1FF8A6499631C7E1C1A /* GiveawayCongratsSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C95B740988B02A7A472F8C /* GiveawayCongratsSheetModel.swift */; };
 		EDE2B63A1AB34C74CC65C898 /* CongratsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */; };
 		F35D444BFD44486391C161D6 /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 0B6E1320AC744E9FAEC2F50F /* Sentry */; };
 		F425EEF25FDF6BFE036A49E2 /* GiveawayWinnerPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */; };
@@ -502,12 +505,14 @@
 		0488057E2A6456204E582B15 /* CongratsActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsActionTests.swift; sourceTree = "<group>"; };
 		0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetModel.swift; sourceTree = "<group>"; };
 		1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCoordinator.swift; sourceTree = "<group>"; };
+		2261DEC52F41A8CC973B73FF /* GiveawayCongratsSheetModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCongratsSheetModelTests.swift; sourceTree = "<group>"; };
 		2B82DD37711E160592E3842D /* GiveawayMyResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayMyResult.swift; sourceTree = "<group>"; };
 		36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSubmission.swift; sourceTree = "<group>"; };
 		3809555E7296131D612667B9 /* GiveawayWinnerPendingPushTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPendingPushTests.swift; sourceTree = "<group>"; };
 		3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayOverlayModel.swift; sourceTree = "<group>"; };
 		3B83C3893A771EB211B3AF8F /* StationListLiveSortTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StationListLiveSortTests.swift; sourceTree = "<group>"; };
 		4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayPlayerOverlayView.swift; sourceTree = "<group>"; };
+		51C95B740988B02A7A472F8C /* GiveawayCongratsSheetModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCongratsSheetModel.swift; sourceTree = "<group>"; };
 		61840B16734426EAC4079351 /* GiveawayFeature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayFeature.swift; sourceTree = "<group>"; };
 		6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayParticipation.swift; sourceTree = "<group>"; };
 		70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPendingPush.swift; sourceTree = "<group>"; };
@@ -827,6 +832,16 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		358480181ADB29C686D6482F /* GiveawayCongratsSheet */ = {
+			isa = PBXGroup;
+			children = (
+				51C95B740988B02A7A472F8C /* GiveawayCongratsSheetModel.swift */,
+				2261DEC52F41A8CC973B73FF /* GiveawayCongratsSheetModelTests.swift */,
+			);
+			name = GiveawayCongratsSheet;
+			path = GiveawayCongratsSheet;
+			sourceTree = "<group>";
+		};
 		5BCFD236E4802E5BC59860C6 /* GiveawayWinnerSheet */ = {
 			isa = PBXGroup;
 			children = (
@@ -1056,6 +1071,7 @@
 				FE110A0000000000000000A0 /* WelcomeMessage */,
 				D3536A062BFA4F49006942D6 /* ContentView.swift */,
 				5BCFD236E4802E5BC59860C6 /* GiveawayWinnerSheet */,
+				358480181ADB29C686D6482F /* GiveawayCongratsSheet */,
 			);
 			path = Pages;
 			sourceTree = "<group>";
@@ -2072,6 +2088,7 @@
 				36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */,
 				5FBBC84B39A22DF69240A54E /* GiveawayWinnerSheetView.swift in Sources */,
 				51CBBA46B5E06C646C37BD3A /* GiveawayWinnerPendingPush.swift in Sources */,
+				EDC6A1FF8A6499631C7E1C1A /* GiveawayCongratsSheetModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2259,6 +2276,7 @@
 				3E9CF257B133D2AD4734F378 /* GiveawayWinnerSheetModel.swift in Sources */,
 				54419FC022E2F30E137BEDD6 /* GiveawayWinnerSheetView.swift in Sources */,
 				2ADE71F9A72B59B6B6C727B5 /* GiveawayWinnerPendingPush.swift in Sources */,
+				B196C20AFDE46B1A6FBA8194 /* GiveawayCongratsSheetModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2341,6 +2359,7 @@
 				FE654232793406CA6A2FA1FE /* GiveawayWinnerSheetModelTests.swift in Sources */,
 				F9A35F1CB53E4F9D4E750430 /* StationListLiveSortTests.swift in Sources */,
 				37BCC67C3543B124A9EDB4C8 /* GiveawayWinnerPendingPushTests.swift in Sources */,
+				45C15A64DBFAC157AF8EBA65 /* GiveawayCongratsSheetModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -13,9 +13,12 @@
 		1DBE6EEE6CD7879ED93BB12C /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
 		1E09F417B01F258C6D38D660 /* GiveawayPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */; };
 		1F6F57E01E254F5483BD939B /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
+		2ADE71F9A72B59B6B6C727B5 /* GiveawayWinnerPendingPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */; };
 		354451A630DF81468815108F /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
 		36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
+		37BCC67C3543B124A9EDB4C8 /* GiveawayWinnerPendingPushTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3809555E7296131D612667B9 /* GiveawayWinnerPendingPushTests.swift */; };
 		3E9CF257B133D2AD4734F378 /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
+		51CBBA46B5E06C646C37BD3A /* GiveawayWinnerPendingPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */; };
 		54419FC022E2F30E137BEDD6 /* GiveawayWinnerSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */; };
 		5F67160E76C1454189765E5D /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
 		5F721A0797795B3B529757CD /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
@@ -501,11 +504,13 @@
 		1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCoordinator.swift; sourceTree = "<group>"; };
 		2B82DD37711E160592E3842D /* GiveawayMyResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayMyResult.swift; sourceTree = "<group>"; };
 		36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSubmission.swift; sourceTree = "<group>"; };
+		3809555E7296131D612667B9 /* GiveawayWinnerPendingPushTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPendingPushTests.swift; sourceTree = "<group>"; };
 		3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayOverlayModel.swift; sourceTree = "<group>"; };
 		3B83C3893A771EB211B3AF8F /* StationListLiveSortTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StationListLiveSortTests.swift; sourceTree = "<group>"; };
 		4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayPlayerOverlayView.swift; sourceTree = "<group>"; };
 		61840B16734426EAC4079351 /* GiveawayFeature.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayFeature.swift; sourceTree = "<group>"; };
 		6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayParticipation.swift; sourceTree = "<group>"; };
+		70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPendingPush.swift; sourceTree = "<group>"; };
 		917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayBannerState.swift; sourceTree = "<group>"; };
 		9553B35A6FBA27239EF49033 /* GiveawayModelsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayModelsTests.swift; sourceTree = "<group>"; };
 		9E8719F70AFA4992B9037775 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
@@ -977,6 +982,8 @@
 				D7886543EC93B0BA403388A8 /* GiveawayWinnerSubmissionRequest.swift */,
 				0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */,
 				BA44EE33EB697E44CEC84351 /* GiveawayWinnerPushTests.swift */,
+				70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */,
+				3809555E7296131D612667B9 /* GiveawayWinnerPendingPushTests.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -2064,6 +2071,7 @@
 				DDB617A9AA22B4D37A3E3808 /* GiveawayWinnerPush.swift in Sources */,
 				36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */,
 				5FBBC84B39A22DF69240A54E /* GiveawayWinnerSheetView.swift in Sources */,
+				51CBBA46B5E06C646C37BD3A /* GiveawayWinnerPendingPush.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2250,6 +2258,7 @@
 				F425EEF25FDF6BFE036A49E2 /* GiveawayWinnerPush.swift in Sources */,
 				3E9CF257B133D2AD4734F378 /* GiveawayWinnerSheetModel.swift in Sources */,
 				54419FC022E2F30E137BEDD6 /* GiveawayWinnerSheetView.swift in Sources */,
+				2ADE71F9A72B59B6B6C727B5 /* GiveawayWinnerPendingPush.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2331,6 +2340,7 @@
 				9B6663109A6517E11DB2D64E /* GiveawayWinnerPushTests.swift in Sources */,
 				FE654232793406CA6A2FA1FE /* GiveawayWinnerSheetModelTests.swift in Sources */,
 				F9A35F1CB53E4F9D4E750430 /* StationListLiveSortTests.swift in Sources */,
+				37BCC67C3543B124A9EDB4C8 /* GiveawayWinnerPendingPushTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -795,6 +795,11 @@ extension APIClient: DependencyKey {
           path: "/v1/giveaway-events/\(eventId)/winner-submission",
           token: jwtToken, parameters: body.asParameters)
       },
+      recordGiveawayEventCongrats: { jwtToken, eventId, audioBlockId in
+        try await authenticatedPostVoid(
+          path: "/v1/giveaway-events/\(eventId)/congrats",
+          token: jwtToken, parameters: ["audioBlockId": audioBlockId])
+      },
       getSupportConversation: { jwtToken in
         try await authenticatedGet(path: "/v1/conversations/support", token: jwtToken)
       },

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -796,9 +796,20 @@ extension APIClient: DependencyKey {
           token: jwtToken, parameters: body.asParameters)
       },
       recordGiveawayEventCongrats: { jwtToken, eventId, audioBlockId in
-        try await authenticatedPostVoid(
-          path: "/v1/giveaway-events/\(eventId)/congrats",
-          token: jwtToken, parameters: ["audioBlockId": audioBlockId])
+        do {
+          try await authenticatedPostVoid(
+            path: "/v1/giveaway-events/\(eventId)/congrats",
+            token: jwtToken, parameters: ["audioBlockId": audioBlockId])
+        } catch let error as AFError {
+          // 409 = the congrats window has closed server-side. Translate to a domain error so the
+          // caller can mark the action terminal instead of offering a futile retry.
+          if case .responseValidationFailed(reason: .unacceptableStatusCode(let code)) = error,
+            code == 409
+          {
+            throw GiveawayCongratsError.windowClosed
+          }
+          throw error
+        }
       },
       getSupportConversation: { jwtToken in
         try await authenticatedGet(path: "/v1/conversations/support", token: jwtToken)

--- a/PlayolaRadio/Core/API/APIClient.swift
+++ b/PlayolaRadio/Core/API/APIClient.swift
@@ -571,6 +571,12 @@ struct APIClient: Sendable {
     @Sendable (_ jwtToken: String, _ eventId: String, _ body: GiveawayWinnerSubmissionRequest)
       async throws -> Void = { _, _, _ in }
 
+  /// Owner submits a recorded congrats (an uploaded voicetrack `audioBlockId`) for an event; the
+  /// server inserts it as a spin. Idempotent per (eventId, audioBlockId) on the server.
+  var recordGiveawayEventCongrats:
+    @Sendable (_ jwtToken: String, _ eventId: String, _ audioBlockId: String) async throws -> Void =
+      { _, _, _ in }
+
   /// Gets the user's support conversation (may be nil if none exists)
   /// - Parameter jwtToken: The JWT token for authentication
   /// - Returns: SupportConversationResponse containing the conversation (nullable) and unread count

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -219,6 +219,7 @@ extension PushNotificationsClient: DependencyKey {
       await stationPlayer.play(station: station)
     },
     handleGiveawayWinnerPush: { userInfo in
+      guard GiveawayFeature.isLiveDataEnabled else { return }
       guard let push = GiveawayWinnerPush(userInfo: userInfo) else {
         // A malformed winner push is the one rescue path for a missed promotion — never drop it
         // silently. (A non-giveaway payload routed here by mistake is not worth reporting.)

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -89,6 +89,12 @@ struct PushNotificationsClient: Sendable {
   /// - Parameter userInfo: The notification payload
   var handleGiveawayWinnerPush: @Sendable (_ userInfo: [String: any Sendable]) async -> Void
 
+  /// Handle the owner-only "winner pending" giveaway push: the owner can record a congrats. Writes a
+  /// pending `CongratsAction` into durable shared state; the MainContainer arbiter presents the
+  /// congrats sheet. Never clobbers an in-progress (non-terminal) action.
+  /// - Parameter userInfo: The notification payload
+  var handleGiveawayWinnerPendingPush: @Sendable (_ userInfo: [String: any Sendable]) async -> Void
+
   /// Set the app icon badge count
   /// - Parameter count: The badge count to display
   var setBadgeCount: @Sendable (_ count: Int) async -> Void
@@ -240,6 +246,35 @@ extension PushNotificationsClient: DependencyKey {
               winningNumber: push.winningNumber, tapNumber: push.tapNumber,
               status: .resolvedWon(submissionCompleted: submissionCompleted), tappedAt: Date())
           }
+        }
+      }
+    },
+    handleGiveawayWinnerPendingPush: { userInfo in
+      guard GiveawayFeature.isLiveDataEnabled else { return }
+      guard let push = GiveawayWinnerPendingPush(userInfo: userInfo) else {
+        if userInfo["type"] as? String == "giveaway_winner_pending" {
+          reportIssue("Dropped malformed giveaway_winner_pending push: \(userInfo)")
+        }
+        return
+      }
+      @Shared(.pendingCongratsActions) var actions
+      let actionsShared = $actions
+      await MainActor.run {
+        actionsShared.withLock { dict in
+          if let existing = dict[push.eventId], !existing.isTerminal {
+            // Never reset a non-terminal in-progress action (it may hold a recording / audioBlockId);
+            // only refresh metadata.
+            var updated = existing
+            updated.winnerName = push.winnerName ?? existing.winnerName
+            updated.prizeName = push.prizeName ?? existing.prizeName
+            updated.congratsExpiresAt = push.congratsExpiresAt ?? existing.congratsExpiresAt
+            dict[push.eventId] = updated
+            return
+          }
+          dict[push.eventId] = CongratsAction(
+            eventId: push.eventId, stationId: push.stationId, winnerName: push.winnerName,
+            prizeName: push.prizeName, congratsExpiresAt: push.congratsExpiresAt,
+            state: .pending, startedAt: Date())
         }
       }
     },

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -267,9 +267,12 @@ extension PushNotificationsClient: DependencyKey {
       let actionsShared = $actions
       await MainActor.run {
         actionsShared.withLock { dict in
-          if let existing = dict[push.eventId], !existing.isTerminal {
-            // Never reset a non-terminal in-progress action (it may hold a recording / audioBlockId);
-            // only refresh metadata.
+          if let existing = dict[push.eventId] {
+            // A terminal action (submitted / skipped / alreadyClosed) must NOT be resurrected by a
+            // delayed duplicate push — that would re-prompt the owner and allow a second congrats.
+            // A non-terminal in-progress action keeps its recording / audioBlockId; only refresh
+            // metadata.
+            guard !existing.isTerminal else { return }
             var updated = existing
             updated.winnerName = push.winnerName ?? existing.winnerName
             updated.prizeName = push.prizeName ?? existing.prizeName

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -234,9 +234,15 @@ extension PushNotificationsClient: DependencyKey {
       let participationsShared = $participations
       await MainActor.run {
         participationsShared.withLock { dict in
-          // Already a (possibly pending or claimed) win → leave untouched so we never clobber a
-          // `winnerSheetPresentedAt` stamp or re-open a completed claim.
-          if case .resolvedWon = dict[push.eventId]?.status { return }
+          // Already a win. Honor a server "claimed elsewhere" upgrade by flipping a locally-pending
+          // win to completed (so the arbiter stops re-presenting the claim form), but never clobber
+          // the `winnerSheetPresentedAt` stamp or re-open an already-completed claim.
+          if case .resolvedWon(let alreadyCompleted) = dict[push.eventId]?.status {
+            if submissionCompleted, !alreadyCompleted {
+              dict[push.eventId]?.status = .resolvedWon(submissionCompleted: true)
+            }
+            return
+          }
           if dict[push.eventId] != nil {
             dict[push.eventId]?.status = .resolvedWon(submissionCompleted: submissionCompleted)
           } else {

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -280,4 +280,43 @@ struct PushNotificationsTests {
     ])
     #expect(participations.isEmpty)
   }
+
+  // MARK: - handleGiveawayWinnerPendingPush (artist congrats)
+
+  @Test func pendingPushCreatesPendingCongrats() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = [:] }
+    await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+      "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",
+      "winnerName": "Jo", "prizeName": "Two tickets",
+    ])
+    #expect(actions["e1"]?.state == .pending)
+    #expect(actions["e1"]?.winnerName == "Jo")
+    #expect(actions["e1"]?.prizeName == "Two tickets")
+  }
+
+  @Test func pendingPushDoesNotClobberInProgressRecording() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: "P", congratsExpiresAt: nil,
+          state: .recorded(localRecordingPath: "/tmp/r.m4a"), startedAt: Date())
+      ]
+    }
+    await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+      "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1", "winnerName": "Jo",
+    ])
+    // The in-progress recording must survive a duplicate push.
+    #expect(actions["e1"]?.state == .recorded(localRecordingPath: "/tmp/r.m4a"))
+  }
+
+  @Test func pendingPushIgnoresNonPendingType() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = [:] }
+    await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+      "type": "giveaway_closed", "eventId": "e1", "stationId": "s1",
+    ])
+    #expect(actions.isEmpty)
+  }
 }

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -13,7 +13,11 @@ import Testing
 
 @testable import PlayolaRadio
 
+// Serialized: these tests mutate the file-backed `@Shared(.pendingCongratsActions)` /
+// `.giveawayParticipations` stores under shared keys, so parallel Swift Testing could interleave
+// across `await` points and cross-contaminate the on-disk state.
 @MainActor
+@Suite(.serialized)
 struct PushNotificationsTests {
 
   // MARK: - registerForRemoteNotifications

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -264,6 +264,25 @@ struct PushNotificationsTests {
     #expect(participations["e"]?.winnerSheetPresentedAt == presentedAt)
   }
 
+  @Test func winnerPushUpgradesPendingWinWhenServerReportsClaimed() async {
+    let presentedAt = Date(timeIntervalSince1970: 42)
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
+      "e": GiveawayParticipation(
+        id: "e", stationId: "s", prizeName: "Two tickets", winningNumber: 9, tapNumber: 5,
+        status: .resolvedWon(submissionCompleted: false), tappedAt: Date(),
+        winnerSheetPresentedAt: presentedAt)
+    ]
+    var payload = winnerPayload()
+    payload["submissionCompleted"] = true
+    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(payload)
+    // A pending win must flip to completed (claimed on another device) so the arbiter stops
+    // re-presenting the form — while the original presentation stamp survives.
+    #expect(
+      participations["e"]?.status
+        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: true))
+    #expect(participations["e"]?.winnerSheetPresentedAt == presentedAt)
+  }
+
   @Test func winnerPushCreatesParticipationOnReinstall() async {
     @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
     await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -330,6 +330,23 @@ struct PushNotificationsTests {
     #expect(actions["e1"]?.state == .recorded(localRecordingPath: "/tmp/r.m4a"))
   }
 
+  @Test func pendingPushDoesNotResurrectTerminalAction() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: "P", congratsExpiresAt: nil,
+          state: .submitted, startedAt: Date())
+      ]
+    }
+    // A delayed duplicate push after the owner already submitted must not re-prompt or allow a
+    // second congrats — the terminal state stands.
+    await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+      "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1", "winnerName": "Jo",
+    ])
+    #expect(actions["e1"]?.state == .submitted)
+  }
+
   @Test func pendingPushIgnoresNonPendingType() async {
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     $actions.withLock { $0 = [:] }

--- a/PlayolaRadio/Models/CongratsAction.swift
+++ b/PlayolaRadio/Models/CongratsAction.swift
@@ -2,34 +2,45 @@ import Foundation
 
 enum CongratsActionState: Codable, Equatable, Sendable {
   case pending
+  case recorded(localRecordingPath: String)
   case uploaded(audioBlockId: String)
   case submitted
   case alreadyClosed
+  case skipped
 }
 
 struct CongratsAction: Codable, Equatable, Sendable, Identifiable {
-  let giveawayId: String
+  let eventId: String
   let stationId: String
+  var winnerName: String?
+  var prizeName: String?
+  var congratsExpiresAt: Date?
   var state: CongratsActionState
   var startedAt: Date
 
-  var id: String { giveawayId }
+  var id: String { eventId }
 
   var audioBlockId: String? {
     if case .uploaded(let audioBlockId) = state { return audioBlockId }
     return nil
   }
 
+  var localRecordingPath: String? {
+    if case .recorded(let path) = state { return path }
+    return nil
+  }
+
   var isTerminal: Bool {
     switch state {
-    case .submitted, .alreadyClosed: return true
-    case .pending, .uploaded: return false
+    case .submitted, .alreadyClosed, .skipped: return true
+    case .pending, .recorded, .uploaded: return false
     }
   }
 
   static var mock: CongratsAction {
     CongratsAction(
-      giveawayId: "giveaway-1", stationId: "station-1", state: .pending,
+      eventId: "event-1", stationId: "station-1", winnerName: "Jo", prizeName: "Two tickets",
+      congratsExpiresAt: nil, state: .pending,
       startedAt: Date(timeIntervalSince1970: 1_781_722_800))
   }
 }

--- a/PlayolaRadio/Models/CongratsAction.swift
+++ b/PlayolaRadio/Models/CongratsAction.swift
@@ -3,7 +3,7 @@ import Foundation
 enum CongratsActionState: Codable, Equatable, Sendable {
   case pending
   case recorded(localRecordingPath: String)
-  case uploaded(audioBlockId: String)
+  case uploaded(audioBlockId: String, localRecordingPath: String)
   case submitted
   case alreadyClosed
   case skipped
@@ -21,13 +21,16 @@ struct CongratsAction: Codable, Equatable, Sendable, Identifiable {
   var id: String { eventId }
 
   var audioBlockId: String? {
-    if case .uploaded(let audioBlockId) = state { return audioBlockId }
+    if case .uploaded(let audioBlockId, _) = state { return audioBlockId }
     return nil
   }
 
   var localRecordingPath: String? {
-    if case .recorded(let path) = state { return path }
-    return nil
+    switch state {
+    case .recorded(let path): return path
+    case .uploaded(_, let path): return path
+    default: return nil
+    }
   }
 
   var isTerminal: Bool {

--- a/PlayolaRadio/Models/CongratsActionTests.swift
+++ b/PlayolaRadio/Models/CongratsActionTests.swift
@@ -8,7 +8,7 @@ import Testing
 struct CongratsActionTests {
   @Test func codableRoundTripsWithAssociatedValues() throws {
     var action = CongratsAction.mock
-    action.state = .uploaded(audioBlockId: "ab1")
+    action.state = .uploaded(audioBlockId: "ab1", localRecordingPath: "/tmp/rec.m4a")
     let data = try JSONEncoder().encode(action)
     let back = try JSONDecoder().decode(CongratsAction.self, from: data)
     expectNoDifference(back, action)
@@ -19,9 +19,10 @@ struct CongratsActionTests {
     action.state = .recorded(localRecordingPath: "/tmp/rec.m4a")
     #expect(action.localRecordingPath == "/tmp/rec.m4a")
     #expect(action.audioBlockId == nil)
-    action.state = .uploaded(audioBlockId: "ab1")
+    action.state = .uploaded(audioBlockId: "ab1", localRecordingPath: "/tmp/rec.m4a")
     #expect(action.audioBlockId == "ab1")
-    #expect(action.localRecordingPath == nil)
+    // The local file survives the upload transition so a resumed upload can still play back / clean up.
+    #expect(action.localRecordingPath == "/tmp/rec.m4a")
   }
 
   @Test func terminalStates() {
@@ -30,7 +31,7 @@ struct CongratsActionTests {
     #expect(!action.isTerminal)
     action.state = .recorded(localRecordingPath: "/x.m4a")
     #expect(!action.isTerminal)
-    action.state = .uploaded(audioBlockId: "ab1")
+    action.state = .uploaded(audioBlockId: "ab1", localRecordingPath: "/tmp/rec.m4a")
     #expect(!action.isTerminal)
     action.state = .submitted
     #expect(action.isTerminal)

--- a/PlayolaRadio/Models/CongratsActionTests.swift
+++ b/PlayolaRadio/Models/CongratsActionTests.swift
@@ -6,32 +6,37 @@ import Testing
 
 @MainActor
 struct CongratsActionTests {
-  @Test func codableRoundTrips() throws {
-    let action = CongratsAction(
-      giveawayId: "g1", stationId: "s1", state: .uploaded(audioBlockId: "ab1"),
-      startedAt: Date(timeIntervalSince1970: 1_000_000))
+  @Test func codableRoundTripsWithAssociatedValues() throws {
+    var action = CongratsAction.mock
+    action.state = .uploaded(audioBlockId: "ab1")
     let data = try JSONEncoder().encode(action)
     let back = try JSONDecoder().decode(CongratsAction.self, from: data)
     expectNoDifference(back, action)
   }
 
-  @Test func audioBlockIdOnlyPresentWhenUploaded() {
+  @Test func associatedValueAccessors() {
     var action = CongratsAction.mock
+    action.state = .recorded(localRecordingPath: "/tmp/rec.m4a")
+    #expect(action.localRecordingPath == "/tmp/rec.m4a")
     #expect(action.audioBlockId == nil)
     action.state = .uploaded(audioBlockId: "ab1")
     #expect(action.audioBlockId == "ab1")
-    action.state = .submitted
-    #expect(action.audioBlockId == nil)
+    #expect(action.localRecordingPath == nil)
   }
 
-  @Test func isTerminalForSubmittedAndAlreadyClosed() {
+  @Test func terminalStates() {
     var action = CongratsAction.mock
+    action.state = .pending
+    #expect(!action.isTerminal)
+    action.state = .recorded(localRecordingPath: "/x.m4a")
     #expect(!action.isTerminal)
     action.state = .uploaded(audioBlockId: "ab1")
     #expect(!action.isTerminal)
     action.state = .submitted
     #expect(action.isTerminal)
     action.state = .alreadyClosed
+    #expect(action.isTerminal)
+    action.state = .skipped
     #expect(action.isTerminal)
   }
 }

--- a/PlayolaRadio/Models/GiveawayTapResponse.swift
+++ b/PlayolaRadio/Models/GiveawayTapResponse.swift
@@ -16,3 +16,11 @@ struct GiveawayTapResponse: Decodable, Sendable, Equatable {
 enum GiveawayTapError: Error, Equatable {
   case notOpenYet
 }
+
+/// Domain errors for submitting an artist congrats, translated from the transport layer inside
+/// `APIClient`. `.windowClosed` is the server signaling the congrats window has already closed
+/// (HTTP 409); the caller maps it to a terminal `.alreadyClosed` action instead of looping on a
+/// pointless retry. Any other failure propagates as-is (genuinely retryable).
+enum GiveawayCongratsError: Error, Equatable {
+  case windowClosed
+}

--- a/PlayolaRadio/Models/GiveawayWinnerPendingPush.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPendingPush.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+/// The owner-only `giveaway_winner_pending` push: a station owner's giveaway has a winner, so they
+/// can record a congrats. Parsed from an APNs userInfo payload. (winnerName/prizeName/congratsExpiresAt
+/// are structured data fields the server adds alongside the human-readable alert body.)
+struct GiveawayWinnerPendingPush: Equatable, Sendable {
+  let eventId: String
+  let stationId: String
+  let giveawayId: String?
+  let winnerName: String?
+  let prizeName: String?
+  let congratsExpiresAt: Date?
+
+  init?(userInfo: [String: any Sendable]) {
+    guard userInfo["type"] as? String == "giveaway_winner_pending",
+      let eventId = userInfo["eventId"] as? String,
+      let stationId = userInfo["stationId"] as? String
+    else { return nil }
+    self.eventId = eventId
+    self.stationId = stationId
+    self.giveawayId = userInfo["giveawayId"] as? String
+    self.winnerName = userInfo["winnerName"] as? String
+    self.prizeName = userInfo["prizeName"] as? String
+    self.congratsExpiresAt = (userInfo["congratsExpiresAt"] as? String).flatMap(Self.parseISO8601)
+  }
+
+  /// Robust ISO-8601 parse: the server sends fractional seconds, but tolerate a value without them.
+  private static func parseISO8601(_ string: String) -> Date? {
+    let withFractional = ISO8601DateFormatter()
+    withFractional.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+    if let date = withFractional.date(from: string) { return date }
+    let plain = ISO8601DateFormatter()
+    plain.formatOptions = [.withInternetDateTime]
+    return plain.date(from: string)
+  }
+}

--- a/PlayolaRadio/Models/GiveawayWinnerPendingPushTests.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPendingPushTests.swift
@@ -1,0 +1,38 @@
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct GiveawayWinnerPendingPushTests {
+  @Test func parsesValidPendingPush() {
+    let push = GiveawayWinnerPendingPush(userInfo: [
+      "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",
+      "giveawayId": "gw1", "winnerName": "Jo", "prizeName": "Two tickets",
+      "congratsExpiresAt": "2026-06-25T20:00:00.000Z",
+    ])
+    expectNoDifference(push?.eventId, "e1")
+    expectNoDifference(push?.stationId, "s1")
+    expectNoDifference(push?.winnerName, "Jo")
+    expectNoDifference(push?.prizeName, "Two tickets")
+    #expect(push?.congratsExpiresAt != nil)
+  }
+
+  @Test func parsesExpiryWithoutFractionalSeconds() {
+    let push = GiveawayWinnerPendingPush(userInfo: [
+      "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",
+      "congratsExpiresAt": "2026-06-25T20:00:00Z",
+    ])
+    #expect(push?.congratsExpiresAt != nil)
+  }
+
+  @Test func rejectsWrongTypeOrMissingIds() {
+    #expect(
+      GiveawayWinnerPendingPush(userInfo: ["type": "giveaway_closed", "eventId": "e1"]) == nil)
+    #expect(
+      GiveawayWinnerPendingPush(userInfo: ["type": "giveaway_winner_pending", "eventId": "e1"])
+        == nil)  // missing stationId
+    #expect(GiveawayWinnerPendingPush(userInfo: ["type": "giveaway_winner_pending"]) == nil)
+  }
+}

--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -203,7 +203,7 @@ class AuthService: @unchecked Sendable {
     @Shared(.giveawayBanner) var giveawayBanner
     @Shared(.giveawayParticipations) var giveawayParticipations
     @Shared(.dismissedGiveawayBannerIds) var dismissedGiveawayBannerIds
-    @Shared(.pendingCongratsAction) var pendingCongratsAction
+    @Shared(.pendingCongratsActions) var pendingCongratsActions
 
     let jwt = auth.jwt
     let deviceId = registeredDeviceId
@@ -227,7 +227,7 @@ class AuthService: @unchecked Sendable {
     $giveawayBanner.withLock { $0 = nil }
     $giveawayParticipations.withLock { $0 = [:] }
     $dismissedGiveawayBannerIds.withLock { $0 = [] }
-    $pendingCongratsAction.withLock { $0 = nil }
+    $pendingCongratsActions.withLock { $0 = [:] }
 
     UserDefaults.standard.removeObject(forKey: "analytics_session_paused_at")
   }

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -111,6 +111,12 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
         await pushNotifications.handleGiveawayWinnerPush(payload)
         completionHandler(.newData)
       }
+    } else if userInfo["type"] as? String == "giveaway_winner_pending" {
+      let payload = userInfo.sendablePayload()
+      Task {
+        await pushNotifications.handleGiveawayWinnerPendingPush(payload)
+        completionHandler(.newData)
+      }
     } else {
       completionHandler(.noData)
     }
@@ -137,6 +143,16 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
         await pushNotifications.handleGiveawayWinnerPush(payload)
       }
       // The arbiter presents the winner sheet in-app; no redundant OS banner.
+      completionHandler([])
+      return
+    }
+
+    if userInfo["type"] as? String == "giveaway_winner_pending" {
+      let payload = userInfo.sendablePayload()
+      Task {
+        await pushNotifications.handleGiveawayWinnerPendingPush(payload)
+      }
+      // The arbiter presents the congrats sheet in-app; no redundant OS banner.
       completionHandler([])
       return
     }
@@ -175,6 +191,11 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
       // mid-write and drop the win.
       Task {
         await pushNotifications.handleGiveawayWinnerPush(userInfo)
+        completionHandler()
+      }
+    } else if userInfo["type"] as? String == "giveaway_winner_pending" {
+      Task {
+        await pushNotifications.handleGiveawayWinnerPendingPush(userInfo)
         completionHandler()
       }
     } else {

--- a/PlayolaRadio/State/SharedUserDefaults.swift
+++ b/PlayolaRadio/State/SharedUserDefaults.swift
@@ -155,12 +155,13 @@ extension SharedKey where Self == FileStorageKey<Set<String>>.Default {
   }
 }
 
-extension SharedKey where Self == FileStorageKey<CongratsAction?>.Default {
-  /// Durable artist congrats progress; survives a kill and holds the uploaded audioBlockId for retry.
-  static var pendingCongratsAction: Self {
+extension SharedKey where Self == FileStorageKey<[String: CongratsAction]>.Default {
+  /// Durable artist congrats progress, keyed by per-airing event id. Survives a kill and holds the
+  /// recorded file path (`.recorded`) and uploaded audioBlockId (`.uploaded`) for resume/retry.
+  static var pendingCongratsActions: Self {
     Self[
-      .fileStorage(.documentsDirectory.appending(component: "pending-congrats-action.json")),
-      default: nil
+      .fileStorage(.documentsDirectory.appending(component: "pending-congrats-actions.json")),
+      default: [:]
     ]
   }
 }

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -39,7 +39,11 @@ class GiveawayCongratsSheetModel: ViewModel {
     case .recorded(let path):
       recordingURL = URL(fileURLWithPath: path)
       recordingPhase = .review
-    case .uploaded:
+    case .uploaded(_, let path):
+      // The local file survives until submit succeeds, so a resumed upload can still play back
+      // and review before re-sending.
+      recordingURL = URL(fileURLWithPath: path)
+      recordingPhase = .review
       readyToSubmit = true
     default:
       break
@@ -58,16 +62,36 @@ class GiveawayCongratsSheetModel: ViewModel {
   var presentedAlert: PlayolaAlert?
 
   @ObservationIgnored var recordingURL: URL?
+  @ObservationIgnored private var isStartingRecording = false
   @ObservationIgnored private var recordingTask: Task<Void, Never>?
   @ObservationIgnored private var playbackTask: Task<Void, Never>?
 
   // MARK: - User Actions
 
   func viewAppeared() async {
-    try? await audioRecorder.prepareForRecording()
+    // Resuming from a persisted recording (.recorded / .uploaded after a kill): load it so review
+    // shows a real duration and Play works. Otherwise prime the recorder for a fresh take.
+    if let url = recordingURL {
+      try? await audioPlayer.loadFile(url)
+      recordingDuration = await audioPlayer.duration()
+    } else {
+      try? await audioRecorder.prepareForRecording()
+    }
+  }
+
+  func viewDisappeared() async {
+    // SwiftUI swipe-to-dismiss nils the sheet without routing through skip/send, so this is the only
+    // teardown hook for an interactive dismissal — stop the mic/player and suppress re-prompt.
+    await stopActiveCapture()
+    onClose()
   }
 
   func onRecordTapped() async {
+    // Guard synchronously (before the first await) so a rapid double-tap can't start two recorder
+    // sessions while permission/start are in flight.
+    guard recordingPhase == .idle, !isStartingRecording else { return }
+    isStartingRecording = true
+    defer { isStartingRecording = false }
     guard await audioRecorder.requestPermission() else {
       presentedAlert = .congratsMicPermissionDenied
       return
@@ -128,7 +152,7 @@ class GiveawayCongratsSheetModel: ViewModel {
     defer { isSubmitting = false }
 
     // If we already have an uploaded audioBlock (resume after a failed/killed submit), only re-POST.
-    if case .uploaded(let audioBlockId) = pendingCongratsActions[eventId]?.state {
+    if case .uploaded(let audioBlockId, _) = pendingCongratsActions[eventId]?.state {
       await submitCongrats(audioBlockId: audioBlockId)
       return
     }
@@ -137,6 +161,9 @@ class GiveawayCongratsSheetModel: ViewModel {
   }
 
   func skipButtonTapped() async {
+    // Skip is disabled in the UI while a submit is in flight; guard here too so a stray call can't
+    // race the upload/submit and flip an already-sending action to skipped.
+    guard !isSubmitting else { return }
     await stopActiveCapture()
     setState(.skipped)
     cleanUpRecording()
@@ -160,6 +187,8 @@ class GiveawayCongratsSheetModel: ViewModel {
   var stopButtonTitle: String { "Stop" }
   var sendButtonTitle: String { isSubmitting ? "Sending…" : "Send" }
   var canSend: Bool { !isSubmitting && (readyToSubmit || recordingPhase == .review) }
+  var canSkip: Bool { !isSubmitting }
+  var canPlay: Bool { recordingURL != nil }
   var showsRecordButton: Bool { !readyToSubmit && recordingPhase == .idle }
   var showsRecordingControls: Bool { recordingPhase == .recording }
   var showsReview: Bool { readyToSubmit || recordingPhase == .review }
@@ -171,6 +200,8 @@ class GiveawayCongratsSheetModel: ViewModel {
   var reviewControlsOpacity: Double { showsReview ? 1 : 0 }
   var sendButtonDisabled: Bool { !canSend }
   var sendButtonOpacity: Double { canSend ? 1 : 0.5 }
+  var skipButtonOpacity: Double { canSkip ? 1 : 0.5 }
+  var playButtonOpacity: Double { canPlay ? 1 : 0.5 }
   var uploadStatusOpacity: Double { uploadStatusText.isEmpty ? 0 : 1 }
 
   // MARK: - Private Helpers
@@ -192,11 +223,13 @@ class GiveawayCongratsSheetModel: ViewModel {
       presentedAlert = .congratsUploadFailed(error.localizedDescription)
       return
     }
-    setState(.uploaded(audioBlockId: audioBlock.id))
+    setState(.uploaded(audioBlockId: audioBlock.id, localRecordingPath: url.path))
     await submitCongrats(audioBlockId: audioBlock.id)
   }
 
   private func submitCongrats(audioBlockId: String) async {
+    // The owner skipped or dismissed while the upload was running — honor that and don't POST.
+    guard !isActionTerminal else { return }
     guard let jwt = auth.jwt else {
       presentedAlert = .congratsRecordingFailed("Not signed in.")
       return
@@ -212,8 +245,15 @@ class GiveawayCongratsSheetModel: ViewModel {
     }
   }
 
+  private var isActionTerminal: Bool {
+    pendingCongratsActions[eventId]?.isTerminal ?? false
+  }
+
   private func setState(_ state: CongratsActionState) {
     $pendingCongratsActions.withLock {
+      // Never overwrite a terminal decision (skipped/submitted/alreadyClosed). A stale in-flight task
+      // or another model instance must not resurrect or change a finished action.
+      guard let existing = $0[eventId], !existing.isTerminal else { return }
       $0[eventId]?.state = state
     }
   }
@@ -246,6 +286,7 @@ class GiveawayCongratsSheetModel: ViewModel {
   }
 
   private func startRecordingUpdates() {
+    recordingTask?.cancel()
     recordingTask = Task {
       while !Task.isCancelled {
         recordingDuration = await audioRecorder.currentTime()
@@ -261,6 +302,7 @@ class GiveawayCongratsSheetModel: ViewModel {
   }
 
   private func startPlaybackUpdates() {
+    playbackTask?.cancel()
     playbackTask = Task {
       while !Task.isCancelled {
         playbackPosition = await audioPlayer.currentTime()

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -239,6 +239,13 @@ class GiveawayCongratsSheetModel: ViewModel {
       setState(.submitted)
       cleanUpRecording()
       onClose()
+    } catch is GiveawayCongratsError {
+      // The server window closed — retrying can never succeed. Mark terminal, clean up, and dismiss
+      // (the terminal state keeps the arbiter from ever re-prompting) instead of looping the owner
+      // on a retry alert.
+      setState(.alreadyClosed)
+      cleanUpRecording()
+      onClose()
     } catch {
       // Stays `.uploaded` so the user can retry the POST without re-uploading.
       presentedAlert = .congratsSubmitFailed(error.localizedDescription)

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -136,13 +136,15 @@ class GiveawayCongratsSheetModel: ViewModel {
     await uploadThenSubmit(url: url)
   }
 
-  func skipButtonTapped() {
+  func skipButtonTapped() async {
+    await stopActiveCapture()
     setState(.skipped)
     cleanUpRecording()
     onClose()
   }
 
-  func closeButtonTapped() {
+  func closeButtonTapped() async {
+    await stopActiveCapture()
     onClose()
   }
 
@@ -214,6 +216,18 @@ class GiveawayCongratsSheetModel: ViewModel {
     $pendingCongratsActions.withLock {
       $0[eventId]?.state = state
     }
+  }
+
+  /// Tear down any in-flight recording or playback before the sheet closes, so the mic and the
+  /// update loops don't keep running (and keeping `self` alive) after the owner dismisses the flow.
+  private func stopActiveCapture() async {
+    stopRecordingUpdates()
+    stopPlaybackUpdates()
+    if recordingPhase == .recording {
+      _ = try? await audioRecorder.stopRecording()
+    }
+    await audioPlayer.stop()
+    isPlaying = false
   }
 
   private func cleanUpRecording() {

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -142,6 +142,10 @@ class GiveawayCongratsSheetModel: ViewModel {
     isPlaying = false
     waveformSamples = []
     recordingPhase = .idle
+    // Clear the resume flag too — otherwise re-recording from an `.uploaded`-resumed model (which
+    // sets `readyToSubmit = true` in init) would leave `showsRecordButton` false and strand the
+    // owner in review with no recording.
+    readyToSubmit = false
     // `viewAppeared` only primes the recorder once (and only when there was no resume file), so
     // re-arm the audio session here or the next `startRecording()` runs on an unprepared session.
     try? await audioRecorder.prepareForRecording()

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -1,0 +1,299 @@
+import Dependencies
+import Foundation
+import Observation
+import PlayolaPlayer
+import Sharing
+import SwiftUI
+
+@MainActor
+@Observable
+class GiveawayCongratsSheetModel: ViewModel {
+
+  enum Phase: Equatable { case idle, recording, review }
+
+  // MARK: - Dependencies
+  @ObservationIgnored @Dependency(\.audioRecorder) var audioRecorder
+  @ObservationIgnored @Dependency(\.audioPlayer) var audioPlayer
+  @ObservationIgnored @Dependency(\.voicetrackUploadService) var voicetrackUploadService
+  @ObservationIgnored @Dependency(\.api) var api
+
+  // MARK: - Shared State
+  @ObservationIgnored @Shared(.auth) var auth
+  @ObservationIgnored @Shared(.pendingCongratsActions) var pendingCongratsActions
+
+  // MARK: - Initialization
+  private let eventId: String
+  private let stationId: String
+  private let winnerName: String?
+  private let prizeName: String?
+  private let onClose: () -> Void
+
+  init(action: CongratsAction, onClose: @escaping () -> Void) {
+    self.eventId = action.eventId
+    self.stationId = action.stationId
+    self.winnerName = action.winnerName
+    self.prizeName = action.prizeName
+    self.onClose = onClose
+    super.init()
+    switch action.state {
+    case .recorded(let path):
+      recordingURL = URL(fileURLWithPath: path)
+      recordingPhase = .review
+    case .uploaded:
+      readyToSubmit = true
+    default:
+      break
+    }
+  }
+
+  // MARK: - Properties
+  var recordingPhase: Phase = .idle
+  var recordingDuration: TimeInterval = 0
+  var playbackPosition: TimeInterval = 0
+  var isPlaying = false
+  var waveformSamples: [Float] = []
+  var isSubmitting = false
+  var readyToSubmit = false  // reached at `.uploaded` — Send only re-POSTs (no re-record)
+  var uploadStatusText = ""
+  var presentedAlert: PlayolaAlert?
+
+  @ObservationIgnored var recordingURL: URL?
+  @ObservationIgnored private var recordingTask: Task<Void, Never>?
+  @ObservationIgnored private var playbackTask: Task<Void, Never>?
+
+  // MARK: - User Actions
+
+  func viewAppeared() async {
+    try? await audioRecorder.prepareForRecording()
+  }
+
+  func onRecordTapped() async {
+    guard await audioRecorder.requestPermission() else {
+      presentedAlert = .congratsMicPermissionDenied
+      return
+    }
+    do {
+      waveformSamples = []
+      try await audioRecorder.startRecording()
+      recordingPhase = .recording
+      startRecordingUpdates()
+    } catch {
+      presentedAlert = .congratsRecordingFailed(error.localizedDescription)
+    }
+  }
+
+  func onStopTapped() async {
+    stopRecordingUpdates()
+    do {
+      let url = try await audioRecorder.stopRecording()
+      let persisted = try Self.persistRecording(url)
+      recordingURL = persisted
+      try? await audioPlayer.loadFile(persisted)
+      recordingDuration = await audioPlayer.duration()
+      recordingPhase = .review
+      setState(.recorded(localRecordingPath: persisted.path))
+    } catch {
+      presentedAlert = .congratsRecordingFailed(error.localizedDescription)
+    }
+  }
+
+  func onPlayPauseTapped() async {
+    if isPlaying {
+      await audioPlayer.pause()
+      stopPlaybackUpdates()
+      isPlaying = false
+    } else {
+      await audioPlayer.play()
+      startPlaybackUpdates()
+      isPlaying = true
+    }
+  }
+
+  func onReRecordTapped() async {
+    stopPlaybackUpdates()
+    await audioPlayer.stop()
+    recordingURL = nil
+    recordingDuration = 0
+    playbackPosition = 0
+    isPlaying = false
+    waveformSamples = []
+    recordingPhase = .idle
+  }
+
+  func sendButtonTapped() async {
+    guard !isSubmitting else { return }
+    isSubmitting = true
+    presentedAlert = nil
+    uploadStatusText = ""
+    defer { isSubmitting = false }
+
+    // If we already have an uploaded audioBlock (resume after a failed/killed submit), only re-POST.
+    if case .uploaded(let audioBlockId) = pendingCongratsActions[eventId]?.state {
+      await submitCongrats(audioBlockId: audioBlockId)
+      return
+    }
+    guard let url = recordingURL else { return }
+    await uploadThenSubmit(url: url)
+  }
+
+  func skipButtonTapped() {
+    setState(.skipped)
+    cleanUpRecording()
+    onClose()
+  }
+
+  func closeButtonTapped() {
+    onClose()
+  }
+
+  // MARK: - View Helpers
+  var headline: String {
+    let who = winnerName ?? "your winner"
+    if let prizeName { return "Congratulate \(who) on winning \(prizeName)!" }
+    return "Congratulate \(who)!"
+  }
+  var subtitle: String { "Record a short message — we'll play it on your station." }
+  var skipButtonTitle: String { "Skip" }
+  var recordButtonTitle: String { "Record" }
+  var stopButtonTitle: String { "Stop" }
+  var sendButtonTitle: String { isSubmitting ? "Sending…" : "Send" }
+  var canSend: Bool { !isSubmitting && (readyToSubmit || recordingPhase == .review) }
+  var showsRecordButton: Bool { !readyToSubmit && recordingPhase == .idle }
+  var showsRecordingControls: Bool { recordingPhase == .recording }
+  var showsReview: Bool { readyToSubmit || recordingPhase == .review }
+  var durationText: String { Self.formatTime(recordingDuration) }
+
+  // MARK: - Private Helpers
+
+  private func uploadThenSubmit(url: URL) async {
+    guard let jwt = auth.jwt else {
+      presentedAlert = .congratsRecordingFailed("Not signed in.")
+      return
+    }
+    let voicetrack = LocalVoicetrack(originalURL: url, title: "Giveaway Congrats")
+    let audioBlock: AudioBlock
+    do {
+      audioBlock = try await voicetrackUploadService.processVoicetrack(voicetrack, stationId, jwt) {
+        [weak self] status in
+        self?.uploadStatusText = Self.statusText(status)
+      }
+    } catch {
+      // Keep the recording (stays `.recorded`) so the user can retry without re-recording.
+      presentedAlert = .congratsUploadFailed(error.localizedDescription)
+      return
+    }
+    setState(.uploaded(audioBlockId: audioBlock.id))
+    await submitCongrats(audioBlockId: audioBlock.id)
+  }
+
+  private func submitCongrats(audioBlockId: String) async {
+    guard let jwt = auth.jwt else {
+      presentedAlert = .congratsRecordingFailed("Not signed in.")
+      return
+    }
+    do {
+      try await api.recordGiveawayEventCongrats(jwt, eventId, audioBlockId)
+      setState(.submitted)
+      cleanUpRecording()
+      onClose()
+    } catch {
+      // Stays `.uploaded` so the user can retry the POST without re-uploading.
+      presentedAlert = .congratsSubmitFailed(error.localizedDescription)
+    }
+  }
+
+  private func setState(_ state: CongratsActionState) {
+    $pendingCongratsActions.withLock {
+      $0[eventId]?.state = state
+    }
+  }
+
+  private func cleanUpRecording() {
+    if let url = recordingURL { try? FileManager.default.removeItem(at: url) }
+  }
+
+  /// Copy the recorder's output into Application Support so it survives a kill / app suspension during
+  /// the upload (the recorder writes to a transient location).
+  private static func persistRecording(_ source: URL) throws -> URL {
+    let dir = try FileManager.default.url(
+      for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
+    let destination = dir.appendingPathComponent("congrats-\(UUID().uuidString).m4a")
+    try? FileManager.default.removeItem(at: destination)
+    try FileManager.default.copyItem(at: source, to: destination)
+    return destination
+  }
+
+  private func startRecordingUpdates() {
+    recordingTask = Task {
+      while !Task.isCancelled {
+        recordingDuration = await audioRecorder.currentTime()
+        waveformSamples.append(await audioRecorder.getAudioLevel())
+        try? await Task.sleep(for: .milliseconds(100))
+      }
+    }
+  }
+
+  private func stopRecordingUpdates() {
+    recordingTask?.cancel()
+    recordingTask = nil
+  }
+
+  private func startPlaybackUpdates() {
+    playbackTask = Task {
+      while !Task.isCancelled {
+        playbackPosition = await audioPlayer.currentTime()
+        if await !audioPlayer.isPlaying() {
+          isPlaying = false
+          stopPlaybackUpdates()
+          break
+        }
+        try? await Task.sleep(for: .milliseconds(100))
+      }
+    }
+  }
+
+  private func stopPlaybackUpdates() {
+    playbackTask?.cancel()
+    playbackTask = nil
+  }
+
+  private static func statusText(_ status: LocalVoicetrackStatus) -> String {
+    switch status {
+    case .converting: return "Preparing…"
+    case .uploading: return "Uploading…"
+    case .normalizing: return "Processing…"
+    case .finalizing: return "Finishing…"
+    case .completed: return "Done"
+    case .failed: return "Failed"
+    }
+  }
+
+  private static func formatTime(_ time: TimeInterval) -> String {
+    let minutes = Int(time) / 60
+    let seconds = Int(time) % 60
+    return String(format: "%d:%02d", minutes, seconds)
+  }
+}
+
+extension PlayolaAlert {
+  static var congratsMicPermissionDenied: PlayolaAlert {
+    PlayolaAlert(
+      title: "Microphone Access Needed",
+      message: "Enable microphone access in Settings to record a congrats.",
+      dismissButton: .cancel(Text("OK")))
+  }
+  static func congratsRecordingFailed(_ message: String) -> PlayolaAlert {
+    PlayolaAlert(title: "Recording Failed", message: message, dismissButton: .cancel(Text("OK")))
+  }
+  static func congratsUploadFailed(_ message: String) -> PlayolaAlert {
+    PlayolaAlert(
+      title: "Upload Failed",
+      message: "\(message) Your recording was kept — tap Send to try again.",
+      dismissButton: .cancel(Text("OK")))
+  }
+  static func congratsSubmitFailed(_ message: String) -> PlayolaAlert {
+    PlayolaAlert(
+      title: "Couldn't Send", message: "\(message) Tap Send to try again.",
+      dismissButton: .cancel(Text("OK")))
+  }
+}

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -63,6 +63,7 @@ class GiveawayCongratsSheetModel: ViewModel {
 
   @ObservationIgnored var recordingURL: URL?
   @ObservationIgnored private var isStartingRecording = false
+  @ObservationIgnored private var isDismissed = false
   @ObservationIgnored private var recordingTask: Task<Void, Never>?
   @ObservationIgnored private var playbackTask: Task<Void, Never>?
 
@@ -82,6 +83,7 @@ class GiveawayCongratsSheetModel: ViewModel {
   func viewDisappeared() async {
     // SwiftUI swipe-to-dismiss nils the sheet without routing through skip/send, so this is the only
     // teardown hook for an interactive dismissal — stop the mic/player and suppress re-prompt.
+    isDismissed = true
     await stopActiveCapture()
     onClose()
   }
@@ -152,7 +154,7 @@ class GiveawayCongratsSheetModel: ViewModel {
   }
 
   func sendButtonTapped() async {
-    guard !isSubmitting else { return }
+    guard !isDismissed, !isSubmitting else { return }
     isSubmitting = true
     presentedAlert = nil
     uploadStatusText = ""
@@ -178,6 +180,7 @@ class GiveawayCongratsSheetModel: ViewModel {
   }
 
   func closeButtonTapped() async {
+    isDismissed = true
     await stopActiveCapture()
     onClose()
   }
@@ -231,13 +234,14 @@ class GiveawayCongratsSheetModel: ViewModel {
       presentedAlert = .congratsUploadFailed(error.localizedDescription)
       return
     }
+    guard !isDismissed else { return }
     setState(.uploaded(audioBlockId: audioBlock.id, localRecordingPath: url.path))
     await submitCongrats(audioBlockId: audioBlock.id)
   }
 
   private func submitCongrats(audioBlockId: String) async {
     // The owner skipped or dismissed while the upload was running — honor that and don't POST.
-    guard !isActionTerminal else { return }
+    guard !isDismissed, !isActionTerminal else { return }
     guard let jwt = auth.jwt else {
       presentedAlert = .congratsRecordingFailed("Not signed in.")
       return

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -138,6 +138,7 @@ class GiveawayCongratsSheetModel: ViewModel {
   func onReRecordTapped() async {
     stopPlaybackUpdates()
     await audioPlayer.stop()
+    let supersededURL = recordingURL
     recordingURL = nil
     recordingDuration = 0
     playbackPosition = 0
@@ -148,6 +149,10 @@ class GiveawayCongratsSheetModel: ViewModel {
     // sets `readyToSubmit = true` in init) would leave `showsRecordButton` false and strand the
     // owner in review with no recording.
     readyToSubmit = false
+    setState(.pending)
+    if let supersededURL {
+      try? FileManager.default.removeItem(at: supersededURL)
+    }
     // `viewAppeared` only primes the recorder once (and only when there was no resume file), so
     // re-arm the audio session here or the next `startRecording()` runs on an unprepared session.
     try? await audioRecorder.prepareForRecording()
@@ -234,8 +239,8 @@ class GiveawayCongratsSheetModel: ViewModel {
       presentedAlert = .congratsUploadFailed(error.localizedDescription)
       return
     }
-    guard !isDismissed else { return }
     setState(.uploaded(audioBlockId: audioBlock.id, localRecordingPath: url.path))
+    guard !isDismissed else { return }
     await submitCongrats(audioBlockId: audioBlock.id)
   }
 

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -142,6 +142,9 @@ class GiveawayCongratsSheetModel: ViewModel {
     isPlaying = false
     waveformSamples = []
     recordingPhase = .idle
+    // `viewAppeared` only primes the recorder once (and only when there was no resume file), so
+    // re-arm the audio session here or the next `startRecording()` runs on an unprepared session.
+    try? await audioRecorder.prepareForRecording()
   }
 
   func sendButtonTapped() async {
@@ -186,6 +189,7 @@ class GiveawayCongratsSheetModel: ViewModel {
   var recordButtonTitle: String { "Record" }
   var stopButtonTitle: String { "Stop" }
   var sendButtonTitle: String { isSubmitting ? "Sending…" : "Send" }
+  var playButtonTitle: String { isPlaying ? "Pause" : "Play" }
   var canSend: Bool { !isSubmitting && (readyToSubmit || recordingPhase == .review) }
   var canSkip: Bool { !isSubmitting }
   var canPlay: Bool { recordingURL != nil }

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -163,6 +163,14 @@ class GiveawayCongratsSheetModel: ViewModel {
   var showsReview: Bool { readyToSubmit || recordingPhase == .review }
   var durationText: String { Self.formatTime(recordingDuration) }
 
+  // Opacity-driven view swaps (the view stays control-flow-free).
+  var recordButtonOpacity: Double { showsRecordButton ? 1 : 0 }
+  var recordingControlsOpacity: Double { showsRecordingControls ? 1 : 0 }
+  var reviewControlsOpacity: Double { showsReview ? 1 : 0 }
+  var sendButtonDisabled: Bool { !canSend }
+  var sendButtonOpacity: Double { canSend ? 1 : 0.5 }
+  var uploadStatusOpacity: Double { uploadStatusText.isEmpty ? 0 : 1 }
+
   // MARK: - Private Helpers
 
   private func uploadThenSubmit(url: URL) async {

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -93,6 +93,30 @@ struct GiveawayCongratsSheetModelTests {
     #expect(closed.value)
   }
 
+  @Test func windowClosedMarksActionTerminalAndCloses() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+          state: .uploaded(audioBlockId: "ab1", localRecordingPath: "/tmp/r.m4a"), startedAt: Date()
+        )
+      ]
+    }
+    let closed = LockIsolated(false)
+    let model = withDependencies {
+      $0.api.recordGiveawayEventCongrats = { _, _, _ in throw GiveawayCongratsError.windowClosed }
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: { closed.setValue(true) })
+    }
+    await model.sendButtonTapped()
+    // A closed window is terminal — no retry loop; the action is marked closed and the sheet dismisses.
+    expectNoDifference(actions["e1"]?.state, CongratsActionState.alreadyClosed)
+    #expect(closed.value)
+    #expect(model.presentedAlert == nil)
+  }
+
   @Test func skipIsIgnoredWhileSubmitting() async {
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     $actions.withLock { $0 = ["e1": recordedAction()] }

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import CustomDump
 import Dependencies
 import Foundation
@@ -77,13 +78,48 @@ struct GiveawayCongratsSheetModelTests {
     #expect(model.presentedAlert != nil)
   }
 
-  @Test func skipMarksSkippedAndCloses() {
+  @Test func skipMarksSkippedAndCloses() async {
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     $actions.withLock { $0 = ["e1": recordedAction()] }
-    var closed = false
-    let model = GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: { closed = true })
-    model.skipButtonTapped()
+    let closed = LockIsolated(false)
+    let model = withDependencies {
+      $0.audioPlayer.stop = {}
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: { closed.setValue(true) })
+    }
+    await model.skipButtonTapped()
     expectNoDifference(actions["e1"]?.state, CongratsActionState.skipped)
-    #expect(closed)
+    #expect(closed.value)
+  }
+
+  @Test func skipWhileRecordingStopsTheRecorder() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+          state: .pending, startedAt: Date())
+      ]
+    }
+    let stopped = LockIsolated(false)
+    let model = withDependencies {
+      $0.audioRecorder.requestPermission = { true }
+      $0.audioRecorder.startRecording = {}
+      $0.audioRecorder.currentTime = { 0 }
+      $0.audioRecorder.getAudioLevel = { 0 }
+      $0.audioRecorder.stopRecording = {
+        stopped.setValue(true)
+        return URL(fileURLWithPath: "/tmp/x.m4a")
+      }
+      $0.audioPlayer.stop = {}
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.onRecordTapped()
+    #expect(model.recordingPhase == .recording)
+    // Skipping mid-recording must stop the mic, not leave the update loop running.
+    await model.skipButtonTapped()
+    #expect(stopped.value)
+    expectNoDifference(actions["e1"]?.state, CongratsActionState.skipped)
   }
 }

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -117,6 +117,29 @@ struct GiveawayCongratsSheetModelTests {
     #expect(model.presentedAlert == nil)
   }
 
+  @Test func reRecordReArmsTheRecorder() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = ["e1": recordedAction()] }
+    let prepared = LockIsolated(0)
+    let model = withDependencies {
+      $0.audioPlayer.stop = {}
+      $0.audioRecorder.prepareForRecording = { prepared.withValue { $0 += 1 } }
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.onReRecordTapped()
+    // The next take must run on a freshly prepared session, not the one stopRecording() left behind.
+    #expect(prepared.value == 1)
+    #expect(model.recordingPhase == .idle)
+  }
+
+  @Test func playButtonTitleReflectsPlaybackState() {
+    let model = GiveawayCongratsSheetModel(action: recordedAction(), onClose: {})
+    #expect(model.playButtonTitle == "Play")
+    model.isPlaying = true
+    #expect(model.playButtonTitle == "Pause")
+  }
+
   @Test func skipIsIgnoredWhileSubmitting() async {
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     $actions.withLock { $0 = ["e1": recordedAction()] }

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -8,7 +8,11 @@ import Testing
 
 @testable import PlayolaRadio
 
+// Serialized: these tests mutate the file-backed `@Shared(.pendingCongratsActions)` store under a
+// shared key, so parallel Swift Testing could interleave across `await` points and cross-contaminate
+// the on-disk state.
 @MainActor
+@Suite(.serialized)
 struct GiveawayCongratsSheetModelTests {
   private func recordedAction() -> CongratsAction {
     CongratsAction(
@@ -131,6 +135,23 @@ struct GiveawayCongratsSheetModelTests {
     // The next take must run on a freshly prepared session, not the one stopRecording() left behind.
     #expect(prepared.value == 1)
     #expect(model.recordingPhase == .idle)
+  }
+
+  @Test func reRecordFromUploadedResumeReturnsToRecordButton() async {
+    let action = CongratsAction(
+      eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: "P", congratsExpiresAt: nil,
+      state: .uploaded(audioBlockId: "ab1", localRecordingPath: "/tmp/r.m4a"), startedAt: Date())
+    let model = withDependencies {
+      $0.audioPlayer.stop = {}
+      $0.audioRecorder.prepareForRecording = {}
+    } operation: {
+      GiveawayCongratsSheetModel(action: action, onClose: {})
+    }
+    #expect(model.readyToSubmit)  // resumed uploaded → review state
+    await model.onReRecordTapped()
+    // Re-record must drop the resume flag so the Record button comes back (not stranded in review).
+    #expect(!model.readyToSubmit)
+    #expect(model.showsRecordButton)
   }
 
   @Test func playButtonTitleReflectsPlaybackState() {

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -65,7 +65,8 @@ struct GiveawayCongratsSheetModelTests {
       $0 = [
         "e1": CongratsAction(
           eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
-          state: .uploaded(audioBlockId: "ab1"), startedAt: Date())
+          state: .uploaded(audioBlockId: "ab1", localRecordingPath: "/tmp/r.m4a"),
+          startedAt: Date())
       ]
     }
     let model = withDependencies {
@@ -90,6 +91,49 @@ struct GiveawayCongratsSheetModelTests {
     await model.skipButtonTapped()
     expectNoDifference(actions["e1"]?.state, CongratsActionState.skipped)
     #expect(closed.value)
+  }
+
+  @Test func skipIsIgnoredWhileSubmitting() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = ["e1": recordedAction()] }
+    let closed = LockIsolated(false)
+    let model = withDependencies {
+      $0.audioPlayer.stop = {}
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: { closed.setValue(true) })
+    }
+    model.isSubmitting = true
+    await model.skipButtonTapped()
+    // A skip mid-submit must not flip the action or close the sheet out from under the upload.
+    #expect(actions["e1"]?.state == .recorded(localRecordingPath: "/tmp/r.m4a"))
+    #expect(!closed.value)
+  }
+
+  @Test func uploadedResumeIsReplayableAndSendable() {
+    let action = CongratsAction(
+      eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: "P", congratsExpiresAt: nil,
+      state: .uploaded(audioBlockId: "ab1", localRecordingPath: "/tmp/r.m4a"), startedAt: Date())
+    let model = GiveawayCongratsSheetModel(action: action, onClose: {})
+    // Resuming an uploaded action after a kill still offers playback (local file survives) and Send.
+    #expect(model.recordingURL?.path == "/tmp/r.m4a")
+    #expect(model.canPlay)
+    #expect(model.canSend)
+    #expect(model.showsReview)
+  }
+
+  @Test func recordedResumeLoadsDurationForReview() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = ["e1": recordedAction()] }
+    let loaded = LockIsolated<URL?>(nil)
+    let model = withDependencies {
+      $0.audioPlayer.loadFile = { url in loaded.setValue(url) }
+      $0.audioPlayer.duration = { 7 }
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.viewAppeared()
+    #expect(loaded.value?.path == "/tmp/r.m4a")
+    #expect(model.recordingDuration == 7)
   }
 
   @Test func skipWhileRecordingStopsTheRecorder() async {

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -1,0 +1,89 @@
+import CustomDump
+import Dependencies
+import Foundation
+import PlayolaPlayer
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@MainActor
+struct GiveawayCongratsSheetModelTests {
+  private func recordedAction() -> CongratsAction {
+    CongratsAction(
+      eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: "Two tickets",
+      congratsExpiresAt: nil, state: .recorded(localRecordingPath: "/tmp/r.m4a"), startedAt: Date())
+  }
+
+  @Test func headlineUsesWinnerAndPrize() {
+    let model = GiveawayCongratsSheetModel(action: recordedAction(), onClose: {})
+    #expect(model.headline == "Congratulate Jo on winning Two tickets!")
+  }
+
+  @Test func sendUploadsThenSubmitsAndMarksSubmitted() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = ["e1": recordedAction()] }
+    let block = AudioBlock.mockWith()
+    var congratsPosted: (String, String)?
+    let model = withDependencies {
+      $0.voicetrackUploadService.processVoicetrack = { _, _, _, _ in block }
+      $0.api.recordGiveawayEventCongrats = { _, eventId, audioBlockId in
+        congratsPosted = (eventId, audioBlockId)
+      }
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.sendButtonTapped()
+    expectNoDifference(actions["e1"]?.state, CongratsActionState.submitted)
+    expectNoDifference(congratsPosted?.0, "e1")
+    expectNoDifference(congratsPosted?.1, block.id)
+  }
+
+  @Test func uploadFailureStaysRecordedForRetry() async {
+    struct Boom: Error {}
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = ["e1": recordedAction()] }
+    let model = withDependencies {
+      $0.voicetrackUploadService.processVoicetrack = { _, _, _, _ in throw Boom() }
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.sendButtonTapped()
+    // Recording is not lost; user can retry.
+    #expect(actions["e1"]?.localRecordingPath == "/tmp/r.m4a")
+    #expect(model.presentedAlert != nil)
+  }
+
+  @Test func postFailureStaysUploadedForRetry() async {
+    struct Boom: Error {}
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+          state: .uploaded(audioBlockId: "ab1"), startedAt: Date())
+      ]
+    }
+    let model = withDependencies {
+      $0.api.recordGiveawayEventCongrats = { _, _, _ in throw Boom() }
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.sendButtonTapped()  // reached at .uploaded → re-POST only
+    #expect(actions["e1"]?.audioBlockId == "ab1")  // stays uploaded, retryable
+    #expect(model.presentedAlert != nil)
+  }
+
+  @Test func skipMarksSkippedAndCloses() {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = ["e1": recordedAction()] }
+    var closed = false
+    let model = GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: { closed = true })
+    model.skipButtonTapped()
+    expectNoDifference(actions["e1"]?.state, CongratsActionState.skipped)
+    #expect(closed)
+  }
+}

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -111,7 +111,8 @@ struct GiveawayCongratsSheetModelTests {
     await sendTask.value
     #expect(!postedCongrats.value)
     expectNoDifference(
-      actions["e1"]?.state, CongratsActionState.recorded(localRecordingPath: "/tmp/r.m4a"))
+      actions["e1"]?.state,
+      CongratsActionState.uploaded(audioBlockId: "ab1", localRecordingPath: "/tmp/r.m4a"))
   }
 
   @Test func skipMarksSkippedAndCloses() async {
@@ -169,9 +170,11 @@ struct GiveawayCongratsSheetModelTests {
   }
 
   @Test func reRecordFromUploadedResumeReturnsToRecordButton() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     let action = CongratsAction(
       eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: "P", congratsExpiresAt: nil,
       state: .uploaded(audioBlockId: "ab1", localRecordingPath: "/tmp/r.m4a"), startedAt: Date())
+    $actions.withLock { $0 = ["e1": action] }
     let model = withDependencies {
       $0.audioPlayer.stop = {}
       $0.audioRecorder.prepareForRecording = {}
@@ -183,6 +186,9 @@ struct GiveawayCongratsSheetModelTests {
     // Re-record must drop the resume flag so the Record button comes back (not stranded in review).
     #expect(!model.readyToSubmit)
     #expect(model.showsRecordButton)
+    // The discarded uploaded take must not be restored or re-sent if this model is killed before
+    // the next stop-recording pass persists a replacement.
+    expectNoDifference(actions["e1"]?.state, CongratsActionState.pending)
   }
 
   @Test func playButtonTitleReflectsPlaybackState() {

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -83,6 +83,37 @@ struct GiveawayCongratsSheetModelTests {
     #expect(model.presentedAlert != nil)
   }
 
+  @Test func dismissDuringUploadDoesNotPostCongrats() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = ["e1": recordedAction()] }
+    let block = AudioBlock.mockWith(id: "ab1")
+    let postedCongrats = LockIsolated(false)
+    let (uploadStartedStream, uploadStartedContinuation) = AsyncStream<Void>.makeStream()
+    let (releaseUploadStream, releaseUploadContinuation) = AsyncStream<Void>.makeStream()
+    var uploadStarted = uploadStartedStream.makeAsyncIterator()
+    let model = withDependencies {
+      $0.voicetrackUploadService.processVoicetrack = { _, _, _, _ in
+        uploadStartedContinuation.yield()
+        var releaseUpload = releaseUploadStream.makeAsyncIterator()
+        _ = await releaseUpload.next()
+        return block
+      }
+      $0.api.recordGiveawayEventCongrats = { _, _, _ in postedCongrats.setValue(true) }
+      $0.audioPlayer.stop = {}
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    let sendTask = Task { await model.sendButtonTapped() }
+    _ = await uploadStarted.next()
+    await model.viewDisappeared()
+    releaseUploadContinuation.yield()
+    await sendTask.value
+    #expect(!postedCongrats.value)
+    expectNoDifference(
+      actions["e1"]?.state, CongratsActionState.recorded(localRecordingPath: "/tmp/r.m4a"))
+  }
+
   @Test func skipMarksSkippedAndCloses() async {
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     $actions.withLock { $0 = ["e1": recordedAction()] }

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
@@ -56,7 +56,7 @@ struct GiveawayCongratsSheetView: View {
         .frame(height: 120)
 
         Button(
-          action: { model.skipButtonTapped() },
+          action: { Task { await model.skipButtonTapped() } },
           label: {
             Text(model.skipButtonTitle)
               .font(.custom(FontNames.Inter_400_Regular, size: 14))

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
@@ -1,0 +1,134 @@
+import SwiftUI
+
+struct GiveawayCongratsSheetView: View {
+  @Bindable var model: GiveawayCongratsSheetModel
+
+  var body: some View {
+    ZStack {
+      Color.black.ignoresSafeArea()
+
+      VStack(spacing: 16) {
+        Text(model.headline)
+          .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 24))
+          .foregroundColor(.white)
+          .multilineTextAlignment(.center)
+
+        Text(model.subtitle)
+          .font(.custom(FontNames.Inter_400_Regular, size: 14))
+          .foregroundColor(Color(hex: "#C7C7C7"))
+          .multilineTextAlignment(.center)
+
+        ZStack {
+          LiveWaveformView(samples: model.waveformSamples)
+            .opacity(model.recordingControlsOpacity)
+          WaveformView(samples: model.waveformSamples)
+            .opacity(model.reviewControlsOpacity)
+        }
+        .frame(height: 90)
+        .padding(.top, 8)
+
+        Text(model.durationText)
+          .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+          .foregroundColor(.white)
+
+        Text(model.uploadStatusText)
+          .font(.custom(FontNames.Inter_400_Regular, size: 13))
+          .foregroundColor(Color(hex: "#C7C7C7"))
+          .opacity(model.uploadStatusOpacity)
+
+        ZStack {
+          GiveawayCongratsPrimaryButton(
+            title: model.recordButtonTitle, action: { Task { await model.onRecordTapped() } }
+          )
+          .opacity(model.recordButtonOpacity)
+          .allowsHitTesting(model.showsRecordButton)
+
+          GiveawayCongratsPrimaryButton(
+            title: model.stopButtonTitle, action: { Task { await model.onStopTapped() } }
+          )
+          .opacity(model.recordingControlsOpacity)
+          .allowsHitTesting(model.showsRecordingControls)
+
+          GiveawayCongratsReviewControls(model: model)
+            .opacity(model.reviewControlsOpacity)
+            .allowsHitTesting(model.showsReview)
+        }
+        .frame(height: 120)
+
+        Button(
+          action: { model.skipButtonTapped() },
+          label: {
+            Text(model.skipButtonTitle)
+              .font(.custom(FontNames.Inter_400_Regular, size: 14))
+              .foregroundColor(Color(hex: "#868686"))
+          }
+        )
+      }
+      .padding(.horizontal, 24)
+      .padding(.vertical, 32)
+    }
+    .playolaAlert($model.presentedAlert)
+    .task { await model.viewAppeared() }
+  }
+}
+
+private struct GiveawayCongratsReviewControls: View {
+  let model: GiveawayCongratsSheetModel
+
+  var body: some View {
+    VStack(spacing: 12) {
+      Button(
+        action: { Task { await model.onPlayPauseTapped() } },
+        label: {
+          Text("Play")
+            .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(
+              RoundedRectangle(cornerRadius: 14).stroke(Color(hex: "#3A3A3A"), lineWidth: 2))
+        }
+      )
+      Button(
+        action: { Task { await model.sendButtonTapped() } },
+        label: {
+          Text(model.sendButtonTitle)
+            .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 48)
+            .background(RoundedRectangle(cornerRadius: 14).fill(Color.playolaRed))
+        }
+      )
+      .disabled(model.sendButtonDisabled)
+      .opacity(model.sendButtonOpacity)
+    }
+  }
+}
+
+private struct GiveawayCongratsPrimaryButton: View {
+  let title: String
+  let action: () -> Void
+
+  var body: some View {
+    Button(
+      action: action,
+      label: {
+        Text(title)
+          .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 18))
+          .tracking(1)
+          .foregroundColor(.white)
+          .frame(maxWidth: .infinity)
+          .frame(height: 56)
+          .background(RoundedRectangle(cornerRadius: 28).fill(Color.playolaRed))
+      }
+    )
+  }
+}
+
+#if DEBUG
+  #Preview("Congrats — record") {
+    GiveawayCongratsSheetView(
+      model: GiveawayCongratsSheetModel(action: .mock, onClose: {}))
+  }
+#endif

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
@@ -63,12 +63,15 @@ struct GiveawayCongratsSheetView: View {
               .foregroundColor(Color(hex: "#868686"))
           }
         )
+        .disabled(!model.canSkip)
+        .opacity(model.skipButtonOpacity)
       }
       .padding(.horizontal, 24)
       .padding(.vertical, 32)
     }
     .playolaAlert($model.presentedAlert)
     .task { await model.viewAppeared() }
+    .onDisappear { Task { await model.viewDisappeared() } }
   }
 }
 
@@ -89,6 +92,8 @@ private struct GiveawayCongratsReviewControls: View {
               RoundedRectangle(cornerRadius: 14).stroke(Color(hex: "#3A3A3A"), lineWidth: 2))
         }
       )
+      .disabled(!model.canPlay)
+      .opacity(model.playButtonOpacity)
       Button(
         action: { Task { await model.sendButtonTapped() } },
         label: {

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
@@ -83,7 +83,7 @@ private struct GiveawayCongratsReviewControls: View {
       Button(
         action: { Task { await model.onPlayPauseTapped() } },
         label: {
-          Text("Play")
+          Text(model.playButtonTitle)
             .font(.custom(FontNames.Inter_600_SemiBold, size: 16))
             .foregroundColor(.white)
             .frame(maxWidth: .infinity)

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
@@ -65,7 +65,9 @@ class GiveawayWinnerSheetModel: ViewModel {
     do {
       try await api.submitGiveawayWinnerDetails(jwt, participation.id, request)
       markSubmissionCompleted()
-      onClose()
+      // Show the confirmation screen (with a Done button) rather than dismissing instantly, so the
+      // winner gets a clear "we'll email you" acknowledgement.
+      showsClaimedConfirmation = true
     } catch {
       // Keep the sheet open with the field intact so the user can retry (the server upserts).
       presentedAlert = .giveawaySubmissionFailed
@@ -100,8 +102,10 @@ class GiveawayWinnerSheetModel: ViewModel {
 
   var claimButtonTitle: String { isSubmitting ? "Submitting…" : "Claim Prize" }
   var claimedEmoji: String { "🎉" }
-  var claimedTitle: String { "You're all set" }
-  var claimedSubtitle: String { "Check your email — we'll be in touch about your prize." }
+  var claimedTitle: String { "Congrats!" }
+  var claimedSubtitle: String {
+    "We'll send you an email in the next few minutes to arrange your prize. Thanks!"
+  }
   var closeButtonTitle: String { "Done" }
 
   // Opacity-driven view swaps (the view stays control-flow-free).

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
@@ -47,23 +47,29 @@ struct GiveawayWinnerSheetModelTests {
     #expect(model.email == "me@playola.fm")
   }
 
-  @Test func claimSuccessMarksSubmissionCompletedAndCloses() async {
+  @Test func claimSuccessMarksSubmittedAndShowsConfirmation() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
       "e": wonParticipation()
     ]
     var closed = false
-    await withDependencies {
+    let model = await withDependencies {
       $0.api.submitGiveawayWinnerDetails = { _, _, _ in }
     } operation: {
       let model = GiveawayWinnerSheetModel(
         participation: participations["e"]!, onClose: { closed = true })
       fill(model)
       await model.claimButtonTapped()
+      return model
     }
     #expect(
       participations["e"]?.status
         == GiveawayParticipationStatus.resolvedWon(submissionCompleted: true))
+    // The confirmation screen is shown (with a Done button); the sheet is NOT dismissed yet.
+    #expect(model.showsClaimedConfirmation == true)
+    #expect(closed == false)
+    // Tapping Done dismisses.
+    model.closeButtonTapped()
     #expect(closed == true)
   }
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -49,7 +49,7 @@ struct MainContainer: View {
         get: {
           switch model.mainContainerNavigationCoordinator.presentedSheet {
           case .player, .feedbackSheet, .share, .redeemPrize, .artistSuggestion, .welcomeMessage,
-            .giveawayWinner:
+            .giveawayWinner, .giveawayCongrats:
             return model.mainContainerNavigationCoordinator.presentedSheet
           default:
             return nil
@@ -78,6 +78,8 @@ struct MainContainer: View {
             WelcomeMessagePageView(model: welcomeModel)
           case .giveawayWinner(let winnerModel):
             GiveawayWinnerSheetView(model: winnerModel)
+          case .giveawayCongrats(let congratsModel):
+            GiveawayCongratsSheetView(model: congratsModel)
           default:
             EmptyView()
           }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -38,6 +38,15 @@ class MainContainerModel: ViewModel {
   @ObservationIgnored @Shared(.isBroadcaster) var isBroadcaster
   @ObservationIgnored @Shared(.appVersionRequirements) var appVersionRequirements
   @ObservationIgnored @Shared(.giveawayParticipations) var giveawayParticipations
+  @ObservationIgnored @Shared(.pendingCongratsActions) var pendingCongratsActions
+
+  /// Client-side ceiling for presenting a congrats whose push carried no `congratsExpiresAt`. After
+  /// this long past `startedAt` we stop prompting the owner (the schedule slot is almost certainly gone).
+  private static let congratsClientCutoff: TimeInterval = 60 * 60
+
+  /// Congrats sheets the owner closed (or finished) this foreground. Prevents the publisher-driven
+  /// re-run from immediately re-presenting a just-dismissed sheet. Cleared on each foreground.
+  @ObservationIgnored private var dismissedCongratsThisForeground: Set<String> = []
 
   enum ActiveTab {
     // Listening mode tabs
@@ -154,9 +163,19 @@ class MainContainerModel: ViewModel {
         Task { await self?.processGiveawayResolutions() }
       }
       .store(in: &cancellables)
+    // A `giveaway_winner_pending` push writes a new congrats action; surface its sheet immediately
+    // (same willSet → Task deferral rationale as the participations observer above).
+    $pendingCongratsActions.publisher
+      .sink { [weak self] _ in
+        Task { await self?.processGiveawayResolutions() }
+      }
+      .store(in: &cancellables)
   }
 
   func refreshOnForeground() async {
+    // A new foreground is a fresh chance to prompt: a congrats the owner closed last session
+    // re-presents now (if still pending and unexpired).
+    dismissedCongratsThisForeground.removeAll()
     do {
       let retrievedStationsLists = try await api.getStations()
       applyStationLists(retrievedStationsLists)
@@ -337,6 +356,9 @@ class MainContainerModel: ViewModel {
   func processGiveawayResolutions() async {
     presentPendingGiveawayWinnerIfNeeded()
     await fireGiveawayLossToastIfNeeded()
+    // Winner sheet wins the stage: if the call above presented one, this sees a non-empty/-player
+    // sheet and defers the congrats to the next foreground.
+    presentPendingCongratsIfNeeded()
   }
 
   private func presentPendingGiveawayWinnerIfNeeded() {
@@ -387,6 +409,55 @@ class MainContainerModel: ViewModel {
   private func dismissGiveawayWinnerSheet() {
     if case .giveawayWinner = mainContainerNavigationCoordinator.presentedSheet {
       mainContainerNavigationCoordinator.presentedSheet = nil
+    }
+  }
+
+  // MARK: - Artist Congrats Presentation
+
+  /// Presents the most-urgent pending congrats (owner side) when the stage is clear. Lower priority
+  /// than the winner sheet and unrelated modals, and never re-prompts a sheet dismissed this
+  /// foreground.
+  private func presentPendingCongratsIfNeeded() {
+    switch mainContainerNavigationCoordinator.presentedSheet {
+    case .none, .player: break
+    default: return
+    }
+    let candidate = pendingCongratsActions.values
+      .filter { !$0.isTerminal }
+      .filter { !dismissedCongratsThisForeground.contains($0.eventId) }
+      .filter { !isCongratsExpired($0) }
+      .sorted(by: Self.congratsIsMoreUrgent)
+      .first
+    guard let action = candidate else { return }
+    let model = GiveawayCongratsSheetModel(
+      action: action,
+      onClose: { [weak self] in self?.dismissGiveawayCongratsSheet(eventId: action.eventId) })
+    mainContainerNavigationCoordinator.presentedSheet = .giveawayCongrats(model)
+  }
+
+  private func dismissGiveawayCongratsSheet(eventId: String) {
+    // Suppress re-presentation for the rest of this foreground (the action may still be non-terminal
+    // if the owner closed without sending). A future foreground clears this and re-prompts.
+    dismissedCongratsThisForeground.insert(eventId)
+    if case .giveawayCongrats = mainContainerNavigationCoordinator.presentedSheet {
+      mainContainerNavigationCoordinator.presentedSheet = nil
+    }
+  }
+
+  private func isCongratsExpired(_ action: CongratsAction) -> Bool {
+    let cutoff =
+      action.congratsExpiresAt ?? action.startedAt.addingTimeInterval(Self.congratsClientCutoff)
+    return now >= cutoff
+  }
+
+  /// Soonest expiry first; nil-expiry actions sort last; `startedAt` breaks ties.
+  private static func congratsIsMoreUrgent(_ lhs: CongratsAction, _ rhs: CongratsAction) -> Bool {
+    switch (lhs.congratsExpiresAt, rhs.congratsExpiresAt) {
+    case (let left?, let right?):
+      return left == right ? lhs.startedAt < rhs.startedAt : left < right
+    case (nil, _?): return false
+    case (_?, nil): return true
+    case (nil, nil): return lhs.startedAt < rhs.startedAt
     }
   }
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -1314,7 +1314,7 @@ extension MainContainerTests {
         return
       }
       // Owner closes without sending — action stays pending but must not pop back up this foreground.
-      congratsModel.closeButtonTapped()
+      await congratsModel.closeButtonTapped()
 
       await model.processGiveawayResolutions()
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -1163,6 +1163,167 @@ struct MainContainerTests {
   }
 }
 
+// MARK: - Artist Congrats Arbiter Tests
+
+@MainActor
+extension MainContainerTests {
+
+  private func pendingCongrats(
+    eventId: String = "e1", state: CongratsActionState = .pending,
+    congratsExpiresAt: Date? = nil, startedAt: Date = Date(timeIntervalSince1970: 100)
+  ) -> CongratsAction {
+    CongratsAction(
+      eventId: eventId, stationId: "s1", winnerName: "Jo", prizeName: "P",
+      congratsExpiresAt: congratsExpiresAt, state: state, startedAt: startedAt)
+  }
+
+  @Test func processGiveawayResolutionsPresentsCongratsWhenStageClear() async {
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = nil
+      @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+      $actions.withLock { $0 = ["e1": pendingCongrats()] }
+      let model = withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 200))
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+
+      if case .giveawayCongrats = navCoordinator.presentedSheet {
+        // Test passes
+      } else {
+        Issue.record("Expected the congrats sheet to be presented")
+      }
+      $actions.withLock { $0 = [:] }
+    }
+  }
+
+  @Test func processGiveawayResolutionsPrefersWinnerSheetOverCongrats() async {
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = nil
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock {
+        $0 = [
+          "w": GiveawayParticipation(
+            id: "w", stationId: "s", prizeName: "P", winningNumber: 9, tapNumber: 9,
+            status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+        ]
+      }
+      @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+      $actions.withLock { $0 = ["e1": pendingCongrats()] }
+      let model = withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 200))
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+
+      // The owner-side congrats must yield to the listener-side winner sheet.
+      if case .giveawayWinner = navCoordinator.presentedSheet {
+        // Test passes
+      } else {
+        Issue.record("Expected the winner sheet to win the stage over congrats")
+      }
+      $participations.withLock { $0 = [:] }
+      $actions.withLock { $0 = [:] }
+    }
+  }
+
+  @Test func processGiveawayResolutionsSkipsExpiredCongrats() async {
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = nil
+      @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+      $actions.withLock {
+        $0 = ["e1": pendingCongrats(congratsExpiresAt: Date(timeIntervalSince1970: 50))]
+      }
+      let model = withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 200))
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+
+      #expect(navCoordinator.presentedSheet == nil)
+      $actions.withLock { $0 = [:] }
+    }
+  }
+
+  @Test func processGiveawayResolutionsSkipsTerminalCongrats() async {
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = nil
+      @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+      $actions.withLock { $0 = ["e1": pendingCongrats(state: .submitted)] }
+      let model = withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 200))
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+
+      #expect(navCoordinator.presentedSheet == nil)
+      $actions.withLock { $0 = [:] }
+    }
+  }
+
+  @Test func processGiveawayResolutionsDoesNotClobberAnotherSheetWithCongrats() async {
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = .share(ShareSheetModel(items: ["x"]))
+      @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+      $actions.withLock { $0 = ["e1": pendingCongrats()] }
+      let model = withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 200))
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+
+      if case .share = navCoordinator.presentedSheet {
+        // Test passes
+      } else {
+        Issue.record("Expected the share sheet to be left untouched")
+      }
+      $actions.withLock { $0 = [:] }
+    }
+  }
+
+  @Test func processGiveawayResolutionsDoesNotRepromptDismissedCongrats() async {
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = nil
+      @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+      $actions.withLock { $0 = ["e1": pendingCongrats()] }
+      let model = withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 200))
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+      guard case .giveawayCongrats(let congratsModel) = navCoordinator.presentedSheet else {
+        Issue.record("Expected the congrats sheet to be presented")
+        return
+      }
+      // Owner closes without sending — action stays pending but must not pop back up this foreground.
+      congratsModel.closeButtonTapped()
+
+      await model.processGiveawayResolutions()
+
+      #expect(navCoordinator.presentedSheet == nil)
+      $actions.withLock { $0 = [:] }
+    }
+  }
+}
+
 // Drain the fire-and-forget Task in MainContainerModel.showFeedbackSheet()
 // (it awaits analytics.track then assigns presentedSheet). Polling on the
 // observable end-state is resilient to changes in the number of internal

--- a/PlayolaRadio/Views/Reusable Components/PlayolaSheet.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaSheet.swift
@@ -32,4 +32,5 @@ enum PlayolaSheet: Hashable, Identifiable, Equatable {
   case artistSuggestion(StationSuggestionPageModel)
   case welcomeMessage(WelcomeMessagePageModel)
   case giveawayWinner(GiveawayWinnerSheetModel)
+  case giveawayCongrats(GiveawayCongratsSheetModel)
 }

--- a/docs/superpowers/plans/2026-06-25-artist-congrats.md
+++ b/docs/superpowers/plans/2026-06-25-artist-congrats.md
@@ -1,0 +1,538 @@
+# Artist Congrats Recording (M3) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development or superpowers:executing-plans to implement task-by-task. Steps use `- [ ]` checkboxes. Invoke the applicable `pfw-*` skills before writing Swift (pfw-observable-models, pfw-dependencies, pfw-sharing, pfw-modern-swiftui, pfw-testing, pfw-custom-dump).
+
+**Goal:** The station owner records an audio congrats for a giveaway winner; it uploads via the existing voicetrack pipeline and is submitted to the server, which airs it.
+
+**Architecture:** Mirrors M2. The owner-only `giveaway_winner_pending` push writes a durable `CongratsAction` into `@Shared(.pendingCongratsActions)` (keyed by eventId); `MainContainerModel` (the existing arbiter) presents a dedicated congrats sheet; the sheet records (reusing RecordPage components) → uploads via `VoicetrackUploadService` → POSTs the congrats. The push handler/arbiter only mutate/present; the sheet model drives record→upload→submit with durable resume/retry.
+
+**Tech Stack:** SwiftUI, `@Observable` MV models, swift-dependencies, swift-sharing, XCTest/Swift Testing.
+
+## Global Constraints
+
+- Inherits `GiveawayFeature.isLiveDataEnabled` (dark in prod, live in staging) — same gate as M1/M2; no new gating machinery. `develop` stays deployable.
+- Keyed by the **per-airing event id** (`eventId`), never `giveawayId`.
+- Reuse, don't reinvent: `VoicetrackUploadService.processVoicetrack`, RecordPage's `@Dependency(\.audioRecorder)`/`@Dependency(\.audioPlayer)` + `LiveWaveformView`/`WaveformView`, `LocalVoicetrack`, the M2 `MainContainerModel` arbiter + APNs delegate wiring.
+- New `.swift` files hand-registered in `project.pbxproj` (explicit refs, app+staging targets; tests → test target). Exclude Xcode pbxproj churn (`name =`/`plugin:` re-normalization) from commits.
+- Every `@DependencyClient` property needs an explicit default/`testValue`.
+- Views contain **zero control flow** (opacity/`allowsHitTesting` off model booleans; bindings via dynamic-member, never `Binding(get:set:)`).
+- **Run `make lint` AND `make format-check` before every push** (the pre-commit hook runs swift-format only, NOT SwiftLint). Use `Button(action:label:)` (never trailing-closure label). Revert Xcode pbxproj churn.
+- Tests: Swift Testing (`@Test`, `@MainActor struct`), `expectNoDifference` for value compares, no `Task.sleep`. For file-backed `@Shared` (`pendingCongratsActions`), set values with an explicit `$shared.withLock { $0 = … }` and wrap arbiter tests in `await withMainSerialExecutor { … }` (see `.claude/TESTING.md`).
+- `xcodebuild test` with `-skipPackagePluginValidation -skipMacroValidation` + a concrete sim id.
+
+**Spec:** `docs/superpowers/specs/2026-06-25-artist-congrats-design.md`
+
+---
+
+## Stage 1 — Foundations
+
+### Task 1: Revise `CongratsAction` (state model + eventId key)
+
+**Files:**
+- Modify: `PlayolaRadio/Models/CongratsAction.swift`
+- Test: `PlayolaRadio/Models/CongratsActionTests.swift`
+
+**Interfaces:**
+- Produces:
+  - `enum CongratsActionState: Codable, Equatable, Sendable { case pending; case recorded(localRecordingPath: String); case uploaded(audioBlockId: String); case submitted; case alreadyClosed; case skipped }`
+  - `struct CongratsAction { let eventId; let stationId; var winnerName: String?; var prizeName: String?; var congratsExpiresAt: Date?; var state; var startedAt; var id: String { eventId } }`
+  - helpers: `var audioBlockId: String?` (from `.uploaded`), `var localRecordingPath: String?` (from `.recorded`), `var isTerminal: Bool` (submitted/alreadyClosed/skipped).
+
+- [ ] **Step 1: Write the failing tests** (extend the existing `CongratsActionTests`):
+
+```swift
+@Test func terminalStates() {
+  var a = CongratsAction.mock
+  a.state = .pending; #expect(!a.isTerminal)
+  a.state = .recorded(localRecordingPath: "/x.m4a"); #expect(!a.isTerminal)
+  a.state = .uploaded(audioBlockId: "ab1"); #expect(!a.isTerminal)
+  a.state = .submitted; #expect(a.isTerminal)
+  a.state = .alreadyClosed; #expect(a.isTerminal)
+  a.state = .skipped; #expect(a.isTerminal)
+}
+
+@Test func associatedValueAccessors() {
+  var a = CongratsAction.mock
+  a.state = .recorded(localRecordingPath: "/tmp/rec.m4a")
+  #expect(a.localRecordingPath == "/tmp/rec.m4a")
+  #expect(a.audioBlockId == nil)
+  a.state = .uploaded(audioBlockId: "ab1")
+  #expect(a.audioBlockId == "ab1")
+  #expect(a.localRecordingPath == nil)
+}
+
+@Test func codableRoundTripsWithAssociatedValues() throws {
+  var a = CongratsAction.mock
+  a.state = .uploaded(audioBlockId: "ab1")
+  let data = try JSONEncoder().encode(a)
+  expectNoDifference(try JSONDecoder().decode(CongratsAction.self, from: data), a)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** the revised enum + struct:
+
+```swift
+import Foundation
+
+enum CongratsActionState: Codable, Equatable, Sendable {
+  case pending
+  case recorded(localRecordingPath: String)
+  case uploaded(audioBlockId: String)
+  case submitted
+  case alreadyClosed
+  case skipped
+}
+
+struct CongratsAction: Codable, Equatable, Sendable, Identifiable {
+  let eventId: String
+  let stationId: String
+  var winnerName: String?
+  var prizeName: String?
+  var congratsExpiresAt: Date?
+  var state: CongratsActionState
+  var startedAt: Date
+
+  var id: String { eventId }
+
+  var audioBlockId: String? {
+    if case .uploaded(let audioBlockId) = state { return audioBlockId }
+    return nil
+  }
+
+  var localRecordingPath: String? {
+    if case .recorded(let path) = state { return path }
+    return nil
+  }
+
+  var isTerminal: Bool {
+    switch state {
+    case .submitted, .alreadyClosed, .skipped: return true
+    case .pending, .recorded, .uploaded: return false
+    }
+  }
+
+  static var mock: CongratsAction {
+    CongratsAction(
+      eventId: "event-1", stationId: "station-1", winnerName: "Jo", prizeName: "Two tickets",
+      congratsExpiresAt: nil, state: .pending,
+      startedAt: Date(timeIntervalSince1970: 1_781_722_800))
+  }
+}
+```
+
+- [ ] **Step 4: Run, verify pass. Commit** — `feat(congrats): revise CongratsAction state model, key by eventId`.
+
+---
+
+### Task 2: `pendingCongratsActions` shared dict + `GiveawayWinnerPendingPush`
+
+**Files:**
+- Modify: `PlayolaRadio/State/SharedUserDefaults.swift` (replace the `pendingCongratsAction` single-optional key)
+- Create: `PlayolaRadio/Models/GiveawayWinnerPendingPush.swift`
+- Test: `PlayolaRadio/Models/GiveawayWinnerPendingPushTests.swift`
+- Register the new file in `project.pbxproj`.
+
+**Interfaces:**
+- Produces:
+  - `@Shared(.pendingCongratsActions) var pendingCongratsActions: [String: CongratsAction]` (file storage `pending-congrats-actions.json`, default `[:]`).
+  - `GiveawayWinnerPendingPush` — `init?(userInfo: [String: any Sendable])`; nil unless `type == "giveaway_winner_pending"` and `eventId`/`stationId` present. Fields: `eventId, stationId, giveawayId?, winnerName?, prizeName?, congratsExpiresAt?`.
+
+- [ ] **Step 1: Failing test** (`GiveawayWinnerPendingPushTests`):
+
+```swift
+@Test func parsesValidPendingPush() {
+  let p = GiveawayWinnerPendingPush(userInfo: [
+    "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",
+    "winnerName": "Jo", "prizeName": "Two tickets",
+    "congratsExpiresAt": "2026-06-25T20:00:00.000Z",
+  ])
+  expectNoDifference(p?.eventId, "e1")
+  expectNoDifference(p?.winnerName, "Jo")
+  #expect(p?.congratsExpiresAt != nil)
+}
+
+@Test func rejectsWrongTypeOrMissingIds() {
+  #expect(GiveawayWinnerPendingPush(userInfo: ["type": "giveaway_closed", "eventId": "e1"]) == nil)
+  #expect(GiveawayWinnerPendingPush(userInfo: ["type": "giveaway_winner_pending"]) == nil)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** the shared key (in `SharedUserDefaults.swift`, replacing the old single-optional key):
+
+```swift
+extension SharedKey where Self == FileStorageKey<[String: CongratsAction]>.Default {
+  /// Durable artist congrats progress, keyed by per-airing event id. Survives a kill and holds the
+  /// recorded file path (`.recorded`) and uploaded audioBlockId (`.uploaded`) for resume/retry.
+  static var pendingCongratsActions: Self {
+    Self[
+      .fileStorage(.documentsDirectory.appending(component: "pending-congrats-actions.json")),
+      default: [:]]
+  }
+}
+```
+
+And `GiveawayWinnerPendingPush.swift`:
+
+```swift
+import Foundation
+
+struct GiveawayWinnerPendingPush: Equatable, Sendable {
+  let eventId: String
+  let stationId: String
+  let giveawayId: String?
+  let winnerName: String?
+  let prizeName: String?
+  let congratsExpiresAt: Date?
+
+  init?(userInfo: [String: any Sendable]) {
+    guard userInfo["type"] as? String == "giveaway_winner_pending",
+      let eventId = userInfo["eventId"] as? String,
+      let stationId = userInfo["stationId"] as? String
+    else { return nil }
+    self.eventId = eventId
+    self.stationId = stationId
+    self.giveawayId = userInfo["giveawayId"] as? String
+    self.winnerName = userInfo["winnerName"] as? String
+    self.prizeName = userInfo["prizeName"] as? String
+    self.congratsExpiresAt = (userInfo["congratsExpiresAt"] as? String).flatMap {
+      ISO8601DateFormatter.playolaInternetDateTime.date(from: $0)
+    }
+  }
+}
+```
+
+> Use the project's existing ISO-8601 parsing helper (grep for how `serverTime`/`opensAt` strings are parsed in `GiveawayEvent`/the shared decoder); match it rather than introducing a new formatter if one exists.
+
+- [ ] **Step 4: Register file; remove any remaining references to the old `pendingCongratsAction` key (none expected — it's unused). Run, verify pass.**
+
+- [ ] **Step 5: Commit** — `feat(congrats): event-keyed pendingCongratsActions store + winner-pending push model`.
+
+---
+
+### Task 3: APIClient `recordGiveawayEventCongrats`
+
+**Files:**
+- Modify: `PlayolaRadio/Core/API/APIClient.swift` (giveaway section), `PlayolaRadio/Core/API/APIClient+Live.swift`
+
+**Interfaces:**
+- Produces: `var recordGiveawayEventCongrats: @Sendable (_ jwt: String, _ eventId: String, _ audioBlockId: String) async throws -> Void = { _,_,_ in }`.
+
+- [ ] **Step 1: Add the client property** (after the M2 giveaway methods):
+
+```swift
+/// Owner submits a recorded congrats (an uploaded voicetrack `audioBlockId`) for an event; the
+/// server inserts it as a spin. Idempotent per (eventId, audioBlockId) on the server.
+var recordGiveawayEventCongrats:
+  @Sendable (_ jwtToken: String, _ eventId: String, _ audioBlockId: String) async throws -> Void = {
+    _, _, _ in
+  }
+```
+
+- [ ] **Step 2: Live impl** (in `APIClient+Live.swift`, after `submitGiveawayWinnerDetails`):
+
+```swift
+recordGiveawayEventCongrats: { jwtToken, eventId, audioBlockId in
+  try await authenticatedPostVoid(
+    path: "/v1/giveaway-events/\(eventId)/congrats",
+    token: jwtToken, parameters: ["audioBlockId": audioBlockId])
+},
+```
+
+- [ ] **Step 3: Build (run a fast suite to compile). Commit** — `feat(api): record giveaway event congrats endpoint`.
+
+---
+
+## Stage 2 — Push handler
+
+### Task 4: `handleGiveawayWinnerPendingPush` + APNs wiring
+
+**Files:**
+- Modify: `PlayolaRadio/Core/PushNotifications/PushNotifications.swift`
+- Modify: `PlayolaRadio/PlayolaRadioApp.swift` (3 delegate entry points)
+- Test: `PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift`
+
+**Interfaces:**
+- Produces: `PushNotificationsClient.handleGiveawayWinnerPendingPush: @Sendable ([String: any Sendable]) async -> Void` — gated on `isLiveDataEnabled`; writes/merges a `CongratsAction(.pending)` keyed by eventId; **never clobbers a non-terminal action** (only refresh metadata).
+
+- [ ] **Step 1: Failing tests** (mirror the M2 winner-push tests):
+
+```swift
+@Test func pendingPushCreatesPendingCongrats() async {
+  @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+  await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+    "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",
+    "winnerName": "Jo", "prizeName": "Two tickets",
+  ])
+  #expect(actions["e1"]?.state == .pending)
+  #expect(actions["e1"]?.winnerName == "Jo")
+}
+
+@Test func pendingPushDoesNotClobberInProgressRecording() async {
+  @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+  $actions.withLock {
+    $0 = ["e1": CongratsAction(
+      eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: "P",
+      congratsExpiresAt: nil, state: .recorded(localRecordingPath: "/tmp/r.m4a"), startedAt: Date())]
+  }
+  await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+    "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1", "winnerName": "Jo",
+  ])
+  // The in-progress recording must survive a duplicate push.
+  #expect(actions["e1"]?.state == .recorded(localRecordingPath: "/tmp/r.m4a"))
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** the handler (live client closure):
+
+```swift
+handleGiveawayWinnerPendingPush: { userInfo in
+  guard GiveawayFeature.isLiveDataEnabled else { return }
+  guard let push = GiveawayWinnerPendingPush(userInfo: userInfo) else {
+    if userInfo["type"] as? String == "giveaway_winner_pending" {
+      reportIssue("Dropped malformed giveaway_winner_pending push: \(userInfo)")
+    }
+    return
+  }
+  @Shared(.pendingCongratsActions) var actions
+  let actionsShared = $actions
+  await MainActor.run {
+    actionsShared.withLock { dict in
+      if let existing = dict[push.eventId] {
+        // Never reset a non-terminal in-progress action; only refresh metadata.
+        if !existing.isTerminal {
+          var updated = existing
+          updated.winnerName = push.winnerName ?? existing.winnerName
+          updated.prizeName = push.prizeName ?? existing.prizeName
+          updated.congratsExpiresAt = push.congratsExpiresAt ?? existing.congratsExpiresAt
+          dict[push.eventId] = updated
+          return
+        }
+      }
+      dict[push.eventId] = CongratsAction(
+        eventId: push.eventId, stationId: push.stationId, winnerName: push.winnerName,
+        prizeName: push.prizeName, congratsExpiresAt: push.congratsExpiresAt,
+        state: .pending, startedAt: Date())
+    }
+  }
+}
+```
+
+Add the property to the `@DependencyClient` struct (with default). Wire the 3 delegate entry points in `PlayolaRadioApp.swift` for `type == "giveaway_winner_pending"` exactly like the M2 `giveaway_winner` branch (background `didReceiveRemoteNotification` → call then `completionHandler(.newData)`; `willPresent` → call, `completionHandler([])`; `didReceive` → call inside the Task, then `completionHandler()`).
+
+- [ ] **Step 4: Run, verify pass. Commit** — `feat(congrats): winner-pending push handler writes pending CongratsAction`.
+
+---
+
+## Stage 3 — Congrats sheet model
+
+### Task 5: `GiveawayCongratsSheetModel` (record → upload → submit, resume/retry/skip)
+
+**Files:**
+- Create: `PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift`
+- Test: `PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift`
+- Register both in `project.pbxproj`.
+
+**Interfaces:**
+- Consumes: `@Dependency(\.audioRecorder)`, `@Dependency(\.audioPlayer)`, `@Dependency(\.voicetrackUploadService)` (or `VoicetrackUploadService` key — grep its dependency key), `@Dependency(\.api)`, `@Shared(.auth)`, `@Shared(.pendingCongratsActions)`. Reuse the recording-phase pattern from `RecordPageModel` (audioRecorder.requestPermission/startRecording/stopRecording→URL/currentTime/getAudioLevel; audioPlayer for playback).
+- Produces: `@MainActor @Observable final class GiveawayCongratsSheetModel: ViewModel`:
+  - `init(action: CongratsAction, onClose: @escaping () -> Void)`
+  - `headline: String` ("Congratulate \<winnerName\> on winning \<prizeName\>", with sensible fallbacks)
+  - record/review state mirroring RecordPage (`recordingPhase`, `waveformSamples`, `recordingDuration`, playback)
+  - `onRecordTapped()/onStopTapped()/onPlayTapped()` async
+  - `sendButtonTapped() async` (record→persist→upload→submit), `skipButtonTapped()`, `closeButtonTapped()`
+  - view helpers (`canSend`, `sendButtonTitle`, `isUploading`, `uploadStatusText`, opacity swaps, `presentedAlert`)
+
+- [ ] **Step 1: Failing tests** (use a `VoicetrackUploadService` test double + `api` override):
+
+```swift
+@Test func sendUploadsThenSubmitsAndMarksSubmitted() async {
+  @Shared(.auth) var auth = Auth(jwt: "jwt")
+  @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+  $actions.withLock {
+    $0 = ["e1": CongratsAction(
+      eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: "P", congratsExpiresAt: nil,
+      state: .recorded(localRecordingPath: "/tmp/r.m4a"), startedAt: Date())]
+  }
+  var congratsPosted: (String, String)?
+  let model = withDependencies {
+    $0.voicetrackUploadService.processVoicetrack = { _, _, _, _ in AudioBlock.mock(id: "ab1") }
+    $0.api.recordGiveawayEventCongrats = { _, eventId, audioBlockId in
+      congratsPosted = (eventId, audioBlockId)
+    }
+  } operation: {
+    GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+  }
+  await model.sendButtonTapped()
+  expectNoDifference(actions["e1"]?.state, .submitted)
+  expectNoDifference(congratsPosted?.0, "e1")
+  expectNoDifference(congratsPosted?.1, "ab1")
+}
+
+@Test func uploadFailureStaysRecordedForRetry() async {
+  struct Boom: Error {}
+  @Shared(.auth) var auth = Auth(jwt: "jwt")
+  @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+  $actions.withLock {
+    $0 = ["e1": CongratsAction(eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil,
+      congratsExpiresAt: nil, state: .recorded(localRecordingPath: "/tmp/r.m4a"), startedAt: Date())]
+  }
+  let model = withDependencies {
+    $0.voicetrackUploadService.processVoicetrack = { _, _, _, _ in throw Boom() }
+  } operation: { GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {}) }
+  await model.sendButtonTapped()
+  // Recording is not lost; user can retry.
+  #expect(actions["e1"]?.localRecordingPath == "/tmp/r.m4a")
+  #expect(model.presentedAlert != nil)
+}
+
+@Test func postFailureStaysUploadedForRetry() async {
+  struct Boom: Error {}
+  @Shared(.auth) var auth = Auth(jwt: "jwt")
+  @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+  $actions.withLock {
+    $0 = ["e1": CongratsAction(eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil,
+      congratsExpiresAt: nil, state: .uploaded(audioBlockId: "ab1"), startedAt: Date())]
+  }
+  let model = withDependencies {
+    $0.api.recordGiveawayEventCongrats = { _, _, _ in throw Boom() }
+  } operation: { GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {}) }
+  await model.sendButtonTapped()  // reached at .uploaded → re-POST only
+  #expect(actions["e1"]?.audioBlockId == "ab1")  // stays uploaded, retryable
+}
+
+@Test func skipMarksSkippedAndCloses() {
+  @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+  $actions.withLock { $0 = ["e1": .mock] }
+  var closed = false
+  let model = GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: { closed = true })
+  model.skipButtonTapped()
+  expectNoDifference(actions["e1"]?.state, .skipped)
+  #expect(closed)
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement** following `pfw-observable-models`. Key logic:
+  - **Send** routes on the current persisted state: `.pending`/just-recorded → persist the stopped recording's file into Application Support, set `.recorded(path)`, then upload; `.recorded` → upload from the path; `.uploaded` → POST only.
+  - Upload: build `LocalVoicetrack(originalURL: URL(fileURLWithPath: path))`, read a **fresh** `auth.jwt`, call `voicetrackUploadService.processVoicetrack(_, action.stationId, jwt, { status in self.uploadStatus = status })`; on the returned `AudioBlock`, `$pendingCongratsActions.withLock { $0[eventId]?.state = .uploaded(audioBlockId: block.id) }`.
+  - Submit: read a **fresh** `auth.jwt` again, `api.recordGiveawayEventCongrats(jwt, eventId, audioBlockId)`; success → `.submitted` + delete the local file + `onClose()`. Failure → keep `.uploaded`, set `presentedAlert`. A closed/expired error (map from the server's distinct error) → `.alreadyClosed` + `onClose()`.
+  - Persist the recording file under `Application Support` (a small `CongratsRecordingStore` helper or inline `FileManager`); delete on submitted/skipped/alreadyClosed.
+  - Reuse RecordPage's record/stop/playback methods verbatim where possible (extract shared helpers only if clean).
+
+- [ ] **Step 4: Run, verify pass. Commit** — `feat(congrats): congrats sheet model (record/upload/submit, resume + retry)`.
+
+---
+
+## Stage 4 — Sheet view + presentation
+
+### Task 6: Congrats sheet view + `PlayolaSheet.giveawayCongrats`
+
+**Files:**
+- Create: `PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift`
+- Modify: `PlayolaRadio/Views/Reusable Components/PlayolaSheet.swift` (add case)
+- Modify: `PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift` (host the case **and** add it to the `.sheet` binding getter allow-list — the M2 P1 lesson: the content case alone is unreachable)
+- Register the view in `project.pbxproj`.
+
+**Interfaces:**
+- Produces: `case giveawayCongrats(GiveawayCongratsSheetModel)`; `GiveawayCongratsSheetView(model:)`.
+
+- [ ] **Step 1:** Add the enum case + host it in MainContainer's `.sheet` content switch **and** add `.giveawayCongrats` to the getter's `case .player, …:` allow-list (line ~51). Build the view from RecordPage's layout (`LiveWaveformView`/`WaveformView`, record/stop/play buttons, Send, Skip) — **zero control flow** (opacity/disabled off model booleans), `Button(action:label:)` form, `.playolaAlert($model.presentedAlert)`.
+- [ ] **Step 2:** Add `#Preview`s (pending/recorded/uploading). Build; verify previews render. (Model covered in Task 5.)
+- [ ] **Step 3: Commit** — `feat(congrats): congrats sheet view + PlayolaSheet case + host wiring`.
+
+---
+
+### Task 7: MainContainer arbiter — present congrats (priority, expiry, no re-prompt same session)
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift`
+- Test: `PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift`
+
+**Interfaces:**
+- Consumes: `@Shared(.pendingCongratsActions)`, `@Dependency(\.date.now)`, the nav coordinator, `GiveawayCongratsSheetModel`.
+- Produces: extends `processGiveawayResolutions()` (or a sibling `processPendingCongrats()`) — present the most-urgent non-terminal, non-expired congrats when no blocking sheet AND no pending winner sheet is up (winner sheet wins). Track a per-session "dismissed this foreground" set so a dismissed congrats doesn't immediately re-present. Gated on `isLiveDataEnabled`.
+
+- [ ] **Step 1: Failing tests** (wrap in `withMainSerialExecutor`, explicit `withLock`, per the M2 deflake lesson):
+
+```swift
+@Test func presentsPendingCongratsWhenNoWinnerSheet() async {
+  await withMainSerialExecutor {
+    @Shared(.mainContainerNavigationCoordinator) var nav
+    nav.presentedSheet = nil
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+    $participations.withLock { $0 = [:] }
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = ["e1": CongratsAction(eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: "P",
+        congratsExpiresAt: nil, state: .pending, startedAt: Date(timeIntervalSince1970: 100))]
+    }
+    let model = MainContainerModel()
+    await model.processGiveawayResolutions()
+    if case .giveawayCongrats = nav.presentedSheet {} else { Issue.record("expected congrats sheet") }
+  }
+}
+
+@Test func winnerSheetTakesPriorityOverCongrats() async {
+  await withMainSerialExecutor {
+    @Shared(.mainContainerNavigationCoordinator) var nav
+    nav.presentedSheet = nil
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+    $participations.withLock {
+      $0 = ["w": GiveawayParticipation(id: "w", stationId: "s", prizeName: "P", winningNumber: 9,
+        tapNumber: 9, status: .resolvedWon(submissionCompleted: false), tappedAt: Date())]
+    }
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = ["e1": .mock] }
+    let model = MainContainerModel()
+    await model.processGiveawayResolutions()
+    if case .giveawayWinner = nav.presentedSheet {} else { Issue.record("winner sheet should win") }
+  }
+}
+
+@Test func expiredCongratsNotPresented() async {
+  await withMainSerialExecutor {
+    @Shared(.mainContainerNavigationCoordinator) var nav
+    nav.presentedSheet = nil
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = ["e1": CongratsAction(eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil,
+        congratsExpiresAt: Date(timeIntervalSince1970: 50), state: .pending,
+        startedAt: Date(timeIntervalSince1970: 10))]
+    }
+    let model = withDependencies { $0.date = .constant(Date(timeIntervalSince1970: 100)) }
+      operation: { MainContainerModel() }
+    await model.processGiveawayResolutions()
+    #expect(nav.presentedSheet == nil)
+  }
+}
+```
+
+- [ ] **Step 2: Run, verify fail.**
+
+- [ ] **Step 3: Implement.** After the winner-sheet/loser-toast logic, add congrats presentation: if a winner sheet was just presented or is up, return (priority). Filter `pendingCongratsActions.values` to non-terminal AND not-expired (`congratsExpiresAt > now`, or — when nil — `startedAt + Self.congratsClientCutoff > now`, `congratsClientCutoff = 60 * 60`) AND not in the per-foreground dismissed set; sort by `congratsExpiresAt` (nil last) then `startedAt`; present the first as `.giveawayCongrats(GiveawayCongratsSheetModel(action:onClose:))`. `onClose` adds the eventId to the dismissed-this-foreground set and clears the sheet. Reset the dismissed set on each foreground (`refreshOnForeground`).
+
+- [ ] **Step 4: Run, verify pass. Commit** — `feat(congrats): MainContainer arbiter presents congrats (priority + expiry)`.
+
+---
+
+## Final verification
+
+- [ ] Full `xcodebuild test` (not just build) on a concrete sim, `-skipPackagePluginValidation -skipMacroValidation`. All giveaway + container + push + record suites green.
+- [ ] `make lint` (0 violations) AND `make format-check` (PASS). Revert Xcode pbxproj churn; confirm only new file refs in the pbxproj diff.
+- [ ] Simulator smoke (staging): simulate a `giveaway_winner_pending` push (or a DEBUG inject) → congrats sheet → record → Send → submitted; kill mid-upload → reopen → resumes from the recording.
+- [ ] Codex review (pass/fail gate) + challenge on the diff; fix findings.
+- [ ] PR against `develop`; body notes the server deps (spec §8: structured push fields + idempotent congrats POST) and that the feature is gated dark in prod.
+
+## Self-review notes (spec coverage)
+
+- Discovery push → Task 4. State model (recorded/uploaded + persisted recording) → Task 1. Event-keyed store → Task 2. APIClient → Task 3. Sheet model (record/upload/submit/resume/retry/skip, fresh JWT) → Task 5. View + PlayolaSheet case + binding allow-list → Task 6. Arbiter (priority, expiry, no-re-prompt-same-session) → Task 7.
+- Server deps (structured push fields, idempotent congrats POST) = external (spec §8).
+- Out of scope (spec §7): listener hearing the congrats, pending-congrats list endpoint, video.
+- Confirm during impl: the exact `VoicetrackUploadService` dependency key name, `AudioBlock.mock(id:)` availability (add a test helper if absent), the project's ISO-8601 date parsing helper, and `RecordPage` component visibility (extract shared helpers only if clean — don't fork the recorder).


### PR DESCRIPTION
## Live Giveaway — M3: Artist Congrats Recording (owner side)

When a giveaway closes, the station **owner** is prompted to record a short audio congrats for their winner. The app records it, uploads it through the existing voicetrack pipeline, and POSTs it to the server, which inserts it into the schedule as a spin. The flow is push-driven, durable across app kills, and idempotent.

This milestone is **gated dark in prod** behind `GiveawayFeature.isLiveDataEnabled` (both push handlers now check it).

### Flow
1. Server sends a `giveaway_winner_pending` push (eventId, stationId, winnerName?, prizeName?, congratsExpiresAt?).
2. Push handler writes a `CongratsAction(.pending)` keyed by `eventId` into `@Shared(.pendingCongratsActions)` (file-backed). Never clobbers an in-progress or terminal action.
3. The `MainContainer` arbiter presents the dedicated congrats sheet when the stage is clear — **lower priority than the winner sheet** and unrelated modals, skips terminal/expired actions, and won't re-prompt a sheet dismissed this foreground (resets next foreground).
4. The sheet records → uploads (`processVoicetrack`) → POSTs `/v1/giveaway-events/{eventId}/congrats`. State machine persists at each step (`.pending → .recorded → .uploaded → .submitted`) so a kill/retry resumes without re-recording or re-uploading.

### Durability & edge handling
- Recording is copied into Application Support so it survives suspension during upload; `.uploaded` carries the local path so a resumed upload can still replay, re-send, and clean up.
- `setState` refuses to overwrite a terminal decision; submit aborts if the action went terminal mid-upload; Skip is disabled while submitting — closes the skip-races-submit window.
- Interactive swipe-dismiss tears down the mic/player via `.onDisappear` (SwiftUI bypasses skip/send on swipe).
- A `409` from the congrats POST (server window closed) maps to `GiveawayCongratsError.windowClosed` → terminal `.alreadyClosed` + dismiss (no retry loop).
- Duplicate `giveaway_winner_pending` pushes never resurrect a terminal action.

### Server dependencies (being built in parallel)
- **`giveaway_winner_pending` push**: type + `eventId`, `stationId` required; `winnerName`, `prizeName`, `congratsExpiresAt` optional. Targeted at the station owner when the event closes.
- **`POST /v1/giveaway-events/{eventId}/congrats`** body `{ audioBlockId }`, idempotent. **Return `409` when the congrats window has closed** (client maps to terminal).

### Tests
Full suite green (1138 tests). New coverage: arbiter priority/expiry/terminal-skip/no-clobber/no-reprompt; push idempotency (no-resurrect-terminal, pending→completed win upgrade); congrats state machine resume/retry, skip-races-submit, double-tap-record guard, closed-window terminal, resume replay/duration.

### Review gates (Architect-with-Codex pipeline)
- Codex **review**: GATE PASS (2 P2s fixed: skip-mid-record teardown, pending-win upgrade).
- Codex **challenge** (adversarial): 4 P1 + 4 P2 surfaced, all fixed (lifecycle leaks, dismissal cleanup, CAS state guards, resume correctness).
- Codex **re-review**: GATE PASS (2 of 3 P2s fixed here; see follow-up).

### Known follow-up (out of scope)
Codex flagged that the **M2 in-player loser reveal** (`GiveawayOverlayModel.visibleGiveaway`) can collapse when the coordinator clears `activeGiveaway` at event close, before any minimum display. This is pre-existing M2 code (not in this diff) and is intentionally backstopped by the guaranteed one-time loser toast. Tracking separately rather than expanding this PR into M2 overlay internals.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an owner-side giveaway “congrats” flow with a full-screen sheet to record, review, upload, submit, and skip—resuming in-progress work when available.
  * Added handling for an owner-only “winner pending” push to surface pending congrats actions.
  * Updated navigation/arbiter logic to present the congrats sheet at the right time with priority and expiry rules.
* **Bug Fixes**
  * Improved resilience to delayed/duplicate pushes, preventing reopening completed claims and handling window-closed outcomes.
  * Updated winner-claim success to show a confirmation screen instead of dismissing immediately.
* **Documentation**
  * Added an implementation plan for the “Artist Congrats” feature.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->