### PR TITLE
Isolate @Shared state per test with .freshSharedState trait

### DIFF
--- a/.claude/TESTING.md
+++ b/.claude/TESTING.md
@@ -11,47 +11,63 @@
 
 ## @Shared State in Tests
 
-Declare `@Shared` inside each test with initial values. Use `$shared.withLock { }` to update:
+### The harness: `.freshSharedState` on every suite
+
+Every test suite MUST carry the `.freshSharedState` trait (defined in
+`PlayolaRadioTests/SharedStateTestTrait.swift`). It runs each test in a fresh, empty dependency
+scope, so persisted (`.fileStorage` / `.appStorage`) and in-memory `@Shared` keys start empty and
+are isolated from every other test — including tests running in parallel.
 
 ```swift
-func testToggleUpdatesStations() async {
-  @Shared(.showSecretStations) var showSecretStations = false
-  let model = HomePageModel()
+@Suite(.freshSharedState)
+@MainActor
+struct HomePageTests {
+  @Test func toggleUpdatesStations() async {
+    @Shared(.showSecretStations) var showSecretStations = false
+    let model = HomePageModel()
 
-  XCTAssertEqual(model.forYouStations.count, 1)
+    #expect(model.forYouStations.count == 1)
 
-  $showSecretStations.withLock { $0 = true }
-  XCTAssertEqual(model.forYouStations.count, 2)  // No sleep needed!
-}
-```
-
-### Important: @Shared initialization is a DEFAULT, not a write
-
-`@Shared(.auth) var auth = Auth(jwt: "test-jwt")` sets a **default fallback** — it does NOT write to the store. If a leaked async task from a prior test already wrote to that key, the existing value persists. The swift-sharing library resets its `PersistentReferences` cache between tests via a `testCaseWillStart:` observer, but leaked escaping `Task { }` blocks from prior tests can interfere with this reset timing (see [swift-dependencies#127](https://github.com/pointfreeco/swift-dependencies/issues/127)).
-
-**When tests are flaky on CI but pass locally**, wrap in `withMainSerialExecutor` to serialize async execution and prevent leaked tasks from other tests from running during your test's `@Shared` initialization:
-
-```swift
-func testSomethingWithSharedAuth() async {
-  await withMainSerialExecutor {
-    @Shared(.auth) var auth = Auth(jwt: "test-jwt")
-    // ... rest of test
+    $showSecretStations.withLock { $0 = true }   // drive a mid-test change
+    #expect(model.forYouStations.count == 2)     // No sleep needed!
   }
 }
 ```
 
-This is especially important for `@Shared` keys backed by `.fileStorage` (like `.auth`), which go through more async machinery than `.inMemory` keys.
+With the trait, the `= value` seed is authoritative — you do **not** need `withLock` just to
+establish initial state, and you do **not** need `withMainSerialExecutor` for isolation.
 
-### File-backed keys: reset with `withLock` after the declaration
+### Why the trait is required: @Shared initialization is a DEFAULT, not a write
 
-Because the `= initialValue` declaration is only a fallback (it does NOT write), a `.fileStorage`-backed key can still hold a stale value from a previous test run, which silently invalidates assertions like `#expect(participations["e1"] == nil)`. For file-backed keys, follow the declaration with an explicit `withLock` reset so the store holds a known value — this is the one case where `withLock` is used for initial-state setup rather than only to drive a mid-test change:
+`@Shared(.auth) var auth = Auth(jwt: "test-jwt")` sets a **default** used only when the key has no
+already-loaded value — it does NOT write to the store. Persisted keys resolve their backing store
+from the `defaultFileStorage` / `defaultAppStorage` / `defaultInMemoryStorage` dependencies, which
+swift-dependencies caches in a **process-global** `DependencyValues`. That cache is partitioned by
+the current Swift Testing test id, so a test's *own* task normally gets its own store — but the
+isolation is fragile: async work running outside the test's task context (overlapping/leaked `Task`s
+from another test under parallel execution, or `Task.detached`, which drops the test context)
+resolves against the shared partition. So without the trait, an earlier test's write to a persisted
+key can survive into a later test, whose `= value` seed is then silently ignored — stale reads,
+order-dependent, flaky under parallel execution (e.g. `participations["e1"]` reads `nil` only when
+run alongside other suites).
 
-```swift
-@Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
-$participations.withLock { $0 = ["e1": .mock] }  // real write, not a fallback
-```
+`.freshSharedState` fixes this at the harness level by binding each test its own empty stores and a
+fresh `@Shared` reference cache as a task-local for the whole test (inherited by child `Task {}`
+work; it does not cover `Task.detached` or state built outside the test body). It reproduces
+DependenciesTestSupport's `.dependencies` trait (which this test target does not link) in ~20 lines.
 
-Combine with `withMainSerialExecutor` for any test that reads the store back after an `await`.
+### When you still reach for `withLock` / `withMainSerialExecutor`
+
+The trait makes these unnecessary for *isolation*, but they remain valid tools:
+
+- `$shared.withLock { $0 = ... }` — to drive a **mid-test change** after the model is observing, or
+  to force a real write for a value you then read back across an `await`.
+- `withMainSerialExecutor { ... }` — to deterministically order a model's **internal** fire-and-forget
+  `Task { }` work (see "Code That Spawns Internal Tasks" below). This is about task scheduling, not
+  `@Shared` isolation, so those uses are NOT redundant with the trait.
+
+Do **not** use class-level `@Shared` stored properties in tests: a property initialized outside the
+test method body runs outside the trait's per-test scope and will not be isolated.
 
 ## Mocking Dependencies
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,23 +48,51 @@ The Playola server monorepo is expected at `../playola` (sibling directory). If 
 - **Tests run in Xcode** - the user will run all tests for you in Xcode
 - **Test naming**: camelCase without underscores (e.g., `testOnRecordTappedRequestsPermission`)
 - **Tests colocated with code**: `HomePageModel.swift` → `HomePageTests.swift` in same folder
-- **Framework**: XCTest with `@MainActor` on all test classes
+- **Framework**: swift-testing (`@Test` / `@Suite` / `#expect`) with `@MainActor` on model/view-model suites
 
 ### Testing with @Shared state
 
-Declare `@Shared` locally inside each test method with an initial value:
+Every test suite MUST carry the `.freshSharedState` trait so each test runs in a fresh, empty
+dependency scope (see `PlayolaRadioTests/SharedStateTestTrait.swift`). Declare `@Shared` locally
+inside each test method with an initial value:
 
 ```swift
-func testSomething() {
-  @Shared(.stationLists) var stationLists = makeTestStationLists()
-  @Shared(.showSecretStations) var showSecretStations = false
+@Suite(.freshSharedState)
+@MainActor
+struct SomeTests {
+  @Test func something() {
+    @Shared(.stationLists) var stationLists = makeTestStationLists()
+    @Shared(.showSecretStations) var showSecretStations = false
 
-  let model = SomeModel()
-  // test...
+    let model = SomeModel()
+    // test...
+  }
 }
 ```
 
-Do NOT use class-level `@Shared` properties or `$shared.withLock` in tests.
+**New test files:** add `@Suite(.freshSharedState)` above the suite struct (merge with other
+traits, e.g. `@Suite(.serialized, .freshSharedState)`). A suite without it can read `@Shared`
+state leaked from another test.
+
+**Why the trait is required.** `@Shared(.key) var x = value` sets a *default* that is used only
+when the key has no already-loaded value — it is NOT a write. Persisted keys (`.fileStorage`,
+`.appStorage`) resolve their backing store from a process-global dependency cache. That cache is
+partitioned by the current Swift Testing test id, so a test's *own* task normally gets its own
+store — but that isolation is fragile: async work that runs outside the test's task context
+(overlapping/leaked `Task`s from another test under parallel execution, or `Task.detached`, which
+drops the test context) resolves against the shared partition. An earlier test's write can then
+survive into a later test, whose `= value` seed is silently ignored — the order-dependent,
+parallel-only stale reads we used to see (e.g. `participations["e1"]` reading `nil` only when run
+alongside other suites). `.freshSharedState` binds a fresh empty store as a task-local for the whole
+test (inherited by child `Task {}` work), so the `= value` seed is authoritative. In-memory-only
+keys are isolated too. (It does not cover `Task.detached` or state initialized outside the test
+body.)
+
+Because the store starts empty, you normally don't need `$shared.withLock` just to set up initial
+state — the `= value` default is enough. Reach for `$shared.withLock { $0 = ... }` when you need to
+drive a *change* mid-test (after the model is observing), or to force a real write for a value type
+you then read back across an `await`. Do NOT use class-level `@Shared` properties in tests
+(a stored property initialized outside the test body is not covered by the trait's scope).
 
 ### Test anti-patterns
 

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -194,6 +194,7 @@
 		D317C0D92EF3500B00DBC82E /* APIClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = D317C0D72EF3500500DBC82E /* APIClient+Live.swift */; };
 		D31C43A82D3C19640021AAE4 /* StationPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31C43A72D3C195B0021AAE4 /* StationPlayer.swift */; };
 		D31C43AA2D3C39110021AAE4 /* StationPlayerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31C43A92D3C390C0021AAE4 /* StationPlayerMock.swift */; };
