### PR TITLE
fix(congrats): confirm M4A major brand before classifying ftyp box

### DIFF
--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -350,13 +350,14 @@ class GiveawayCongratsSheetModel: ViewModel {
     {
       return "wav"
     }
-    // An `ftyp` box marks an ISO Base Media file; confirm the major brand is MPEG-4 audio/video before
-    // claiming `m4a`, so a MOV/HEIF/other ISO container isn't silently renamed.
-    if Array(bytes[4..<8]) == Array("ftyp".utf8), bytes.count >= 12 {
-      let knownM4ABrands = ["M4A ", "isom", "mp42", "mp41"].map { Array($0.utf8) }
-      if knownM4ABrands.contains(Array(bytes[8..<12])) {
-        return "m4a"
-      }
+    // An `ftyp` box marks an ISO Base Media file, but that family also covers MP4 video, MOV, and HEIF.
+    // Only the `M4A ` major brand (trailing space) is audio-exclusive — generic brands like `isom`/`mp42`
+    // are shared with video, so matching them would misname a `.mp4` video as `m4a` (the very failure this
+    // is meant to prevent). Require `M4A ` at bytes 8–12; anything else falls back to the source extension.
+    if Array(bytes[4..<8]) == Array("ftyp".utf8), bytes.count >= 12,
+      Array(bytes[8..<12]) == Array("M4A ".utf8)
+    {
+      return "m4a"
     }
     return nil
   }

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -350,8 +350,13 @@ class GiveawayCongratsSheetModel: ViewModel {
     {
       return "wav"
     }
-    if Array(bytes[4..<8]) == Array("ftyp".utf8) {
-      return "m4a"
+    // An `ftyp` box marks an ISO Base Media file; confirm the major brand is MPEG-4 audio/video before
+    // claiming `m4a`, so a MOV/HEIF/other ISO container isn't silently renamed.
+    if Array(bytes[4..<8]) == Array("ftyp".utf8), bytes.count >= 12 {
+      let knownM4ABrands = ["M4A ", "isom", "mp42", "mp41"].map { Array($0.utf8) }
+      if knownM4ABrands.contains(Array(bytes[8..<12])) {
+        return "m4a"
+      }
     }
     return nil
   }

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -276,11 +276,14 @@ struct GiveawayCongratsSheetModelTests {
   }
 
   @Test func stopRecordingDetectsRealM4AByMajorBrand() async throws {
-    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [
-      "e1": CongratsAction(
-        eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
-        state: .pending, startedAt: Date())
-    ]
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+          state: .pending, startedAt: Date())
+      ]
+    }
     // A genuine MPEG-4 audio file: `ftyp` box (4-byte size) + the `M4A ` major brand.
     let source = FileManager.default.temporaryDirectory
       .appendingPathComponent("voicetrack_\(UUID().uuidString)")
@@ -300,11 +303,14 @@ struct GiveawayCongratsSheetModelTests {
   }
 
   @Test func stopRecordingDoesNotMisclassifyQuickTimeAsM4A() async throws {
-    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [
-      "e1": CongratsAction(
-        eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
-        state: .pending, startedAt: Date())
-    ]
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+          state: .pending, startedAt: Date())
+      ]
+    }
     // A QuickTime MOV also starts with an `ftyp` box, but its `qt  ` brand must not be read as M4A.
     let source = FileManager.default.temporaryDirectory
       .appendingPathComponent("voicetrack_\(UUID().uuidString).mov")

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -275,6 +275,61 @@ struct GiveawayCongratsSheetModelTests {
     try? FileManager.default.removeItem(at: source)
   }
 
