### PR TITLE
Show a spinner on the giveaway TAP button while the tap is in flight

### DIFF
--- a/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsClient.swift
@@ -160,7 +160,7 @@ extension AnalyticsClient: DependencyKey {
       },
       initialize: {
         await MainActor.run {
-          Mixpanel.initialize(
+          _ = Mixpanel.initialize(
             token: Config.shared.mixpanelToken,
             trackAutomaticEvents: false
           )

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -305,7 +305,8 @@ class MainContainerModel: ViewModel {
   }
 
   private func showFeedbackSheet() {
-    Task {
+    Task { [weak self] in
+      guard let self else { return }
       let feedbackModel = FeedbackSheetModel(
         title: "Would you be up for letting us know what we can do better?",
         placeholderText: "",

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModel.swift
@@ -20,9 +20,14 @@ class GiveawayOverlayModel: ViewModel {
     super.init()
   }
 
+  // MARK: - Properties
+  var isTapping = false
+
   // MARK: - User Actions
   func tapButtonTapped() async {
-    guard let giveaway = visibleGiveaway else { return }
+    guard let giveaway = visibleGiveaway, !isTapping else { return }
+    isTapping = true
+    defer { isTapping = false }
     do {
       try await onTap?(giveaway)
     } catch {
@@ -77,6 +82,11 @@ class GiveawayOverlayModel: ViewModel {
   }
 
   var buttonTitle: String { "TAP HERE" }
+
+  /// While a tap is in flight the title fades out and the spinner fades in, so the button reads as
+  /// "working" without changing size.
+  var buttonTitleOpacity: Double { isTapping ? 0 : 1 }
+  var tapSpinnerOpacity: Double { isTapping ? 1 : 0 }
 
   var loserRevealHeadline: String {
     guard let participation else { return "" }

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -119,6 +119,60 @@ struct GiveawayOverlayModelTests {
     #expect(called == false)
   }
 
+  @Test func tapButtonShowsSpinnerWhileInFlight() async {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
+    let model = GiveawayOverlayModel()
+    #expect(model.isTapping == false)
+    #expect(model.tapSpinnerOpacity == 0)
+    #expect(model.buttonTitleOpacity == 1)
+
+    var tappingDuringTap: Bool?
+    var spinnerOpacityDuringTap: Double?
+    var titleOpacityDuringTap: Double?
+    model.onTap = { _ in
+      tappingDuringTap = model.isTapping
+      spinnerOpacityDuringTap = model.tapSpinnerOpacity
+      titleOpacityDuringTap = model.buttonTitleOpacity
+    }
+    await model.tapButtonTapped()
+
+    #expect(tappingDuringTap == true)
+    #expect(spinnerOpacityDuringTap == 1)
+    #expect(titleOpacityDuringTap == 0)
+    #expect(model.isTapping == false)
+    #expect(model.tapSpinnerOpacity == 0)
+    #expect(model.buttonTitleOpacity == 1)
+  }
+
+  @Test func tapButtonClearsSpinnerAfterError() async {
+    struct Boom: Error {}
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
+    let model = GiveawayOverlayModel()
+    model.onTap = { _ in throw Boom() }
+    model.onError = { _ in }
+    await model.tapButtonTapped()
+    #expect(model.isTapping == false)
+    #expect(model.tapSpinnerOpacity == 0)
+    #expect(model.buttonTitleOpacity == 1)
+  }
+
+  @Test func tapButtonIgnoresReentrantTapWhileInFlight() async {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = openGiveaway()
+    let model = GiveawayOverlayModel()
+    var callCount = 0
+    model.onTap = { _ in
+      callCount += 1
+      if callCount == 1 {
+        await model.tapButtonTapped()
+      }
+    }
+    await model.tapButtonTapped()
+    #expect(callCount == 1)
+  }
+
   @Test func tapButtonRoutesThrownErrorToOnError() async {
     struct Boom: Error {}
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
@@ -51,16 +51,25 @@ private struct GiveawayOverlayPromptView: View {
       Button(
         action: { Task { await model.tapButtonTapped() } },
         label: {
-          Text(model.buttonTitle)
-            .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 20))
-            .tracking(2)
-            .foregroundColor(.white)
-            .frame(maxWidth: .infinity)
-            .frame(height: 54)
-            .background(RoundedRectangle(cornerRadius: 27).fill(Color.playolaRed))
-            .overlay(RoundedRectangle(cornerRadius: 27).stroke(Color.white, lineWidth: 3))
+          ZStack {
+            Text(model.buttonTitle)
+              .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 20))
+              .tracking(2)
+              .foregroundColor(.white)
+              .opacity(model.buttonTitleOpacity)
+
+            ProgressView()
+              .progressViewStyle(.circular)
+              .tint(.white)
+              .opacity(model.tapSpinnerOpacity)
+          }
+          .frame(maxWidth: .infinity)
+          .frame(height: 54)
+          .background(RoundedRectangle(cornerRadius: 27).fill(Color.playolaRed))
+          .overlay(RoundedRectangle(cornerRadius: 27).stroke(Color.white, lineWidth: 3))
         }
       )
+      .disabled(model.isTapping)
       .padding(.top, 20)
     }
     .frame(maxWidth: .infinity)
@@ -110,6 +119,15 @@ private struct GiveawayOverlayLoserRevealView: View {
     ZStack {
       Color.black.ignoresSafeArea()
       GiveawayPlayerOverlayView(model: previewModel(lost: false))
+    }
+  }
+
+  #Preview("Overlay — Tapping") {
+    let model = previewModel(lost: false)
+    model.isTapping = true
+    return ZStack {
+      Color.black.ignoresSafeArea()
+      GiveawayPlayerOverlayView(model: model)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayPlayerOverlayView.swift
@@ -57,12 +57,15 @@ private struct GiveawayOverlayPromptView: View {
               .tracking(2)
               .foregroundColor(.white)
               .opacity(model.buttonTitleOpacity)
+              .accessibilityHidden(model.isTapping)
 
             ProgressView()
               .progressViewStyle(.circular)
               .tint(.white)
               .opacity(model.tapSpinnerOpacity)
+              .accessibilityHidden(!model.isTapping)
           }
+          .animation(.easeInOut(duration: 0.2), value: model.isTapping)
           .frame(maxWidth: .infinity)
           .frame(height: 54)
           .background(RoundedRectangle(cornerRadius: 27).fill(Color.playolaRed))


### PR DESCRIPTION
## What & why

Tapping **TAP HERE** on a live giveaway fired the server call (`tapGiveawayEvent`) with **zero UI feedback** — the button stayed fully interactive and visually unchanged for the entire round-trip. On a slow connection the tap read as a no-op, inviting frantic re-taps.

## Changes

**Giveaway tap feedback**
- `GiveawayOverlayModel`: new `isTapping` flag, set for the duration of the `onTap` await and reset on success *or* error (`defer`). `tapButtonTapped()` now guards against re-entrant taps. Exposes `buttonTitleOpacity` / `tapSpinnerOpacity` helpers so the view stays logic-free (per the model-owns-everything convention).
- `GiveawayPlayerOverlayView`: the button label is now a `ZStack` cross-fading the `TAP HERE` text out and a white circular `ProgressView` in, with `.disabled(model.isTapping)`. Same size/shape/colors. Added an `Overlay — Tapping` preview so the live spinner is viewable in the Xcode canvas.

**Warning cleanup** (pre-existing, unrelated — surfaced by warnings-as-errors)
- `AnalyticsClient`: discard the unused `Mixpanel.initialize` result so `MainActor.run`'s body is `Void`.
- `MainContainerModel`: capture `self` weakly in `showFeedbackSheet`'s `Task` so ownership matches the inner `onSuccess [weak self]` (avoids the "weak ownership differs from implicitly-captured strong reference" warning).

## Behavior
- **Tap** → title fades out, white spinner spins on the red button, button disabled.
- **Success** → participation records, overlay collapses (or winner sheet takes over) — spinner goes with it.
- **Failure** → spinner clears, title returns, existing "Tap Didn't Go Through" alert shows.

## Testing
- 3 new tests in `GiveawayOverlayModelTests` (spinner shows while in flight, spinner clears after error, re-entrant tap ignored). Full suite green (13/13).
- `make lint` clean; app target builds clean under warnings-as-errors (Xcode 26.5, matching CI).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the giveaway tap flow: the button is disabled while a tap is in progress, with the label fading out and a spinner shown until completion.
  * Added stronger re-entrancy protection so repeated taps are ignored while the first tap is still running.
  * Made the feedback sheet presentation more reliable when navigating away from the screen.
* **Tests**
  * Expanded async test coverage for spinner behavior, error recovery, and re-entrant tap handling during the giveaway tap flow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->