### PR TITLE
Remove misfiring "First Aired" episode badge

### DIFF
--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRow.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRow.swift
@@ -11,17 +11,13 @@ struct EpisodeRow: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
-      // Episode Title row with optional Originally Aired badge
+      // Episode Title row
       HStack {
         Text(model.airing.episode?.title ?? "Unknown Episode")
           .font(.custom(FontNames.Inter_600_SemiBold, size: 15))
           .foregroundColor(.white)
 
         Spacer()
-
-        if model.hasAiredBefore {
-          OriginallyAiredBadge(dateText: model.originallyAiredDateText)
-        }
       }
 
       // Calendar badge and tune in text
@@ -95,22 +91,6 @@ struct CalendarDateBadge: View {
   }
 }
 
-// MARK: - Originally Aired Badge
-
-struct OriginallyAiredBadge: View {
-  let dateText: String
-
-  var body: some View {
-    Text("First Aired \(dateText)")
-      .font(.custom(FontNames.Inter_500_Medium, size: 11))
-      .foregroundColor(Color(hex: "#bababa"))
-      .padding(.horizontal, 8)
-      .padding(.vertical, 4)
-      .background(Color(hex: "#2a2a2a"))
-      .cornerRadius(4)
-  }
-}
-
 // MARK: - Preview
 
 #Preview {
@@ -125,28 +105,22 @@ struct OriginallyAiredBadge: View {
       )
     )
 
-    // Previously aired episode (next week)
+    // Upcoming episode (next week)
     EpisodeRow(
       model: EpisodeRowModel(
         airing: .mockWith(
           airtime: Date().addingTimeInterval(86400 * 10),
-          episode: .mockWith(
-            title: "Nashville Sessions",
-            createdAt: Date().addingTimeInterval(-86400 * 14)
-          )
+          episode: .mockWith(title: "Nashville Sessions")
         )
       )
     )
 
-    // Another episode (beyond next week)
+    // Upcoming episode (beyond next week)
     EpisodeRow(
       model: EpisodeRowModel(
         airing: .mockWith(
           airtime: Date().addingTimeInterval(86400 * 20),
-          episode: .mockWith(
-            title: "Texas Country Vibes",
-            createdAt: Date().addingTimeInterval(-86400 * 7)
-          )
+          episode: .mockWith(title: "Texas Country Vibes")
         )
       )
     )

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
@@ -23,11 +23,6 @@ class EpisodeRowModel: ViewModel {
     airing.airtime > now
   }
 
-  var hasAiredBefore: Bool {
-    guard let episode = airing.episode else { return false }
-    return episode.createdAt < airing.airtime.addingTimeInterval(-86400)
-  }
-
   var tuneInText: String {
     let time = formattedTime
     let dayOfWeek = dayOfWeekString
@@ -40,13 +35,6 @@ class EpisodeRowModel: ViewModel {
       let dayWithOrdinal = dayOfMonthWithOrdinal
       return "Tune in \(dayOfWeek) the \(dayWithOrdinal) at \(time)"
     }
-  }
-
-  var originallyAiredDateText: String {
-    guard let createdAt = airing.episode?.createdAt else { return "" }
-    let formatter = DateFormatter()
-    formatter.dateFormat = "M/d/yy"
-    return formatter.string(from: createdAt)
   }
 
   // MARK: - Private Helpers


### PR DESCRIPTION
The "First Aired" badge on episode rows was driven by a heuristic (episode `createdAt` more than 24h before airtime) rather than any real rerun data, which does not exist on the server. Any show scheduled in advance was mislabeled as a rerun and shown a bogus "First Aired" date — e.g. a giveaway set up days ahead of its slot. With no reliable rerun signal available client-side (the series list only fetches upcoming airings), this removes the badge, its view, and the backing model computed properties (`hasAiredBefore`, `originallyAiredDateText`). Existing `EpisodeRowModelTests` pass and lint/format are clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the “Originally Aired” badge from episode listings.
  * Simplified episode title rows by eliminating previously aired status indicators.
* **Bug Fixes**
  * Updated episode previews to accurately reflect the streamlined listing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->