### PR TITLE
Downsample remote artwork to fix memory-pressure crash

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -458,6 +458,8 @@
 		D3FACE010000000000000002 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
 		D3FACE010000000000000003 /* InDevelopmentBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000001 /* InDevelopmentBadge.swift */; };
 		D3FACE010000000000000005 /* ArtistSuggestionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE010000000000000004 /* ArtistSuggestionTests.swift */; };
+		D3FACE020000000000000002 /* RemoteArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE020000000000000001 /* RemoteArtwork.swift */; };
+		D3FACE020000000000000003 /* RemoteArtwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FACE020000000000000001 /* RemoteArtwork.swift */; };
 		D3FE88842E37EF29009AE7B7 /* PrizeTier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FE88832E37EF24009AE7B7 /* PrizeTier.swift */; };
 		D3FEC8082EDF646A00A33AE8 /* ChooseStationToBroadcastPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */; };
 		D3FEC8092EDF646A00A33AE8 /* ChooseStationToBroadcastPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3FEC8072EDF646300A33AE8 /* ChooseStationToBroadcastPageView.swift */; };
@@ -761,6 +763,7 @@
 		D3F493D22EEE58CF008ED463 /* VoicetrackUploadService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicetrackUploadService.swift; sourceTree = "<group>"; };
 		D3FA61292E00583F00E9DF49 /* PlayerPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPageModel.swift; sourceTree = "<group>"; };
 		D3FACE010000000000000001 /* InDevelopmentBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InDevelopmentBadge.swift; sourceTree = "<group>"; };
+		D3FACE020000000000000001 /* RemoteArtwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteArtwork.swift; sourceTree = "<group>"; };
 		D3FACE010000000000000004 /* ArtistSuggestionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtistSuggestionTests.swift; sourceTree = "<group>"; };
 		D3FE88832E37EF24009AE7B7 /* PrizeTier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrizeTier.swift; sourceTree = "<group>"; };
 		D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationToBroadcastPageTests.swift; sourceTree = "<group>"; };
@@ -1086,6 +1089,7 @@
 				D3B744C62E3139860042A427 /* ListeningTimeTile */,
 				D35EFC222F17D4CC000F64A4 /* LiveBadge.swift */,
 				D3FACE010000000000000001 /* InDevelopmentBadge.swift */,
+				D3FACE020000000000000001 /* RemoteArtwork.swift */,
 				D35EFBF42F1576EF000F64A4 /* NewFeatureTile */,
 				D3137DBA2D3976550070033A /* PlayolaAlert.swift */,
 				D3137DCE2D3AA1E10070033A /* PlayolaSheet.swift */,
@@ -1949,6 +1953,7 @@
 				D30F00532E8592F0007BCC73 /* ListeningTracker.swift in Sources */,
 				D35EFC242F17D4CC000F64A4 /* LiveBadge.swift in Sources */,
 				D3FACE010000000000000003 /* InDevelopmentBadge.swift in Sources */,
+				D3FACE020000000000000003 /* RemoteArtwork.swift in Sources */,
 				D30F00542E8592F0007BCC73 /* ViewModel.swift in Sources */,
 				D30F00552E8592F0007BCC73 /* SignInPageView.swift in Sources */,
 				D30F00562E8592F0007BCC73 /* UrlStation.swift in Sources */,
@@ -2138,6 +2143,7 @@
 				D3B744B72E2FED940042A427 /* ListeningTracker.swift in Sources */,
 				D35EFC232F17D4CC000F64A4 /* LiveBadge.swift in Sources */,
 				D3FACE010000000000000002 /* InDevelopmentBadge.swift in Sources */,
