### PR TITLE
fix(giveaway): address PR #340 review (test isolation + error observability)

### DIFF
--- a/.claude/TESTING.md
+++ b/.claude/TESTING.md
@@ -42,6 +42,17 @@ func testSomethingWithSharedAuth() async {
 
 This is especially important for `@Shared` keys backed by `.fileStorage` (like `.auth`), which go through more async machinery than `.inMemory` keys.
 
+### File-backed keys: reset with `withLock` after the declaration
+
+Because the `= initialValue` declaration is only a fallback (it does NOT write), a `.fileStorage`-backed key can still hold a stale value from a previous test run, which silently invalidates assertions like `#expect(participations["e1"] == nil)`. For file-backed keys, follow the declaration with an explicit `withLock` reset so the store holds a known value — this is the one case where `withLock` is used for initial-state setup rather than only to drive a mid-test change:
+
+```swift
+@Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+$participations.withLock { $0 = ["e1": .mock] }  // real write, not a fallback
+```
+
+Combine with `withMainSerialExecutor` for any test that reads the store back after an `await`.
+
 ## Mocking Dependencies
 
 Use `withDependencies` to mock API calls:

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import CustomDump
 import Dependencies
 import Foundation
@@ -8,7 +9,11 @@ import Testing
 
 // swiftlint:disable redundant_optional_initialization
 
+// Serialized: these tests mutate the file-backed `@Shared(.giveawayParticipations)` store under a
+// shared key, so parallel Swift Testing could interleave across `await` points and cross-contaminate
+// the on-disk state.
 @MainActor
+@Suite(.serialized)
 struct GiveawayCoordinatorTests {
   private struct BoomError: Error {}
 
@@ -216,93 +221,113 @@ struct GiveawayCoordinatorTests {
   }
 
   @Test func tapPersistsResolvedLossOnNonWinningTap() async {
-    let tappedAt = Date(timeIntervalSince1970: 1000)
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
-    await withDependencies {
-      $0.date = .constant(tappedAt)
-      $0.api.tapGiveawayEvent = { _, _ in
-        GiveawayTapResponse(tapNumber: 7, isWinner: false, status: .open)
+    await withMainSerialExecutor {
+      let tappedAt = Date(timeIntervalSince1970: 1000)
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = [:] }
+      await withDependencies {
+        $0.date = .constant(tappedAt)
+        $0.api.tapGiveawayEvent = { _, _ in
+          GiveawayTapResponse(tapNumber: 7, isWinner: false, status: .open)
+        }
+      } operation: {
+        try? await GiveawayCoordinator().tap(event: openEvent())
       }
-    } operation: {
-      try? await GiveawayCoordinator().tap(event: openEvent())
+      // Resolved immediately from the tap response, keyed by the per-airing event id.
+      expectNoDifference(
+        participations["e1"],
+        GiveawayParticipation(
+          id: "e1", stationId: "s1", prizeName: "Two tickets", prizeDescription: "Front row",
+          winningNumber: 9, tapNumber: 7, status: .resolvedLost(toastShown: false),
+          tappedAt: tappedAt))
     }
-    // Resolved immediately from the tap response, keyed by the per-airing event id.
-    expectNoDifference(
-      participations["e1"],
-      GiveawayParticipation(
-        id: "e1", stationId: "s1", prizeName: "Two tickets", prizeDescription: "Front row",
-        winningNumber: 9, tapNumber: 7, status: .resolvedLost(toastShown: false),
-        tappedAt: tappedAt))
   }
 
   @Test func tapPersistsResolvedWonOnWinningTap() async {
-    let tappedAt = Date(timeIntervalSince1970: 1000)
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
-    await withDependencies {
-      $0.date = .constant(tappedAt)
-      $0.api.tapGiveawayEvent = { _, _ in
-        GiveawayTapResponse(tapNumber: 9, isWinner: true, status: .open)
+    await withMainSerialExecutor {
+      let tappedAt = Date(timeIntervalSince1970: 1000)
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = [:] }
+      await withDependencies {
+        $0.date = .constant(tappedAt)
+        $0.api.tapGiveawayEvent = { _, _ in
+          GiveawayTapResponse(tapNumber: 9, isWinner: true, status: .open)
+        }
+      } operation: {
+        try? await GiveawayCoordinator().tap(event: openEvent())
       }
-    } operation: {
-      try? await GiveawayCoordinator().tap(event: openEvent())
+      expectNoDifference(
+        participations["e1"],
+        GiveawayParticipation(
+          id: "e1", stationId: "s1", prizeName: "Two tickets", prizeDescription: "Front row",
+          winningNumber: 9, tapNumber: 9, status: .resolvedWon(submissionCompleted: false),
+          tappedAt: tappedAt))
     }
-    expectNoDifference(
-      participations["e1"],
-      GiveawayParticipation(
-        id: "e1", stationId: "s1", prizeName: "Two tickets", prizeDescription: "Front row",
-        winningNumber: 9, tapNumber: 9, status: .resolvedWon(submissionCompleted: false),
-        tappedAt: tappedAt))
   }
 
   @Test func tapWithoutJWTIsNoOp() async {
-    @Shared(.auth) var auth = Auth()
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
-    // The default tap stub would persist a participation if the JWT guard failed to short-circuit.
-    try? await GiveawayCoordinator().tap(event: openEvent())
-    #expect(participations["e1"] == nil)
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth()
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = [:] }
+      // The default tap stub would persist a participation if the JWT guard failed to short-circuit.
+      try? await GiveawayCoordinator().tap(event: openEvent())
+      #expect(participations["e1"] == nil)
+    }
   }
 
   @Test func tapIgnoredWhenAlreadyParticipating() async {
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    // A sentinel tapNumber that the success stub (5) would overwrite if the dedup guard failed.
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e1": GiveawayParticipation(
-        id: "e1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9, tapNumber: 99,
-        status: .tappedStandby, tappedAt: Date(timeIntervalSince1970: 500))
-    ]
-    await withDependencies {
-      $0.api.tapGiveawayEvent = { _, _ in .mock }
-    } operation: {
-      try? await GiveawayCoordinator().tap(event: openEvent())
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      // A sentinel tapNumber that the success stub (5) would overwrite if the dedup guard failed.
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock {
+        $0 = [
+          "e1": GiveawayParticipation(
+            id: "e1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9, tapNumber: 99,
+            status: .tappedStandby, tappedAt: Date(timeIntervalSince1970: 500))
+        ]
+      }
+      await withDependencies {
+        $0.api.tapGiveawayEvent = { _, _ in .mock }
+      } operation: {
+        try? await GiveawayCoordinator().tap(event: openEvent())
+      }
+      #expect(participations["e1"]?.tapNumber == 99)
     }
-    #expect(participations["e1"]?.tapNumber == 99)
   }
 
   @Test func tapStaysSilentAndDoesNotPersistOnNotOpenYet() async {
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
-    // A 400 race is surfaced by the API as `.notOpenYet`; tap swallows it silently (no rethrow).
-    await withDependencies {
-      $0.api.tapGiveawayEvent = { _, _ in throw GiveawayTapError.notOpenYet }
-    } operation: {
-      try? await GiveawayCoordinator().tap(event: openEvent())
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = [:] }
+      // A 400 race is surfaced by the API as `.notOpenYet`; tap swallows it silently (no rethrow).
+      await withDependencies {
+        $0.api.tapGiveawayEvent = { _, _ in throw GiveawayTapError.notOpenYet }
+      } operation: {
+        try? await GiveawayCoordinator().tap(event: openEvent())
+      }
+      #expect(participations["e1"] == nil)
     }