+  @Test func stopRecordingDetectsRealM4AByMajorBrand() async throws {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+          state: .pending, startedAt: Date())
+      ]
+    }
+    // A genuine MPEG-4 audio file: `ftyp` box (4-byte size) + the `M4A ` major brand.
+    let source = FileManager.default.temporaryDirectory
+      .appendingPathComponent("voicetrack_\(UUID().uuidString)")
+    try Data([0, 0, 0, 0x18, 0x66, 0x74, 0x79, 0x70, 0x4D, 0x34, 0x41, 0x20]).write(to: source)
+    let model = withDependencies {
+      $0.audioRecorder.stopRecording = { source }
+      $0.audioPlayer.loadFile = { _ in }
+      $0.audioPlayer.duration = { 5 }
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.onStopTapped()
+    #expect(model.recordingURL?.pathExtension == "m4a")
+    if let url = model.recordingURL { try? FileManager.default.removeItem(at: url) }
+    try? FileManager.default.removeItem(at: source)
+  }
+
+  @Test func stopRecordingDoesNotMisclassifyQuickTimeAsM4A() async throws {
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
+    $actions.withLock {
+      $0 = [
+        "e1": CongratsAction(
+          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+          state: .pending, startedAt: Date())
+      ]
+    }
+    // A QuickTime MOV also starts with an `ftyp` box, but its `qt  ` brand must not be read as M4A.
+    let source = FileManager.default.temporaryDirectory
+      .appendingPathComponent("voicetrack_\(UUID().uuidString).mov")
+    try Data([0, 0, 0, 0x14, 0x66, 0x74, 0x79, 0x70, 0x71, 0x74, 0x20, 0x20]).write(to: source)
+    let model = withDependencies {
+      $0.audioRecorder.stopRecording = { source }
+      $0.audioPlayer.loadFile = { _ in }
+      $0.audioPlayer.duration = { 5 }
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      GiveawayCongratsSheetModel(action: actions["e1"]!, onClose: {})
+    }
+    await model.onStopTapped()
+    // Unrecognized container falls back to the source extension — never silently renamed `.m4a`.
+    #expect(model.recordingURL?.pathExtension == "mov")
+    if let url = model.recordingURL { try? FileManager.default.removeItem(at: url) }
+    try? FileManager.default.removeItem(at: source)
+  }
+
   @Test func sendNormalizesStaleMislabeledRecordingBeforeConversion() async throws {
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -276,14 +276,11 @@ struct GiveawayCongratsSheetModelTests {
   }
 
   @Test func stopRecordingDetectsRealM4AByMajorBrand() async throws {
-    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
-    $actions.withLock {
-      $0 = [
-        "e1": CongratsAction(
-          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
-          state: .pending, startedAt: Date())
-      ]
-    }
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [
+      "e1": CongratsAction(
+        eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+        state: .pending, startedAt: Date())
+    ]
     // A genuine MPEG-4 audio file: `ftyp` box (4-byte size) + the `M4A ` major brand.
     let source = FileManager.default.temporaryDirectory
       .appendingPathComponent("voicetrack_\(UUID().uuidString)")
@@ -303,14 +300,11 @@ struct GiveawayCongratsSheetModelTests {
   }
 
   @Test func stopRecordingDoesNotMisclassifyQuickTimeAsM4A() async throws {
-    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
-    $actions.withLock {
-      $0 = [
-        "e1": CongratsAction(
-          eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
-          state: .pending, startedAt: Date())
-      ]
-    }
+    @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [
+      "e1": CongratsAction(
+        eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil, congratsExpiresAt: nil,
+        state: .pending, startedAt: Date())
+    ]
     // A QuickTime MOV also starts with an `ftyp` box, but its `qt  ` brand must not be read as M4A.
     let source = FileManager.default.temporaryDirectory
       .appendingPathComponent("voicetrack_\(UUID().uuidString).mov")


### PR DESCRIPTION
## What

Addresses the Greptile P2 review comment on PR #346.

`GiveawayCongratsSheetModel.audioContainerExtension(of:)` classified **any** ISO Base Media file (MP4 video, QuickTime MOV, HEIF, …) as `.m4a` because it only checked the four-byte `ftyp` box type at offset 4–8, not the major brand that follows.

Harmless in the current recording flow — the recorder only ever emits WAV or AVFoundation M4A — but a precision gap if the helper is reused or the recorder's output format changes.

## Change

- Require an MPEG-4 audio/video major brand (`M4A `, `isom`, `mp42`, `mp41`) at bytes 8–12 before returning `m4a`. Anything else falls back to the source path extension instead of being silently renamed `.m4a`.
- Adds two regression tests:
  - `stopRecordingDetectsRealM4AByMajorBrand` — a genuine `ftyp`/`M4A ` file is still detected as `m4a`.
  - `stopRecordingDoesNotMisclassifyQuickTimeAsM4A` — a QuickTime `ftyp` (`qt  ` brand) is **not** classified as `m4a`.

## Why target `develop`

The flagged code lives on `develop`; PR #346 is a build-only version bump into `main`. Per branch policy, the fix lands on `develop` and flows into the next release rather than being injected into the release-to-main PR.

## Testing

`GiveawayCongratsSheetModelTests` — all 19 tests pass. `make lint` clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio container/type detection to only label recordings as `.m4a` when the file’s `ftyp` box matches the expected `M4A ` major brand.
  * Avoided mislabeling other ISO base media containers that should remain non-`.m4a` (preventing incorrect downstream handling).

* **Tests**
  * Added async unit tests validating `.m4a` detection via `ftyp` major brand sniffing.
  * Added coverage ensuring QuickTime-style containers are not renamed to `.m4a`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->