### PR TITLE
feat: countdown to prize-show end on upcoming giveaway banner

### DIFF
--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBanner.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBanner.swift
@@ -40,6 +40,7 @@ struct UpcomingGiveawayBanner: View {
     .opacity(model.bannerOpacity)
     .allowsHitTesting(false)
     .clipped()
+    .task(id: ObjectIdentifier(model)) { await model.task() }
   }
 }
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModel.swift
@@ -7,14 +7,36 @@ import Sharing
 @Observable
 class UpcomingGiveawayBannerModel: ViewModel {
 
+  // MARK: - Dependencies
+  @ObservationIgnored @Dependency(\.continuousClock) var clock
+  @ObservationIgnored @Dependency(\.date.now) var currentDate
+
   // MARK: - Shared State
   @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
   @ObservationIgnored @Shared(.activeGiveaway) var activeGiveaway
   @ObservationIgnored @Shared(.upcomingGiveaways) var upcomingGiveaways
 
+  // MARK: - Properties
+
+  /// Current time, refreshed once a minute by `task()`. `nil` until the view starts the refresh; the
+  /// window phrase stays hidden (timeless fallback) until then.
+  var now: Date?
+
   // MARK: - Initialization
   override init() {
     super.init()
+  }
+
+  // MARK: - User Actions
+
+  /// Ticks `now` once a minute so the window phrase steps down (~40 → ~35 …) without a
+  /// per-second countdown.
+  func task() async {
+    now = currentDate
+    while !Task.isCancelled {
+      do { try await clock.sleep(for: .seconds(60)) } catch { break }
+      now = currentDate
+    }
   }
 
   // MARK: - View Helpers
@@ -26,12 +48,15 @@ class UpcomingGiveawayBannerModel: ViewModel {
 
   var bannerOpacity: Double { isVisible ? 1 : 0 }
 
-  /// Deliberately omits any open time — the indicator builds anticipation without revealing when the
-  /// contest opens.
+  /// Leads with the prize-show window ("… giveaway in the next ~40 min") whenever the show holding
+  /// the prize is the one currently on air. Otherwise falls back to the timeless invite, which never
+  /// reveals when the contest itself opens.
   var bannerText: String {
-    guard let event = upcomingGiveaway?.event, let stationName = currentStationName else {
-      return ""
+    guard let event = upcomingGiveaway?.event else { return "" }
+    if let windowPhrase {
+      return "\(event.prizeName) giveaway in the next \(windowPhrase)"
     }
+    guard let stationName = currentStationName else { return "" }
     return "Win a \(event.prizeName) — coming up on \(stationName)"
   }
 
@@ -53,5 +78,25 @@ class UpcomingGiveawayBannerModel: ViewModel {
       return nil
     }
     return info
+  }
+
+  /// End of the show (airing) that holds the prize — but only when that show is the one currently on
+  /// air, since that's the only case where the now-playing spin carries its `endTime`.
+  private var prizeShowEndTime: Date? {
+    guard let airingId = upcomingGiveaway?.event.airingId,
+      let airing = nowPlaying?.playolaSpinPlaying?.airing,
+      airing.id == airingId
+    else { return nil }
+    return airing.endTime
+  }
+
+  /// The window remaining until the prize show ends, rounded to the nearest 5 minutes. `nil` when the
+  /// show end is unknown or already past.
+  private var windowPhrase: String? {
+    guard let endTime = prizeShowEndTime, let now else { return nil }
+    let remaining = endTime.timeIntervalSince(now)
+    guard remaining > 0 else { return nil }
+    let roundedMinutes = Int((remaining / 60 / 5).rounded()) * 5
+    return roundedMinutes <= 0 ? "few minutes" : "~\(roundedMinutes) min"
   }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModel.swift
@@ -16,16 +16,16 @@ class UpcomingGiveawayBannerModel: ViewModel {
   @ObservationIgnored @Shared(.activeGiveaway) var activeGiveaway
   @ObservationIgnored @Shared(.upcomingGiveaways) var upcomingGiveaways
 
-  // MARK: - Properties
-
-  /// Current time, refreshed once a minute by `task()`. `nil` until the view starts the refresh; the
-  /// window phrase stays hidden (timeless fallback) until then.
-  var now: Date?
-
   // MARK: - Initialization
   override init() {
     super.init()
   }
+
+  // MARK: - Properties
+
+  /// Current time, refreshed once a minute by `task()`. `nil` until the view starts the refresh, at
+  /// which point the window phrase falls back to `currentDate` so the countdown shows on first paint.
+  var now: Date?
 
   // MARK: - User Actions
 
@@ -93,8 +93,8 @@ class UpcomingGiveawayBannerModel: ViewModel {
   /// The window remaining until the prize show ends, rounded to the nearest 5 minutes. `nil` when the
   /// show end is unknown or already past.
   private var windowPhrase: String? {
-    guard let endTime = prizeShowEndTime, let now else { return nil }
-    let remaining = endTime.timeIntervalSince(now)
+    guard let endTime = prizeShowEndTime else { return nil }
+    let remaining = endTime.timeIntervalSince(now ?? currentDate)
     guard remaining > 0 else { return nil }
     let roundedMinutes = Int((remaining / 60 / 5).rounded()) * 5
     return roundedMinutes <= 0 ? "few minutes" : "~\(roundedMinutes) min"

--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
@@ -1,3 +1,4 @@
+import Dependencies
 import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
@@ -99,6 +100,22 @@ struct UpcomingGiveawayBannerModelTests {
     ]
     let model = makeModel()
     #expect(model.isVisible == true)
+  }
+
+  @Test func usesCurrentDateForWindowBeforeFirstTick() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
+      airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(38 * 60))
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      scheduled(id: "e1", station: "s1", airingId: "a1")
+    ]
+    let model = withDependencies {
+      $0.date = .constant(Self.referenceNow)
+    } operation: {
+      UpcomingGiveawayBannerModel()
+    }
+    #expect(model.now == nil)
+    #expect(model.bannerText == "Two tickets giveaway in the next ~40 min")
   }
 
   @Test func showsWindowPhraseWhenPrizeShowIsCurrentlyAiring() {

--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import IdentifiedCollections
+import PlayolaPlayer
 import Sharing
 import Testing
 
@@ -9,16 +10,41 @@ import Testing
 
 @MainActor
 struct UpcomingGiveawayBannerModelTests {
+  private static let referenceNow = Date(timeIntervalSince1970: 1_800_000_000)
+
   private func playolaNowPlaying(id: String = "s1") -> NowPlaying {
     NowPlaying.mockWith(station: AnyStation.mockPlayola(id: id))
   }
 
-  private func scheduled(id: String, station: String, prize: String = "Two tickets")
-    -> UpcomingGiveawayInfo
+  private func airing(id: String, endTime: Date?) -> Airing {
+    Airing(
+      id: id, episodeId: "ep", stationId: "s1",
+      airtime: Self.referenceNow, createdAt: Self.referenceNow, updatedAt: Self.referenceNow,
+      endTime: endTime)
+  }
+
+  private func playolaNowPlaying(stationId: String = "s1", airingId: String, endTime: Date?)
+    -> NowPlaying
   {
+    NowPlaying.mockWith(
+      spin: Spin.mockWith(airing: airing(id: airingId, endTime: endTime)),
+      station: AnyStation.mockPlayola(id: stationId))
+  }
+
+  private func scheduled(
+    id: String, station: String, prize: String = "Two tickets", airingId: String? = nil
+  ) -> UpcomingGiveawayInfo {
     UpcomingGiveawayInfo(
       event: GiveawayEvent(
-        id: id, stationId: station, prizeName: prize, winningNumber: 9, status: .scheduled))
+        id: id, stationId: station, prizeName: prize, winningNumber: 9, status: .scheduled,
+        airingId: airingId))
+  }
+
+  /// Builds the model and simulates the once-a-minute tick having fired at `referenceNow`.
+  private func makeModel() -> UpcomingGiveawayBannerModel {
+    let model = UpcomingGiveawayBannerModel()
+    model.now = Self.referenceNow
+    return model
   }
 
   @Test func hiddenWhenNotPlayingAStation() {
@@ -26,7 +52,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1")
     ]
-    let model = UpcomingGiveawayBannerModel()
+    let model = makeModel()
     #expect(model.isVisible == false)
     #expect(model.bannerOpacity == 0)
     #expect(model.bannerText == "")
@@ -37,7 +63,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e2", station: "other")
     ]