-    #expect(participations["e1"] == nil)
   }
 
   @Test func tapRethrowsUnexpectedErrorAndDoesNotPersist() async {
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
-    await #expect(throws: BoomError.self) {
-      try await withDependencies {
-        $0.api.tapGiveawayEvent = { _, _ in throw BoomError() }
-      } operation: {
-        try await GiveawayCoordinator().tap(event: openEvent())
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = [:] }
+      await #expect(throws: BoomError.self) {
+        try await withDependencies {
+          $0.api.tapGiveawayEvent = { _, _ in throw BoomError() }
+        } operation: {
+          try await GiveawayCoordinator().tap(event: openEvent())
+        }
       }
+      #expect(participations["e1"] == nil)
     }
-    #expect(participations["e1"] == nil)
   }
 
   // MARK: - Loss Backstop
@@ -314,82 +339,90 @@ struct GiveawayCoordinatorTests {
   }
 
   @Test func backstopFlipsLossToWinWhenPromoted() async {
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e1": lostParticipation()
-    ]
-    await withDependencies {
-      $0.api.giveawayEventMyResult = { _, _ in
-        GiveawayMyResult(tapNumber: 5, isWinner: true, status: .closed, winningNumber: 9)
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = ["e1": lostParticipation()] }
+      await withDependencies {
+        $0.api.giveawayEventMyResult = { _, _ in
+          GiveawayMyResult(tapNumber: 5, isWinner: true, status: .closed, winningNumber: 9)
+        }
+      } operation: {
+        await GiveawayCoordinator().reconcileResolvedLoss(jwt: "jwt", eventId: "e1")
       }
-    } operation: {
-      await GiveawayCoordinator().reconcileResolvedLoss(jwt: "jwt", eventId: "e1")
+      #expect(
+        participations["e1"]?.status
+          == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
     }