+		FE01A0C72DFCB368002BAC30 /* SharedStateTestTrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */; };
 		D31C43D42D3C783B0021AAE4 /* PlayolaPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = D31C43D32D3C783B0021AAE4 /* PlayolaPlayer */; };
 		D31CD5232DFBA1F2009B9780 /* ViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CD5222DFBA1EC009B9780 /* ViewModel.swift */; };
 		D31CD5272DFBB4DF009B9780 /* MainContainerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31CD5252DFBB47D009B9780 /* MainContainerTests.swift */; };
@@ -587,6 +588,7 @@
 		D317C0D72EF3500500DBC82E /* APIClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Live.swift"; sourceTree = "<group>"; };
 		D31C43A72D3C195B0021AAE4 /* StationPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayer.swift; sourceTree = "<group>"; };
 		D31C43A92D3C390C0021AAE4 /* StationPlayerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerMock.swift; sourceTree = "<group>"; };
+		FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateTestTrait.swift; sourceTree = "<group>"; };
 		D31CD5222DFBA1EC009B9780 /* ViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewModel.swift; sourceTree = "<group>"; };
 		D31CD5252DFBB47D009B9780 /* MainContainerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContainerTests.swift; sourceTree = "<group>"; };
 		D3219C162EDD22100008AFDA /* BroadcastPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BroadcastPageView.swift; sourceTree = "<group>"; };
@@ -1173,6 +1175,7 @@
 			isa = PBXGroup;
 			children = (
 				D3137DBE2D3981750070033A /* Mocks */,
