### PR TITLE
Derive TestFlight build number from App Store Connect

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,37 +41,44 @@ def committed_build_number
   File.read(pbxproj).scan(/CURRENT_PROJECT_VERSION = (\d+);/).flatten.map(&:to_i).max || 0
 end
 
+# Highest build number that exists for the app on App Store Connect, across ALL
+# marketing versions and processing states. Deliberately NOT latest_testflight_build_number:
+# that action sorts by uploadedDate and returns the most recently *uploaded* build, which
+# is not necessarily the numeric max — an out-of-order or cross-marketing-version upload
+# could hand back a lower number that then collides. Build.all paginates every build, so
+# taking the numeric max in Ruby is immune to upload order and to API string-sort quirks.
+# Requires Spaceship auth (asc_api_key sets the token via set_spaceship_token).
+def highest_testflight_build_number(app_identifier:)
+  app = Spaceship::ConnectAPI::App.find(app_identifier)
+  UI.user_error!("App #{app_identifier} not found on App Store Connect — check credentials/identifier.") unless app
+  Spaceship::ConnectAPI::Build.all(app_id: app.id).map { |b| b.version.to_i }.max || 0
+end
+
 # Derive the TestFlight build number from App Store Connect instead of trusting the
 # checked-in CURRENT_PROJECT_VERSION. Hotfix and release branches historically drifted
 # out of sync and reused a build number (7.3.0 and 7.3.1 both shipped as build 98,
 # because develop still read 97 when 7.3.1 was cut). Querying ASC for the highest build
 # that exists for THIS app and adding one makes collisions structurally impossible,
 # independent of branch or marketing version.
-def next_testflight_build_number(app_identifier:, api_key:)
-  latest = latest_testflight_build_number(
-    api_key: api_key,
-    app_identifier: app_identifier,
-    initial_build_number: 0
-  ).to_i
+def next_testflight_build_number(app_identifier:)
+  latest = highest_testflight_build_number(app_identifier: app_identifier)
 
-  # Hard guard: a non-positive result means the ASC query failed (auth error, wrong
-  # app, network) — these apps always have upload history. Fail loudly rather than
-  # ship build 1. This is the "did the query actually work" preflight check.
+  # Hard guard: zero means no builds were returned — either the query failed or we are
+  # pointed at the wrong app (these apps always have upload history). Fail loudly rather
+  # than ship build 1. This is the "did the query actually work" preflight check.
   if latest <= 0
     UI.user_error!(
-      "latest_testflight_build_number returned #{latest} for #{app_identifier}. " \
-      "The App Store Connect query likely failed (auth/network/wrong app) — refusing to upload."
+      "No builds found for #{app_identifier} on App Store Connect (query failed or wrong app) — refusing to upload."
     )
   end
 
-  # Use the committed CURRENT_PROJECT_VERSION only as a LOWER BOUND, never as an
-  # equality guard. latest_testflight_build_number returns the most recent upload,
-  # which is not guaranteed to be the numeric max; the committed floor guards against
-  # that under-reporting. It is per-app safe: staging is a separate ASC sequence that
-  # may legitimately trail prod, so this advances its number rather than failing closed.
+  # Keep the committed CURRENT_PROJECT_VERSION as a redundant LOWER BOUND. ASC is the
+  # source of truth, but this cheaply covers eventual-consistency gaps (a just-uploaded
+  # build not yet listed). It is per-app safe: staging is a separate ASC sequence that
+  # may legitimately trail prod, so this only ever advances the number, never blocks it.
   floor = committed_build_number
   nxt = [latest, floor].max + 1
-  UI.message("Build number for #{app_identifier}: #{nxt} (ASC latest #{latest}, committed floor #{floor})")
+  UI.message("Build number for #{app_identifier}: #{nxt} (ASC max #{latest}, committed floor #{floor})")
   nxt
 end
 
@@ -96,7 +103,10 @@ platform :ios do
       key_content: key,
       # A raw PEM always contains the literal "-----BEGIN"; base64 never can
       # (its alphabet has no dashes), so this disambiguates the two reliably.
-      is_key_content_base64: !key.include?("-----BEGIN")
+      is_key_content_base64: !key.include?("-----BEGIN"),
+      # Authorize direct Spaceship::ConnectAPI queries (highest_testflight_build_number)
+      # in addition to returning the key hash for upload_to_testflight.
+      set_spaceship_token: true
     )
   end
 
