### PR TITLE
Gate giveaway 'coming up' surfaces on station being live

### DIFF
--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -206,7 +206,7 @@ class HomePageModel: ViewModel {
   }
 
   func hasUpcomingGiveawayForStation(_ stationId: String) -> Bool {
-    upcomingGiveaways[id: stationId] != nil
+    liveStatusForStation(stationId) != nil && upcomingGiveaways[id: stationId] != nil
   }
 
   // MARK: - Private Helpers

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -767,4 +767,52 @@ struct HomePageTests {
     }
   }
 
+  // MARK: - Giveaway Badge (live-gated) Tests
+
+  @Test
+  func testHasUpcomingGiveawayForStationTrueWhenStationIsLive() {
+    let station = Station.mockWith(id: "live-station", curatorName: "DJ Live")
+    @Shared(.liveStations) var liveStations = [
+      LiveStationInfo(stationId: "live-station", liveStatus: .showAiring, station: station)
+    ]
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e1", stationId: "live-station", prizeName: "Prize", winningNumber: 1,
+          status: .scheduled))
+    ]
+
+    let model = HomePageModel()
+
+    #expect(model.hasUpcomingGiveawayForStation("live-station"))
+  }
+
+  @Test
+  func testHasUpcomingGiveawayForStationFalseWhenStationNotLive() {
+    @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e1", stationId: "not-live-station", prizeName: "Prize", winningNumber: 1,
+          status: .scheduled))
+    ]
+
+    let model = HomePageModel()
+
+    #expect(!model.hasUpcomingGiveawayForStation("not-live-station"))
+  }
+
+  @Test
+  func testHasUpcomingGiveawayForStationFalseWhenLiveButNoGiveaway() {
+    let station = Station.mockWith(id: "live-station", curatorName: "DJ Live")
+    @Shared(.liveStations) var liveStations = [
+      LiveStationInfo(stationId: "live-station", liveStatus: .voicetracking, station: station)
+    ]
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = []
+
+    let model = HomePageModel()
+
+    #expect(!model.hasUpcomingGiveawayForStation("live-station"))
+  }
+
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModel.swift
@@ -15,6 +15,7 @@ class UpcomingGiveawayBannerModel: ViewModel {
   @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
   @ObservationIgnored @Shared(.activeGiveaway) var activeGiveaway
   @ObservationIgnored @Shared(.upcomingGiveaways) var upcomingGiveaways
+  @ObservationIgnored @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
 
   // MARK: - Initialization
   override init() {
@@ -41,9 +42,10 @@ class UpcomingGiveawayBannerModel: ViewModel {
 
   // MARK: - View Helpers
 
-  /// Visible only while the now-playing station has an upcoming giveaway and its contest has not yet
-  /// opened. Reading `activeGiveaway` is what lets the banner self-hide the instant the tap overlay
-  /// takes over.
+  /// Visible only while the now-playing station is live and has an upcoming giveaway whose contest has
+  /// not yet opened. Gating on `liveStations` mirrors the station-list / Home badge, so the banner
+  /// won't surface a giveaway that's still hours/days out. Reading `activeGiveaway` is what lets the
+  /// banner self-hide the instant the tap overlay takes over.
   var isVisible: Bool { upcomingGiveaway != nil }
 
   var bannerOpacity: Double { isVisible ? 1 : 0 }
@@ -72,6 +74,7 @@ class UpcomingGiveawayBannerModel: ViewModel {
 
   private var upcomingGiveaway: UpcomingGiveawayInfo? {
     guard let stationId = currentStation?.id,
+      liveStations.contains(where: { $0.stationId == stationId }),
       let info = upcomingGiveaways[id: stationId]
     else { return nil }
     if let active = activeGiveaway, active.status == .open, active.stationId == stationId {

--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
@@ -42,6 +42,12 @@ struct UpcomingGiveawayBannerModelTests {
         airingId: airingId))
   }
 
+  private func makeLiveStations(_ ids: String...) -> [LiveStationInfo] {
+    ids.map {
+      LiveStationInfo(stationId: $0, liveStatus: .showAiring, station: Station.mockWith(id: $0))
+    }
+  }
+
   /// Builds the model and simulates the once-a-minute tick having fired at `referenceNow`.
   private func makeModel() -> UpcomingGiveawayBannerModel {
     let model = UpcomingGiveawayBannerModel()
@@ -51,6 +57,7 @@ struct UpcomingGiveawayBannerModelTests {
 
   @Test func hiddenWhenNotPlayingAStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1")
     ]
@@ -62,6 +69,7 @@ struct UpcomingGiveawayBannerModelTests {
 
   @Test func hiddenWhenNoUpcomingForCurrentStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e2", station: "other")
     ]
@@ -69,9 +77,23 @@ struct UpcomingGiveawayBannerModelTests {
     #expect(model.isVisible == false)
   }
 
+  @Test func hiddenWhenCurrentStationNotLive() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      scheduled(id: "e1", station: "s1")
+    ]
+    let model = makeModel()
+    #expect(model.isVisible == false)
+    #expect(model.bannerOpacity == 0)
+    #expect(model.bannerText == "")
+  }
+
   @Test func visibleWithBannerTextWhenUpcomingForCurrentStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", prize: "Two tickets")
     ]
@@ -85,6 +107,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = GiveawayEvent(
       id: "e1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9, status: .open)
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1")
     ]
@@ -96,6 +119,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = GiveawayEvent(
       id: "eOther", stationId: "other", prizeName: "x", winningNumber: 9, status: .open)
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1")
     ]
@@ -107,6 +131,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(38 * 60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -124,6 +149,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(38 * 60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -136,6 +162,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(43 * 60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -148,6 +175,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(90))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -160,6 +188,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "other-airing", endTime: Self.referenceNow.addingTimeInterval(38 * 60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -171,6 +200,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: nil)
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -182,6 +212,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(-60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListLiveSortTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListLiveSortTests.swift
@@ -188,4 +188,90 @@ struct StationListLiveSortTests {
 
     expectNoDifference(model.cancellables.count, 3)
   }
+
+  // MARK: - Giveaway Badge (live-gated) Tests
+
+  @Test
+  func testGiveawayBadgeShowsOnlyOnLiveStations() async {
+    @Shared(.showSecretStations) var showSecretStations = false
+    let now = Date()
+
+    let liveStation = Station.mockWith(id: "live-station", name: "Live Station")
+    let offlineStation = Station.mockWith(id: "offline-station", name: "Offline Station")
+
+    let list = StationList(
+      id: "test-list",
+      name: "Test List",
+      slug: "test-list",
+      hidden: false,
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+      items: [
+        APIStationItem(sortOrder: 0, visibility: .visible, station: liveStation, urlStation: nil),
+        APIStationItem(
+          sortOrder: 1, visibility: .visible, station: offlineStation, urlStation: nil),
+      ]
+    )
+    @Shared(.stationLists) var stationLists = IdentifiedArray(uniqueElements: [list])
+    @Shared(.liveStations) var liveStations: [LiveStationInfo] = [
+      LiveStationInfo(stationId: "live-station", liveStatus: .showAiring, station: liveStation)
+    ]
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e-live", stationId: "live-station", prizeName: "Prize", winningNumber: 1,
+          status: .scheduled)),
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e-offline", stationId: "offline-station", prizeName: "Prize", winningNumber: 2,
+          status: .scheduled)),
+    ]
+
+    let model = StationListModel()
+    await model.viewAppeared()
+
+    let rows = model.displayedSections[0].rows
+    #expect(rows.first { $0.id == "live-station" }?.hasUpcomingGiveaway == true)
+    #expect(rows.first { $0.id == "offline-station" }?.hasUpcomingGiveaway == false)
+  }
+
+  @Test
+  func testGiveawayBadgeAppearsWhenStationGoesLive() async {
+    @Shared(.showSecretStations) var showSecretStations = false
+    let now = Date()
+
+    let station = Station.mockWith(id: "station-1", name: "Station 1")
+    let list = StationList(
+      id: "test-list",
+      name: "Test List",
+      slug: "test-list",
+      hidden: false,
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+      items: [
+        APIStationItem(sortOrder: 0, visibility: .visible, station: station, urlStation: nil)
+      ]
+    )
+    @Shared(.stationLists) var stationLists = IdentifiedArray(uniqueElements: [list])
+    @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e1", stationId: "station-1", prizeName: "Prize", winningNumber: 1,
+          status: .scheduled))
+    ]
+
+    let model = StationListModel()
+    await model.viewAppeared()
+
+    #expect(model.displayedSections[0].rows.first?.hasUpcomingGiveaway == false)
+
+    $liveStations.withLock {
+      $0 = [LiveStationInfo(stationId: "station-1", liveStatus: .showAiring, station: station)]
+    }
+
+    #expect(model.displayedSections[0].rows.first?.hasUpcomingGiveaway == true)
+  }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -617,10 +617,12 @@ class StationListModel: ViewModel {
         id: list.id,
         title: list.title,
         rows: liveSortedStationItems(for: list, liveStations: liveStations).map { item in
-          DisplayedStationSection.Row(
+          let liveStatus = liveStations.first { $0.stationId == item.anyStation.id }?.liveStatus
+          return DisplayedStationSection.Row(
             item: item,
-            liveStatus: liveStations.first { $0.stationId == item.anyStation.id }?.liveStatus,
-            hasUpcomingGiveaway: upcomingGiveaways[id: item.anyStation.id] != nil
+            liveStatus: liveStatus,
+            hasUpcomingGiveaway: liveStatus != nil
+              && upcomingGiveaways[id: item.anyStation.id] != nil
           )
         }
       )


### PR DESCRIPTION
The giveaway badge (station list + Home) and the player-page banner showed a giveaway the moment it existed in the feed as `.scheduled`, with no time check — so a giveaway a day out surfaced immediately (e.g. Micky and the Motorcars). This gates all three coming-up surfaces on the station being in `liveStations`, the same server-driven signal the LIVE badge uses, so a giveaway only surfaces while its station is live. Adds regression tests covering the not-live case on every surface.