### PR TITLE
Unify iOS 26 TLS mitigation and add multi-transport connectivity probe

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -191,6 +191,10 @@
 		D317C0D62EF33DB000DBC82E /* PushNotificationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D317C0D32EF33DA600DBC82E /* PushNotificationsTests.swift */; };
 		D317C0D82EF3500B00DBC82E /* APIClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = D317C0D72EF3500500DBC82E /* APIClient+Live.swift */; };
 		D317C0D92EF3500B00DBC82E /* APIClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = D317C0D72EF3500500DBC82E /* APIClient+Live.swift */; };
+		A1750A0000000000000000F2 /* PlayolaTLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F1 /* PlayolaTLS.swift */; };
+		A1750A0000000000000000F3 /* PlayolaTLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F1 /* PlayolaTLS.swift */; };
+		A1750A0000000000000000F5 /* ConnectivityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F4 /* ConnectivityProbe.swift */; };
+		A1750A0000000000000000F6 /* ConnectivityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F4 /* ConnectivityProbe.swift */; };
 		D31C43A82D3C19640021AAE4 /* StationPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31C43A72D3C195B0021AAE4 /* StationPlayer.swift */; };
 		D31C43AA2D3C39110021AAE4 /* StationPlayerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31C43A92D3C390C0021AAE4 /* StationPlayerMock.swift */; };
 		FE01A0C72DFCB368002BAC30 /* SharedStateTestTrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */; };
@@ -239,6 +243,7 @@
 		D35673C82D3EBFBA00E4E926 /* NowPlayingUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C72D3EBFB000E4E926 /* NowPlayingUpdater.swift */; };
 		D35905EC2DFCDA140064A9C1 /* StationListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35905EB2DFCDA110064A9C1 /* StationListModel.swift */; };
 		D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */; };
+		A1750A0000000000000000F8 /* ConnectivityProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F7 /* ConnectivityProbeTests.swift */; };
 		D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */; };
 		D35EFBEE2F1092A7000F64A4 /* RRuleFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */; };
 		D35EFBF02F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
@@ -583,6 +588,8 @@
 		D317C0D02EF2027000DBC82E /* VoicetrackStatusResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicetrackStatusResponse.swift; sourceTree = "<group>"; };
 		D317C0D32EF33DA600DBC82E /* PushNotificationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsTests.swift; sourceTree = "<group>"; };
 		D317C0D72EF3500500DBC82E /* APIClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Live.swift"; sourceTree = "<group>"; };
+		A1750A0000000000000000F1 /* PlayolaTLS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaTLS.swift; sourceTree = "<group>"; };
+		A1750A0000000000000000F4 /* ConnectivityProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityProbe.swift; sourceTree = "<group>"; };
 		D31C43A72D3C195B0021AAE4 /* StationPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayer.swift; sourceTree = "<group>"; };
 		D31C43A92D3C390C0021AAE4 /* StationPlayerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerMock.swift; sourceTree = "<group>"; };
 		FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateTestTrait.swift; sourceTree = "<group>"; };
@@ -627,6 +634,7 @@
 		D35673CA2D3EE5E100E4E926 /* Secrets-Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-Development.xcconfig"; sourceTree = "<group>"; };
 		D35905EB2DFCDA110064A9C1 /* StationListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListModel.swift; sourceTree = "<group>"; };
 		D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
+		A1750A0000000000000000F7 /* ConnectivityProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityProbeTests.swift; sourceTree = "<group>"; };
 		D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerTests.swift; sourceTree = "<group>"; };
 		D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatterTests.swift; sourceTree = "<group>"; };
 		D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatter.swift; sourceTree = "<group>"; };
@@ -1473,6 +1481,9 @@
 			children = (
 				D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */,
 				D317C0D72EF3500500DBC82E /* APIClient+Live.swift */,
+				A1750A0000000000000000F1 /* PlayolaTLS.swift */,
+				A1750A0000000000000000F4 /* ConnectivityProbe.swift */,
+				A1750A0000000000000000F7 /* ConnectivityProbeTests.swift */,
 				D339E5682BFD1C0800B9E35B /* APIClient.swift */,
 			);
 			path = API;
@@ -1941,6 +1952,8 @@
 				D3B9C7AC2F534D50002D75C2 /* IntroUploadService.swift in Sources */,
 				D30F004A2E8592F0007BCC73 /* UrlStreamListeningSessionReporter.swift in Sources */,
 				D317C0D92EF3500B00DBC82E /* APIClient+Live.swift in Sources */,