-    #expect(
-      participations["e1"]?.status
-        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
   }
 
   @Test func backstopLeavesLossWhenStillLost() async {
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e1": lostParticipation()
-    ]
-    await withDependencies {
-      $0.api.giveawayEventMyResult = { _, _ in
-        GiveawayMyResult(tapNumber: 5, isWinner: false, status: .closed, winningNumber: 9)
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = ["e1": lostParticipation()] }
+      await withDependencies {
+        $0.api.giveawayEventMyResult = { _, _ in
+          GiveawayMyResult(tapNumber: 5, isWinner: false, status: .closed, winningNumber: 9)
+        }
+      } operation: {
+        await GiveawayCoordinator().reconcileResolvedLoss(jwt: "jwt", eventId: "e1")
       }
-    } operation: {
-      await GiveawayCoordinator().reconcileResolvedLoss(jwt: "jwt", eventId: "e1")
+      #expect(
+        participations["e1"]?.status
+          == GiveawayParticipationStatus.resolvedLost(toastShown: true))
     }
-    #expect(
-      participations["e1"]?.status
-        == GiveawayParticipationStatus.resolvedLost(toastShown: true))
   }
 
   @Test func backstopIgnoresStillOpenResult() async {
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e1": lostParticipation()
-    ]
-    await withDependencies {
-      $0.api.giveawayEventMyResult = { _, _ in
-        GiveawayMyResult(tapNumber: 5, isWinner: false, status: .open, winningNumber: 9)
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = ["e1": lostParticipation()] }
+      await withDependencies {
+        $0.api.giveawayEventMyResult = { _, _ in
+          GiveawayMyResult(tapNumber: 5, isWinner: false, status: .open, winningNumber: 9)
+        }
+      } operation: {
+        await GiveawayCoordinator().reconcileResolvedLoss(jwt: "jwt", eventId: "e1")
       }
-    } operation: {
-      await GiveawayCoordinator().reconcileResolvedLoss(jwt: "jwt", eventId: "e1")
+      #expect(
+        participations["e1"]?.status
+          == GiveawayParticipationStatus.resolvedLost(toastShown: true))
     }
