### PR TITLE
Instrument forced-upgrade gate (Shown/Update-Tapped analytics)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ claude-files/
 DerivedData/
 
 .sentryclirc
+
+# Swift compile cache from CLI xcodebuild runs
+.swift-cache/

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -105,6 +105,9 @@
 		D30F005E2E8592F0007BCC73 /* CPListItem+InitWithRemoteUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C22D3E871800E4E926 /* CPListItem+InitWithRemoteUrl.swift */; };
 		D30F005F2E8592F0007BCC73 /* MainContainerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744AC2E2FCD8E0042A427 /* MainContainerModel.swift */; };
 		D30F00602E8592F0007BCC73 /* ContactPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39591162E39932300720CF8 /* ContactPageModel.swift */; };
+		E1AB0000000000000000AB01 /* AppVersionGateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA01 /* AppVersionGateModel.swift */; };
+		E1AB0000000000000000AB02 /* AppVersionGateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA01 /* AppVersionGateModel.swift */; };
+		E1AB0000000000000000AB03 /* AppVersionGateModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */; };
 		D30F00612E8592F0007BCC73 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
 		D30F00622E8592F0007BCC73 /* MailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E57D2BFD750700B9E35B /* MailService.swift */; };
 		D30F00632E8592F0007BCC73 /* FRadioPlayerMetadata+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E56E2BFD306600B9E35B /* FRadioPlayerMetadata+Equatable.swift */; };