+				D3FACE020000000000000002 /* RemoteArtwork.swift in Sources */,
 				D31CD5232DFBA1F2009B9780 /* ViewModel.swift in Sources */,
 				D3B6626A2D40103C00975D2F /* SignInPageView.swift in Sources */,
 				D30AE8A72E75C92700D9FBCA /* UrlStation.swift in Sources */,

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -215,6 +215,13 @@ struct PlayolaRadioApp: App {
     // Register SVG coder for SDWebImage
     SDImageCodersManager.shared.addCoder(SDImageSVGCoder.shared)
 
+    // Cap SDWebImage's in-memory decoded-image cache so cached artwork can't
+    // dominate graphics memory and trigger jetsam during long sessions.
+    // maxMemoryCost is decoded pixel bytes (~width*height*4); 64 MB holds a
+    // few hundred downsampled thumbnails, well under the device pressure point.
+    SDImageCache.shared.config.maxMemoryCost = 64 * 1024 * 1024
+    SDImageCache.shared.config.maxMemoryCount = 100
+
     @Dependency(\.nowPlayingUpdater) var nowPlayingUpdater
     nowPlayingUpdater.setupRemoteControlCenter()
 

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
@@ -181,6 +181,7 @@ struct BroadcastPageView: View {
 // MARK: - Staging Row View
 
 struct StagingRowView: View {
+  @Environment(\.displayScale) private var displayScale
   let item: any StagingItem
 
   var body: some View {
@@ -188,7 +189,9 @@ struct StagingRowView: View {
       // Icon or album image
       if let imageUrl = item.albumImageUrl {
         WebImage(
-          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 40, height: 40))
+          url: imageUrl,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 40, height: 40), scale: displayScale)
         )
         .resizable()
         .aspectRatio(contentMode: .fill)
@@ -549,6 +552,7 @@ struct BroadcastActionButton: View {
 // MARK: - Schedule Item Image
 
 struct ScheduleItemImage: View {
+  @Environment(\.displayScale) private var displayScale
   let spin: Spin
 
   var body: some View {
@@ -556,7 +560,9 @@ struct ScheduleItemImage: View {
     case "song":
       if let imageUrl = spin.audioBlock.imageUrl {
         WebImage(
-          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+          url: imageUrl,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 45, height: 45), scale: displayScale)
         )
         .resizable()
         .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
@@ -187,11 +187,13 @@ struct StagingRowView: View {
     HStack(spacing: 12) {
       // Icon or album image
       if let imageUrl = item.albumImageUrl {
-        WebImage(url: imageUrl)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 40, height: 40)
-          .clipShape(Circle())
+        WebImage(
+          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 40, height: 40))
+        )
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+        .frame(width: 40, height: 40)
+        .clipShape(Circle())
       } else if let icon = item.icon {
         ZStack {
           Circle()
@@ -553,11 +555,13 @@ struct ScheduleItemImage: View {
     switch spin.audioBlock.type {
     case "song":
       if let imageUrl = spin.audioBlock.imageUrl {
-        WebImage(url: imageUrl)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 45, height: 45)
-          .clipped()
+        WebImage(
+          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+        )
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+        .frame(width: 45, height: 45)
+        .clipped()
       } else {
         RoundedRectangle(cornerRadius: 4)
           .fill(Color(hex: "#666666"))

--- a/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageView.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageView.swift
@@ -32,13 +32,14 @@ struct ChooseStationPageView: View {
 }
 
 private struct StationRow: View {
+  @Environment(\.displayScale) private var displayScale
   let station: Station
 
   var body: some View {
     HStack(spacing: 16) {
       WebImage(
         url: station.imageUrl,
-        context: RemoteArtwork.downsampleContext(CGSize(width: 64, height: 64))
+        context: RemoteArtwork.downsampleContext(CGSize(width: 64, height: 64), scale: displayScale)
       ) { image in
         image
           .resizable()

--- a/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageView.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageView.swift
@@ -36,7 +36,10 @@ private struct StationRow: View {
 
   var body: some View {
     HStack(spacing: 16) {
-      WebImage(url: station.imageUrl) { image in
+      WebImage(
+        url: station.imageUrl,
+        context: RemoteArtwork.downsampleContext(CGSize(width: 64, height: 64))
+      ) { image in
         image
           .resizable()
           .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
@@ -22,6 +22,7 @@ struct GiveawayWinnerSheetView: View {
 }
 
 private struct GiveawayWinnerFormView: View {
+  @Environment(\.displayScale) private var displayScale
   @Bindable var model: GiveawayWinnerSheetModel
 
   var body: some View {
@@ -29,7 +30,8 @@ private struct GiveawayWinnerFormView: View {
       VStack(spacing: 16) {
         WebImage(
           url: model.prizeImageUrl,
-          context: RemoteArtwork.downsampleContext(CGSize(width: 160, height: 160))
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 160, height: 160), scale: displayScale)
         )
         .resizable()
         .scaledToFill()

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetView.swift
@@ -27,12 +27,15 @@ private struct GiveawayWinnerFormView: View {
   var body: some View {
     ScrollView {
       VStack(spacing: 16) {
-        WebImage(url: model.prizeImageUrl)
-          .resizable()
-          .scaledToFill()
-          .frame(width: 160, height: 160)
-          .clipShape(RoundedRectangle(cornerRadius: 14))
-          .padding(.top, 24)
+        WebImage(
+          url: model.prizeImageUrl,
+          context: RemoteArtwork.downsampleContext(CGSize(width: 160, height: 160))
+        )
+        .resizable()
+        .scaledToFill()
+        .frame(width: 160, height: 160)
+        .clipShape(RoundedRectangle(cornerRadius: 14))
+        .padding(.top, 24)
 
         Text(model.headline)
           .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 26))

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
@@ -10,6 +10,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct StationCardView: View {
+  @Environment(\.displayScale) private var displayScale
   let station: AnyStation
   let liveStatus: LiveStatus?
   let onRadioStationSelected: (AnyStation) -> Void
@@ -24,7 +25,8 @@ struct StationCardView: View {
           ZStack(alignment: .topLeading) {
             WebImage(
               url: imageURL,
-              context: RemoteArtwork.downsampleContext(CGSize(width: 160, height: 160))
+              context: RemoteArtwork.downsampleContext(
+                CGSize(width: 160, height: 160), scale: displayScale)
             ) { image in
               image
                 .resizable()

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
@@ -22,7 +22,10 @@ struct StationCardView: View {
       label: {
         HStack(spacing: 2) {
           ZStack(alignment: .topLeading) {
-            WebImage(url: imageURL) { image in
+            WebImage(
+              url: imageURL,
+              context: RemoteArtwork.downsampleContext(CGSize(width: 160, height: 160))
+            ) { image in
               image
                 .resizable()
                 .aspectRatio(contentMode: .fill)
@@ -83,7 +86,7 @@ struct HomePageStationList: View {
         .foregroundColor(.white)
         .padding(.bottom, 8)
 
-      VStack(spacing: 12) {
+      LazyVStack(spacing: 12) {
         ForEach(stations) { station in
           StationCardView(
             station: station,

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
@@ -275,11 +275,13 @@ struct LibrarySongRow: View {
   var body: some View {
     HStack(spacing: 12) {
       if let imageUrl = song.imageUrl {
-        WebImage(url: imageUrl)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 45, height: 45)
-          .clipped()
+        WebImage(
+          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+        )
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+        .frame(width: 45, height: 45)
+        .clipped()
       } else {
         RoundedRectangle(cornerRadius: 4)
           .fill(Color(hex: "#666666"))
@@ -376,11 +378,13 @@ struct LibraryRequestRow: View {
     HStack(spacing: 12) {
       ZStack(alignment: .bottomTrailing) {
         if let imageUrl = request.imageUrl {
-          WebImage(url: imageUrl)
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-            .frame(width: 45, height: 45)
-            .clipped()
+          WebImage(
+            url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+          )
+          .resizable()
+          .aspectRatio(contentMode: .fill)
+          .frame(width: 45, height: 45)
+          .clipped()
         } else {
           RoundedRectangle(cornerRadius: 4)
             .fill(Color(hex: "#666666"))

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
@@ -262,6 +262,7 @@ struct SectionHeader: View {
 // MARK: - Library Song Row
 
 struct LibrarySongRow: View {
+  @Environment(\.displayScale) private var displayScale
   let song: LibrarySong
   let isProcessing: Bool
   let hasPendingRequest: Bool
@@ -276,7 +277,9 @@ struct LibrarySongRow: View {
     HStack(spacing: 12) {
       if let imageUrl = song.imageUrl {
         WebImage(
-          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+          url: imageUrl,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 45, height: 45), scale: displayScale)
         )
         .resizable()
         .aspectRatio(contentMode: .fill)
@@ -362,6 +365,7 @@ struct LibrarySongRow: View {
 // MARK: - Library Request Row
 
 struct LibraryRequestRow: View {
+  @Environment(\.displayScale) private var displayScale
   let request: StationLibraryRequest
   let typeLabel: String
   let typeColor: Color
@@ -379,7 +383,9 @@ struct LibraryRequestRow: View {
       ZStack(alignment: .bottomTrailing) {
         if let imageUrl = request.imageUrl {
           WebImage(
-            url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+            url: imageUrl,
+            context: RemoteArtwork.downsampleContext(
+              CGSize(width: 45, height: 45), scale: displayScale)
           )
           .resizable()
           .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
@@ -115,7 +115,10 @@ struct SongRow: View {
   var body: some View {
     HStack(spacing: 12) {
       // Album Art Placeholder
-      WebImage(url: audioBlock.imageUrl) { image in
+      WebImage(
+        url: audioBlock.imageUrl,
+        context: RemoteArtwork.downsampleContext(CGSize(width: 56, height: 56))
+      ) { image in
         image
           .resizable()
           .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPage.swift
@@ -108,6 +108,7 @@ struct LikedSongsPage: View {
 }
 
 struct SongRow: View {
+  @Environment(\.displayScale) private var displayScale
   let audioBlock: AudioBlock
   let likedDate: Date
   let model: LikedSongsPageModel
@@ -117,7 +118,7 @@ struct SongRow: View {
       // Album Art Placeholder
       WebImage(
         url: audioBlock.imageUrl,
-        context: RemoteArtwork.downsampleContext(CGSize(width: 56, height: 56))
+        context: RemoteArtwork.downsampleContext(CGSize(width: 56, height: 56), scale: displayScale)
       ) { image in
         image
           .resizable()

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
@@ -77,11 +77,13 @@ struct ListenerQuestionDetailPageView: View {
   private var listenerAvatar: some View {
     Group {
       if let imageUrl = model.listenerProfileImageUrl {
-        WebImage(url: imageUrl)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 48, height: 48)
-          .clipShape(Circle())
+        WebImage(
+          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 48, height: 48))
+        )
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+        .frame(width: 48, height: 48)
+        .clipShape(Circle())
       } else {
         Circle()
           .fill(Color.elevatedSurface)

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
@@ -7,6 +7,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct ListenerQuestionDetailPageView: View {
+  @Environment(\.displayScale) private var displayScale
   @Bindable var model: ListenerQuestionDetailPageModel
 
   var body: some View {
@@ -78,7 +79,9 @@ struct ListenerQuestionDetailPageView: View {
     Group {
       if let imageUrl = model.listenerProfileImageUrl {
         WebImage(
-          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 48, height: 48))
+          url: imageUrl,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 48, height: 48), scale: displayScale)
         )
         .resizable()
         .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
@@ -141,7 +141,10 @@ struct NotificationsSettingsPageView: View {
 
   private func stationRow(item: StationNotificationItem) -> some View {
     HStack(spacing: 16) {
-      WebImage(url: item.station.imageUrl) { image in
+      WebImage(
+        url: item.station.imageUrl,
+        context: RemoteArtwork.downsampleContext(CGSize(width: 56, height: 56))
+      ) { image in
         image
           .resizable()
           .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
@@ -9,6 +9,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct NotificationsSettingsPageView: View {
+  @Environment(\.displayScale) private var displayScale
   @Bindable var model: NotificationsSettingsPageModel
   @Environment(\.dismiss) private var dismiss
 
@@ -143,7 +144,7 @@ struct NotificationsSettingsPageView: View {
     HStack(spacing: 16) {
       WebImage(
         url: item.station.imageUrl,
-        context: RemoteArtwork.downsampleContext(CGSize(width: 56, height: 56))
+        context: RemoteArtwork.downsampleContext(CGSize(width: 56, height: 56), scale: displayScale)
       ) { image in
         image
           .resizable()

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -11,6 +11,7 @@ import SwiftUI
 struct PlayerPage: View {
   @Environment(\.dismiss) private var dismiss
   @Environment(\.scenePhase) var scenePhase
+  @Environment(\.displayScale) private var displayScale
   @Bindable var model: PlayerPageModel
 
   var body: some View {
@@ -59,7 +60,8 @@ struct PlayerPage: View {
           context: RemoteArtwork.downsampleContext(
             CGSize(
               width: UIScreen.main.bounds.width - 148,
-              height: UIScreen.main.bounds.width - 148))
+              height: UIScreen.main.bounds.width - 148),
+            scale: displayScale)
         ) { image in
           image
             .resizable()

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -54,7 +54,13 @@ struct PlayerPage: View {
       ScrollView {
 
         // Main Image
-        WebImage(url: model.stationArtUrl) { image in
+        WebImage(
+          url: model.stationArtUrl,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(
+              width: UIScreen.main.bounds.width - 148,
+              height: UIScreen.main.bounds.width - 148))
+        ) { image in
           image
             .resizable()
             .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
@@ -89,12 +89,14 @@ struct RecordIntroPageView: View {
   private var songInfoHeader: some View {
     HStack(spacing: 12) {
       if let imageUrl = model.songImageUrl {
-        WebImage(url: imageUrl)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 56, height: 56)
-          .cornerRadius(6)
-          .clipped()
+        WebImage(
+          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 56, height: 56))
+        )
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+        .frame(width: 56, height: 56)
+        .cornerRadius(6)
+        .clipped()
       } else {
         RoundedRectangle(cornerRadius: 6)
           .fill(Color(hex: "#666666"))

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
@@ -7,6 +7,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct RecordIntroPageView: View {
+  @Environment(\.displayScale) private var displayScale
   @Bindable var model: RecordIntroPageModel
 
   var body: some View {
@@ -90,7 +91,9 @@ struct RecordIntroPageView: View {
     HStack(spacing: 12) {
       if let imageUrl = model.songImageUrl {
         WebImage(
-          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 56, height: 56))
+          url: imageUrl,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 56, height: 56), scale: displayScale)
         )
         .resizable()
         .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
@@ -31,13 +31,16 @@ struct PrizeTierRow: View {
           .fill(Color(white: 0.15))
           .frame(width: 56, height: 56)
 
-        WebImage(url: prizeTier.imageIconUrl)
-          .renderingMode(.template)
-          .resizable()
-          .aspectRatio(contentMode: .fit)
-          .frame(width: 28, height: 28)
-          .foregroundColor(
-            isRedeemed ? Color(red: 153 / 255, green: 153 / 255, blue: 153 / 255) : .white)
+        WebImage(
+          url: prizeTier.imageIconUrl,
+          context: RemoteArtwork.downsampleContext(CGSize(width: 28, height: 28))
+        )
+        .renderingMode(.template)
+        .resizable()
+        .aspectRatio(contentMode: .fit)
+        .frame(width: 28, height: 28)
+        .foregroundColor(
+          isRedeemed ? Color(red: 153 / 255, green: 153 / 255, blue: 153 / 255) : .white)
       }
 
       // Content

--- a/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
@@ -8,6 +8,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct PrizeTierRow: View {
+  @Environment(\.displayScale) private var displayScale
   let tierLabel: String
   let prizeTier: PrizeTier
   let requiredHoursLabel: String
@@ -33,7 +34,8 @@ struct PrizeTierRow: View {
 
         WebImage(
           url: prizeTier.imageIconUrl,
-          context: RemoteArtwork.downsampleContext(CGSize(width: 28, height: 28))
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 28, height: 28), scale: displayScale)
         )
         .renderingMode(.template)
         .resizable()

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
@@ -8,6 +8,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct SeriesCard: View {
+  @Environment(\.displayScale) private var displayScale
   @Bindable var model: SeriesCardModel
 
   var body: some View {
@@ -87,7 +88,9 @@ struct SeriesCard: View {
       // Station Image
       if let imageUrl = model.showWithAirings.station?.imageUrl {
         WebImage(
-          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 48, height: 48))
+          url: imageUrl,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 48, height: 48), scale: displayScale)
         ) { image in
           image
             .resizable()

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
@@ -86,7 +86,9 @@ struct SeriesCard: View {
     HStack(alignment: .top, spacing: 12) {
       // Station Image
       if let imageUrl = model.showWithAirings.station?.imageUrl {
-        WebImage(url: imageUrl) { image in
+        WebImage(
+          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 48, height: 48))
+        ) { image in
           image
             .resizable()
             .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
@@ -143,11 +143,13 @@ struct SongSearchResultRow: View {
   var body: some View {
     HStack(spacing: 12) {
       if let imageUrl = audioBlock.imageUrl {
-        WebImage(url: imageUrl)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 45, height: 45)
-          .clipped()
+        WebImage(
+          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+        )
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+        .frame(width: 45, height: 45)
+        .clipped()
       } else {
         RoundedRectangle(cornerRadius: 4)
           .fill(Color(hex: "#666666"))
@@ -197,11 +199,13 @@ struct SongRequestResultRow: View {
   var body: some View {
     HStack(spacing: 12) {
       if let imageUrl = songRequest.imageUrl {
-        WebImage(url: imageUrl)
-          .resizable()
-          .aspectRatio(contentMode: .fill)
-          .frame(width: 45, height: 45)
-          .clipped()
+        WebImage(
+          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+        )
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+        .frame(width: 45, height: 45)
+        .clipped()
       } else {
         RoundedRectangle(cornerRadius: 4)
           .fill(Color(hex: "#666666"))

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
@@ -137,6 +137,7 @@ struct SongSearchPageView: View {
 }
 
 struct SongSearchResultRow: View {
+  @Environment(\.displayScale) private var displayScale
   let audioBlock: AudioBlock
   let onSelect: () -> Void
 
@@ -144,7 +145,9 @@ struct SongSearchResultRow: View {
     HStack(spacing: 12) {
       if let imageUrl = audioBlock.imageUrl {
         WebImage(
-          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+          url: imageUrl,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 45, height: 45), scale: displayScale)
         )
         .resizable()
         .aspectRatio(contentMode: .fill)
@@ -191,6 +194,7 @@ struct SongSearchResultRow: View {
 }
 
 struct SongRequestResultRow: View {
+  @Environment(\.displayScale) private var displayScale
   let songRequest: SongRequest
   var buttonText: String = "REQUEST"
   var isProcessing: Bool = false
@@ -200,7 +204,9 @@ struct SongRequestResultRow: View {
     HStack(spacing: 12) {
       if let imageUrl = songRequest.imageUrl {
         WebImage(
-          url: imageUrl, context: RemoteArtwork.downsampleContext(CGSize(width: 45, height: 45))
+          url: imageUrl,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 45, height: 45), scale: displayScale)
         )
         .resizable()
         .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
@@ -8,6 +8,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct PresetTile: View {
+  @Environment(\.displayScale) private var displayScale
   let display: PresetDisplayItem
   let isEditing: Bool
   let onTap: () async -> Void
@@ -20,7 +21,7 @@ struct PresetTile: View {
     VStack(alignment: .leading, spacing: 6) {
       WebImage(
         url: display.imageUrl,
-        context: RemoteArtwork.downsampleContext(CGSize(width: 92, height: 92))
+        context: RemoteArtwork.downsampleContext(CGSize(width: 92, height: 92), scale: displayScale)
       ) { image in
         image.resizable().aspectRatio(contentMode: .fill)
       } placeholder: {

--- a/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
@@ -18,7 +18,10 @@ struct PresetTile: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
-      WebImage(url: display.imageUrl) { image in
+      WebImage(
+        url: display.imageUrl,
+        context: RemoteArtwork.downsampleContext(CGSize(width: 92, height: 92))
+      ) { image in
         image.resizable().aspectRatio(contentMode: .fill)
       } placeholder: {
         Color(hex: "#333333")

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
@@ -19,7 +19,10 @@ struct StationListStationRowView: View {
     HStack(spacing: 0) {
       Button(action: action) {
         HStack(spacing: 16) {
-          WebImage(url: model.imageUrl) { image in
+          WebImage(
+            url: model.imageUrl,
+            context: RemoteArtwork.downsampleContext(CGSize(width: 64, height: 64))
+          ) { image in
             image
               .resizable()
               .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
@@ -9,6 +9,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct StationListStationRowView: View {
+  @Environment(\.displayScale) private var displayScale
   let model: StationListStationRowModel
   let action: () -> Void
   let isPreset: Bool
@@ -21,7 +22,8 @@ struct StationListStationRowView: View {
         HStack(spacing: 16) {
           WebImage(
             url: model.imageUrl,
-            context: RemoteArtwork.downsampleContext(CGSize(width: 64, height: 64))
+            context: RemoteArtwork.downsampleContext(
+              CGSize(width: 64, height: 64), scale: displayScale)
           ) { image in
             image
               .resizable()

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
@@ -19,7 +19,11 @@ struct WelcomeMessagePageView: View {
     GeometryReader { geo in
       VStack(spacing: 0) {
         ZStack(alignment: .bottom) {
-          WebImage(url: model.imageURL) { image in
+          WebImage(
+            url: model.imageURL,
+            context: RemoteArtwork.downsampleContext(
+              CGSize(width: geo.size.width, height: geo.size.height * 0.44))
+          ) { image in
             image.resizable()
           } placeholder: {
             WelcomePalette.cardSurface

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
@@ -13,6 +13,7 @@ private enum WelcomePalette {
 }
 
 struct WelcomeMessagePageView: View {
+  @Environment(\.displayScale) private var displayScale
   let model: WelcomeMessagePageModel
 
   var body: some View {
@@ -22,7 +23,8 @@ struct WelcomeMessagePageView: View {
           WebImage(
             url: model.imageURL,
             context: RemoteArtwork.downsampleContext(
-              CGSize(width: geo.size.width, height: geo.size.height * 0.44))
+              CGSize(width: geo.size.width, height: geo.size.height * 0.44),
+              scale: displayScale)
           ) { image in
             image.resizable()
           } placeholder: {

--- a/PlayolaRadio/Views/Reusable Components/RemoteArtwork.swift
+++ b/PlayolaRadio/Views/Reusable Components/RemoteArtwork.swift
@@ -13,8 +13,12 @@ enum RemoteArtwork {
   /// SDWebImage `context` that decodes a remote image down to its on-screen
   /// pixel size (display points × screen scale) instead of the full source
   /// resolution. Pass to `WebImage(url:context:)` so large source artwork is
-  /// not kept in memory at full size. The decode preserves aspect ratio, so it
-  /// stays correct under both `.fit` and `.fill` content modes.
+  /// not kept in memory at full size.
+  ///
+  /// `imagePreserveAspectRatio` is set explicitly so a non-square source is
+  /// scaled to fit the box (never stretched to it); the existing
+  /// `.aspectRatio`/`.scaledToFill` modifier at each call site then handles the
+  /// final crop, keeping artwork the same shape it was before downsampling.
   static func downsampleContext(
     _ displaySize: CGSize,
     scale: CGFloat = UIScreen.main.scale
@@ -23,7 +27,8 @@ enum RemoteArtwork {
       .imageThumbnailPixelSize: CGSize(
         width: displaySize.width * scale,
         height: displaySize.height * scale
-      )
+      ),
+      .imagePreserveAspectRatio: true,
     ]
   }
 }

--- a/PlayolaRadio/Views/Reusable Components/RemoteArtwork.swift
+++ b/PlayolaRadio/Views/Reusable Components/RemoteArtwork.swift
@@ -1,0 +1,29 @@
+//
+//  RemoteArtwork.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 6/26/26.
+//
+
+import SDWebImage
+import UIKit
+
+/// Helpers for displaying remote artwork without ballooning graphics memory.
+enum RemoteArtwork {
+  /// SDWebImage `context` that decodes a remote image down to its on-screen
+  /// pixel size (display points × screen scale) instead of the full source
+  /// resolution. Pass to `WebImage(url:context:)` so large source artwork is
+  /// not kept in memory at full size. The decode preserves aspect ratio, so it
+  /// stays correct under both `.fit` and `.fill` content modes.
+  static func downsampleContext(
+    _ displaySize: CGSize,
+    scale: CGFloat = UIScreen.main.scale
+  ) -> [SDWebImageContextOption: Any] {
+    [
+      .imageThumbnailPixelSize: CGSize(
+        width: displaySize.width * scale,
+        height: displaySize.height * scale
+      )
+    ]
+  }
+}

--- a/PlayolaRadio/Views/Reusable Components/RemoteArtwork.swift
+++ b/PlayolaRadio/Views/Reusable Components/RemoteArtwork.swift
@@ -5,8 +5,8 @@
 //  Created by Brian D Keane on 6/26/26.
 //
 
+import CoreGraphics
 import SDWebImage
-import UIKit
 
 /// Helpers for displaying remote artwork without ballooning graphics memory.
 enum RemoteArtwork {
@@ -15,13 +15,17 @@ enum RemoteArtwork {
   /// resolution. Pass to `WebImage(url:context:)` so large source artwork is
   /// not kept in memory at full size.
   ///
+  /// Callers pass `scale` from `@Environment(\.displayScale)` so the decode
+  /// matches the actual display the view is rendered on (and to avoid the
+  /// deprecated `UIScreen.main`).
+  ///
   /// `imagePreserveAspectRatio` is set explicitly so a non-square source is
   /// scaled to fit the box (never stretched to it); the existing
   /// `.aspectRatio`/`.scaledToFill` modifier at each call site then handles the
   /// final crop, keeping artwork the same shape it was before downsampling.
   static func downsampleContext(
     _ displaySize: CGSize,
-    scale: CGFloat = UIScreen.main.scale
+    scale: CGFloat
   ) -> [SDWebImageContextOption: Any] {
     [
       .imageThumbnailPixelSize: CGSize(

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -13,6 +13,7 @@ import Sharing
 import SwiftUI
 
 struct SmallPlayer: View {
+  @Environment(\.displayScale) private var displayScale
   @Shared(.nowPlaying) var nowPlaying: NowPlaying?
   @Dependency(\.likesManager) var likesManager
   @Dependency(\.stationPlayer) var stationPlayer
@@ -57,7 +58,9 @@ struct SmallPlayer: View {
       HStack(spacing: 16) {
         // Artwork
         WebImage(
-          url: artworkURL, context: RemoteArtwork.downsampleContext(CGSize(width: 64, height: 64))
+          url: artworkURL,
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 64, height: 64), scale: displayScale)
         ) { image in
           image
             .resizable()

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -56,7 +56,9 @@ struct SmallPlayer: View {
       // Player bar
       HStack(spacing: 16) {
         // Artwork
-        WebImage(url: artworkURL) { image in
+        WebImage(
+          url: artworkURL, context: RemoteArtwork.downsampleContext(CGSize(width: 64, height: 64))
+        ) { image in
           image
             .resizable()
             .scaledToFill()

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
@@ -17,7 +17,10 @@ struct SongDrawerView: View {
 
       // HEADER
       HStack(spacing: 16) {
-        WebImage(url: model.audioBlock.imageUrl) { image in
+        WebImage(
+          url: model.audioBlock.imageUrl,
+          context: RemoteArtwork.downsampleContext(CGSize(width: 48, height: 48))
+        ) { image in
           image
             .resizable()
             .aspectRatio(contentMode: .fill)

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
@@ -10,6 +10,7 @@ import SDWebImageSwiftUI
 import SwiftUI
 
 struct SongDrawerView: View {
+  @Environment(\.displayScale) private var displayScale
   @Bindable var model: SongDrawerModel
 
   var body: some View {
@@ -19,7 +20,8 @@ struct SongDrawerView: View {
       HStack(spacing: 16) {
         WebImage(
           url: model.audioBlock.imageUrl,
-          context: RemoteArtwork.downsampleContext(CGSize(width: 48, height: 48))
+          context: RemoteArtwork.downsampleContext(
+            CGSize(width: 48, height: 48), scale: displayScale)
         ) { image in
           image
             .resizable()


### PR DESCRIPTION
Long listening sessions were getting the app jetsam-killed by image/graphics memory growth because nothing downsampled remote artwork — station/album images decoded at full source resolution regardless of display size (e.g. ~6.7 MB per home card shown at 160×160). This adds a `RemoteArtwork.downsampleContext` helper that decodes via SDWebImage's `.imageThumbnailPixelSize` at display points × screen scale, and applies it to all 21 `WebImage` sites. It also caps the SDImageCache memory cache (64 MB / 100 images) at launch and makes the home station list a `LazyVStack` so off-screen cards never decode. No display sizes, corner radii, content modes, or placeholders changed — only the decode resolution.

Known follow-up (not in this PR): lock-screen/CarPlay artwork still decodes full-res via `UIImage.image(from:)`, which bypasses SDWebImage; that path can be downsampled separately with ImageIO if memory still climbs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / Performance**
  * Improved remote artwork loading across the app by downsampling images to the display size, reducing decoding work while preserving the same visual sizing.
  * Reduced long-session memory pressure by capping the in-memory decoded image cache.
  * Artwork, station images, avatars, and prize icons now load more efficiently across key screens, including the player and library views.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->