-    #expect(
-      participations["e1"]?.status
-        == GiveawayParticipationStatus.resolvedLost(toastShown: true))
   }
 
   @Test func foregroundReconcileFlipsRecentLossButSkipsStale() async {
-    let nowDate = Date(timeIntervalSince1970: 1_000_000)
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "recent": GiveawayParticipation(
-        id: "recent", stationId: "s1", prizeName: "P", winningNumber: 9, tapNumber: 5,
-        status: .resolvedLost(toastShown: true), tappedAt: nowDate.addingTimeInterval(-60)),
-      "stale": GiveawayParticipation(
-        id: "stale", stationId: "s1", prizeName: "P", winningNumber: 9, tapNumber: 5,
-        status: .resolvedLost(toastShown: true),
-        tappedAt: nowDate.addingTimeInterval(-7 * 60 * 60)),
-    ]
-    await withDependencies {
-      $0.date = .constant(nowDate)
-      $0.api.giveawayEventMyResult = { _, _ in
-        GiveawayMyResult(tapNumber: 5, isWinner: true, status: .closed, winningNumber: 9)
+    await withMainSerialExecutor {
+      let nowDate = Date(timeIntervalSince1970: 1_000_000)
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock {
+        $0 = [
+          "recent": GiveawayParticipation(
+            id: "recent", stationId: "s1", prizeName: "P", winningNumber: 9, tapNumber: 5,
+            status: .resolvedLost(toastShown: true), tappedAt: nowDate.addingTimeInterval(-60)),
+          "stale": GiveawayParticipation(
+            id: "stale", stationId: "s1", prizeName: "P", winningNumber: 9, tapNumber: 5,
+            status: .resolvedLost(toastShown: true),
+            tappedAt: nowDate.addingTimeInterval(-7 * 60 * 60)),
+        ]
       }
-    } operation: {
-      await GiveawayCoordinator().reconcileRecentResolvedLosses()
+      await withDependencies {
+        $0.date = .constant(nowDate)
+        $0.api.giveawayEventMyResult = { _, _ in
+          GiveawayMyResult(tapNumber: 5, isWinner: true, status: .closed, winningNumber: 9)
+        }
+      } operation: {
+        await GiveawayCoordinator().reconcileRecentResolvedLosses()
+      }
+      #expect(
+        participations["recent"]?.status
+          == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
+      #expect(
+        participations["stale"]?.status
+          == GiveawayParticipationStatus.resolvedLost(toastShown: true))
     }
-    #expect(
-      participations["recent"]?.status
-        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
-    #expect(
-      participations["stale"]?.status
-        == GiveawayParticipationStatus.resolvedLost(toastShown: true))
   }
 }
 

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -1,5 +1,6 @@
 import Dependencies
 import Foundation
+import IssueReporting
 import Observation
 import PlayolaPlayer
 import Sharing
@@ -73,10 +74,13 @@ class GiveawayCongratsSheetModel: ViewModel {
     // Resuming from a persisted recording (.recorded / .uploaded after a kill): load it so review
     // shows a real duration and Play works. Otherwise prime the recorder for a fresh take.
     if let url = recordingURL {
-      try? await audioPlayer.loadFile(url)
+      await withErrorReporting { try await audioPlayer.loadFile(url) }
       recordingDuration = await audioPlayer.duration()
     } else {
-      try? await audioRecorder.prepareForRecording()
+      // Priming the recorder stays non-fatal — a failure here surfaces to the user when they tap
+      // Record (startRecording throws → congratsRecordingFailed) — but report it so the audio-session
+      // setup failure isn't swallowed without a trace.
+      await withErrorReporting { try await audioRecorder.prepareForRecording() }
     }
   }
 

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -159,7 +159,9 @@ class GiveawayCongratsSheetModel: ViewModel {
     }
     // `viewAppeared` only primes the recorder once (and only when there was no resume file), so
     // re-arm the audio session here or the next `startRecording()` runs on an unprepared session.
-    try? await audioRecorder.prepareForRecording()
+    // Non-fatal like the prime in `viewAppeared` (surfaces at record time), but report it so an
+    // audio-session setup failure isn't swallowed without a trace.
+    await withErrorReporting { try await audioRecorder.prepareForRecording() }
   }
 
   func sendButtonTapped() async {

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModel.swift
@@ -1,5 +1,6 @@
 import Dependencies
 import Foundation
+import IssueReporting
 import Observation
 import Sharing
 import SwiftUI
@@ -52,7 +53,9 @@ class GiveawayWinnerSheetModel: ViewModel {
         showsClaimedConfirmation = true
       }
     } catch {
-      // Fail open — leave the form available.
+      // Fail open — leave the form available — but record the error so a failing eligibility check
+      // isn't indistinguishable from one that passed (a re-submit upserts server-side, so it's safe).
+      reportIssue(error)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
@@ -1,3 +1,4 @@
+import ConcurrencyExtras
 import Dependencies
 import Foundation
 import Sharing
@@ -5,7 +6,11 @@ import Testing
 
 @testable import PlayolaRadio
 
+// Serialized: these tests mutate the file-backed `@Shared(.giveawayParticipations)` store under a
+// shared key, so parallel Swift Testing could interleave across `await` points and cross-contaminate
+// the on-disk state.
 @MainActor
+@Suite(.serialized)
 struct GiveawayWinnerSheetModelTests {
   private func wonParticipation(tapNumber: Int = 9, winningNumber: Int = 9)
     -> GiveawayParticipation
@@ -48,74 +53,78 @@ struct GiveawayWinnerSheetModelTests {
   }
 
   @Test func claimSuccessMarksSubmittedAndShowsConfirmation() async {
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e": wonParticipation()
-    ]
-    var closed = false
-    let model = await withDependencies {
-      $0.api.submitGiveawayWinnerDetails = { _, _, _ in }
-    } operation: {
-      let model = GiveawayWinnerSheetModel(
-        participation: participations["e"]!, onClose: { closed = true })
-      fill(model)
-      await model.claimButtonTapped()
-      return model
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = ["e": wonParticipation()] }
+      var closed = false
+      let model = await withDependencies {
+        $0.api.submitGiveawayWinnerDetails = { _, _, _ in }
+      } operation: {
+        let model = GiveawayWinnerSheetModel(
+          participation: participations["e"]!, onClose: { closed = true })
+        fill(model)
+        await model.claimButtonTapped()
+        return model
+      }
+      #expect(
+        participations["e"]?.status
+          == GiveawayParticipationStatus.resolvedWon(submissionCompleted: true))
+      // The confirmation screen is shown (with a Done button); the sheet is NOT dismissed yet.
+      #expect(model.showsClaimedConfirmation == true)
+      #expect(closed == false)
+      // Tapping Done dismisses.
+      model.closeButtonTapped()
+      #expect(closed == true)
     }