@@ -710,6 +713,8 @@
 		D382671B2E00C13E0006BAC2 /* SmallPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallPlayer.swift; sourceTree = "<group>"; };
 		D39591142E39931D00720CF8 /* ContactPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPageView.swift; sourceTree = "<group>"; };
 		D39591162E39932300720CF8 /* ContactPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPageModel.swift; sourceTree = "<group>"; };
+		E1AB0000000000000000AA01 /* AppVersionGateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionGateModel.swift; sourceTree = "<group>"; };
+		E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionGateModelTests.swift; sourceTree = "<group>"; };
 		D39591182E39932800720CF8 /* ContactPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPageTests.swift; sourceTree = "<group>"; };
 		D39591252E3BB6FC00720CF8 /* EditProfilePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfilePageView.swift; sourceTree = "<group>"; };
 		D39591272E3BB70500720CF8 /* EditProfilePageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfilePageModel.swift; sourceTree = "<group>"; };
@@ -1072,6 +1077,7 @@
 		D339E55C2BFD0FB000B9E35B /* Pages */ = {
 			isa = PBXGroup;
 			children = (
+				E1AB0000000000000000AC01 /* AppVersionGate */,
 				D3776A022F22BA1A00200ADF /* AskQuestionPage */,
 				D3776A162F243F7A00200ADF /* BroadcastersListenerQuestionPage */,
 				D3219C152EDD22060008AFDA /* BroadcastPage */,
@@ -1544,6 +1550,15 @@
 			path = PushNotifications;
 			sourceTree = "<group>";
 		};
+		E1AB0000000000000000AC01 /* AppVersionGate */ = {
+			isa = PBXGroup;
+			children = (
+				E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */,
+				E1AB0000000000000000AA01 /* AppVersionGateModel.swift */,
+			);
+			path = AppVersionGate;
+			sourceTree = "<group>";
+		};
 		D39591132E39930500720CF8 /* ContactPage */ = {
 			isa = PBXGroup;
 			children = (
@@ -2010,6 +2025,7 @@
 				FE110A0000000000000000B3 /* WelcomeMessagePageView.swift in Sources */,
 				D30C01C52F5C9C8400889E6D /* UserPrize.swift in Sources */,
 				D30F00602E8592F0007BCC73 /* ContactPageModel.swift in Sources */,
+				E1AB0000000000000000AB01 /* AppVersionGateModel.swift in Sources */,
 				D3F493BB2EEDD2B3008ED463 /* RecordPageView.swift in Sources */,
 				D30F00612E8592F0007BCC73 /* Toast.swift in Sources */,
 				D30F00622E8592F0007BCC73 /* MailService.swift in Sources */,
@@ -2205,6 +2221,7 @@
 				FE110A0000000000000000B6 /* WelcomeMessagePageView.swift in Sources */,
 				D30C01C62F5C9C8500889E6D /* UserPrize.swift in Sources */,
 				D39591172E39932600720CF8 /* ContactPageModel.swift in Sources */,
+				E1AB0000000000000000AB02 /* AppVersionGateModel.swift in Sources */,
 				D3F493BC2EEDD2B3008ED463 /* RecordPageView.swift in Sources */,
 				D302576B2E63423D00F4228B /* Toast.swift in Sources */,
 				D339E57E2BFD750700B9E35B /* MailService.swift in Sources */,
@@ -2401,6 +2418,7 @@
 				D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */,
 				E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */,
 				D395911A2E39933800720CF8 /* ContactPageTests.swift in Sources */,
+				E1AB0000000000000000AB03 /* AppVersionGateModelTests.swift in Sources */,
 				D3B744BC2E312FB60042A427 /* ListeningTrackerTests.swift in Sources */,
 				D3B744A82E2F185F0042A427 /* SmallPlayerTests.swift in Sources */,
 				F94F092AC0FB044790B38A0E /* GiveawayModelsTests.swift in Sources */,

--- a/PlayolaRadio/Core/Analytics/AnalyticsEvent.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsEvent.swift
@@ -16,6 +16,10 @@ enum AnalyticsEvent: Equatable {
   case appBackgrounded
   case appForegrounded
 
+  // MARK: App Version Gate
+  case updateGateShown(currentVersion: String, requiredVersion: String, trigger: UpdateGateTrigger)
+  case updateGateUpdateTapped(currentVersion: String, requiredVersion: String)
+
   // MARK: Authentication
   case signInStarted(method: AuthMethod)
   case signInCompleted(method: AuthMethod, userId: String)
@@ -86,6 +90,8 @@ extension AnalyticsEvent {
     case .appOpened: return "App Opened"
     case .appBackgrounded: return "App Backgrounded"
     case .appForegrounded: return "App Foregrounded"
+    case .updateGateShown: return "Update Gate Shown"
+    case .updateGateUpdateTapped: return "Update Gate Update Tapped"
     case .signInStarted: return "Sign In Started"
     case .signInCompleted: return "Sign In Completed"
     case .signInFailed: return "Sign In Failed"
@@ -137,6 +143,19 @@ extension AnalyticsEvent {
 
     case .appBackgrounded, .appForegrounded:
       return [:]
+
+    case .updateGateShown(let currentVersion, let requiredVersion, let trigger):
+      return [
+        "current_version": currentVersion,
+        "required_version": requiredVersion,
+        "trigger": trigger.rawValue,
+      ]
+
+    case .updateGateUpdateTapped(let currentVersion, let requiredVersion):
+      return [
+        "current_version": currentVersion,
+        "required_version": requiredVersion,
+      ]
 
     case .signInStarted(let method):
       return ["method": method.rawValue]
@@ -325,6 +344,15 @@ enum AppOpenSource: String {
   case pushNotification = "push_notification"
   case sharedLink = "shared_link"
   case deepLink = "deep_link"
+}
+
+enum UpdateGateTrigger: String {
+  /// User's app version is below the general minimum required version.
+  case minimumVersion = "minimum_version"
+  /// A known broadcaster's app version is below the broadcaster minimum, detected on launch.
+  case broadcaster = "broadcaster"
+  /// The user was newly discovered to be a broadcaster mid-session while below the broadcaster minimum.
+  case broadcasterDiscovered = "broadcaster_discovered"
 }
 
 enum AuthMethod: String {

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -11,6 +11,7 @@ import Dependencies
 import Foundation
 import Sharing
 import SwiftUI
+import UIKit
 
 @MainActor
 @Observable
@@ -28,19 +29,17 @@ class AppVersionGateModel: ViewModel {
 
   // MARK: - Properties
 
-  var requiresUpdate = false
-
-  /// The versions the currently-shown gate was presented with, so the
-  /// "Update Tapped" event reports the same required_version as its "Shown"
-  /// event (rather than re-deriving it and mislabeling broadcaster gates).
-  private var activeGate: (currentVersion: String, requiredVersion: String)?
-
-  // MARK: - Display Text
+  var presentedAlert: PlayolaAlert?
 
   let alertTitle = "Update Required"
   let alertMessage = "A new version of Playola Radio is available. Please update to continue."
   let updateButtonTitle = "Update"
   let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id6480465361")!
+
+  /// The versions the currently-shown gate was presented with, so the
+  /// "Update Tapped" event reports the same required_version as its "Shown"
+  /// event (rather than re-deriving it and mislabeling broadcaster gates).
+  @ObservationIgnored private var activeGate: (currentVersion: String, requiredVersion: String)?
 
   // MARK: - User Actions
 
@@ -77,15 +76,18 @@ class AppVersionGateModel: ViewModel {
   /// a broadcaster on a too-old build (via the `.requiresAppUpdate` notification).
   func broadcasterUpdateDiscovered() async {
     let currentVersion = Bundle.main.releaseVersionNumber ?? ""
-    let requiredVersion = appVersionRequirements?.minimumBroadcasterVersion ?? currentVersion
+    // If requirements haven't loaded yet, report an empty (unknown) required
+    // version rather than the current build, which would be a nonsensical
+    // "required version" in the analytics.
+    let requiredVersion = appVersionRequirements?.minimumBroadcasterVersion ?? ""
     await presentUpdateGate(
       currentVersion: currentVersion,
       requiredVersion: requiredVersion,
       trigger: .broadcasterDiscovered)
   }
 
-  /// Tracks the tap. The caller (the view) must `await` this before opening the
-  /// App Store, so the event is enqueued before the app is backgrounded and lost.
+  /// Tracks the tap. Called from the alert action before opening the App Store,
+  /// so the event is enqueued before the app is backgrounded and the event lost.
   func updateButtonTapped() async {
     let currentVersion = activeGate?.currentVersion ?? Bundle.main.releaseVersionNumber ?? ""
     let requiredVersion =
@@ -101,15 +103,27 @@ class AppVersionGateModel: ViewModel {
     requiredVersion: String,
     trigger: UpdateGateTrigger
   ) async {
-    // Only track on the false → true transition so repeated launches/notifications
-    // for an already-shown gate don't inflate "shown" counts.
-    guard !requiresUpdate else { return }
-    requiresUpdate = true
+    // Only present/track on the not-shown → shown transition so repeated launches
+    // or notifications for an already-shown gate don't inflate "shown" counts.
+    guard presentedAlert == nil else { return }
     activeGate = (currentVersion, requiredVersion)
+    presentedAlert = makeUpdateRequiredAlert()
     await analytics.track(
       .updateGateShown(
         currentVersion: currentVersion,
         requiredVersion: requiredVersion,
         trigger: trigger))
+  }
+
+  private func makeUpdateRequiredAlert() -> PlayolaAlert {
+    PlayolaAlert(
+      title: alertTitle,
+      message: alertMessage,
+      primaryButtonText: updateButtonTitle,
+      primaryAction: { [weak self] in
+        guard let self else { return }
+        await self.updateButtonTapped()
+        _ = await UIApplication.shared.open(self.appStoreURL)
+      })
   }
 }

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -1,0 +1,115 @@
+//
+//  AppVersionGateModel.swift
+//  PlayolaRadio
+//
+//  Owns the "Update Required" forced-upgrade gate: it decides whether the
+//  running build is too old to continue, drives the blocking alert, and
+//  instruments the gate so we can measure whether users update or abandon.
+//
+
+import Dependencies
+import Foundation
+import Sharing
+import SwiftUI
+
+@MainActor
+@Observable
+class AppVersionGateModel: ViewModel {
+
+  // MARK: - Dependencies
+
+  @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.analytics) var analytics
+
+  // MARK: - Shared State
+
+  @ObservationIgnored @Shared(.appVersionRequirements) var appVersionRequirements
+  @ObservationIgnored @Shared(.isBroadcaster) var isBroadcaster
+
+  // MARK: - Properties
+
+  var requiresUpdate = false
+
+  /// The versions the currently-shown gate was presented with, so the
+  /// "Update Tapped" event reports the same required_version as its "Shown"
+  /// event (rather than re-deriving it and mislabeling broadcaster gates).
+  private var activeGate: (currentVersion: String, requiredVersion: String)?
+
+  // MARK: - Display Text
+
+  let alertTitle = "Update Required"
+  let alertMessage = "A new version of Playola Radio is available. Please update to continue."
+  let updateButtonTitle = "Update"
+  let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id6480465361")!
+
+  // MARK: - User Actions
+
+  func checkVersionRequirements() async {
+    do {
+      let requirements = try await api.getAppVersionRequirements()
+      $appVersionRequirements.withLock { $0 = requirements }
+
+      guard let currentVersion = Bundle.main.releaseVersionNumber else { return }
+
+      if isVersion(currentVersion, lessThan: requirements.minimumVersion) {
+        await presentUpdateGate(
+          currentVersion: currentVersion,
+          requiredVersion: requirements.minimumVersion,
+          trigger: .minimumVersion)
+        return
+      }
+
+      if isBroadcaster,
+        isVersion(currentVersion, lessThan: requirements.minimumBroadcasterVersion)
+      {
+        await presentUpdateGate(
+          currentVersion: currentVersion,
+          requiredVersion: requirements.minimumBroadcasterVersion,
+          trigger: .broadcaster)
+        return
+      }
+    } catch {
+      // Network failure → fail open (allow app)
+    }
+  }
+
+  /// Invoked when another part of the app discovers mid-session that the user is
+  /// a broadcaster on a too-old build (via the `.requiresAppUpdate` notification).
+  func broadcasterUpdateDiscovered() async {
+    let currentVersion = Bundle.main.releaseVersionNumber ?? ""
+    let requiredVersion = appVersionRequirements?.minimumBroadcasterVersion ?? currentVersion
+    await presentUpdateGate(
+      currentVersion: currentVersion,
+      requiredVersion: requiredVersion,
+      trigger: .broadcasterDiscovered)
+  }
+
+  /// Tracks the tap. The caller (the view) must `await` this before opening the
+  /// App Store, so the event is enqueued before the app is backgrounded and lost.
+  func updateButtonTapped() async {
+    let currentVersion = activeGate?.currentVersion ?? Bundle.main.releaseVersionNumber ?? ""
+    let requiredVersion =
+      activeGate?.requiredVersion ?? appVersionRequirements?.minimumVersion ?? ""
+    await analytics.track(
+      .updateGateUpdateTapped(currentVersion: currentVersion, requiredVersion: requiredVersion))
+  }
+
+  // MARK: - Private Helpers
+
+  private func presentUpdateGate(
+    currentVersion: String,
+    requiredVersion: String,
+    trigger: UpdateGateTrigger
+  ) async {
+    // Only track on the false → true transition so repeated launches/notifications
+    // for an already-shown gate don't inflate "shown" counts.
+    guard !requiresUpdate else { return }
+    requiresUpdate = true
+    activeGate = (currentVersion, requiredVersion)
+    await analytics.track(
+      .updateGateShown(
+        currentVersion: currentVersion,
+        requiredVersion: requiredVersion,
+        trigger: trigger))
+  }
+}

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
@@ -1,0 +1,228 @@
+//
+//  AppVersionGateModelTests.swift
+//  PlayolaRadio
+//
+
+import ConcurrencyExtras
+import Dependencies
+import Foundation
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+@MainActor
+struct AppVersionGateModelTests {
+
+  // A version far above any real build so the running bundle always compares as "too old".
+  private let unreachableVersion = "999.0.0"
+  // A version below any real build so the running bundle is always "up to date".
+  private let ancientVersion = "0.0.1"
+
+  private func gateShownEvents(_ events: [AnalyticsEvent]) -> [AnalyticsEvent] {
+    events.filter { if case .updateGateShown = $0 { return true } else { return false } }
+  }
+
+  @Test
+  func testShowsGateAndTracksWhenBelowMinimumVersion() async {
+    @Shared(.isBroadcaster) var isBroadcaster = false
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [unreachableVersion, ancientVersion] in
+        AppVersionRequirements(
+          minimumVersion: unreachableVersion, minimumBroadcasterVersion: ancientVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == true)
+      let shown = gateShownEvents(captured.value)
+      #expect(shown.count == 1)
+      #expect(
+        shown.first
+          == .updateGateShown(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: unreachableVersion,
+            trigger: .minimumVersion))
+    }
+  }
+
+  @Test
+  func testDoesNotShowGateWhenVersionIsCurrent() async {
+    @Shared(.isBroadcaster) var isBroadcaster = true
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [ancientVersion] in
+        AppVersionRequirements(
+          minimumVersion: ancientVersion, minimumBroadcasterVersion: ancientVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == false)
+      #expect(gateShownEvents(captured.value).isEmpty)
+    }
+  }
+
+  @Test
+  func testShowsBroadcasterGateWhenBroadcasterIsBelowBroadcasterMinimum() async {
+    @Shared(.isBroadcaster) var isBroadcaster = true
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [ancientVersion, unreachableVersion] in
+        AppVersionRequirements(
+          minimumVersion: ancientVersion, minimumBroadcasterVersion: unreachableVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == true)
+      let shown = gateShownEvents(captured.value)
+      #expect(shown.count == 1)
+      #expect(
+        shown.first
+          == .updateGateShown(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: unreachableVersion,
+            trigger: .broadcaster))
+    }
+  }
+
+  @Test
+  func testNonBroadcasterIsNotGatedByBroadcasterMinimum() async {
+    @Shared(.isBroadcaster) var isBroadcaster = false
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [ancientVersion, unreachableVersion] in
+        AppVersionRequirements(
+          minimumVersion: ancientVersion, minimumBroadcasterVersion: unreachableVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == false)
+      #expect(gateShownEvents(captured.value).isEmpty)
+    }
+  }
+
+  @Test
+  func testNetworkFailureFailsOpenAndTracksNothing() async {
+    @Shared(.isBroadcaster) var isBroadcaster = true
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    struct RequirementsError: Error {}
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { throw RequirementsError() }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == false)
+      #expect(captured.value.isEmpty)
+    }
+  }
+
+  @Test
+  func testBroadcasterDiscoveredNotificationShowsGateAndTracks() async {
+    @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
+      minimumVersion: "1.0.0", minimumBroadcasterVersion: "9.9.9")
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.broadcasterUpdateDiscovered()
+
+      #expect(model.requiresUpdate == true)
+      let shown = gateShownEvents(captured.value)
+      #expect(shown.count == 1)
+      #expect(
+        shown.first
+          == .updateGateShown(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: "9.9.9",
+            trigger: .broadcasterDiscovered))
+    }
+  }
+
+  @Test
+  func testUpdateTappedReusesShownGateRequiredVersion() async {
+    // A broadcaster gate is shown with the broadcaster minimum; the tap event must
+    // report that same required_version, not the general minimumVersion.
+    @Shared(.isBroadcaster) var isBroadcaster = true
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [ancientVersion, unreachableVersion] in
+        AppVersionRequirements(
+          minimumVersion: ancientVersion, minimumBroadcasterVersion: unreachableVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+      await model.updateButtonTapped()
+
+      #expect(
+        captured.value.contains(
+          .updateGateUpdateTapped(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: unreachableVersion)))
+    }
+  }
+
+  @Test
+  func testDuplicatePresentDoesNotDoubleTrackShown() async {
+    @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
+      minimumVersion: "1.0.0", minimumBroadcasterVersion: "9.9.9")
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.broadcasterUpdateDiscovered()
+      await model.broadcasterUpdateDiscovered()
+
+      #expect(model.requiresUpdate == true)
+      #expect(gateShownEvents(captured.value).count == 1)
+    }
+  }
+
+  @Test
+  func testUpdateButtonTappedTracksEvent() async {
+    @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
+      minimumVersion: "1.2.3", minimumBroadcasterVersion: "1.2.3")
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.updateButtonTapped()
+
+      #expect(
+        captured.value == [
+          .updateGateUpdateTapped(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: "1.2.3")
+        ])
+    }
+  }
+}

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
@@ -39,7 +39,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == true)
+      #expect(model.presentedAlert != nil)
       let shown = gateShownEvents(captured.value)
       #expect(shown.count == 1)
       #expect(