+				A1750A0000000000000000F2 /* PlayolaTLS.swift in Sources */,
+				A1750A0000000000000000F5 /* ConnectivityProbe.swift in Sources */,
 				D3776A062F22BA1A00200ADF /* AskQuestionPageModel.swift in Sources */,
 				D3776A072F22BA1A00200ADF /* AskQuestionPageView.swift in Sources */,
 				D3776A0E2F22CB8600200ADF /* ListenerQuestionPresignedURLResponse.swift in Sources */,
@@ -2134,6 +2147,8 @@
 				D3B9C7AA2F534D50002D75C2 /* IntroUploadService.swift in Sources */,
 				D3D6CE5F2D5ECED50059BDCA /* UrlStreamListeningSessionReporter.swift in Sources */,
 				D317C0D82EF3500B00DBC82E /* APIClient+Live.swift in Sources */,
+				A1750A0000000000000000F3 /* PlayolaTLS.swift in Sources */,
+				A1750A0000000000000000F6 /* ConnectivityProbe.swift in Sources */,
 				D3776A032F22BA1A00200ADF /* AskQuestionPageModel.swift in Sources */,
 				D3776A042F22BA1A00200ADF /* AskQuestionPageView.swift in Sources */,
 				D3776A0F2F22CB8600200ADF /* ListenerQuestionPresignedURLResponse.swift in Sources */,
@@ -2350,6 +2365,7 @@
 				FE01A0C72DFCB368002BAC30 /* SharedStateTestTrait.swift in Sources */,
 				D3776A4D2F2BE8F900200ADF /* LibraryPageTests.swift in Sources */,
 				D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */,