-    #expect(
-      participations["e"]?.status
-        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: true))
-    // The confirmation screen is shown (with a Done button); the sheet is NOT dismissed yet.
-    #expect(model.showsClaimedConfirmation == true)
-    #expect(closed == false)
-    // Tapping Done dismisses.
-    model.closeButtonTapped()
-    #expect(closed == true)
   }
 
   @Test func claimFailureKeepsSheetOpenWithError() async {
     struct Boom: Error {}
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e": wonParticipation()
-    ]
-    var closed = false
-    let presentedAlert: PlayolaAlert? = await withDependencies {
-      $0.api.submitGiveawayWinnerDetails = { _, _, _ in throw Boom() }
-    } operation: {
-      let model = GiveawayWinnerSheetModel(
-        participation: participations["e"]!, onClose: { closed = true })
-      fill(model)
-      await model.claimButtonTapped()
-      return model.presentedAlert
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = ["e": wonParticipation()] }
+      var closed = false
+      let presentedAlert: PlayolaAlert? = await withDependencies {
+        $0.api.submitGiveawayWinnerDetails = { _, _, _ in throw Boom() }
+      } operation: {
+        let model = GiveawayWinnerSheetModel(
+          participation: participations["e"]!, onClose: { closed = true })
+        fill(model)
+        await model.claimButtonTapped()
+        return model.presentedAlert
+      }
+      #expect(closed == false)
+      #expect(presentedAlert != nil)
+      #expect(
+        participations["e"]?.status
+          == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
     }
-    #expect(closed == false)
-    #expect(presentedAlert != nil)
-    #expect(
-      participations["e"]?.status
-        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
   }
 
   @Test func pushProvenanceAlreadyClaimedShowsConfirmation() async {
-    @Shared(.auth) var auth = Auth(jwt: "jwt")
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "e": wonParticipation(tapNumber: 5, winningNumber: 9)
-    ]
-    let showsConfirmation: Bool = await withDependencies {
-      $0.api.giveawayEvent = { _, _ in
-        GiveawayEvent(
-          id: "e", stationId: "s", prizeName: "Two tickets", winningNumber: 9, status: .closed,
-          viewer: GiveawayEventViewer(hasTapped: true, isWinner: true, canSubmitMailingInfo: false))
+    await withMainSerialExecutor {
+      @Shared(.auth) var auth = Auth(jwt: "jwt")
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = ["e": wonParticipation(tapNumber: 5, winningNumber: 9)] }
+      let showsConfirmation: Bool = await withDependencies {
+        $0.api.giveawayEvent = { _, _ in
+          GiveawayEvent(
+            id: "e", stationId: "s", prizeName: "Two tickets", winningNumber: 9, status: .closed,
+            viewer: GiveawayEventViewer(
+              hasTapped: true, isWinner: true, canSubmitMailingInfo: false))
+        }
+      } operation: {
+        let model = GiveawayWinnerSheetModel(
+          participation: participations["e"]!, onClose: {})
+        await model.task()
+        return model.showsClaimedConfirmation
       }
-    } operation: {
-      let model = GiveawayWinnerSheetModel(
-        participation: participations["e"]!, onClose: {})
-      await model.task()
-      return model.showsClaimedConfirmation
+      #expect(showsConfirmation == true)
+      #expect(
+        participations["e"]?.status
+          == GiveawayParticipationStatus.resolvedWon(submissionCompleted: true))
     }