@@ -66,7 +66,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == false)
+      #expect(model.presentedAlert == nil)
       #expect(gateShownEvents(captured.value).isEmpty)
     }
   }
@@ -86,7 +86,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == true)
+      #expect(model.presentedAlert != nil)
       let shown = gateShownEvents(captured.value)
       #expect(shown.count == 1)
       #expect(
@@ -113,7 +113,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == false)
+      #expect(model.presentedAlert == nil)
       #expect(gateShownEvents(captured.value).isEmpty)
     }
   }
@@ -132,7 +132,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == false)
+      #expect(model.presentedAlert == nil)
       #expect(captured.value.isEmpty)
     }
   }
@@ -149,7 +149,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.broadcasterUpdateDiscovered()
 
-      #expect(model.requiresUpdate == true)
+      #expect(model.presentedAlert != nil)
       let shown = gateShownEvents(captured.value)
       #expect(shown.count == 1)
       #expect(
@@ -157,6 +157,28 @@ struct AppVersionGateModelTests {
           == .updateGateShown(
             currentVersion: Bundle.main.releaseVersionNumber ?? "",
             requiredVersion: "9.9.9",
+            trigger: .broadcasterDiscovered))
+    }
+  }
+
+  @Test
+  func testBroadcasterDiscoveredWithoutRequirementsReportsEmptyRequiredVersion() async {
+    // Requirements not loaded (fresh empty store): the gate still blocks, but must
+    // not masquerade the current build as the required version.
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.broadcasterUpdateDiscovered()
+
+      #expect(model.presentedAlert != nil)
+      #expect(
+        gateShownEvents(captured.value).first
+          == .updateGateShown(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: "",
             trigger: .broadcasterDiscovered))
     }
   }