+				A1750A0000000000000000F8 /* ConnectivityProbeTests.swift in Sources */,
 				D3B662762D41B0D200975D2F /* SignInPageTests.swift in Sources */,
 				D39728562F5F03FF008591E3 /* VersionComparisonTests.swift in Sources */,
 				D3C7E5EF2EF0C58900EDD3ED /* StagingItemTests.swift in Sources */,

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -27,67 +27,12 @@ private struct CreateVoicetrackParameters: Encodable, Sendable {
 
 private let sharedIsoDecoder = JSONDecoderWithIsoFull()
 
-// TEMPORARY: Global TLS 1.2 cap.
-//
-// On iOS 26, URLSession sends a TLS 1.3 ClientHello that includes the X25519MLKEM768
-// post-quantum hybrid key share (~1.6 KB). Some users sit behind middleboxes
-// (antivirus SSL inspection, parental-control routers, captive portals, etc.) that
-// drop the larger ClientHello and surface as NSURLErrorSecureConnectionFailed (-1200),
-// which makes every API request fail silently on those networks. PR #269 added a
-// per-call TLS 1.2 fallback for sign-in, but follow-up testing showed the issue
-// affects every endpoint — sign-in succeeds, then profile / listening-tracker /
-// station fetches silently fail and the UI renders blank or stale data.
-//
-// As a stopgap, every Alamofire request in this file is routed through `apiSession`,
-// which caps the URLSession to TLS 1.2 so the ClientHello stays small enough for
-// these middleboxes to pass through.
-//
-// REVERT WHEN: Apple ships an iOS 26 fix (watch 26.5+ release notes) OR exposes a
-// supported opt-out for the post-quantum hybrid key share so we can keep TLS 1.3.
-// At that point, replace `apiSession` usages with bare `AF` again and consider
-// restoring a per-call retry (the prior signInPostWithTLS12Fallback pattern) for
-// defense in depth on networks that still misbehave.
-private let apiSession: Alamofire.Session = {
-  let configuration = URLSessionConfiguration.af.default
-  configuration.tlsMaximumSupportedProtocolVersion = .TLSv12
-  return Alamofire.Session(configuration: configuration)
-}()
-
-// Companion to `apiSession`: a separate session with no TLS cap, used by
-// `probeTLS13()` to test whether TLS 1.3 works on the user's network. When
-// success rates climb across the user base, the cap above is safe to revert.
-private let tls13ProbeSession: Alamofire.Session = {
-  Alamofire.Session(configuration: URLSessionConfiguration.af.default)
-}()
-
-// Fires once per build per device. Hits a small unauthenticated endpoint over
-// TLS 1.3 (no cap) and reports outcome to Sentry as `tls13_probe`. Aggregating
-// the outcome across users tells us when the iOS 26 middlebox issue has cleared
-// up enough to revert the global TLS 1.2 cap.
-func probeTLS13() async {
-  @Shared(.tls13ProbeLastSentBuild) var lastSentBuild: String?
-  guard let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String,
-    lastSentBuild != currentBuild
-  else { return }
-
-  let url = "\(Config.shared.baseUrl.absoluteString)/v1/app-version-requirements"
-  let outcome: String
-  do {
-    _ = try await tls13ProbeSession.request(url)
-      .validate(statusCode: 200..<300)
-      .serializingData()
-      .value
-    outcome = "success"
-  } catch {
-    outcome = "failure"
-  }
-
-  @Dependency(\.errorReporting) var errorReporting
-  await errorReporting.reportMessage(
-    "tls13_probe",
-    ["tls13_probe_outcome": outcome])
-  $lastSentBuild.withLock { $0 = currentBuild }
-}
+// TEMPORARY: Global TLS 1.2 cap. Every Alamofire request in this file is routed through
+// `apiSession`, which caps the URLSession to TLS 1.2 so the iOS 26 post-quantum ClientHello
+// stays small enough for broken middleboxes to pass through. The policy itself lives in
+// `PlayolaTLS` (single source of truth); the aggregated `tls13_probe` Sentry trend
+// (see `ConnectivityProbe`) tells us when it is safe to revert. Full background there.
+private let apiSession = Alamofire.Session(configuration: PlayolaTLS.mitigated(.af.default))
 
 private func signInPost(
   authMethod: AuthMethod,

--- a/PlayolaRadio/Core/API/ConnectivityProbe.swift
+++ b/PlayolaRadio/Core/API/ConnectivityProbe.swift
@@ -1,0 +1,242 @@
+//
+//  ConnectivityProbe.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 7/10/26.
+//
+
+import Dependencies
+import Foundation
+import Sharing
+
+// MARK: - Pure model + diagnosis (unit-tested)
+
+/// Outcome of a single probe request.
+enum ProbeOutcome: String, Sendable, Equatable {
+  case success
+  case failure
+  /// The request succeeded but negotiated a different protocol than intended
+  /// (e.g. an HTTP/3 probe that fell back to HTTP/2 over TCP). Only meaningful
+  /// for the HTTP/3 probe, where it means "QUIC/UDP did not actually carry this".
+  case fellBack
+  case skipped
+}
+
+/// One connectivity probe run: our API host reached four ways, plus a control host.
+///
+/// The point is to distinguish the competing failure theories for the iOS 26
+/// NSURLErrorSecureConnectionFailed reports, per network:
+/// - `apiTLS13`: uncapped, forced TLS 1.3, HTTP/2 — the original probe. Fails when a
+///   middlebox drops the oversized post-quantum ClientHello.
+/// - `apiTLS12`: the production profile (capped to TLS 1.2), HTTP/2 — does the shipped
+///   mitigation actually get through?
+/// - `apiHTTP3`: forced TLS 1.3 with HTTP/3 requested — does routing over QUIC/UDP survive
+///   where TCP does not? (verified via the negotiated protocol, not just success)
+/// - `controlHost`: the production profile to a DIFFERENT host on the same CDN (Cloudflare).
+///   Succeeding here while every API transport fails implicates domain/SNI filtering of us
+///   specifically, not a broken network.
+struct ConnectivityProbeResult: Sendable, Equatable {
+  var apiTLS13: ProbeOutcome
+  var apiTLS12: ProbeOutcome
+  var apiHTTP3: ProbeOutcome
+  var controlHost: ProbeOutcome
+}
+
+/// The network condition inferred from a probe result. This is the signal that tells us
+/// which remediation (keep the cap / enable HTTP/3 / nothing client-side) actually helps.
+enum ProbeDiagnosis: String, Sendable, Equatable {
+  /// TLS 1.3 to our API works — no iOS 26 problem on this network.
+  case healthy
+  /// TLS 1.3 works but the production profile (capped to TLS 1.2) fails — the global cap is
+  /// itself breaking this network. This is the signal that the cap should become adaptive /
+  /// be dropped, since real requests use the capped path.
+  case cappedPathBroken
+  /// TLS 1.3 fails but TLS 1.2 works — the classic oversized-ClientHello drop. The shipped
+  /// global cap is the fix.
+  case clientHelloDrop
+  /// TLS 1.2 also fails but HTTP/3 works — enabling HTTP/3 for real requests would help.
+  case http3Rescues
+  /// Every transport to our API fails but the control host (same CDN, different domain)
+  /// works — points to domain/SNI filtering of playola specifically. No client TLS change helps.
+  case hostFiltered
+  /// The control host also fails — broader connectivity problem, not specific to us.
+  case noConnectivity
+  /// Not enough signal to classify (e.g. the control probe was skipped).
+  case indeterminate
+}
+
+enum ConnectivityProbe {
+  /// Classify a probe result. Order matters: the first transport that reaches our API wins,
+  /// so `healthy` beats `clientHelloDrop` beats `http3Rescues`. Only when every API transport
+  /// fails do we consult the control host to separate "it's just us" from "network is down".
+  static func diagnose(_ result: ConnectivityProbeResult) -> ProbeDiagnosis {
+    if result.apiTLS13 == .success {
+      // Real requests ride the capped TLS 1.2 path; if 1.3 works but 1.2 doesn't, the cap
+      // itself is the problem here — surface it instead of hiding it under `.healthy`.
+      return result.apiTLS12 == .failure ? .cappedPathBroken : .healthy
+    }
+    if result.apiTLS12 == .success { return .clientHelloDrop }
+    if result.apiHTTP3 == .success { return .http3Rescues }
+
+    switch result.controlHost {
+    case .success: return .hostFiltered
+    case .failure: return .noConnectivity
+    case .fellBack, .skipped: return .indeterminate
+    }
+  }
+
+  /// Sentry tags for a probe run. `tls13_probe_outcome` is kept byte-compatible with the
+  /// original probe so the existing 30-day trend query keeps working; the rest is new signal.
+  static func tags(for result: ConnectivityProbeResult) -> [String: String] {
+    [
+      "tls13_probe_outcome": result.apiTLS13 == .success ? "success" : "failure",
+      "probe_api_tls13": result.apiTLS13.rawValue,
+      "probe_api_tls12": result.apiTLS12.rawValue,
+      "probe_api_http3": result.apiHTTP3.rawValue,
+      "probe_control": result.controlHost.rawValue,
+      "probe_diagnosis": diagnose(result).rawValue,
+    ]
+  }
+}
+
+// MARK: - Network runner (thin I/O, not unit-tested)
+
+/// Fires once per build per device from app launch. Runs the four probes and reports a single
+/// `tls13_probe` Sentry event whose tags carry the per-transport outcomes and diagnosis.
+/// Aggregating `probe_diagnosis` across users is what lets us choose the next remediation and,
+/// eventually, revert the global TLS 1.2 cap.
+func runConnectivityProbe() async {
+  @Shared(.tls13ProbeLastSentBuild) var lastSentBuild: String?
+  guard let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String,
+    lastSentBuild != currentBuild
+  else { return }
+
+  let result = await ConnectivityProbe.run(baseURL: Config.shared.baseUrl)
+
+  @Dependency(\.errorReporting) var errorReporting
+  await errorReporting.reportMessage("tls13_probe", ConnectivityProbe.tags(for: result))
+  $lastSentBuild.withLock { $0 = currentBuild }
+}
+
+extension ConnectivityProbe {
+  /// A small unauthenticated endpoint, cheap to hit repeatedly.
+  private static let apiProbePath = "/v1/app-version-requirements"
+  /// Different domain, same CDN (Cloudflare) as our API, so a success here isolates
+  /// domain/SNI filtering from CDN-wide or network-wide blocking.
+  private static let controlURL = URL(string: "https://www.cloudflare.com/cdn-cgi/trace")!
+
+  /// A `.default` configuration with all caching disabled so every probe performs a real
+  /// network handshake. A cached `/v1/app-version-requirements` response would otherwise report
+  /// `success` (or a `nil` negotiated protocol for the HTTP/3 probe) without measuring TLS/QUIC.
+  private static func probeBaseConfiguration() -> URLSessionConfiguration {
+    let config = URLSessionConfiguration.default
+    config.urlCache = nil
+    config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+    return config
+  }
+
+  /// Forces TLS 1.3 exactly (both bounds pinned — leaving `max` at the default sentinel while
+  /// bumping `min` to 1.3 yields an empty version window and a `NO_SUPPORTED_VERSIONS_ENABLED`
+  /// config error instead of an actual network measurement).
+  private static func forcedTLS13Configuration() -> URLSessionConfiguration {
+    let config = probeBaseConfiguration()
+    config.tlsMinimumSupportedProtocolVersion = .TLSv13
+    config.tlsMaximumSupportedProtocolVersion = .TLSv13
+    return config
+  }
+
+  /// Uncapped, forced to TLS 1.3 — the request fails if the network can't carry a 1.3 handshake.
+  private static let tls13Session = URLSession(configuration: forcedTLS13Configuration())
+
+  /// The exact production profile (capped to TLS 1.2, caching disabled for the probe). Used for
+  /// the API 1.2 probe and the control host so they are apples-to-apples with real requests.
+  private static let tls12Session = URLSession(
+    configuration: PlayolaTLS.mitigated(probeBaseConfiguration()))
+
+  /// Forced TLS 1.3, used with `assumesHTTP3Capable` requests to probe QUIC/UDP.
+  private static let http3Session = URLSession(configuration: forcedTLS13Configuration())
+
+  static func run(baseURL: URL) async -> ConnectivityProbeResult {
+    let apiURL = baseURL.appendingPathComponent(apiProbePath)
+
+    // Sequential (not concurrent) so probes to the same host don't share/coalesce a
+    // connection and muddy the per-transport signal.
+    let tls13 = await attempt(apiURL, session: tls13Session).outcome(expectingProtocol: nil)
+    let tls12 = await attempt(apiURL, session: tls12Session).outcome(expectingProtocol: nil)
+    let http3 = await attempt(apiURL, session: http3Session, assumesHTTP3: true)
+      .outcome(expectingProtocol: "h3")
+    let control = await attempt(controlURL, session: tls12Session).outcome(expectingProtocol: nil)
+
+    return ConnectivityProbeResult(
+      apiTLS13: tls13, apiTLS12: tls12, apiHTTP3: http3, controlHost: control)
+  }
+
+  private struct Attempt {
+    var succeeded: Bool
+    var negotiatedProtocol: String?
+
+    /// Map a raw attempt to an outcome. When `expectingProtocol` is set (the HTTP/3 probe),
+    /// a success that negotiated a different protocol counts as `fellBack`, not `success`.
+    func outcome(expectingProtocol expected: String?) -> ProbeOutcome {
+      guard succeeded else { return .failure }
+      if let expected, negotiatedProtocol != expected { return .fellBack }
+      return .success
+    }
+  }
+
+  private static func attempt(
+    _ url: URL,
+    session: URLSession,
+    assumesHTTP3: Bool = false
+  ) async -> Attempt {
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 10
+    if assumesHTTP3 { request.assumesHTTP3Capable = true }
+
+    let collector = ProbeMetricsCollector()
+    do {
+      let (_, response) = try await session.data(for: request, delegate: collector)
+      let httpOK =
+        (response as? HTTPURLResponse).map { (200..<300).contains($0.statusCode) } ?? false
+      // A cache hit is not a network measurement — reject it so we never report a transport as
+      // reachable without an actual handshake.
+      let ok = httpOK && !collector.servedFromCache
+      return Attempt(succeeded: ok, negotiatedProtocol: collector.negotiatedProtocol)
+    } catch {
+      return Attempt(succeeded: false, negotiatedProtocol: collector.negotiatedProtocol)
+    }
+  }
+}
+
+/// Captures the negotiated network protocol ("h3" / "h2" / "http/1.1") for a task so the
+/// HTTP/3 probe can tell a real QUIC success from a silent TCP fallback.
+private final class ProbeMetricsCollector: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+  private let lock = NSLock()
+  private var storedProtocol: String?
+  private var storedServedFromCache = false
+
+  var negotiatedProtocol: String? {
+    lock.lock()
+    defer { lock.unlock() }
+    return storedProtocol
+  }
+
+  /// True only when the response positively came from a local cache (not a network load).
+  var servedFromCache: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return storedServedFromCache
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didFinishCollecting metrics: URLSessionTaskMetrics
+  ) {
+    let last = metrics.transactionMetrics.last
+    lock.lock()
+    storedProtocol = last?.networkProtocolName
+    storedServedFromCache = last?.resourceFetchType == .localCache
+    lock.unlock()
+  }
+}

