### PR TITLE
fix(congrats): audio conversion, station muting, and skip re-prompt

### DIFF
--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -17,6 +17,7 @@ class GiveawayCongratsSheetModel: ViewModel {
   @ObservationIgnored @Dependency(\.audioPlayer) var audioPlayer
   @ObservationIgnored @Dependency(\.voicetrackUploadService) var voicetrackUploadService
   @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.stationPlayer) var stationPlayer
 
   // MARK: - Shared State
   @ObservationIgnored @Shared(.auth) var auth
@@ -71,6 +72,11 @@ class GiveawayCongratsSheetModel: ViewModel {
   // MARK: - User Actions
 
   func viewAppeared() async {
+    // The owner records and plays back over a live station; mute it so the station audio doesn't
+    // bleed into the recording or talk over the playback. Matches every other capture/playback flow
+    // (ContactPage, AskQuestion, WelcomeMessage, PlayerPage) that stops the station before taking
+    // over the audio session.
+    stationPlayer.stop()
     // Resuming from a persisted recording (.recorded / .uploaded after a kill): load it so review
     // shows a real duration and Play works. Otherwise prime the recorder for a fresh take.
     if let url = recordingURL {
@@ -233,7 +239,16 @@ class GiveawayCongratsSheetModel: ViewModel {
       presentedAlert = .congratsRecordingFailed("Not signed in.")
       return
     }
-    let voicetrack = LocalVoicetrack(originalURL: url, title: "Giveaway Congrats")
+    // A recording persisted by an earlier build (before the extension fix) can be WAV bytes inside a
+    // `.m4a` file, which makes the converter fail. Normalize to the real container before handing it
+    // off, and migrate the persisted state so resume/retry point at the corrected file.
+    let uploadURL = Self.audioURLMatchingContent(url)
+    if uploadURL != url {
+      recordingURL = uploadURL
+      setState(.recorded(localRecordingPath: uploadURL.path))
+      try? FileManager.default.removeItem(at: url)
+    }
+    let voicetrack = LocalVoicetrack(originalURL: uploadURL, title: "Giveaway Congrats")
     let audioBlock: AudioBlock
     do {
       audioBlock = try await voicetrackUploadService.processVoicetrack(voicetrack, stationId, jwt) {
@@ -245,7 +260,7 @@ class GiveawayCongratsSheetModel: ViewModel {
       presentedAlert = .congratsUploadFailed(error.localizedDescription)
       return
     }
-    setState(.uploaded(audioBlockId: audioBlock.id, localRecordingPath: url.path))
+    setState(.uploaded(audioBlockId: audioBlock.id, localRecordingPath: uploadURL.path))
     guard !isDismissed else { return }
     await submitCongrats(audioBlockId: audioBlock.id)
   }
@@ -306,13 +321,52 @@ class GiveawayCongratsSheetModel: ViewModel {
 
   /// Copy the recorder's output into Application Support so it survives a kill / app suspension during
   /// the upload (the recorder writes to a transient location).
+  ///
+  /// Name the copy by its real container (the recorder produces Linear PCM `.wav`). Renaming WAV bytes
+  /// to `.m4a` makes `AVURLAsset` infer an MPEG-4 container from the extension, fail to parse the WAV
+  /// bytes, and the converter throws "Audio conversion failed" on every Send.
   private static func persistRecording(_ source: URL) throws -> URL {
     let dir = try FileManager.default.url(
       for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)
-    let destination = dir.appendingPathComponent("congrats-\(UUID().uuidString).m4a")
+    let ext =
+      audioContainerExtension(of: source)
+      ?? (source.pathExtension.isEmpty ? "wav" : source.pathExtension)
+    let destination = dir.appendingPathComponent("congrats-\(UUID().uuidString).\(ext)")
     try? FileManager.default.removeItem(at: destination)
     try FileManager.default.copyItem(at: source, to: destination)
     return destination
+  }
+
+  /// Magic-byte container detection (`wav`/`m4a`), or nil if unrecognized. AVFoundation infers a file's
+  /// container from its path extension, so this lets callers name files by their actual content instead
+  /// of trusting a (possibly stale) extension.
+  private static func audioContainerExtension(of url: URL) -> String? {
+    guard let handle = try? FileHandle(forReadingFrom: url) else { return nil }
+    defer { try? handle.close() }
+    guard let header = try? handle.read(upToCount: 12), header.count >= 8 else { return nil }
+    let bytes = [UInt8](header)
+    if bytes.count >= 12, Array(bytes[0..<4]) == Array("RIFF".utf8),
+      Array(bytes[8..<12]) == Array("WAVE".utf8)
+    {
+      return "wav"
+    }
+    if Array(bytes[4..<8]) == Array("ftyp".utf8) {
+      return "m4a"
+    }
+    return nil
+  }
+
+  /// If `url`'s extension doesn't match its actual container, copy the bytes into a correctly-named
+  /// sibling so AVFoundation reads the real format. Returns the original URL when it already matches
+  /// (or the content can't be identified).
+  private static func audioURLMatchingContent(_ url: URL) -> URL {
+    guard let contentExt = audioContainerExtension(of: url),
+      url.pathExtension.lowercased() != contentExt
+    else { return url }
+    let corrected = url.deletingPathExtension().appendingPathExtension(contentExt)
+    try? FileManager.default.removeItem(at: corrected)
+    guard (try? FileManager.default.copyItem(at: url, to: corrected)) != nil else { return url }
+    return corrected
   }
 
   private func startRecordingUpdates() {

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -233,6 +233,7 @@ struct GiveawayCongratsSheetModelTests {
     let model = withDependencies {
       $0.audioPlayer.loadFile = { url in loaded.setValue(url) }
       $0.audioPlayer.duration = { 7 }
+      $0.stationPlayer = StationPlayerMock()
     } operation: {
       GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
     }
@@ -260,7 +261,7 @@ struct GiveawayCongratsSheetModelTests {
       $0.audioRecorder.stopRecording = { source }
       $0.audioPlayer.loadFile = { _ in }
       $0.audioPlayer.duration = { 5 }
-      $0.stationPlayer = StationPlayer()
+      $0.stationPlayer = StationPlayerMock()
     } operation: {
       GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
     }
@@ -296,7 +297,7 @@ struct GiveawayCongratsSheetModelTests {
         return AudioBlock.mockWith()
       }
       $0.api.recordGiveawayEventCongrats = { _, _, _ in }
-      $0.stationPlayer = StationPlayer()
+      $0.stationPlayer = StationPlayerMock()
     } operation: {
       GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
     }
@@ -310,8 +311,7 @@ struct GiveawayCongratsSheetModelTests {
   @Test func viewAppearedStopsStationPlayback() async {
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     $actions.withLock { $0 = ["e1": recordedAction()] }
-    let stationPlayer = StationPlayer()
-    stationPlayer.state = StationPlayer.State(playbackStatus: .playing(AnyStation.mock))
+    let stationPlayer = StationPlayerMock.mockPlayingPlayer()
     let model = withDependencies {
       $0.stationPlayer = stationPlayer
       $0.audioPlayer.loadFile = { _ in }
@@ -321,7 +321,7 @@ struct GiveawayCongratsSheetModelTests {
     }
     await model.viewAppeared()
     // The station must be muted as soon as the congrats sheet appears, for both recording and review.
-    expectNoDifference(stationPlayer.state.playbackStatus, .stopped)
+    expectNoDifference(stationPlayer.stopCalledCount, 1)
   }
 
   @Test func skipWhileRecordingStopsTheRecorder() async {

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -241,6 +241,89 @@ struct GiveawayCongratsSheetModelTests {
     #expect(model.recordingDuration == 7)
   }
 
+  @Test func stopRecordingPreservesSourceExtensionForConverter() async throws {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+          state: .pending, startedAt: Date())
+      ]
+    }
+    // The live recorder writes Linear PCM into a `.wav` container. A real RIFF/WAVE header mirrors that
+    // so the persisted copy is named by its sniffed content, not a trusted extension.
+    let source = FileManager.default.temporaryDirectory
+      .appendingPathComponent("voicetrack_\(UUID().uuidString).wav")
+    // RIFF / WAVE magic bytes.
+    try Data([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45]).write(to: source)
+    let model = withDependencies {
+      $0.audioRecorder.stopRecording = { source }
+      $0.audioPlayer.loadFile = { _ in }
+      $0.audioPlayer.duration = { 5 }
+      $0.stationPlayer = StationPlayer()
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.onStopTapped()
+    // Renaming WAV bytes to `.m4a` makes AVAssetExportSession fail ("Audio conversion failed") on
+    // every Send — the persisted file must keep the recorder's container extension.
+    #expect(model.recordingURL?.pathExtension == "wav")
+    let persisted = try #require(model.recordingURL)
+    #expect(FileManager.default.fileExists(atPath: persisted.path))
+    try? FileManager.default.removeItem(at: persisted)
+    try? FileManager.default.removeItem(at: source)
+  }
+
+  @Test func sendNormalizesStaleMislabeledRecordingBeforeConversion() async throws {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    // A recording persisted by the pre-fix build: WAV bytes inside a `.m4a` file.
+    let stale = FileManager.default.temporaryDirectory
+      .appendingPathComponent("congrats-\(UUID().uuidString).m4a")
+    // RIFF / WAVE magic bytes in a file the pre-fix build mislabeled `.m4a`.
+    try Data([0x52, 0x49, 0x46, 0x46, 0, 0, 0, 0, 0x57, 0x41, 0x56, 0x45]).write(to: stale)
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+          state: .recorded(localRecordingPath: stale.path), startedAt: Date())
+      ]
+    }
+    let uploadedExt = LockIsolated<String?>(nil)
+    let model = withDependencies {
+      $0.voicetrackUploadService.processVoicetrack = { voicetrack, _, _, _ in
+        uploadedExt.setValue(voicetrack.originalURL.pathExtension)
+        return AudioBlock.mockWith()
+      }
+      $0.api.recordGiveawayEventCongrats = { _, _, _ in }
+      $0.stationPlayer = StationPlayer()
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.sendButtonTapped()
+    // The converter must receive a file whose extension matches its WAV bytes, not the stale `.m4a`.
+    expectNoDifference(uploadedExt.value, "wav")
+    if let url = model.recordingURL { try? FileManager.default.removeItem(at: url) }
+    try? FileManager.default.removeItem(at: stale)
+  }
+
+  @Test func viewAppearedStopsStationPlayback() async {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock { $0 = ["e1": recordedAction()] }
+    let stationPlayer = StationPlayer()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .playing(AnyStation.mock))
+    let model = withDependencies {
+      $0.stationPlayer = stationPlayer
+      $0.audioPlayer.loadFile = { _ in }
+      $0.audioPlayer.duration = { 5 }
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.viewAppeared()
+    // The station must be muted as soon as the congrats sheet appears, for both recording and review.
+    expectNoDifference(stationPlayer.state.playbackStatus, .stopped)
+  }
+
   @Test func skipWhileRecordingStopsTheRecorder() async {
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     $actions.withLock {

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -1311,7 +1311,7 @@ extension MainContainerTests {
       defer { $actions.withLock { $0 = [:] } }
       let model = withDependencies {
         $0.date = .constant(Date(timeIntervalSince1970: 200))
-        $0.stationPlayer = StationPlayer()
+        $0.stationPlayer = StationPlayerMock()
       } operation: {
         MainContainerModel()
       }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -1296,6 +1296,42 @@ extension MainContainerTests {
     }
   }
 
+  @Test func processGiveawayResolutionsDoesNotRepromptSkippedCongrats() async {
+    await withMainSerialExecutor {
+      @Shared(.mainContainerNavigationCoordinator) var navCoordinator
+      navCoordinator.presentedSheet = nil
+      // The winner sheet outranks congrats, so any won participation left on disk by a sibling test
+      // would present it instead — reset so the congrats path is the one under test.
+      @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
+      $participations.withLock { $0 = [:] }
+      @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+      $actions.withLock { $0 = ["e1": pendingCongrats()] }
+      // Reset on every exit (even an early guard failure) so this file-backed store never leaks into
+      // a sibling test.
+      defer { $actions.withLock { $0 = [:] } }
+      let model = withDependencies {
+        $0.date = .constant(Date(timeIntervalSince1970: 200))
+        $0.stationPlayer = StationPlayer()
+      } operation: {
+        MainContainerModel()
+      }
+
+      await model.processGiveawayResolutions()
+      guard case .giveawayCongrats(let congratsModel) = navCoordinator.presentedSheet else {
+        Issue.record("Expected the congrats sheet to be presented")
+        return
+      }
+      // Owner taps Skip — the action becomes terminal (.skipped) and the arbiter must never re-present
+      // it, this foreground or any future one.
+      await congratsModel.skipButtonTapped()
+      #expect(actions["e1"]?.state == .skipped)
+
+      await model.processGiveawayResolutions()
+
+      #expect(navCoordinator.presentedSheet == nil)
+    }
+  }
+
   @Test func processGiveawayResolutionsDoesNotRepromptDismissedCongrats() async {
     await withMainSerialExecutor {
       @Shared(.mainContainerNavigationCoordinator) var navCoordinator


### PR DESCRIPTION
Fixes three device-reported bugs in the giveaway congrats flow. The "Audio conversion failed" error on every Send was caused by `persistRecording` copying the recorder's Linear-PCM `.wav` output into a `.m4a`-named file, so `AVAssetExportSession` inferred the wrong container and found no audio track; the recording is now named by its sniffed magic bytes and any mismatched-extension file is normalized to its real container before conversion (which also rescues files saved by the pre-fix build). The station player is now stopped in `viewAppeared()` so it no longer bleeds into recording or playback, matching the other capture flows. Skip was already persisting a terminal `.skipped` state that the MainContainer arbiter suppresses, so that path gets an end-to-end regression test only. Verified with `xcodebuild test` (GiveawayCongratsSheetModelTests + the MainContainer arbiter test), `make lint`, and a clean Codex adversarial review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of saved audio so recordings preserve the correct media format and reliably upload, even when an earlier recording was mislabeled with the wrong extension.
  * When the giveaway congrats screen opens, station playback now stops immediately to prevent overlapping audio.
  * Skipped giveaway congrats screens are no longer presented again after dismissal, including across repeated resolution processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->