@@ -200,7 +222,7 @@ struct AppVersionGateModelTests {
       await model.broadcasterUpdateDiscovered()
       await model.broadcasterUpdateDiscovered()
 
-      #expect(model.requiresUpdate == true)
+      #expect(model.presentedAlert != nil)
       #expect(gateShownEvents(captured.value).count == 1)
     }
   }

--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -17,12 +17,9 @@ extension Notification.Name {
 @MainActor
 struct ContentView: View {
   @Shared(.auth) var auth
-  @Shared(.appVersionRequirements) var appVersionRequirements
-  @Shared(.isBroadcaster) var isBroadcaster
-  @Dependency(\.api) var api
   @Dependency(\.analytics) var analytics
   @State private var hasTrackedAppOpen = false
-  @State private var requiresUpdate = false
+  @State private var versionGate = AppVersionGateModel()
 
   @Dependency(\.stationPlayer) private var stationPlayer
   @Dependency(\.nowPlayingUpdater) private var nowPlayingUpdater
@@ -37,10 +34,6 @@ struct ContentView: View {
     _ = nowPlayingUpdater
   }
 
-  private let appStoreURL = URL(
-    string: "itms-apps://itunes.apple.com/app/id6480465361"
-  )!
-
   var body: some View {
     Group {
       if auth.isLoggedIn {
@@ -50,18 +43,21 @@ struct ContentView: View {
       }
     }
     .alert(
-      "Update Required",
-      isPresented: $requiresUpdate
+      versionGate.alertTitle,
+      isPresented: $versionGate.requiresUpdate
     ) {
-      Button("Update") {
-        UIApplication.shared.open(appStoreURL)
-        requiresUpdate = true
+      Button(versionGate.updateButtonTitle) {
+        versionGate.requiresUpdate = true
+        Task {
+          await versionGate.updateButtonTapped()
+          _ = await UIApplication.shared.open(versionGate.appStoreURL)
+        }
       }
     } message: {
-      Text("A new version of Playola Radio is available. Please update to continue.")
+      Text(versionGate.alertMessage)
     }
     .task {
-      await checkVersionRequirements()
+      await versionGate.checkVersionRequirements()
 
       guard !hasTrackedAppOpen else { return }
       hasTrackedAppOpen = true
@@ -73,30 +69,7 @@ struct ContentView: View {
         ))
     }
     .onReceive(NotificationCenter.default.publisher(for: .requiresAppUpdate)) { _ in
-      requiresUpdate = true
-    }
-  }
-
-  private func checkVersionRequirements() async {
-    do {
-      let requirements = try await api.getAppVersionRequirements()
-      $appVersionRequirements.withLock { $0 = requirements }
-
-      guard let currentVersion = Bundle.main.releaseVersionNumber else { return }
-
-      if isVersion(currentVersion, lessThan: requirements.minimumVersion) {
-        requiresUpdate = true
-        return
-      }
-
-      if isBroadcaster,
-        isVersion(currentVersion, lessThan: requirements.minimumBroadcasterVersion)
-      {
-        requiresUpdate = true
-        return
-      }
-    } catch {
-      // Network failure → fail open (allow app)
+      Task { await versionGate.broadcasterUpdateDiscovered() }
     }
   }
 

--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -8,7 +8,6 @@
 import Dependencies
 import Sharing
 import SwiftUI
-import UIKit
 
 extension Notification.Name {
   static let requiresAppUpdate = Notification.Name("requiresAppUpdate")
@@ -42,20 +41,7 @@ struct ContentView: View {
         SignInPage(model: SignInPageModel())
       }
     }
-    .alert(
-      versionGate.alertTitle,
-      isPresented: $versionGate.requiresUpdate
-    ) {
-      Button(versionGate.updateButtonTitle) {
-        versionGate.requiresUpdate = true
-        Task {
-          await versionGate.updateButtonTapped()
-          _ = await UIApplication.shared.open(versionGate.appStoreURL)
-        }
-      }
-    } message: {
-      Text(versionGate.alertMessage)
-    }
+    .playolaAlert($versionGate.presentedAlert)
     .task {
       await versionGate.checkVersionRequirements()
 

--- a/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
@@ -45,6 +45,26 @@ struct PlayolaAlert: Equatable, Identifiable, Hashable {
     self.tertiaryAction = nil
   }
 
+  /// A single-button alert whose only action is `primaryAction` and which has no
+  /// dismiss/cancel button. Use for blocking prompts like a forced-update gate.
+  init(
+    title: String,
+    message: String?,
+    primaryButtonText: String,
+    primaryAction: @escaping @MainActor () async -> Void
+  ) {
+    self.title = title
+    self.message = message
+    self.dismissButton = nil
+    self.secondaryButton = nil
+    self.primaryButtonText = primaryButtonText
+    self.secondaryButtonText = nil
+    self.tertiaryButtonText = nil
+    self.primaryAction = primaryAction
+    self.secondaryAction = nil
+    self.tertiaryAction = nil
+  }
+
   init(
     title: String,
     message: String?,


### PR DESCRIPTION
Extracts the forced-upgrade "Update Required" gate out of `ContentView` into a testable `AppVersionGateModel` and adds two analytics events — `Update Gate Shown` (with trigger + current/required version) and `Update Gate Update Tapped` — so a future forced upgrade can be *measured* (shown → updated vs abandoned) instead of inferred from app-version telemetry. Also gitignores the `.swift-cache/` CLI build artifact.

Note: this only fires for builds that ship with the code, so it instruments **future** gates, not one already in flight. Tap analytics is enqueued before the App Store opens (so backgrounding doesn't drop it), the tap event reuses the shown gate's `required_version`, and duplicate presents don't double-count "shown". Covered by 9 unit tests (all passing); reviewed with Codex (no P1s; its P2s on tap-loss, required-version, and dedupe are fixed).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added app version checking to identify when an update is required.
  * Added update prompts for outdated app versions and newly discovered broadcaster updates.
  * Added analytics tracking for update prompts and update button selections.

* **Bug Fixes**
  * Update checks now fail open when version requirements cannot be retrieved, allowing the app to continue normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->