--- a/PlayolaRadio/Core/API/ConnectivityProbe.swift
+++ b/PlayolaRadio/Core/API/ConnectivityProbe.swift
@@ -6,6 +6,7 @@
 //
 
 import Dependencies
+import DependenciesMacros
 import Foundation
 import Sharing
 
@@ -71,8 +72,10 @@ enum ConnectivityProbe {
   /// fails do we consult the control host to separate "it's just us" from "network is down".
   static func diagnose(_ result: ConnectivityProbeResult) -> ProbeDiagnosis {
     if result.apiTLS13 == .success {
-      // Real requests ride the capped TLS 1.2 path; if 1.3 works but 1.2 doesn't, the cap
-      // itself is the problem here — surface it instead of hiding it under `.healthy`.
+      // Real requests ride the capped TLS 1.2 path; if 1.3 works but 1.2 explicitly fails, the
+      // cap itself is the problem here — surface it instead of hiding it under `.healthy`. The
+      // runner only ever produces `.success`/`.failure` for TLS 1.2, so any non-`.failure` value
+      // (including an unreachable `.skipped`) means "1.3 works, no capped-path evidence" → healthy.
       return result.apiTLS12 == .failure ? .cappedPathBroken : .healthy
     }
     if result.apiTLS12 == .success { return .clientHelloDrop }
@@ -118,6 +121,30 @@ func runConnectivityProbe() async {
   $lastSentBuild.withLock { $0 = currentBuild }
 }
 
+// MARK: - Dependency
+
+/// Wraps the launch-time probe so it can be overridden. The live value performs real network I/O;
+/// the test value is a no-op so test suites don't fire probes on every app-host launch.
+@DependencyClient
+struct ConnectivityProbeClient: Sendable {
+  var run: @Sendable () async -> Void
+}
+
+extension ConnectivityProbeClient: TestDependencyKey {
+  static let testValue = Self(run: {})
+}
+
+extension ConnectivityProbeClient: DependencyKey {
+  static let liveValue = Self(run: { await runConnectivityProbe() })
+}
+
+extension DependencyValues {
+  var connectivityProbe: ConnectivityProbeClient {
+    get { self[ConnectivityProbeClient.self] }
+    set { self[ConnectivityProbeClient.self] = newValue }
+  }
+}
+
 extension ConnectivityProbe {
   /// A small unauthenticated endpoint, cheap to hit repeatedly.
   private static let apiProbePath = "/v1/app-version-requirements"
@@ -153,7 +180,10 @@ extension ConnectivityProbe {
   private static let tls12Session = URLSession(
     configuration: PlayolaTLS.mitigated(probeBaseConfiguration()))
 
-  /// Forced TLS 1.3, used with `assumesHTTP3Capable` requests to probe QUIC/UDP.
+  /// Forced TLS 1.3, used with `assumesHTTP3Capable` requests to probe QUIC/UDP. Deliberately a
+  /// SEPARATE session from `tls13Session` (despite the identical configuration): a shared session
+  /// would let this sequential request reuse the TLS 1.3 probe's already-open HTTP/2 TCP
+  /// connection and never attempt QUIC, silently defeating the h3 measurement.
   private static let http3Session = URLSession(configuration: forcedTLS13Configuration())
 
   static func run(baseURL: URL) async -> ConnectivityProbeResult {

--- a/PlayolaRadio/Core/API/ConnectivityProbeTests.swift
+++ b/PlayolaRadio/Core/API/ConnectivityProbeTests.swift
@@ -12,6 +12,7 @@ import Testing
 @testable import PlayolaRadio
 
 @Suite(.freshSharedState)
+@MainActor
 struct ConnectivityProbeTests {
 
   // MARK: - diagnose
@@ -73,6 +74,14 @@ struct ConnectivityProbeTests {
   func skippedControlWithFailingApiIsIndeterminate() {
     let result = ConnectivityProbeResult(
       apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .failure, controlHost: .skipped)
+    #expect(ConnectivityProbe.diagnose(result) == .indeterminate)
+  }
+
+  @Test
+  func fellBackControlWithFailingApiIsIndeterminate() {
+    // Covers the `.fellBack` half of the `case .fellBack, .skipped` control arm.
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .failure, controlHost: .fellBack)
     #expect(ConnectivityProbe.diagnose(result) == .indeterminate)
   }
 

--- a/PlayolaRadio/Core/API/ConnectivityProbeTests.swift
+++ b/PlayolaRadio/Core/API/ConnectivityProbeTests.swift
@@ -1,0 +1,109 @@
+//
+//  ConnectivityProbeTests.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 7/10/26.
+//
+
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+struct ConnectivityProbeTests {
+
+  // MARK: - diagnose
+
+  @Test
+  func tls13AndTls12SuccessIsHealthy() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .success, apiTLS12: .success, apiHTTP3: .failure, controlHost: .failure)
+    #expect(ConnectivityProbe.diagnose(result) == .healthy)
+  }
+
+  @Test
+  func tls13SuccessButCappedTls12FailureIsCappedPathBroken() {
+    // Real requests ride the capped 1.2 path, so 1.3-works-but-1.2-fails means the cap itself
+    // is breaking this network — must not be hidden under `.healthy`.
+    let result = ConnectivityProbeResult(
+      apiTLS13: .success, apiTLS12: .failure, apiHTTP3: .success, controlHost: .success)
+    #expect(ConnectivityProbe.diagnose(result) == .cappedPathBroken)
+  }
+
+  @Test
+  func tls13FailsButTls12WorksIsClientHelloDrop() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .success, apiHTTP3: .failure, controlHost: .failure)
+    #expect(ConnectivityProbe.diagnose(result) == .clientHelloDrop)
+  }
+
+  @Test
+  func tcpFailsButHttp3WorksIsHttp3Rescues() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .success, controlHost: .failure)
+    #expect(ConnectivityProbe.diagnose(result) == .http3Rescues)
+  }
+
+  @Test
+  func http3FellBackDoesNotCountAsRescue() {
+    // A success that silently fell back to TCP/HTTP-2 is NOT an HTTP/3 win, so with every
+    // real API transport failing and the control up, this is host filtering.
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .fellBack, controlHost: .success)
+    #expect(ConnectivityProbe.diagnose(result) == .hostFiltered)
+  }
+
+  @Test
+  func allApiTransportsFailButControlWorksIsHostFiltered() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .failure, controlHost: .success)
+    #expect(ConnectivityProbe.diagnose(result) == .hostFiltered)
+  }
+
+  @Test
+  func everythingFailsIncludingControlIsNoConnectivity() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .failure, controlHost: .failure)
+    #expect(ConnectivityProbe.diagnose(result) == .noConnectivity)
+  }
+
+  @Test
+  func skippedControlWithFailingApiIsIndeterminate() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .failure, controlHost: .skipped)
+    #expect(ConnectivityProbe.diagnose(result) == .indeterminate)
+  }
+
+  // MARK: - tags
+
+  @Test
+  func tagsCarryEveryTransportAndDiagnosis() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .success, apiHTTP3: .fellBack, controlHost: .success)
+    expectNoDifference(
+      ConnectivityProbe.tags(for: result),
+      [
+        "tls13_probe_outcome": "failure",
+        "probe_api_tls13": "failure",
+        "probe_api_tls12": "success",
+        "probe_api_http3": "fellBack",
+        "probe_control": "success",
+        "probe_diagnosis": "clientHelloDrop",
+      ])
+  }
+
+  @Test
+  func tls13ProbeOutcomeStaysBackwardCompatibleWithTheOldProbe() {
+    // The legacy Sentry trend groups on `tls13_probe_outcome` = success/failure of the
+    // uncapped TLS 1.3 probe. That mapping must not drift.
+    let success = ConnectivityProbeResult(
+      apiTLS13: .success, apiTLS12: .success, apiHTTP3: .success, controlHost: .success)
+    #expect(ConnectivityProbe.tags(for: success)["tls13_probe_outcome"] == "success")
+
+    let failure = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .success, apiHTTP3: .success, controlHost: .success)
+    #expect(ConnectivityProbe.tags(for: failure)["tls13_probe_outcome"] == "failure")
+  }
+}