-    let model = UpcomingGiveawayBannerModel()
+    let model = makeModel()
     #expect(model.isVisible == false)
   }
 
@@ -47,7 +73,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", prize: "Two tickets")
     ]
-    let model = UpcomingGiveawayBannerModel()
+    let model = makeModel()
     #expect(model.isVisible == true)
     #expect(model.bannerOpacity == 1)
     #expect(model.bannerText == "Win a Two tickets — coming up on Mock Radio Show")
@@ -60,7 +86,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1")
     ]
-    let model = UpcomingGiveawayBannerModel()
+    let model = makeModel()
     #expect(model.isVisible == false)
   }
 
@@ -71,8 +97,74 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1")
     ]
-    let model = UpcomingGiveawayBannerModel()
+    let model = makeModel()
     #expect(model.isVisible == true)
+  }
+
+  @Test func showsWindowPhraseWhenPrizeShowIsCurrentlyAiring() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
+      airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(38 * 60))
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      scheduled(id: "e1", station: "s1", airingId: "a1")
+    ]
+    let model = makeModel()
+    #expect(model.bannerText == "Two tickets giveaway in the next ~40 min")
+  }
+
+  @Test func roundsWindowToNearestFiveMinutes() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
+      airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(43 * 60))
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      scheduled(id: "e1", station: "s1", airingId: "a1")
+    ]
+    let model = makeModel()
+    #expect(model.bannerText == "Two tickets giveaway in the next ~45 min")
+  }
+
+  @Test func showsFewMinutesPhraseNearShowEnd() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
+      airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(90))
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      scheduled(id: "e1", station: "s1", airingId: "a1")
+    ]
+    let model = makeModel()
+    #expect(model.bannerText == "Two tickets giveaway in the next few minutes")
+  }
+
+  @Test func fallsBackToTimelessCopyWhenAiringDoesNotMatch() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
+      airingId: "other-airing", endTime: Self.referenceNow.addingTimeInterval(38 * 60))
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      scheduled(id: "e1", station: "s1", airingId: "a1")
+    ]
+    let model = makeModel()
+    #expect(model.bannerText == "Win a Two tickets — coming up on Mock Radio Show")
+  }
+
+  @Test func fallsBackToTimelessCopyWhenEndTimeMissing() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
+      airingId: "a1", endTime: nil)
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      scheduled(id: "e1", station: "s1", airingId: "a1")
+    ]
+    let model = makeModel()
+    #expect(model.bannerText == "Win a Two tickets — coming up on Mock Radio Show")
+  }
+
+  @Test func fallsBackToTimelessCopyWhenWindowAlreadyPassed() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
+      airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(-60))
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      scheduled(id: "e1", station: "s1", airingId: "a1")
+    ]
+    let model = makeModel()
+    #expect(model.bannerText == "Win a Two tickets — coming up on Mock Radio Show")
   }
 }
 


