### PR TITLE
Sort live stations to the top of the Home "For You" list

### DIFF
--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -194,8 +194,9 @@ class HomePageModel: ViewModel {
       artistList
       .stationItems(includeHidden: showSecretStations, includeComingSoon: true)
       .filter { shouldShowStationItem($0, showSecretStations: showSecretStations) }
+      .filter { $0.anyStationIfPresent != nil }
       .sorted { $0.liveSortPriority(liveStations) < $1.liveSortPriority(liveStations) }
-      .compactMap { $0.anyStation }
+      .compactMap { $0.anyStationIfPresent }
 
     return IdentifiedArray(uniqueElements: stations)
   }

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -194,6 +194,7 @@ class HomePageModel: ViewModel {
       artistList
       .stationItems(includeHidden: showSecretStations, includeComingSoon: true)
       .filter { shouldShowStationItem($0, showSecretStations: showSecretStations) }
+      .sorted { $0.liveSortPriority(liveStations) < $1.liveSortPriority(liveStations) }
       .compactMap { $0.anyStation }
 
     return IdentifiedArray(uniqueElements: stations)

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -415,6 +415,21 @@ struct HomePageTests {
       ["voicetracking", "show-airing", "offline"])
   }
 
+  @Test
+  func testForYouStationsOmitsRowsWithNeitherPlayolaNorUrlStation() async {
+    let realStation = Station.mockWith(id: "real-station", curatorName: "DJ Real")
+    let artistList = StationList.mockArtistList(items: [
+      .mockWith(sortOrder: 0, visibility: .visible, station: nil, urlStation: nil),
+      .mockWith(sortOrder: 1, visibility: .visible, station: realStation),
+    ])
+
+    @Shared(.stationLists) var stationLists = IdentifiedArray(uniqueElements: [artistList])
+
+    let model = HomePageModel()
+
+    expectNoDifference(model.forYouStations.map(\.id), ["real-station"])
+  }
+
   // MARK: - Scheduled Shows Tests
 
   @Test

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -6,6 +6,7 @@
 //
 
 import ConcurrencyExtras
+import CustomDump
 import Dependencies
 import Foundation
 import IdentifiedCollections
@@ -342,6 +343,76 @@ struct HomePageTests {
 
     $showSecretStations.withLock { $0 = false }
     #expect(model.forYouStations.count == 1)
+  }
+
+  // MARK: - Live Station Sorting Tests
+
+  @Test
+  func testForYouStationsSortsVoicetrackingStationsToTheTop() async {
+    let offlineTop = Station.mockWith(id: "offline-top", curatorName: "DJ Offline Top")
+    let offlineMiddle = Station.mockWith(id: "offline-middle", curatorName: "DJ Offline Middle")
+    let liveStation = Station.mockWith(id: "live-station", curatorName: "DJ Live")
+
+    let artistList = StationList.mockArtistList(items: [
+      .mockWith(sortOrder: 0, visibility: .visible, station: offlineTop),
+      .mockWith(sortOrder: 1, visibility: .visible, station: offlineMiddle),
+      .mockWith(sortOrder: 2, visibility: .visible, station: liveStation),
+    ])
+
+    @Shared(.stationLists) var stationLists = IdentifiedArray(uniqueElements: [artistList])
+    @Shared(.liveStations) var liveStations = [
+      LiveStationInfo(stationId: "live-station", liveStatus: .voicetracking, station: liveStation)
+    ]
+
+    let model = HomePageModel()
+
+    expectNoDifference(
+      model.forYouStations.map(\.id),
+      ["live-station", "offline-top", "offline-middle"])
+  }
+
+  @Test
+  func testForYouStationsKeepsSortOrderWhenNoStationIsLive() async {
+    let first = Station.mockWith(id: "first", curatorName: "DJ First")
+    let second = Station.mockWith(id: "second", curatorName: "DJ Second")
+
+    let artistList = StationList.mockArtistList(items: [
+      .mockWith(sortOrder: 0, visibility: .visible, station: first),
+      .mockWith(sortOrder: 1, visibility: .visible, station: second),
+    ])
+
+    @Shared(.stationLists) var stationLists = IdentifiedArray(uniqueElements: [artistList])
+    @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
+
+    let model = HomePageModel()
+
+    expectNoDifference(model.forYouStations.map(\.id), ["first", "second"])
+  }
+
+  @Test
+  func testForYouStationsOrdersVoicetrackingAboveShowAiringAboveOffline() async {
+    let offline = Station.mockWith(id: "offline", curatorName: "DJ Offline")
+    let showAiring = Station.mockWith(id: "show-airing", curatorName: "DJ Show")
+    let voicetracking = Station.mockWith(id: "voicetracking", curatorName: "DJ Voice")
+
+    let artistList = StationList.mockArtistList(items: [
+      .mockWith(sortOrder: 0, visibility: .visible, station: offline),
+      .mockWith(sortOrder: 1, visibility: .visible, station: showAiring),
+      .mockWith(sortOrder: 2, visibility: .visible, station: voicetracking),
+    ])
+
+    @Shared(.stationLists) var stationLists = IdentifiedArray(uniqueElements: [artistList])
+    @Shared(.liveStations) var liveStations = [
+      LiveStationInfo(stationId: "show-airing", liveStatus: .showAiring, station: showAiring),
+      LiveStationInfo(
+        stationId: "voicetracking", liveStatus: .voicetracking, station: voicetracking),
+    ]
+
+    let model = HomePageModel()
+
+    expectNoDifference(
+      model.forYouStations.map(\.id),
+      ["voicetracking", "show-airing", "offline"])
   }
 
   // MARK: - Scheduled Shows Tests