--- a/PlayolaRadio/Core/API/PlayolaTLS.swift
+++ b/PlayolaRadio/Core/API/PlayolaTLS.swift
@@ -1,0 +1,39 @@
+//
+//  PlayolaTLS.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 7/10/26.
+//
+
+import Foundation
+
+/// Single source of truth for the TEMPORARY iOS 26 TLS mitigation.
+///
+/// On iOS 26, URLSession sends a TLS 1.3 ClientHello that includes the X25519MLKEM768
+/// post-quantum hybrid key share (~1.1 KB). It spans two TCP segments, and some middleboxes
+/// (antivirus SSL inspection, parental-control routers, captive portals, etc.) drop the
+/// oversized ClientHello and surface it as NSURLErrorSecureConnectionFailed (-1200) — every
+/// request fails on those networks. Capping the session to TLS 1.2 keeps the ClientHello small
+/// enough to pass.
+///
+/// Every first-party URLSession / Alamofire session in the app routes through here so the
+/// policy lives in exactly one place. When we later make this adaptive (try 1.3, fall back to
+/// 1.2) or add HTTP/3, this is the seam to change.
+///
+/// REVERT WHEN: Apple ships an iOS 26 fix (watch the `tls13_probe` Sentry trend) OR exposes a
+/// supported opt-out for the post-quantum hybrid key share so we can keep TLS 1.3.
+enum PlayolaTLS {
+  /// Applies the TLS 1.2 cap to a configuration and returns it. Callers pass whatever base
+  /// configuration they need (default, Alamofire's default, or one with custom caching).
+  static func mitigated(_ configuration: URLSessionConfiguration) -> URLSessionConfiguration {
+    configuration.tlsMaximumSupportedProtocolVersion = .TLSv12
+    return configuration
+  }
+
+  /// Shared TLS-mitigated `URLSession` for FIRST-PARTY requests that do NOT go through
+  /// Alamofire (e.g. the listening-session reporter). Deliberately not used for remote artwork
+  /// loaders: those can hit third-party / TLS-1.3-only image hosts, where capping to 1.2 would
+  /// break loads on the healthy majority of networks for no real gain (artwork is cosmetic and
+  /// the main artwork path is SDWebImage, which is uncapped anyway).
+  static let sharedSession = URLSession(configuration: mitigated(.default))
+}