+				FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */,
 			);
 			path = PlayolaRadioTests;
 			sourceTree = "<group>";
@@ -2350,6 +2353,7 @@
 				D317C0CF2EF200D100DBC82E /* VoicetrackUploadServiceTests.swift in Sources */,
 				D35EFBFA2F1579E5000F64A4 /* NewFeatureTileTests.swift in Sources */,
 				D31C43AA2D3C39110021AAE4 /* StationPlayerMock.swift in Sources */,
+				FE01A0C72DFCB368002BAC30 /* SharedStateTestTrait.swift in Sources */,
 				D3776A4D2F2BE8F900200ADF /* LibraryPageTests.swift in Sources */,
 				D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */,
 				D3B662762D41B0D200975D2F /* SignInPageTests.swift in Sources */,

--- a/PlayolaRadio/CarPlay/CarPlayPlaybackTransitionTests.swift
+++ b/PlayolaRadio/CarPlay/CarPlayPlaybackTransitionTests.swift
@@ -8,6 +8,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct CarPlayPlaybackTransitionTests {
 

--- a/PlayolaRadio/Core/API/APIClientTests.swift
+++ b/PlayolaRadio/Core/API/APIClientTests.swift
@@ -10,6 +10,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct APIClientTests {
 

--- a/PlayolaRadio/Core/Analytics/AnalyticsClientTests.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsClientTests.swift
@@ -9,6 +9,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct AnalyticsClientTests {
   private static let pauseKey = "analytics_session_paused_at"

--- a/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
+++ b/PlayolaRadio/Core/AppRating/AppRatingClientTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 // swiftlint:disable redundant_optional_initialization
 
+@Suite(.freshSharedState)
 @MainActor
 struct AppRatingClientTests {
 

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -15,6 +15,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct NowPlayingUpdaterTests {
 

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -16,6 +16,7 @@ import Testing
 
 private struct PlayFailureTestError: Error {}
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationPlayerTests {
 

--- a/PlayolaRadio/Core/AudioRecording/IntroUploadServiceTests.swift
+++ b/PlayolaRadio/Core/AudioRecording/IntroUploadServiceTests.swift
@@ -10,6 +10,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct IntroUploadServiceTests {
 

--- a/PlayolaRadio/Core/AudioRecording/VoicetrackUploadServiceTests.swift
+++ b/PlayolaRadio/Core/AudioRecording/VoicetrackUploadServiceTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 struct VoicetrackUploadServiceTests {
 
   // MARK: - Test Data

--- a/PlayolaRadio/Core/Auth/PlayolaTokenProvider/PlayolaTokenProviderTests.swift
+++ b/PlayolaRadio/Core/Auth/PlayolaTokenProvider/PlayolaTokenProviderTests.swift
@@ -14,6 +14,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct PlayolaTokenProviderTests {
 

--- a/PlayolaRadio/Core/Formatters/RRuleFormatterTests.swift
+++ b/PlayolaRadio/Core/Formatters/RRuleFormatterTests.swift
@@ -10,6 +10,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct RRuleFormatterTests {
   // MARK: - Single Day Tests

--- a/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Giveaways/GiveawayCoordinatorTests.swift
@@ -14,7 +14,7 @@ import Testing
 // shared key, so parallel Swift Testing could interleave across `await` points and cross-contaminate
 // the on-disk state.
 @MainActor
-@Suite(.serialized)
+@Suite(.serialized, .freshSharedState)
 struct GiveawayCoordinatorTests {
   private struct BoomError: Error {}
 

--- a/PlayolaRadio/Core/Likes/LikeOperationTests.swift
+++ b/PlayolaRadio/Core/Likes/LikeOperationTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 struct LikeOperationTests {
 
   // MARK: - Test Data

--- a/PlayolaRadio/Core/Likes/LikesManagerTests.swift
+++ b/PlayolaRadio/Core/Likes/LikesManagerTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct LikesManagerTests {
 

--- a/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
+++ b/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 // swiftlint:disable redundant_optional_initialization
 
+@Suite(.freshSharedState)
 @MainActor
 struct ListeningTrackerTests {
 

--- a/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinatorTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct MainContainerNavigationCoordinatorTests {
 

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -17,7 +17,7 @@ import Testing
 // `.giveawayParticipations` stores under shared keys, so parallel Swift Testing could interleave
 // across `await` points and cross-contaminate the on-disk state.
 @MainActor
-@Suite(.serialized)
+@Suite(.serialized, .freshSharedState)
 struct PushNotificationsTests {
 
   // MARK: - registerForRemoteNotifications

--- a/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationActionTests.swift
@@ -7,6 +7,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct PlayStationActionTests {
   private func makeStationLists() -> IdentifiedArrayOf<StationList> {

--- a/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
+++ b/PlayolaRadio/Core/SiriIntents/StationVoiceCatalogTests.swift
@@ -6,6 +6,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationVoiceCatalogTests {
   @Test

--- a/PlayolaRadio/Core/Toast/ToastClientTests.swift
+++ b/PlayolaRadio/Core/Toast/ToastClientTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct ToastClientTests {
 

--- a/PlayolaRadio/Extensions/Version+Comparison/VersionComparisonTests.swift
+++ b/PlayolaRadio/Extensions/Version+Comparison/VersionComparisonTests.swift
@@ -7,6 +7,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct VersionComparisonTests {
   @Test

--- a/PlayolaRadio/Models/ArtistSuggestionTests.swift
+++ b/PlayolaRadio/Models/ArtistSuggestionTests.swift
@@ -9,6 +9,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 struct ArtistSuggestionStatusTests {
 
   @Test

--- a/PlayolaRadio/Models/CongratsActionTests.swift
+++ b/PlayolaRadio/Models/CongratsActionTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct CongratsActionTests {
   @Test func codableRoundTripsWithAssociatedValues() throws {

--- a/PlayolaRadio/Models/GiveawayModelsTests.swift
+++ b/PlayolaRadio/Models/GiveawayModelsTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct GiveawayModelsTests {
   private func decoder() -> JSONDecoder { JSONDecoderWithIsoFull() }

--- a/PlayolaRadio/Models/GiveawayParticipationTests.swift
+++ b/PlayolaRadio/Models/GiveawayParticipationTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct GiveawayParticipationTests {
   @Test func codableRoundTrips() throws {

--- a/PlayolaRadio/Models/GiveawayWinnerPendingPushTests.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPendingPushTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct GiveawayWinnerPendingPushTests {
   @Test func parsesValidPendingPush() {

--- a/PlayolaRadio/Models/GiveawayWinnerPushTests.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPushTests.swift
@@ -4,6 +4,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct GiveawayWinnerPushTests {
   @Test func parsesValidWinnerPush() {

--- a/PlayolaRadio/Models/Preset/PresetTests.swift
+++ b/PlayolaRadio/Models/Preset/PresetTests.swift
@@ -9,6 +9,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct PresetTests {
 

--- a/PlayolaRadio/Models/SongSeed/SongSeedTests.swift
+++ b/PlayolaRadio/Models/SongSeed/SongSeedTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 struct SongRequestTests {
 
   @Test

--- a/PlayolaRadio/Models/StagingItem/StagingItemTests.swift
+++ b/PlayolaRadio/Models/StagingItem/StagingItemTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 struct StagingItemTests {
 
   // MARK: - LocalVoicetrack Conformance Tests

--- a/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/AskQuestionPage/AskQuestionPageTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct AskQuestionPageTests {
   // MARK: - Init

--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageTests.swift
@@ -15,6 +15,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct BroadcastPageTests {
   // MARK: - Test Helpers

--- a/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastersListenerQuestionPage/BroadcastersListenerQuestionPageTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct BroadcastersListenerQuestionPageTests {
   private let testStationId = "test-station-id"

--- a/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageTests.swift
@@ -9,6 +9,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct ChooseStationPageTests {
   @Test

--- a/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationToBroadcastPage/ChooseStationToBroadcastPageTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct ChooseStationToBroadcastPageTests {
   @Test

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -14,6 +14,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct ContactPageTests {
   @Test

--- a/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ConversationListPage/ConversationListPageTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct ConversationListPageTests {
   private func makeConversation(

--- a/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageTests.swift
+++ b/PlayolaRadio/Views/Pages/EditProfilePage/EditProfilePageTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct EditProfilePageTests {
   @Test

--- a/PlayolaRadio/Views/Pages/FeedbackSheet/FeedbackSheetTests.swift
+++ b/PlayolaRadio/Views/Pages/FeedbackSheet/FeedbackSheetTests.swift
@@ -10,6 +10,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct FeedbackSheetTests {
   @Test

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -12,7 +12,7 @@ import Testing
 // shared key, so parallel Swift Testing could interleave across `await` points and cross-contaminate
 // the on-disk state.
 @MainActor
-@Suite(.serialized)
+@Suite(.serialized, .freshSharedState)
 struct GiveawayCongratsSheetModelTests {
   private func recordedAction() -> CongratsAction {
     CongratsAction(

--- a/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayWinnerSheet/GiveawayWinnerSheetModelTests.swift
@@ -10,7 +10,7 @@ import Testing
 // shared key, so parallel Swift Testing could interleave across `await` points and cross-contaminate
 // the on-disk state.
 @MainActor
-@Suite(.serialized)
+@Suite(.serialized, .freshSharedState)
 struct GiveawayWinnerSheetModelTests {
   private func wonParticipation(tapNumber: Int = 9, winningNumber: Int = 9)
     -> GiveawayParticipation

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -19,6 +19,7 @@ import Testing
 // `createTestJWT` is defined in MainContainerTests.swift and shared
 // across the test target.
 
+@Suite(.freshSharedState)
 @MainActor
 struct HomePageTests {
   // MARK: - ViewAppeared Tests

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct LibraryPageTests {
   // MARK: - Helpers

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsPageTests.swift
@@ -6,6 +6,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct LikedSongsPageTests {
   @Test

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct ListenerQuestionDetailPageTests {
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerTests.swift
@@ -58,6 +58,7 @@ func createTestJWT(
   return "\(headerString).\(payloadString).fake_signature"
 }
 
+@Suite(.freshSharedState)
 @MainActor
 struct MainContainerTests {
   // MARK: - ViewAppeared Tests

--- a/PlayolaRadio/Views/Pages/MainContainer/WelcomeMessageEligibilityTests.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/WelcomeMessageEligibilityTests.swift
@@ -16,6 +16,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct WelcomeMessageEligibilityTests {
   @Test

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageTests.swift
@@ -15,6 +15,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct NotificationsSettingsPageTests {
   @Test

--- a/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/GiveawayOverlayModelTests.swift
@@ -10,7 +10,7 @@ import Testing
 // shared key, so parallel Swift Testing could interleave across `await` points and cross-contaminate
 // the on-disk state.
 @MainActor
-@Suite(.serialized)
+@Suite(.serialized, .freshSharedState)
 struct GiveawayOverlayModelTests {
   // giveawayId is deliberately distinct from the event id so tests pin participation keying to the
   // per-airing event id (`id`), not the stable `giveawayId`.

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -14,6 +14,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct PlayerPageTests {
   // MARK: - viewAppeared Tests

--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
@@ -9,6 +9,7 @@ import Testing
 
 // swiftlint:disable redundant_optional_initialization
 
+@Suite(.freshSharedState)
 @MainActor
 struct UpcomingGiveawayBannerModelTests {
   private static let referenceNow = Date(timeIntervalSince1970: 1_800_000_000)

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct RecordIntroPageTests {
   private func makeModel() -> RecordIntroPageModel {

--- a/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RecordPage/RecordPageTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct RecordPageTests {
   // MARK: - Lifecycle

--- a/PlayolaRadio/Views/Pages/RewardsPage/RedeemPrizeSheetTests.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RedeemPrizeSheetTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct RedeemPrizeSheetModelTests {
 

--- a/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageTests.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/RewardsPageTests.swift
@@ -16,6 +16,7 @@ import Testing
 
 // swiftlint:disable redundant_optional_initialization
 
+@Suite(.freshSharedState)
 @MainActor
 struct RewardsPageModelTests {
   func createMockListeningTracker(totalTimeMS: Int) -> ListeningTracker {

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowTests.swift
@@ -10,6 +10,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct EpisodeRowModelTests {
 

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCardTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct SeriesCardModelTests {
   @Test

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesListPageTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct SeriesListPageModelTests {
   @Test

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageTests.swift
@@ -15,6 +15,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct SignInPageTests {
   @Test

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageTests.swift
@@ -15,6 +15,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct SongSearchPageTests {
   @Test

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListLiveSortTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListLiveSortTests.swift
@@ -14,6 +14,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationListLiveSortTests {
   @Test

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -16,6 +16,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationListPageTests {
   // MARK: - View Appeared Tests
@@ -738,6 +739,7 @@ private func makeStationListModel(
 
 // MARK: - Notification Permission Prompt Tests
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationListNotificationPromptTests {
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetComingSoonTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetComingSoonTests.swift
@@ -11,6 +11,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationListPresetComingSoonTests {
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetErrorReportingTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetErrorReportingTests.swift
@@ -14,6 +14,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationListPresetErrorReportingTests {
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPresetTests.swift
@@ -14,6 +14,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationListPresetTests {
 

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationListStationRowTests {
   @Test

--- a/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationSuggestionPage/StationSuggestionPageTests.swift
@@ -13,6 +13,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct StationSuggestionPageTests {
 

--- a/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
+++ b/PlayolaRadio/Views/Pages/SupportPage/SupportPageTests.swift
@@ -14,6 +14,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct SupportPageTests {
   private func makeConversation(id: String) -> Conversation {

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageTests.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct WelcomeMessagePageModelTests {
 

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
@@ -15,6 +15,7 @@ import Testing
 
 // swiftlint:disable redundant_optional_initialization
 
+@Suite(.freshSharedState)
 @MainActor
 struct ListeningTimeTileModelTests {
 

--- a/PlayolaRadio/Views/Reusable Components/NewFeatureTile/NewFeatureTileTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/NewFeatureTile/NewFeatureTileTests.swift
@@ -7,6 +7,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct NewFeatureTileModelTests {
 

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayerTests.swift
@@ -15,6 +15,7 @@ import Testing
 
 // swiftlint:disable redundant_optional_initialization
 
+@Suite(.freshSharedState)
 @MainActor
 struct SmallPlayerTests {
 

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerTests.swift
@@ -12,6 +12,7 @@ import Testing
 
 @testable import PlayolaRadio
 
+@Suite(.freshSharedState)
 @MainActor
 struct SongDrawerTests {
 

--- a/PlayolaRadioTests/SharedStateTestTrait.swift
+++ b/PlayolaRadioTests/SharedStateTestTrait.swift
@@ -1,0 +1,60 @@
+//
+//  SharedStateTestTrait.swift
+//  PlayolaRadioTests
+//
+//  Gives every test a fresh, empty dependency scope so `@Shared` state cannot leak between tests.
+//
+
+import Dependencies
+import Testing
+
+/// A swift-testing trait that isolates each test's `@Shared` state by running the test (and any
+/// child `Task {}` work it spawns) in a fresh, empty dependency scope.
+///
+/// Why this exists: `@Shared(.key) var x = value` sets a *default* that is used only when the key
+/// has no already-loaded value — it is not a write. Persisted keys (`.fileStorage`, `.appStorage`)
+/// resolve their backing store from the `defaultFileStorage` / `defaultAppStorage` /
+/// `defaultInMemoryStorage` dependencies, which swift-dependencies caches in a process-global
+/// `DependencyValues`. That cache is partitioned by the current Swift Testing test id, so a test's
+/// *own* task normally gets its own store — but that isolation is fragile: async work that runs
+/// outside the test's task context (overlapping / leaked `Task`s from another test under parallel
+/// execution, and `Task.detached`, which drops the test context entirely) resolves against the
+/// shared partition. An earlier test's write can then survive into a later test, whose `= value`
+/// seed is silently ignored — the observed order-dependent, parallel-only stale reads.
+///
+/// This reproduces the behavior of DependenciesTestSupport's `.dependencies` trait (which the test
+/// target does not link): each test runs inside `withDependencies { $0 = DependencyValues() }`, so
+/// it gets fresh, empty in-memory file/app storage and a fresh `@Shared` reference cache, bound as a
+/// task-local for the whole test. Child `Task {}` work inherits it, so the isolation no longer
+/// depends on the fragile per-test-id cache partition. (It does not extend to `Task.detached` or to
+/// state initialized outside the test body.) Because `isRecursive` is `true`, a suite-level trait
+/// scopes each test individually, so parallel tests in the same suite are still isolated. The
+/// `isRoot` guard mirrors the library: only the outermost application resets the scope, so nested
+/// suites don't wipe an enclosing scope's overrides.
+struct FreshSharedStateTrait: TestTrait, SuiteTrait, TestScoping {
+  @TaskLocal static var isRoot = true
+
+  var isRecursive: Bool { true }
+
+  func provideScope(
+    for test: Test,
+    testCase: Test.Case?,
+    performing function: @Sendable () async throws -> Void
+  ) async throws {
+    try await withDependencies {
+      if Self.isRoot {
+        $0 = DependencyValues()
+      }
+    } operation: {
+      try await Self.$isRoot.withValue(false) {
+        try await function()
+      }
+    }
+  }
+}
+
+extension Trait where Self == FreshSharedStateTrait {
+  /// Isolates a suite's (or test's) `@Shared` state from every other test by running each test in a
+  /// fresh, empty dependency scope. Apply to every test suite via `@Suite(.freshSharedState)`.
+  static var freshSharedState: FreshSharedStateTrait { FreshSharedStateTrait() }
+}


### PR DESCRIPTION
Test `@Shared(.key) var x = value` seeds are only a *default* (used when the key is unloaded), and swift-dependencies' per-test-id cache partition is racy when async work escapes a test's task under parallel execution, so a prior test's write to a persisted key could leak into a later test and silently override its seed (order-dependent, parallel-only stale reads). This adds `PlayolaRadioTests/SharedStateTestTrait.swift` — a local reproduction of DependenciesTestSupport's `.dependencies` trait (that module isn't linked) that runs each test in `withDependencies { $0 = DependencyValues() }`, giving fresh empty file/app/in-memory stores plus a fresh `@Shared` reference cache bound as a task-local for the whole test. `@Suite(.freshSharedState)` is applied to all 73 test suites (merged with existing `.serialized`); the 903 seed sites are unchanged and no production code was touched. The full suite passes on Xcode 26.5.0 with parallel execution enabled (1171 tests / 73 suites, run twice, zero issues). `CLAUDE.md` and `.claude/TESTING.md` are updated to explain the trait, the corrected leak mechanism, and its limits (`Task.detached` / non-body init are not covered).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated testing guidance to recommend a fresh shared-state setup for each test suite.
  * Clarified best practices for using shared test state and when to apply locking or serial execution.

* **Tests**
  * Added fresh shared-state configuration across many test suites.
  * Improved test isolation to reduce flaky, order-dependent failures and cross-test state leakage.
  * Included the new shared-state test helper in the test target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->