### PR DESCRIPTION
## Problem

When a giveaway is happening, the live/voicetracking station correctly jumps to the **top** of the Radio Stations list, but on the **Home** page's "Artist stations for you" list it did not rise — and with the artist list auto-sorted by popularity on staging, it landed at the **bottom**.

## Root cause

`HomePageModel.forYouStations` rendered the artist list in the raw server `sortOrder` and applied **no** live-status ordering. The Radio Stations list already re-sorts each section by `APIStationItem.liveSortPriority` (voicetracking = 0, show-airing = 1, offline = 2 → live first), which is what lifts a live station to the top there. Home never did this, so it showed whatever order the server sent (manual on prod, popularity auto-sort on staging).

## Fix

Apply the same `liveSortPriority` comparator in `forYouStations`, so a live/giveaway station rises to the top of Home too — matching the Radio Stations list and overriding whatever order the server sends.

```swift
.filter { shouldShowStationItem($0, showSecretStations: showSecretStations) }
.sorted { $0.liveSortPriority(liveStations) < $1.liveSortPriority(liveStations) }
.compactMap { $0.anyStation }
```

Swift's sort is guaranteed stable (SE-0372), so within each live tier the existing `sortOrder`/pinned order is preserved. No giveaway → order is unchanged.

## Testing

Three new tests in `HomePageTests`, verified red-before/green-after by temporarily reverting the one-line fix:
- `testForYouStationsSortsVoicetrackingStationsToTheTop` — live station starting at the **bottom** of an auto-sorted list moves to the top (fails without the fix).
- `testForYouStationsOrdersVoicetrackingAboveShowAiringAboveOffline` — tier ordering (fails without the fix).
- `testForYouStationsKeepsSortOrderWhenNoStationIsLive` — no-giveaway guard (passes either way).

Full `HomePageTests` suite passes (Xcode 26.5.0), `make lint` clean, Codex adversarial review passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “For You” station ordering to prioritize live content, with voicetracking above show-airing and offline.
  * Ensures stations are only shown when they contain valid station data.
  * Preserves the existing station order when there are no live stations available.
* **Tests**
  * Added async test coverage verifying the new “For You” live sorting behavior and omission of invalid station rows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->