-    #expect(showsConfirmation == true)
-    #expect(
-      participations["e"]?.status
-        == GiveawayParticipationStatus.resolvedWon(submissionCompleted: true))
   }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -6,7 +6,11 @@ import Testing
 
 // swiftlint:disable redundant_optional_initialization
 
+// Serialized: these tests mutate the file-backed `@Shared(.giveawayParticipations)` store under a
+// shared key, so parallel Swift Testing could interleave across `await` points and cross-contaminate
+// the on-disk state.
 @MainActor
+@Suite(.serialized)
 struct GiveawayOverlayModelTests {
   // giveawayId is deliberately distinct from the event id so tests pin participation keying to the
   // per-airing event id (`id`), not the stable `giveawayId`.
@@ -62,11 +66,14 @@ struct GiveawayOverlayModelTests {
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
     // Keyed by the event id ("g1"), which differs from the event's giveawayId ("gv1") — so this
     // fails if the overlay ever re-keys by giveawayId.
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "g1": GiveawayParticipation(
-        id: "g1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9,
-        tapNumber: 7, status: .resolvedLost(toastShown: false), tappedAt: Date())
-    ]
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+    $participations.withLock {
+      $0 = [
+        "g1": GiveawayParticipation(
+          id: "g1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9,
+          tapNumber: 7, status: .resolvedLost(toastShown: false), tappedAt: Date())
+      ]
+    }
     let model = GiveawayOverlayModel()
     #expect(model.showsLoserReveal == true)
     #expect(model.showsPrompt == false)
@@ -79,11 +86,14 @@ struct GiveawayOverlayModelTests {
   @Test func resolvedWinCollapsesTheOverlay() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
-    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [
-      "g1": GiveawayParticipation(
-        id: "g1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9,
-        tapNumber: 9, status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
-    ]
+    @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+    $participations.withLock {
+      $0 = [
+        "g1": GiveawayParticipation(
+          id: "g1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9,
+          tapNumber: 9, status: .resolvedWon(submissionCompleted: false), tappedAt: Date())
+      ]
+    }
     let model = GiveawayOverlayModel()
     #expect(model.showsLoserReveal == false)
     #expect(model.showsPrompt == false)


### PR DESCRIPTION
Addresses the five Greptile findings on PR #340 (the 7.3.0 release PR).

**Test isolation (P1):** Adds `@Suite(.serialized)` to `GiveawayCoordinatorTests`, `GiveawayWinnerSheetModelTests`, and `GiveawayOverlayModelTests`, and — for the async read-after-`await` tests — wraps them in `withMainSerialExecutor` with explicit `$participations.withLock { … }` writes (matching `MainContainerTests`), since `.serialized` alone only serializes within a suite and a parallel sibling suite could otherwise clobber the file-backed `@Shared(.giveawayParticipations)` JSON mid-`await`; the fallback-init `= [...]` anti-pattern is converted to real `withLock` writes throughout.

**Error observability (P2):** `GiveawayWinnerSheetModel.task()` now `reportIssue`s the swallowed eligibility-check error (keeping the deliberate fail-open behavior), and `GiveawayCongratsSheetModel.viewAppeared()` wraps recorder priming in `withErrorReporting` (still non-fatal — the real failure still surfaces at record time, just no longer traceless).

Verified: `make format` + `make lint` clean, and all 104 tests across the 5 affected suites pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of giveaway screens by surfacing errors during recording setup and eligibility checks instead of failing silently.
  * Enhanced giveaway win/loss and claim state handling so confirmations and sheet behavior remain consistent.

* **Chores**
  * Strengthened automated test stability for giveaway flows by running affected suites serially and resetting shared giveaway participation state deterministically.
  * Updated testing guidance to avoid stale persisted shared values across runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->