### PR DESCRIPTION
The player-page upcoming-giveaway banner now leads with "[Prize] giveaway in the next ~40 min" while the prize show is the one currently on air, derived from `spin.airing.endTime` (a new optional field added in PlayolaPlayer 0.19.1) matched to the prize show by `airingId`. This bounds the window without revealing the exact open moment, and falls back to the prior timeless "Win a [Prize] — coming up on [Station]" copy when the show isn't airing, the end time is unknown, or the window has passed. The phrase refreshes once a minute, rounds to nearest 5 min with a "few minutes" floor near show-end. Visibility rules are unchanged — the banner still only shows before the tap button and never reappears after. Adds 6 model tests covering the countdown, rounding, and fallback paths.

Note: requires PlayolaPlayer ≥ 0.19.1 (already satisfied by the repo's `upToNextMinor 0.19.0` pin); the same `Airing.startTime/endTime` change still needs to land on the 0.20.0 line.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Giveaway banners now display a timed “in the next ~X min” message (rounded to 5-minute increments) when an upcoming prize window can be determined.
  * The countdown updates automatically while the banner is active.

* **Bug Fixes**
  * Banner text now falls back to the existing timeless message when the timing window is unavailable, missing, or already passed, including when the airing doesn’t match.

* **Tests**
  * Expanded and refactored banner visibility and message-generation tests to cover timing and matching edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->