@@ -113,8 +123,7 @@ platform :ios do
 
     api_key = asc_api_key
     build_number = next_testflight_build_number(
-      app_identifier: "fm.playola.playolaradio.staging",
-      api_key: api_key
+      app_identifier: "fm.playola.playolaradio.staging"
     )
 
     build_app(
@@ -187,8 +196,7 @@ platform :ios do
 
     api_key = asc_api_key
     build_number = next_testflight_build_number(
-      app_identifier: "fm.playola.playolaradio",
-      api_key: api_key
+      app_identifier: "fm.playola.playolaradio"
     )
 
     build_app(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,6 +33,48 @@ def print_failed_tests_summary(output_dir)
   end
 end
 
+# Highest CURRENT_PROJECT_VERSION committed in the project. Used only as a lower
+# bound for the derived build number — never as the shipped value on its own.
+# Returns 0 if the setting can't be parsed so callers can still fall back to ASC.
+def committed_build_number
+  pbxproj = File.expand_path("../PlayolaRadio.xcodeproj/project.pbxproj", __dir__)
+  File.read(pbxproj).scan(/CURRENT_PROJECT_VERSION = (\d+);/).flatten.map(&:to_i).max || 0
+end
+
+# Derive the TestFlight build number from App Store Connect instead of trusting the
+# checked-in CURRENT_PROJECT_VERSION. Hotfix and release branches historically drifted
+# out of sync and reused a build number (7.3.0 and 7.3.1 both shipped as build 98,
+# because develop still read 97 when 7.3.1 was cut). Querying ASC for the highest build
+# that exists for THIS app and adding one makes collisions structurally impossible,
+# independent of branch or marketing version.
+def next_testflight_build_number(app_identifier:, api_key:)
+  latest = latest_testflight_build_number(
+    api_key: api_key,
+    app_identifier: app_identifier,
+    initial_build_number: 0
+  ).to_i
+
+  # Hard guard: a non-positive result means the ASC query failed (auth error, wrong
+  # app, network) — these apps always have upload history. Fail loudly rather than
+  # ship build 1. This is the "did the query actually work" preflight check.
+  if latest <= 0
+    UI.user_error!(
+      "latest_testflight_build_number returned #{latest} for #{app_identifier}. " \
+      "The App Store Connect query likely failed (auth/network/wrong app) — refusing to upload."
+    )
+  end
+
+  # Use the committed CURRENT_PROJECT_VERSION only as a LOWER BOUND, never as an
+  # equality guard. latest_testflight_build_number returns the most recent upload,
+  # which is not guaranteed to be the numeric max; the committed floor guards against
+  # that under-reporting. It is per-app safe: staging is a separate ASC sequence that
+  # may legitimately trail prod, so this advances its number rather than failing closed.
+  floor = committed_build_number
+  nxt = [latest, floor].max + 1
+  UI.message("Build number for #{app_identifier}: #{nxt} (ASC latest #{latest}, committed floor #{floor})")
+  nxt
+end
+
 platform :ios do
   before_all do
     setup_circle_ci if ENV['CI']
@@ -69,12 +111,18 @@ platform :ios do
       readonly: true
     )
 
+    api_key = asc_api_key
+    build_number = next_testflight_build_number(
+      app_identifier: "fm.playola.playolaradio.staging",
+      api_key: api_key
+    )
+
     build_app(
       project: "PlayolaRadio.xcodeproj",
       scheme: "PlayolaRadio-Staging",
       export_method: "app-store",
       output_directory: "./build",
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation",
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation CURRENT_PROJECT_VERSION=#{build_number}",
       export_options: {
         method: "app-store",
         # sentry-cocoa's SwiftPM `Sentry` product links statically (its symbols
@@ -96,8 +144,6 @@ platform :ios do
       project_slug: 'apple-ios',
       include_sources: true
     )
-
-    api_key = asc_api_key
 
     upload_to_testflight(
       api_key: api_key,
@@ -139,12 +185,18 @@ platform :ios do
     print_failed_tests_summary('./fastlane/test_output/xctest') if test_error
     raise test_error if test_error
 
+    api_key = asc_api_key
+    build_number = next_testflight_build_number(
+      app_identifier: "fm.playola.playolaradio",
+      api_key: api_key
+    )
+
     build_app(
       project: "PlayolaRadio.xcodeproj",
       scheme: "PlayolaRadio",
       export_method: "app-store",
       output_directory: "./build",
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation",
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation CURRENT_PROJECT_VERSION=#{build_number}",
       export_options: {
         method: "app-store",
         # See release_staging for rationale: Sentry links statically but Xcode
@@ -164,8 +216,6 @@ platform :ios do
       project_slug: 'apple-ios',
       include_sources: true
     )
-
-    api_key = asc_api_key
 
     upload_to_testflight(
       api_key: api_key,


### PR DESCRIPTION
Both release lanes hand-trusted the checked-in `CURRENT_PROJECT_VERSION`, which drifts across git-flow branches — that is why 7.3.0 and 7.3.1 both shipped as build 98 (develop still read 97 when 7.3.1 was cut off it). Now `release_staging` and `release_production` derive the build number per-app from `latest_testflight_build_number + 1` and inject it at build time via xcargs (`GENERATE_INFOPLIST_FILE` synthesizes `CFBundleVersion` from `CURRENT_PROJECT_VERSION`, so no agvtool or working-tree edit is needed). The committed pbxproj value now only acts as a lower-bound floor guarding against ASC under-reporting, and a non-positive ASC result fails the release loudly so a broken query can't ship build 1. Prod and staging are queried separately since they are distinct ASC apps with independent build sequences. Going forward the manual `CURRENT_PROJECT_VERSION` bump is retired — releases only need to bump `MARKETING_VERSION`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * TestFlight builds now receive automatically calculated build numbers based on the latest App Store Connect build and the project’s committed version.
  * Prevented invalid or duplicate build numbers during staging and production releases.
  * Applied consistent build-number handling across both release workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->