--- a/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
+++ b/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
@@ -67,7 +67,7 @@ public class UrlStreamListeningSessionReporter {
     }
 
     guard let request = createPostRequest(url: url, jsonData: jsonData) else { return }
-    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+    let task = PlayolaTLS.sharedSession.dataTask(with: request) { data, response, error in
       if let error = error {
         print("Error: \(error.localizedDescription)")
         return
@@ -100,7 +100,7 @@ public class UrlStreamListeningSessionReporter {
     }
 
     guard let request = createPostRequest(url: url, jsonData: jsonData) else { return }
-    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+    let task = PlayolaTLS.sharedSession.dataTask(with: request) { data, response, error in
       if let error = error {
         print("Error: \(error.localizedDescription)")
         return

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -235,8 +235,9 @@ struct PlayolaRadioApp: App {
     // (1.3 / 1.2 / HTTP/3) plus a control host. The aggregated `tls13_probe` Sentry events
     // (see `ConnectivityProbe`) tell us which remediation helps and when the iOS 26 middlebox
     // issue has cleared enough to revert the global TLS 1.2 cap.
+    @Dependency(\.connectivityProbe) var connectivityProbe
     Task {
-      await runConnectivityProbe()
+      await connectivityProbe.run()
     }
   }
 

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -231,12 +231,12 @@ struct PlayolaRadioApp: App {
       await analytics.initialize()
     }
 
-    // Once per build per device, probe whether TLS 1.3 works on this user's
-    // network. The aggregated `tls13_probe` Sentry events tell us when the iOS
-    // 26 middlebox issue has cleared enough to revert the global TLS 1.2 cap
-    // in APIClient+Live.swift.
+    // Once per build per device, probe how this user's network handles TLS to our API
+    // (1.3 / 1.2 / HTTP/3) plus a control host. The aggregated `tls13_probe` Sentry events
+    // (see `ConnectivityProbe`) tell us which remediation helps and when the iOS 26 middlebox
+    // issue has cleared enough to revert the global TLS 1.2 cap.
     Task {
-      await probeTLS13()
+      await runConnectivityProbe()
     }
   }
 


### PR DESCRIPTION
The global TLS 1.2 cap covered every Alamofire call, but the listening-session reporter still hit our API over uncapped `URLSession.shared` and silently failed on the broken-middlebox networks the cap exists for; this moves the cap into a single `PlayolaTLS` source of truth and routes the reporter through it. It also replaces the single uncapped-1.3 `probeTLS13()` with `ConnectivityProbe`, which measures our API over TLS 1.3, TLS 1.2, and HTTP/3 (verified via the negotiated protocol) plus a same-CDN control host, then reports one `tls13_probe` Sentry event per build with a new `probe_diagnosis` tag (`healthy` / `cappedPathBroken` / `clientHelloDrop` / `http3Rescues` / `hostFiltered` / `noConnectivity`). The legacy `tls13_probe_outcome` tag is preserved so the existing trend keeps working. This is the instrument-first step whose aggregate diagnosis will tell us whether to enable HTTP/3 or drop the cap; image loaders are intentionally left uncapped since they can hit third-party/TLS-1.3-only art hosts. Verified: full suite 1181/1181 passes, build clean with warnings-as-errors on both app targets (Xcode 26.5), lint clean, and an adversarial Codex review (1 P1 + 2 P2 found and fixed, re-review clean).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic connectivity diagnostics to identify network compatibility issues across supported connection types.
  * Improved network connection handling for greater reliability on affected devices and networks.
  * Added safeguards to prevent repeated connectivity checks during the same app build.

* **Bug Fixes**
  * Improved audio session reporting reliability by applying the app’s network compatibility settings consistently.

* **Tests**
  * Added coverage for connectivity diagnosis scenarios, fallback behavior, and reporting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->