### PR TITLE
Release 7.3.2: Giveaway gating & episode-badge fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ claude-files/
 DerivedData/
 
 .sentryclirc
+
+# Swift compile cache from CLI xcodebuild runs
+.swift-cache/

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -191,6 +191,10 @@
 		D317C0D62EF33DB000DBC82E /* PushNotificationsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D317C0D32EF33DA600DBC82E /* PushNotificationsTests.swift */; };
 		D317C0D82EF3500B00DBC82E /* APIClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = D317C0D72EF3500500DBC82E /* APIClient+Live.swift */; };
 		D317C0D92EF3500B00DBC82E /* APIClient+Live.swift in Sources */ = {isa = PBXBuildFile; fileRef = D317C0D72EF3500500DBC82E /* APIClient+Live.swift */; };
+		A1750A0000000000000000F2 /* PlayolaTLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F1 /* PlayolaTLS.swift */; };
+		A1750A0000000000000000F3 /* PlayolaTLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F1 /* PlayolaTLS.swift */; };
+		A1750A0000000000000000F5 /* ConnectivityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F4 /* ConnectivityProbe.swift */; };
+		A1750A0000000000000000F6 /* ConnectivityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F4 /* ConnectivityProbe.swift */; };
 		D31C43A82D3C19640021AAE4 /* StationPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31C43A72D3C195B0021AAE4 /* StationPlayer.swift */; };
 		D31C43AA2D3C39110021AAE4 /* StationPlayerMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D31C43A92D3C390C0021AAE4 /* StationPlayerMock.swift */; };
 		FE01A0C72DFCB368002BAC30 /* SharedStateTestTrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */; };
@@ -239,6 +243,7 @@
 		D35673C82D3EBFBA00E4E926 /* NowPlayingUpdater.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C72D3EBFB000E4E926 /* NowPlayingUpdater.swift */; };
 		D35905EC2DFCDA140064A9C1 /* StationListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35905EB2DFCDA110064A9C1 /* StationListModel.swift */; };
 		D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */; };
+		A1750A0000000000000000F8 /* ConnectivityProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F7 /* ConnectivityProbeTests.swift */; };
 		D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */; };
 		D35EFBEE2F1092A7000F64A4 /* RRuleFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */; };
 		D35EFBF02F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
@@ -583,6 +588,8 @@
 		D317C0D02EF2027000DBC82E /* VoicetrackStatusResponse.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoicetrackStatusResponse.swift; sourceTree = "<group>"; };
 		D317C0D32EF33DA600DBC82E /* PushNotificationsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationsTests.swift; sourceTree = "<group>"; };
 		D317C0D72EF3500500DBC82E /* APIClient+Live.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "APIClient+Live.swift"; sourceTree = "<group>"; };
+		A1750A0000000000000000F1 /* PlayolaTLS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaTLS.swift; sourceTree = "<group>"; };
+		A1750A0000000000000000F4 /* ConnectivityProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityProbe.swift; sourceTree = "<group>"; };
 		D31C43A72D3C195B0021AAE4 /* StationPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayer.swift; sourceTree = "<group>"; };
 		D31C43A92D3C390C0021AAE4 /* StationPlayerMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerMock.swift; sourceTree = "<group>"; };
 		FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateTestTrait.swift; sourceTree = "<group>"; };
@@ -627,6 +634,7 @@
 		D35673CA2D3EE5E100E4E926 /* Secrets-Development.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-Development.xcconfig"; sourceTree = "<group>"; };
 		D35905EB2DFCDA110064A9C1 /* StationListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListModel.swift; sourceTree = "<group>"; };
 		D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
+		A1750A0000000000000000F7 /* ConnectivityProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityProbeTests.swift; sourceTree = "<group>"; };
 		D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerTests.swift; sourceTree = "<group>"; };
 		D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatterTests.swift; sourceTree = "<group>"; };
 		D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatter.swift; sourceTree = "<group>"; };
@@ -1473,6 +1481,9 @@
 			children = (
 				D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */,
 				D317C0D72EF3500500DBC82E /* APIClient+Live.swift */,
+				A1750A0000000000000000F1 /* PlayolaTLS.swift */,
+				A1750A0000000000000000F4 /* ConnectivityProbe.swift */,
+				A1750A0000000000000000F7 /* ConnectivityProbeTests.swift */,
 				D339E5682BFD1C0800B9E35B /* APIClient.swift */,
 			);
 			path = API;
@@ -1941,6 +1952,8 @@
 				D3B9C7AC2F534D50002D75C2 /* IntroUploadService.swift in Sources */,
 				D30F004A2E8592F0007BCC73 /* UrlStreamListeningSessionReporter.swift in Sources */,
 				D317C0D92EF3500B00DBC82E /* APIClient+Live.swift in Sources */,
+				A1750A0000000000000000F2 /* PlayolaTLS.swift in Sources */,
+				A1750A0000000000000000F5 /* ConnectivityProbe.swift in Sources */,
 				D3776A062F22BA1A00200ADF /* AskQuestionPageModel.swift in Sources */,
 				D3776A072F22BA1A00200ADF /* AskQuestionPageView.swift in Sources */,
 				D3776A0E2F22CB8600200ADF /* ListenerQuestionPresignedURLResponse.swift in Sources */,
@@ -2134,6 +2147,8 @@
 				D3B9C7AA2F534D50002D75C2 /* IntroUploadService.swift in Sources */,
 				D3D6CE5F2D5ECED50059BDCA /* UrlStreamListeningSessionReporter.swift in Sources */,
 				D317C0D82EF3500B00DBC82E /* APIClient+Live.swift in Sources */,
+				A1750A0000000000000000F3 /* PlayolaTLS.swift in Sources */,
+				A1750A0000000000000000F6 /* ConnectivityProbe.swift in Sources */,
 				D3776A032F22BA1A00200ADF /* AskQuestionPageModel.swift in Sources */,
 				D3776A042F22BA1A00200ADF /* AskQuestionPageView.swift in Sources */,
 				D3776A0F2F22CB8600200ADF /* ListenerQuestionPresignedURLResponse.swift in Sources */,
@@ -2350,6 +2365,7 @@
 				FE01A0C72DFCB368002BAC30 /* SharedStateTestTrait.swift in Sources */,
 				D3776A4D2F2BE8F900200ADF /* LibraryPageTests.swift in Sources */,
 				D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */,
+				A1750A0000000000000000F8 /* ConnectivityProbeTests.swift in Sources */,
 				D3B662762D41B0D200975D2F /* SignInPageTests.swift in Sources */,
 				D39728562F5F03FF008591E3 /* VersionComparisonTests.swift in Sources */,
 				D3C7E5EF2EF0C58900EDD3ED /* StagingItemTests.swift in Sources */,

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2468,7 +2468,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 98;
+				CURRENT_PROJECT_VERSION = 99;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2488,7 +2488,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.3.1;
+				MARKETING_VERSION = 7.3.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2513,7 +2513,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 98;
+				CURRENT_PROJECT_VERSION = 99;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2533,7 +2533,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.3.1;
+				MARKETING_VERSION = 7.3.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2558,7 +2558,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 98;
+				CURRENT_PROJECT_VERSION = 99;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2578,7 +2578,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.3.1;
+				MARKETING_VERSION = 7.3.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2724,7 +2724,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 98;
+				CURRENT_PROJECT_VERSION = 99;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = CTFSB7Y8TD;
@@ -2746,7 +2746,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.3.1;
+				MARKETING_VERSION = 7.3.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2771,7 +2771,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 98;
+				CURRENT_PROJECT_VERSION = 99;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2793,7 +2793,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.3.1;
+				MARKETING_VERSION = 7.3.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2813,7 +2813,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 98;
+				CURRENT_PROJECT_VERSION = 99;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2834,7 +2834,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 98;
+				CURRENT_PROJECT_VERSION = 99;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2924,7 +2924,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 98;
+				CURRENT_PROJECT_VERSION = 99;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = CTFSB7Y8TD;
@@ -2946,7 +2946,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.3.1;
+				MARKETING_VERSION = 7.3.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2966,7 +2966,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 98;
+				CURRENT_PROJECT_VERSION = 99;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -105,6 +105,9 @@
 		D30F005E2E8592F0007BCC73 /* CPListItem+InitWithRemoteUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C22D3E871800E4E926 /* CPListItem+InitWithRemoteUrl.swift */; };
 		D30F005F2E8592F0007BCC73 /* MainContainerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744AC2E2FCD8E0042A427 /* MainContainerModel.swift */; };
 		D30F00602E8592F0007BCC73 /* ContactPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39591162E39932300720CF8 /* ContactPageModel.swift */; };
+		E1AB0000000000000000AB01 /* AppVersionGateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA01 /* AppVersionGateModel.swift */; };
+		E1AB0000000000000000AB02 /* AppVersionGateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA01 /* AppVersionGateModel.swift */; };
+		E1AB0000000000000000AB03 /* AppVersionGateModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */; };
 		D30F00612E8592F0007BCC73 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
 		D30F00622E8592F0007BCC73 /* MailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E57D2BFD750700B9E35B /* MailService.swift */; };
 		D30F00632E8592F0007BCC73 /* FRadioPlayerMetadata+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E56E2BFD306600B9E35B /* FRadioPlayerMetadata+Equatable.swift */; };
@@ -710,6 +713,8 @@
 		D382671B2E00C13E0006BAC2 /* SmallPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallPlayer.swift; sourceTree = "<group>"; };
 		D39591142E39931D00720CF8 /* ContactPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPageView.swift; sourceTree = "<group>"; };
 		D39591162E39932300720CF8 /* ContactPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPageModel.swift; sourceTree = "<group>"; };
+		E1AB0000000000000000AA01 /* AppVersionGateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionGateModel.swift; sourceTree = "<group>"; };
+		E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionGateModelTests.swift; sourceTree = "<group>"; };
 		D39591182E39932800720CF8 /* ContactPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPageTests.swift; sourceTree = "<group>"; };
 		D39591252E3BB6FC00720CF8 /* EditProfilePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfilePageView.swift; sourceTree = "<group>"; };
 		D39591272E3BB70500720CF8 /* EditProfilePageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfilePageModel.swift; sourceTree = "<group>"; };
@@ -1072,6 +1077,7 @@
 		D339E55C2BFD0FB000B9E35B /* Pages */ = {
 			isa = PBXGroup;
 			children = (
+				E1AB0000000000000000AC01 /* AppVersionGate */,
 				D3776A022F22BA1A00200ADF /* AskQuestionPage */,
 				D3776A162F243F7A00200ADF /* BroadcastersListenerQuestionPage */,
 				D3219C152EDD22060008AFDA /* BroadcastPage */,
@@ -1544,6 +1550,15 @@
 			path = PushNotifications;
 			sourceTree = "<group>";
 		};
+		E1AB0000000000000000AC01 /* AppVersionGate */ = {
+			isa = PBXGroup;
+			children = (
+				E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */,
+				E1AB0000000000000000AA01 /* AppVersionGateModel.swift */,
+			);
+			path = AppVersionGate;
+			sourceTree = "<group>";
+		};
 		D39591132E39930500720CF8 /* ContactPage */ = {
 			isa = PBXGroup;
 			children = (
@@ -2010,6 +2025,7 @@
 				FE110A0000000000000000B3 /* WelcomeMessagePageView.swift in Sources */,
 				D30C01C52F5C9C8400889E6D /* UserPrize.swift in Sources */,
 				D30F00602E8592F0007BCC73 /* ContactPageModel.swift in Sources */,
+				E1AB0000000000000000AB01 /* AppVersionGateModel.swift in Sources */,
 				D3F493BB2EEDD2B3008ED463 /* RecordPageView.swift in Sources */,
 				D30F00612E8592F0007BCC73 /* Toast.swift in Sources */,
 				D30F00622E8592F0007BCC73 /* MailService.swift in Sources */,
@@ -2205,6 +2221,7 @@
 				FE110A0000000000000000B6 /* WelcomeMessagePageView.swift in Sources */,
 				D30C01C62F5C9C8500889E6D /* UserPrize.swift in Sources */,
 				D39591172E39932600720CF8 /* ContactPageModel.swift in Sources */,
+				E1AB0000000000000000AB02 /* AppVersionGateModel.swift in Sources */,
 				D3F493BC2EEDD2B3008ED463 /* RecordPageView.swift in Sources */,
 				D302576B2E63423D00F4228B /* Toast.swift in Sources */,
 				D339E57E2BFD750700B9E35B /* MailService.swift in Sources */,
@@ -2401,6 +2418,7 @@
 				D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */,
 				E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */,
 				D395911A2E39933800720CF8 /* ContactPageTests.swift in Sources */,
+				E1AB0000000000000000AB03 /* AppVersionGateModelTests.swift in Sources */,
 				D3B744BC2E312FB60042A427 /* ListeningTrackerTests.swift in Sources */,
 				D3B744A82E2F185F0042A427 /* SmallPlayerTests.swift in Sources */,
 				F94F092AC0FB044790B38A0E /* GiveawayModelsTests.swift in Sources */,

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -27,67 +27,12 @@ private struct CreateVoicetrackParameters: Encodable, Sendable {
 
 private let sharedIsoDecoder = JSONDecoderWithIsoFull()
 
-// TEMPORARY: Global TLS 1.2 cap.
-//
-// On iOS 26, URLSession sends a TLS 1.3 ClientHello that includes the X25519MLKEM768
-// post-quantum hybrid key share (~1.6 KB). Some users sit behind middleboxes
-// (antivirus SSL inspection, parental-control routers, captive portals, etc.) that
-// drop the larger ClientHello and surface as NSURLErrorSecureConnectionFailed (-1200),
-// which makes every API request fail silently on those networks. PR #269 added a
-// per-call TLS 1.2 fallback for sign-in, but follow-up testing showed the issue
-// affects every endpoint — sign-in succeeds, then profile / listening-tracker /
-// station fetches silently fail and the UI renders blank or stale data.
-//
-// As a stopgap, every Alamofire request in this file is routed through `apiSession`,
-// which caps the URLSession to TLS 1.2 so the ClientHello stays small enough for
-// these middleboxes to pass through.
-//
-// REVERT WHEN: Apple ships an iOS 26 fix (watch 26.5+ release notes) OR exposes a
-// supported opt-out for the post-quantum hybrid key share so we can keep TLS 1.3.
-// At that point, replace `apiSession` usages with bare `AF` again and consider
-// restoring a per-call retry (the prior signInPostWithTLS12Fallback pattern) for
-// defense in depth on networks that still misbehave.
-private let apiSession: Alamofire.Session = {
-  let configuration = URLSessionConfiguration.af.default
-  configuration.tlsMaximumSupportedProtocolVersion = .TLSv12
-  return Alamofire.Session(configuration: configuration)
-}()
-
-// Companion to `apiSession`: a separate session with no TLS cap, used by
-// `probeTLS13()` to test whether TLS 1.3 works on the user's network. When
-// success rates climb across the user base, the cap above is safe to revert.
-private let tls13ProbeSession: Alamofire.Session = {
-  Alamofire.Session(configuration: URLSessionConfiguration.af.default)
-}()
-
-// Fires once per build per device. Hits a small unauthenticated endpoint over
-// TLS 1.3 (no cap) and reports outcome to Sentry as `tls13_probe`. Aggregating
-// the outcome across users tells us when the iOS 26 middlebox issue has cleared
-// up enough to revert the global TLS 1.2 cap.
-func probeTLS13() async {
-  @Shared(.tls13ProbeLastSentBuild) var lastSentBuild: String?
-  guard let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String,
-    lastSentBuild != currentBuild
-  else { return }
-
-  let url = "\(Config.shared.baseUrl.absoluteString)/v1/app-version-requirements"
-  let outcome: String
-  do {
-    _ = try await tls13ProbeSession.request(url)
-      .validate(statusCode: 200..<300)
-      .serializingData()
-      .value
-    outcome = "success"
-  } catch {
-    outcome = "failure"
-  }
-
-  @Dependency(\.errorReporting) var errorReporting
-  await errorReporting.reportMessage(
-    "tls13_probe",
-    ["tls13_probe_outcome": outcome])
-  $lastSentBuild.withLock { $0 = currentBuild }
-}
+// TEMPORARY: Global TLS 1.2 cap. Every Alamofire request in this file is routed through
+// `apiSession`, which caps the URLSession to TLS 1.2 so the iOS 26 post-quantum ClientHello
+// stays small enough for broken middleboxes to pass through. The policy itself lives in
+// `PlayolaTLS` (single source of truth); the aggregated `tls13_probe` Sentry trend
+// (see `ConnectivityProbe`) tells us when it is safe to revert. Full background there.
+private let apiSession = Alamofire.Session(configuration: PlayolaTLS.mitigated(.af.default))
 
 private func signInPost(
   authMethod: AuthMethod,

--- a/PlayolaRadio/Core/API/ConnectivityProbe.swift
+++ b/PlayolaRadio/Core/API/ConnectivityProbe.swift
@@ -1,0 +1,272 @@
+//
+//  ConnectivityProbe.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 7/10/26.
+//
+
+import Dependencies
+import DependenciesMacros
+import Foundation
+import Sharing
+
+// MARK: - Pure model + diagnosis (unit-tested)
+
+/// Outcome of a single probe request.
+enum ProbeOutcome: String, Sendable, Equatable {
+  case success
+  case failure
+  /// The request succeeded but negotiated a different protocol than intended
+  /// (e.g. an HTTP/3 probe that fell back to HTTP/2 over TCP). Only meaningful
+  /// for the HTTP/3 probe, where it means "QUIC/UDP did not actually carry this".
+  case fellBack
+  case skipped
+}
+
+/// One connectivity probe run: our API host reached four ways, plus a control host.
+///
+/// The point is to distinguish the competing failure theories for the iOS 26
+/// NSURLErrorSecureConnectionFailed reports, per network:
+/// - `apiTLS13`: uncapped, forced TLS 1.3, HTTP/2 — the original probe. Fails when a
+///   middlebox drops the oversized post-quantum ClientHello.
+/// - `apiTLS12`: the production profile (capped to TLS 1.2), HTTP/2 — does the shipped
+///   mitigation actually get through?
+/// - `apiHTTP3`: forced TLS 1.3 with HTTP/3 requested — does routing over QUIC/UDP survive
+///   where TCP does not? (verified via the negotiated protocol, not just success)
+/// - `controlHost`: the production profile to a DIFFERENT host on the same CDN (Cloudflare).
+///   Succeeding here while every API transport fails implicates domain/SNI filtering of us
+///   specifically, not a broken network.
+struct ConnectivityProbeResult: Sendable, Equatable {
+  var apiTLS13: ProbeOutcome
+  var apiTLS12: ProbeOutcome
+  var apiHTTP3: ProbeOutcome
+  var controlHost: ProbeOutcome
+}
+
+/// The network condition inferred from a probe result. This is the signal that tells us
+/// which remediation (keep the cap / enable HTTP/3 / nothing client-side) actually helps.
+enum ProbeDiagnosis: String, Sendable, Equatable {
+  /// TLS 1.3 to our API works — no iOS 26 problem on this network.
+  case healthy
+  /// TLS 1.3 works but the production profile (capped to TLS 1.2) fails — the global cap is
+  /// itself breaking this network. This is the signal that the cap should become adaptive /
+  /// be dropped, since real requests use the capped path.
+  case cappedPathBroken
+  /// TLS 1.3 fails but TLS 1.2 works — the classic oversized-ClientHello drop. The shipped
+  /// global cap is the fix.
+  case clientHelloDrop
+  /// TLS 1.2 also fails but HTTP/3 works — enabling HTTP/3 for real requests would help.
+  case http3Rescues
+  /// Every transport to our API fails but the control host (same CDN, different domain)
+  /// works — points to domain/SNI filtering of playola specifically. No client TLS change helps.
+  case hostFiltered
+  /// The control host also fails — broader connectivity problem, not specific to us.
+  case noConnectivity
+  /// Not enough signal to classify (e.g. the control probe was skipped).
+  case indeterminate
+}
+
+enum ConnectivityProbe {
+  /// Classify a probe result. Order matters: the first transport that reaches our API wins,
+  /// so `healthy` beats `clientHelloDrop` beats `http3Rescues`. Only when every API transport
+  /// fails do we consult the control host to separate "it's just us" from "network is down".
+  static func diagnose(_ result: ConnectivityProbeResult) -> ProbeDiagnosis {
+    if result.apiTLS13 == .success {
+      // Real requests ride the capped TLS 1.2 path; if 1.3 works but 1.2 explicitly fails, the
+      // cap itself is the problem here — surface it instead of hiding it under `.healthy`. The
+      // runner only ever produces `.success`/`.failure` for TLS 1.2, so any non-`.failure` value
+      // (including an unreachable `.skipped`) means "1.3 works, no capped-path evidence" → healthy.
+      return result.apiTLS12 == .failure ? .cappedPathBroken : .healthy
+    }
+    if result.apiTLS12 == .success { return .clientHelloDrop }
+    if result.apiHTTP3 == .success { return .http3Rescues }
+
+    switch result.controlHost {
+    case .success: return .hostFiltered
+    case .failure: return .noConnectivity
+    case .fellBack, .skipped: return .indeterminate
+    }
+  }
+
+  /// Sentry tags for a probe run. `tls13_probe_outcome` is kept byte-compatible with the
+  /// original probe so the existing 30-day trend query keeps working; the rest is new signal.
+  static func tags(for result: ConnectivityProbeResult) -> [String: String] {
+    [
+      "tls13_probe_outcome": result.apiTLS13 == .success ? "success" : "failure",
+      "probe_api_tls13": result.apiTLS13.rawValue,
+      "probe_api_tls12": result.apiTLS12.rawValue,
+      "probe_api_http3": result.apiHTTP3.rawValue,
+      "probe_control": result.controlHost.rawValue,
+      "probe_diagnosis": diagnose(result).rawValue,
+    ]
+  }
+}
+
+// MARK: - Network runner (thin I/O, not unit-tested)
+
+/// Fires once per build per device from app launch. Runs the four probes and reports a single
+/// `tls13_probe` Sentry event whose tags carry the per-transport outcomes and diagnosis.
+/// Aggregating `probe_diagnosis` across users is what lets us choose the next remediation and,
+/// eventually, revert the global TLS 1.2 cap.
+func runConnectivityProbe() async {
+  @Shared(.tls13ProbeLastSentBuild) var lastSentBuild: String?
+  guard let currentBuild = Bundle.main.infoDictionary?["CFBundleVersion"] as? String,
+    lastSentBuild != currentBuild
+  else { return }
+
+  let result = await ConnectivityProbe.run(baseURL: Config.shared.baseUrl)
+
+  @Dependency(\.errorReporting) var errorReporting
+  await errorReporting.reportMessage("tls13_probe", ConnectivityProbe.tags(for: result))
+  $lastSentBuild.withLock { $0 = currentBuild }
+}
+
+// MARK: - Dependency
+
+/// Wraps the launch-time probe so it can be overridden. The live value performs real network I/O;
+/// the test value is a no-op so test suites don't fire probes on every app-host launch.
+@DependencyClient
+struct ConnectivityProbeClient: Sendable {
+  var run: @Sendable () async -> Void
+}
+
+extension ConnectivityProbeClient: TestDependencyKey {
+  static let testValue = Self(run: {})
+}
+
+extension ConnectivityProbeClient: DependencyKey {
+  static let liveValue = Self(run: { await runConnectivityProbe() })
+}
+
+extension DependencyValues {
+  var connectivityProbe: ConnectivityProbeClient {
+    get { self[ConnectivityProbeClient.self] }
+    set { self[ConnectivityProbeClient.self] = newValue }
+  }
+}
+
+extension ConnectivityProbe {
+  /// A small unauthenticated endpoint, cheap to hit repeatedly.
+  private static let apiProbePath = "/v1/app-version-requirements"
+  /// Different domain, same CDN (Cloudflare) as our API, so a success here isolates
+  /// domain/SNI filtering from CDN-wide or network-wide blocking.
+  private static let controlURL = URL(string: "https://www.cloudflare.com/cdn-cgi/trace")!
+
+  /// A `.default` configuration with all caching disabled so every probe performs a real
+  /// network handshake. A cached `/v1/app-version-requirements` response would otherwise report
+  /// `success` (or a `nil` negotiated protocol for the HTTP/3 probe) without measuring TLS/QUIC.
+  private static func probeBaseConfiguration() -> URLSessionConfiguration {
+    let config = URLSessionConfiguration.default
+    config.urlCache = nil
+    config.requestCachePolicy = .reloadIgnoringLocalAndRemoteCacheData
+    return config
+  }
+
+  /// Forces TLS 1.3 exactly (both bounds pinned — leaving `max` at the default sentinel while
+  /// bumping `min` to 1.3 yields an empty version window and a `NO_SUPPORTED_VERSIONS_ENABLED`
+  /// config error instead of an actual network measurement).
+  private static func forcedTLS13Configuration() -> URLSessionConfiguration {
+    let config = probeBaseConfiguration()
+    config.tlsMinimumSupportedProtocolVersion = .TLSv13
+    config.tlsMaximumSupportedProtocolVersion = .TLSv13
+    return config
+  }
+
+  /// Uncapped, forced to TLS 1.3 — the request fails if the network can't carry a 1.3 handshake.
+  private static let tls13Session = URLSession(configuration: forcedTLS13Configuration())
+
+  /// The exact production profile (capped to TLS 1.2, caching disabled for the probe). Used for
+  /// the API 1.2 probe and the control host so they are apples-to-apples with real requests.
+  private static let tls12Session = URLSession(
+    configuration: PlayolaTLS.mitigated(probeBaseConfiguration()))
+
+  /// Forced TLS 1.3, used with `assumesHTTP3Capable` requests to probe QUIC/UDP. Deliberately a
+  /// SEPARATE session from `tls13Session` (despite the identical configuration): a shared session
+  /// would let this sequential request reuse the TLS 1.3 probe's already-open HTTP/2 TCP
+  /// connection and never attempt QUIC, silently defeating the h3 measurement.
+  private static let http3Session = URLSession(configuration: forcedTLS13Configuration())
+
+  static func run(baseURL: URL) async -> ConnectivityProbeResult {
+    let apiURL = baseURL.appendingPathComponent(apiProbePath)
+
+    // Sequential (not concurrent) so probes to the same host don't share/coalesce a
+    // connection and muddy the per-transport signal.
+    let tls13 = await attempt(apiURL, session: tls13Session).outcome(expectingProtocol: nil)
+    let tls12 = await attempt(apiURL, session: tls12Session).outcome(expectingProtocol: nil)
+    let http3 = await attempt(apiURL, session: http3Session, assumesHTTP3: true)
+      .outcome(expectingProtocol: "h3")
+    let control = await attempt(controlURL, session: tls12Session).outcome(expectingProtocol: nil)
+
+    return ConnectivityProbeResult(
+      apiTLS13: tls13, apiTLS12: tls12, apiHTTP3: http3, controlHost: control)
+  }
+
+  private struct Attempt {
+    var succeeded: Bool
+    var negotiatedProtocol: String?
+
+    /// Map a raw attempt to an outcome. When `expectingProtocol` is set (the HTTP/3 probe),
+    /// a success that negotiated a different protocol counts as `fellBack`, not `success`.
+    func outcome(expectingProtocol expected: String?) -> ProbeOutcome {
+      guard succeeded else { return .failure }
+      if let expected, negotiatedProtocol != expected { return .fellBack }
+      return .success
+    }
+  }
+
+  private static func attempt(
+    _ url: URL,
+    session: URLSession,
+    assumesHTTP3: Bool = false
+  ) async -> Attempt {
+    var request = URLRequest(url: url)
+    request.timeoutInterval = 10
+    if assumesHTTP3 { request.assumesHTTP3Capable = true }
+
+    let collector = ProbeMetricsCollector()
+    do {
+      let (_, response) = try await session.data(for: request, delegate: collector)
+      let httpOK =
+        (response as? HTTPURLResponse).map { (200..<300).contains($0.statusCode) } ?? false
+      // A cache hit is not a network measurement — reject it so we never report a transport as
+      // reachable without an actual handshake.
+      let ok = httpOK && !collector.servedFromCache
+      return Attempt(succeeded: ok, negotiatedProtocol: collector.negotiatedProtocol)
+    } catch {
+      return Attempt(succeeded: false, negotiatedProtocol: collector.negotiatedProtocol)
+    }
+  }
+}
+
+/// Captures the negotiated network protocol ("h3" / "h2" / "http/1.1") for a task so the
+/// HTTP/3 probe can tell a real QUIC success from a silent TCP fallback.
+private final class ProbeMetricsCollector: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+  private let lock = NSLock()
+  private var storedProtocol: String?
+  private var storedServedFromCache = false
+
+  var negotiatedProtocol: String? {
+    lock.lock()
+    defer { lock.unlock() }
+    return storedProtocol
+  }
+
+  /// True only when the response positively came from a local cache (not a network load).
+  var servedFromCache: Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    return storedServedFromCache
+  }
+
+  func urlSession(
+    _ session: URLSession,
+    task: URLSessionTask,
+    didFinishCollecting metrics: URLSessionTaskMetrics
+  ) {
+    let last = metrics.transactionMetrics.last
+    lock.lock()
+    storedProtocol = last?.networkProtocolName
+    storedServedFromCache = last?.resourceFetchType == .localCache
+    lock.unlock()
+  }
+}

--- a/PlayolaRadio/Core/API/ConnectivityProbeTests.swift
+++ b/PlayolaRadio/Core/API/ConnectivityProbeTests.swift
@@ -1,0 +1,118 @@
+//
+//  ConnectivityProbeTests.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 7/10/26.
+//
+
+import CustomDump
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+@MainActor
+struct ConnectivityProbeTests {
+
+  // MARK: - diagnose
+
+  @Test
+  func tls13AndTls12SuccessIsHealthy() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .success, apiTLS12: .success, apiHTTP3: .failure, controlHost: .failure)
+    #expect(ConnectivityProbe.diagnose(result) == .healthy)
+  }
+
+  @Test
+  func tls13SuccessButCappedTls12FailureIsCappedPathBroken() {
+    // Real requests ride the capped 1.2 path, so 1.3-works-but-1.2-fails means the cap itself
+    // is breaking this network — must not be hidden under `.healthy`.
+    let result = ConnectivityProbeResult(
+      apiTLS13: .success, apiTLS12: .failure, apiHTTP3: .success, controlHost: .success)
+    #expect(ConnectivityProbe.diagnose(result) == .cappedPathBroken)
+  }
+
+  @Test
+  func tls13FailsButTls12WorksIsClientHelloDrop() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .success, apiHTTP3: .failure, controlHost: .failure)
+    #expect(ConnectivityProbe.diagnose(result) == .clientHelloDrop)
+  }
+
+  @Test
+  func tcpFailsButHttp3WorksIsHttp3Rescues() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .success, controlHost: .failure)
+    #expect(ConnectivityProbe.diagnose(result) == .http3Rescues)
+  }
+
+  @Test
+  func http3FellBackDoesNotCountAsRescue() {
+    // A success that silently fell back to TCP/HTTP-2 is NOT an HTTP/3 win, so with every
+    // real API transport failing and the control up, this is host filtering.
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .fellBack, controlHost: .success)
+    #expect(ConnectivityProbe.diagnose(result) == .hostFiltered)
+  }
+
+  @Test
+  func allApiTransportsFailButControlWorksIsHostFiltered() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .failure, controlHost: .success)
+    #expect(ConnectivityProbe.diagnose(result) == .hostFiltered)
+  }
+
+  @Test
+  func everythingFailsIncludingControlIsNoConnectivity() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .failure, controlHost: .failure)
+    #expect(ConnectivityProbe.diagnose(result) == .noConnectivity)
+  }
+
+  @Test
+  func skippedControlWithFailingApiIsIndeterminate() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .failure, controlHost: .skipped)
+    #expect(ConnectivityProbe.diagnose(result) == .indeterminate)
+  }
+
+  @Test
+  func fellBackControlWithFailingApiIsIndeterminate() {
+    // Covers the `.fellBack` half of the `case .fellBack, .skipped` control arm.
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .failure, apiHTTP3: .failure, controlHost: .fellBack)
+    #expect(ConnectivityProbe.diagnose(result) == .indeterminate)
+  }
+
+  // MARK: - tags
+
+  @Test
+  func tagsCarryEveryTransportAndDiagnosis() {
+    let result = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .success, apiHTTP3: .fellBack, controlHost: .success)
+    expectNoDifference(
+      ConnectivityProbe.tags(for: result),
+      [
+        "tls13_probe_outcome": "failure",
+        "probe_api_tls13": "failure",
+        "probe_api_tls12": "success",
+        "probe_api_http3": "fellBack",
+        "probe_control": "success",
+        "probe_diagnosis": "clientHelloDrop",
+      ])
+  }
+
+  @Test
+  func tls13ProbeOutcomeStaysBackwardCompatibleWithTheOldProbe() {
+    // The legacy Sentry trend groups on `tls13_probe_outcome` = success/failure of the
+    // uncapped TLS 1.3 probe. That mapping must not drift.
+    let success = ConnectivityProbeResult(
+      apiTLS13: .success, apiTLS12: .success, apiHTTP3: .success, controlHost: .success)
+    #expect(ConnectivityProbe.tags(for: success)["tls13_probe_outcome"] == "success")
+
+    let failure = ConnectivityProbeResult(
+      apiTLS13: .failure, apiTLS12: .success, apiHTTP3: .success, controlHost: .success)
+    #expect(ConnectivityProbe.tags(for: failure)["tls13_probe_outcome"] == "failure")
+  }
+}

--- a/PlayolaRadio/Core/API/PlayolaTLS.swift
+++ b/PlayolaRadio/Core/API/PlayolaTLS.swift
@@ -1,0 +1,39 @@
+//
+//  PlayolaTLS.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 7/10/26.
+//
+
+import Foundation
+
+/// Single source of truth for the TEMPORARY iOS 26 TLS mitigation.
+///
+/// On iOS 26, URLSession sends a TLS 1.3 ClientHello that includes the X25519MLKEM768
+/// post-quantum hybrid key share (~1.1 KB). It spans two TCP segments, and some middleboxes
+/// (antivirus SSL inspection, parental-control routers, captive portals, etc.) drop the
+/// oversized ClientHello and surface it as NSURLErrorSecureConnectionFailed (-1200) — every
+/// request fails on those networks. Capping the session to TLS 1.2 keeps the ClientHello small
+/// enough to pass.
+///
+/// Every first-party URLSession / Alamofire session in the app routes through here so the
+/// policy lives in exactly one place. When we later make this adaptive (try 1.3, fall back to
+/// 1.2) or add HTTP/3, this is the seam to change.
+///
+/// REVERT WHEN: Apple ships an iOS 26 fix (watch the `tls13_probe` Sentry trend) OR exposes a
+/// supported opt-out for the post-quantum hybrid key share so we can keep TLS 1.3.
+enum PlayolaTLS {
+  /// Applies the TLS 1.2 cap to a configuration and returns it. Callers pass whatever base
+  /// configuration they need (default, Alamofire's default, or one with custom caching).
+  static func mitigated(_ configuration: URLSessionConfiguration) -> URLSessionConfiguration {
+    configuration.tlsMaximumSupportedProtocolVersion = .TLSv12
+    return configuration
+  }
+
+  /// Shared TLS-mitigated `URLSession` for FIRST-PARTY requests that do NOT go through
+  /// Alamofire (e.g. the listening-session reporter). Deliberately not used for remote artwork
+  /// loaders: those can hit third-party / TLS-1.3-only image hosts, where capping to 1.2 would
+  /// break loads on the healthy majority of networks for no real gain (artwork is cosmetic and
+  /// the main artwork path is SDWebImage, which is uncapped anyway).
+  static let sharedSession = URLSession(configuration: mitigated(.default))
+}

--- a/PlayolaRadio/Core/Analytics/AnalyticsEvent.swift
+++ b/PlayolaRadio/Core/Analytics/AnalyticsEvent.swift
@@ -16,6 +16,10 @@ enum AnalyticsEvent: Equatable {
   case appBackgrounded
   case appForegrounded
 
+  // MARK: App Version Gate
+  case updateGateShown(currentVersion: String, requiredVersion: String, trigger: UpdateGateTrigger)
+  case updateGateUpdateTapped(currentVersion: String, requiredVersion: String)
+
   // MARK: Authentication
   case signInStarted(method: AuthMethod)
   case signInCompleted(method: AuthMethod, userId: String)
@@ -86,6 +90,8 @@ extension AnalyticsEvent {
     case .appOpened: return "App Opened"
     case .appBackgrounded: return "App Backgrounded"
     case .appForegrounded: return "App Foregrounded"
+    case .updateGateShown: return "Update Gate Shown"
+    case .updateGateUpdateTapped: return "Update Gate Update Tapped"
     case .signInStarted: return "Sign In Started"
     case .signInCompleted: return "Sign In Completed"
     case .signInFailed: return "Sign In Failed"
@@ -137,6 +143,19 @@ extension AnalyticsEvent {
 
     case .appBackgrounded, .appForegrounded:
       return [:]
+
+    case .updateGateShown(let currentVersion, let requiredVersion, let trigger):
+      return [
+        "current_version": currentVersion,
+        "required_version": requiredVersion,
+        "trigger": trigger.rawValue,
+      ]
+
+    case .updateGateUpdateTapped(let currentVersion, let requiredVersion):
+      return [
+        "current_version": currentVersion,
+        "required_version": requiredVersion,
+      ]
 
     case .signInStarted(let method):
       return ["method": method.rawValue]
@@ -325,6 +344,15 @@ enum AppOpenSource: String {
   case pushNotification = "push_notification"
   case sharedLink = "shared_link"
   case deepLink = "deep_link"
+}
+
+enum UpdateGateTrigger: String {
+  /// User's app version is below the general minimum required version.
+  case minimumVersion = "minimum_version"
+  /// A known broadcaster's app version is below the broadcaster minimum, detected on launch.
+  case broadcaster = "broadcaster"
+  /// The user was newly discovered to be a broadcaster mid-session while below the broadcaster minimum.
+  case broadcasterDiscovered = "broadcaster_discovered"
 }
 
 enum AuthMethod: String {

--- a/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
+++ b/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
@@ -67,7 +67,7 @@ public class UrlStreamListeningSessionReporter {
     }
 
     guard let request = createPostRequest(url: url, jsonData: jsonData) else { return }
-    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+    let task = PlayolaTLS.sharedSession.dataTask(with: request) { data, response, error in
       if let error = error {
         print("Error: \(error.localizedDescription)")
         return
@@ -100,7 +100,7 @@ public class UrlStreamListeningSessionReporter {
     }
 
     guard let request = createPostRequest(url: url, jsonData: jsonData) else { return }
-    let task = URLSession.shared.dataTask(with: request) { data, response, error in
+    let task = PlayolaTLS.sharedSession.dataTask(with: request) { data, response, error in
       if let error = error {
         print("Error: \(error.localizedDescription)")
         return

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -231,12 +231,13 @@ struct PlayolaRadioApp: App {
       await analytics.initialize()
     }
 
-    // Once per build per device, probe whether TLS 1.3 works on this user's
-    // network. The aggregated `tls13_probe` Sentry events tell us when the iOS
-    // 26 middlebox issue has cleared enough to revert the global TLS 1.2 cap
-    // in APIClient+Live.swift.
+    // Once per build per device, probe how this user's network handles TLS to our API
+    // (1.3 / 1.2 / HTTP/3) plus a control host. The aggregated `tls13_probe` Sentry events
+    // (see `ConnectivityProbe`) tell us which remediation helps and when the iOS 26 middlebox
+    // issue has cleared enough to revert the global TLS 1.2 cap.
+    @Dependency(\.connectivityProbe) var connectivityProbe
     Task {
-      await probeTLS13()
+      await connectivityProbe.run()
     }
   }
 

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -11,6 +11,7 @@ import Dependencies
 import Foundation
 import Sharing
 import SwiftUI
+import UIKit
 
 @MainActor
 @Observable
@@ -28,19 +29,17 @@ class AppVersionGateModel: ViewModel {
 
   // MARK: - Properties
 
-  var requiresUpdate = false
-
-  /// The versions the currently-shown gate was presented with, so the
-  /// "Update Tapped" event reports the same required_version as its "Shown"
-  /// event (rather than re-deriving it and mislabeling broadcaster gates).
-  private var activeGate: (currentVersion: String, requiredVersion: String)?
-
-  // MARK: - Display Text
+  var presentedAlert: PlayolaAlert?
 
   let alertTitle = "Update Required"
   let alertMessage = "A new version of Playola Radio is available. Please update to continue."
   let updateButtonTitle = "Update"
   let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id6480465361")!
+
+  /// The versions the currently-shown gate was presented with, so the
+  /// "Update Tapped" event reports the same required_version as its "Shown"
+  /// event (rather than re-deriving it and mislabeling broadcaster gates).
+  @ObservationIgnored private var activeGate: (currentVersion: String, requiredVersion: String)?
 
   // MARK: - User Actions
 
@@ -77,15 +76,18 @@ class AppVersionGateModel: ViewModel {
   /// a broadcaster on a too-old build (via the `.requiresAppUpdate` notification).
   func broadcasterUpdateDiscovered() async {
     let currentVersion = Bundle.main.releaseVersionNumber ?? ""
-    let requiredVersion = appVersionRequirements?.minimumBroadcasterVersion ?? currentVersion
+    // If requirements haven't loaded yet, report an empty (unknown) required
+    // version rather than the current build, which would be a nonsensical
+    // "required version" in the analytics.
+    let requiredVersion = appVersionRequirements?.minimumBroadcasterVersion ?? ""
     await presentUpdateGate(
       currentVersion: currentVersion,
       requiredVersion: requiredVersion,
       trigger: .broadcasterDiscovered)
   }
 
-  /// Tracks the tap. The caller (the view) must `await` this before opening the
-  /// App Store, so the event is enqueued before the app is backgrounded and lost.
+  /// Tracks the tap. Called from the alert action before opening the App Store,
+  /// so the event is enqueued before the app is backgrounded and the event lost.
   func updateButtonTapped() async {
     let currentVersion = activeGate?.currentVersion ?? Bundle.main.releaseVersionNumber ?? ""
     let requiredVersion =
@@ -101,15 +103,27 @@ class AppVersionGateModel: ViewModel {
     requiredVersion: String,
     trigger: UpdateGateTrigger
   ) async {
-    // Only track on the false → true transition so repeated launches/notifications
-    // for an already-shown gate don't inflate "shown" counts.
-    guard !requiresUpdate else { return }
-    requiresUpdate = true
+    // Only present/track on the not-shown → shown transition so repeated launches
+    // or notifications for an already-shown gate don't inflate "shown" counts.
+    guard presentedAlert == nil else { return }
     activeGate = (currentVersion, requiredVersion)
+    presentedAlert = makeUpdateRequiredAlert()
     await analytics.track(
       .updateGateShown(
         currentVersion: currentVersion,
         requiredVersion: requiredVersion,
         trigger: trigger))
+  }
+
+  private func makeUpdateRequiredAlert() -> PlayolaAlert {
+    PlayolaAlert(
+      title: alertTitle,
+      message: alertMessage,
+      primaryButtonText: updateButtonTitle,
+      primaryAction: { [weak self] in
+        guard let self else { return }
+        await self.updateButtonTapped()
+        _ = await UIApplication.shared.open(self.appStoreURL)
+      })
   }
 }

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -135,7 +135,14 @@ class AppVersionGateModel: ViewModel {
       primaryAction: { [weak self] in
         guard let self else { return }
         await self.updateButtonTapped()
-        _ = await UIApplication.shared.open(self.appStoreURL)
+        let opened = await UIApplication.shared.open(self.appStoreURL)
+        // Normally the App Store foregrounds and `scenePhaseChanged` re-blocks on
+        // return. If it fails to open there is no foreground transition to re-block on,
+        // and the app is still active (no background race), so re-present immediately
+        // rather than let a too-old build slip through the dismissed gate.
+        if !opened {
+          self.presentedAlert = self.makeUpdateRequiredAlert()
+        }
       })
   }
 }

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -1,0 +1,115 @@
+//
+//  AppVersionGateModel.swift
+//  PlayolaRadio
+//
+//  Owns the "Update Required" forced-upgrade gate: it decides whether the
+//  running build is too old to continue, drives the blocking alert, and
+//  instruments the gate so we can measure whether users update or abandon.
+//
+
+import Dependencies
+import Foundation
+import Sharing
+import SwiftUI
+
+@MainActor
+@Observable
+class AppVersionGateModel: ViewModel {
+
+  // MARK: - Dependencies
+
+  @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.analytics) var analytics
+
+  // MARK: - Shared State
+
+  @ObservationIgnored @Shared(.appVersionRequirements) var appVersionRequirements
+  @ObservationIgnored @Shared(.isBroadcaster) var isBroadcaster
+
+  // MARK: - Properties
+
+  var requiresUpdate = false
+
+  /// The versions the currently-shown gate was presented with, so the
+  /// "Update Tapped" event reports the same required_version as its "Shown"
+  /// event (rather than re-deriving it and mislabeling broadcaster gates).
+  private var activeGate: (currentVersion: String, requiredVersion: String)?
+
+  // MARK: - Display Text
+
+  let alertTitle = "Update Required"
+  let alertMessage = "A new version of Playola Radio is available. Please update to continue."
+  let updateButtonTitle = "Update"
+  let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id6480465361")!
+
+  // MARK: - User Actions
+
+  func checkVersionRequirements() async {
+    do {
+      let requirements = try await api.getAppVersionRequirements()
+      $appVersionRequirements.withLock { $0 = requirements }
+
+      guard let currentVersion = Bundle.main.releaseVersionNumber else { return }
+
+      if isVersion(currentVersion, lessThan: requirements.minimumVersion) {
+        await presentUpdateGate(
+          currentVersion: currentVersion,
+          requiredVersion: requirements.minimumVersion,
+          trigger: .minimumVersion)
+        return
+      }
+
+      if isBroadcaster,
+        isVersion(currentVersion, lessThan: requirements.minimumBroadcasterVersion)
+      {
+        await presentUpdateGate(
+          currentVersion: currentVersion,
+          requiredVersion: requirements.minimumBroadcasterVersion,
+          trigger: .broadcaster)
+        return
+      }
+    } catch {
+      // Network failure → fail open (allow app)
+    }
+  }
+
+  /// Invoked when another part of the app discovers mid-session that the user is
+  /// a broadcaster on a too-old build (via the `.requiresAppUpdate` notification).
+  func broadcasterUpdateDiscovered() async {
+    let currentVersion = Bundle.main.releaseVersionNumber ?? ""
+    let requiredVersion = appVersionRequirements?.minimumBroadcasterVersion ?? currentVersion
+    await presentUpdateGate(
+      currentVersion: currentVersion,
+      requiredVersion: requiredVersion,
+      trigger: .broadcasterDiscovered)
+  }
+
+  /// Tracks the tap. The caller (the view) must `await` this before opening the
+  /// App Store, so the event is enqueued before the app is backgrounded and lost.
+  func updateButtonTapped() async {
+    let currentVersion = activeGate?.currentVersion ?? Bundle.main.releaseVersionNumber ?? ""
+    let requiredVersion =
+      activeGate?.requiredVersion ?? appVersionRequirements?.minimumVersion ?? ""
+    await analytics.track(
+      .updateGateUpdateTapped(currentVersion: currentVersion, requiredVersion: requiredVersion))
+  }
+
+  // MARK: - Private Helpers
+
+  private func presentUpdateGate(
+    currentVersion: String,
+    requiredVersion: String,
+    trigger: UpdateGateTrigger
+  ) async {
+    // Only track on the false → true transition so repeated launches/notifications
+    // for an already-shown gate don't inflate "shown" counts.
+    guard !requiresUpdate else { return }
+    requiresUpdate = true
+    activeGate = (currentVersion, requiredVersion)
+    await analytics.track(
+      .updateGateShown(
+        currentVersion: currentVersion,
+        requiredVersion: requiredVersion,
+        trigger: trigger))
+  }
+}

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -87,6 +87,17 @@ class AppVersionGateModel: ViewModel {
       trigger: .broadcasterDiscovered)
   }
 
+  /// Re-presents the gate when the app returns to the foreground. Tapping "Update"
+  /// dismisses the alert (SwiftUI clears `presentedAlert`) and opens the App Store, but
+  /// `UIApplication.open` returns immediately rather than waiting for the user to come
+  /// back, and `checkVersionRequirements()` only runs on cold launch. Without this, a
+  /// user who taps "Update" and returns without updating could keep using an unsupported
+  /// build. Reuses the existing `activeGate`, so it does not re-track a "shown" event.
+  func scenePhaseChanged(newPhase: ScenePhase) {
+    guard newPhase == .active, activeGate != nil, presentedAlert == nil else { return }
+    presentedAlert = makeUpdateRequiredAlert()
+  }
+
   /// Tracks the tap. Called from the alert action before opening the App Store,
   /// so the event is enqueued before the app is backgrounded and the event lost.
   func updateButtonTapped() async {
@@ -125,17 +136,6 @@ class AppVersionGateModel: ViewModel {
         guard let self else { return }
         await self.updateButtonTapped()
         _ = await UIApplication.shared.open(self.appStoreURL)
-        self.reblockAfterAppStoreReturn()
       })
-  }
-
-  /// Re-presents the blocking gate once the App Store is dismissed. `open()` suspends
-  /// while the App Store is foregrounded, so this runs the moment the user returns.
-  /// `checkVersionRequirements()` only runs on cold launch, so without re-presenting, a
-  /// user who taps "Update" and backs out without updating could keep using an
-  /// unsupported build. Reuses the existing `activeGate`, so it does not re-track a
-  /// "shown" event.
-  func reblockAfterAppStoreReturn() {
-    presentedAlert = makeUpdateRequiredAlert()
   }
 }

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -31,10 +31,11 @@ class AppVersionGateModel: ViewModel {
 
   var presentedAlert: PlayolaAlert?
 
-  let alertTitle = "Update Required"
-  let alertMessage = "A new version of Playola Radio is available. Please update to continue."
-  let updateButtonTitle = "Update"
-  let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id6480465361")!
+  private let alertTitle = "Update Required"
+  private let alertMessage =
+    "A new version of Playola Radio is available. Please update to continue."
+  private let updateButtonTitle = "Update"
+  private let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id6480465361")!
 
   /// The versions the currently-shown gate was presented with, so the
   /// "Update Tapped" event reports the same required_version as its "Shown"
@@ -124,6 +125,17 @@ class AppVersionGateModel: ViewModel {
         guard let self else { return }
         await self.updateButtonTapped()
         _ = await UIApplication.shared.open(self.appStoreURL)
+        self.reblockAfterAppStoreReturn()
       })
+  }
+
+  /// Re-presents the blocking gate once the App Store is dismissed. `open()` suspends
+  /// while the App Store is foregrounded, so this runs the moment the user returns.
+  /// `checkVersionRequirements()` only runs on cold launch, so without re-presenting, a
+  /// user who taps "Update" and backs out without updating could keep using an
+  /// unsupported build. Reuses the existing `activeGate`, so it does not re-track a
+  /// "shown" event.
+  func reblockAfterAppStoreReturn() {
+    presentedAlert = makeUpdateRequiredAlert()
   }
 }

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
@@ -228,6 +228,34 @@ struct AppVersionGateModelTests {
   }
 
   @Test
+  func testGateReblocksAfterAppStoreReturnWithoutRetrackingShown() async {
+    // Tapping "Update" clears the alert (SwiftUI sets isPresented = false, which the
+    // binding maps to presentedAlert = nil). checkVersionRequirements() only runs on
+    // cold launch, so the gate must re-present itself when the user returns from the
+    // App Store without updating — without inflating the "shown" analytics count.
+    @Shared(.isBroadcaster) var isBroadcaster = false
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [unreachableVersion, ancientVersion] in
+        AppVersionRequirements(
+          minimumVersion: unreachableVersion, minimumBroadcasterVersion: ancientVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+      #expect(model.presentedAlert != nil)
+
+      model.presentedAlert = nil
+      model.reblockAfterAppStoreReturn()
+
+      #expect(model.presentedAlert != nil)
+      #expect(gateShownEvents(captured.value).count == 1)
+    }
+  }
+
+  @Test
   func testUpdateButtonTappedTracksEvent() async {
     @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
       minimumVersion: "1.2.3", minimumBroadcasterVersion: "1.2.3")

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
@@ -7,6 +7,7 @@ import ConcurrencyExtras
 import Dependencies
 import Foundation
 import Sharing
+import SwiftUI
 import Testing
 
 @testable import PlayolaRadio
@@ -228,11 +229,12 @@ struct AppVersionGateModelTests {
   }
 
   @Test
-  func testGateReblocksAfterAppStoreReturnWithoutRetrackingShown() async {
+  func testGateReblocksWhenAppReturnsToForegroundWithoutRetrackingShown() async {
     // Tapping "Update" clears the alert (SwiftUI sets isPresented = false, which the
-    // binding maps to presentedAlert = nil). checkVersionRequirements() only runs on
-    // cold launch, so the gate must re-present itself when the user returns from the
-    // App Store without updating — without inflating the "shown" analytics count.
+    // binding maps to presentedAlert = nil) and opens the App Store. UIApplication.open
+    // returns immediately, and checkVersionRequirements() only runs on cold launch, so
+    // the gate must re-present when the app returns to the foreground — without
+    // inflating the "shown" analytics count.
     @Shared(.isBroadcaster) var isBroadcaster = false
     let captured = LockIsolated<[AnalyticsEvent]>([])
 
@@ -248,10 +250,38 @@ struct AppVersionGateModelTests {
       #expect(model.presentedAlert != nil)
 
       model.presentedAlert = nil
-      model.reblockAfterAppStoreReturn()
+      model.scenePhaseChanged(newPhase: .active)
 
       #expect(model.presentedAlert != nil)
       #expect(gateShownEvents(captured.value).count == 1)
+    }
+  }
+
+  @Test
+  func testScenePhaseActiveDoesNotPresentGateWhenNoGateIsActive() async {
+    // Returning to the foreground on a supported build must not conjure a gate.
+    let model = AppVersionGateModel()
+    model.scenePhaseChanged(newPhase: .active)
+    #expect(model.presentedAlert == nil)
+  }
+
+  @Test
+  func testScenePhaseChangeToBackgroundLeavesShownGateVisible() async {
+    // Backgrounding while the gate is up (without tapping Update) must not clear it.
+    @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
+      minimumVersion: "1.0.0", minimumBroadcasterVersion: "9.9.9")
+
+    await withDependencies {
+      $0.analytics.track = { _ in }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.broadcasterUpdateDiscovered()
+      let presented = model.presentedAlert
+      #expect(presented != nil)
+
+      model.scenePhaseChanged(newPhase: .background)
+
+      #expect(model.presentedAlert == presented)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
@@ -1,0 +1,228 @@
+//
+//  AppVersionGateModelTests.swift
+//  PlayolaRadio
+//
+
+import ConcurrencyExtras
+import Dependencies
+import Foundation
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+@MainActor
+struct AppVersionGateModelTests {
+
+  // A version far above any real build so the running bundle always compares as "too old".
+  private let unreachableVersion = "999.0.0"
+  // A version below any real build so the running bundle is always "up to date".
+  private let ancientVersion = "0.0.1"
+
+  private func gateShownEvents(_ events: [AnalyticsEvent]) -> [AnalyticsEvent] {
+    events.filter { if case .updateGateShown = $0 { return true } else { return false } }
+  }
+
+  @Test
+  func testShowsGateAndTracksWhenBelowMinimumVersion() async {
+    @Shared(.isBroadcaster) var isBroadcaster = false
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [unreachableVersion, ancientVersion] in
+        AppVersionRequirements(
+          minimumVersion: unreachableVersion, minimumBroadcasterVersion: ancientVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == true)
+      let shown = gateShownEvents(captured.value)
+      #expect(shown.count == 1)
+      #expect(
+        shown.first
+          == .updateGateShown(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: unreachableVersion,
+            trigger: .minimumVersion))
+    }
+  }
+
+  @Test
+  func testDoesNotShowGateWhenVersionIsCurrent() async {
+    @Shared(.isBroadcaster) var isBroadcaster = true
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [ancientVersion] in
+        AppVersionRequirements(
+          minimumVersion: ancientVersion, minimumBroadcasterVersion: ancientVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == false)
+      #expect(gateShownEvents(captured.value).isEmpty)
+    }
+  }
+
+  @Test
+  func testShowsBroadcasterGateWhenBroadcasterIsBelowBroadcasterMinimum() async {
+    @Shared(.isBroadcaster) var isBroadcaster = true
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [ancientVersion, unreachableVersion] in
+        AppVersionRequirements(
+          minimumVersion: ancientVersion, minimumBroadcasterVersion: unreachableVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == true)
+      let shown = gateShownEvents(captured.value)
+      #expect(shown.count == 1)
+      #expect(
+        shown.first
+          == .updateGateShown(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: unreachableVersion,
+            trigger: .broadcaster))
+    }
+  }
+
+  @Test
+  func testNonBroadcasterIsNotGatedByBroadcasterMinimum() async {
+    @Shared(.isBroadcaster) var isBroadcaster = false
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [ancientVersion, unreachableVersion] in
+        AppVersionRequirements(
+          minimumVersion: ancientVersion, minimumBroadcasterVersion: unreachableVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == false)
+      #expect(gateShownEvents(captured.value).isEmpty)
+    }
+  }
+
+  @Test
+  func testNetworkFailureFailsOpenAndTracksNothing() async {
+    @Shared(.isBroadcaster) var isBroadcaster = true
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    struct RequirementsError: Error {}
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { throw RequirementsError() }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+
+      #expect(model.requiresUpdate == false)
+      #expect(captured.value.isEmpty)
+    }
+  }
+
+  @Test
+  func testBroadcasterDiscoveredNotificationShowsGateAndTracks() async {
+    @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
+      minimumVersion: "1.0.0", minimumBroadcasterVersion: "9.9.9")
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.broadcasterUpdateDiscovered()
+
+      #expect(model.requiresUpdate == true)
+      let shown = gateShownEvents(captured.value)
+      #expect(shown.count == 1)
+      #expect(
+        shown.first
+          == .updateGateShown(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: "9.9.9",
+            trigger: .broadcasterDiscovered))
+    }
+  }
+
+  @Test
+  func testUpdateTappedReusesShownGateRequiredVersion() async {
+    // A broadcaster gate is shown with the broadcaster minimum; the tap event must
+    // report that same required_version, not the general minimumVersion.
+    @Shared(.isBroadcaster) var isBroadcaster = true
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [ancientVersion, unreachableVersion] in
+        AppVersionRequirements(
+          minimumVersion: ancientVersion, minimumBroadcasterVersion: unreachableVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+      await model.updateButtonTapped()
+
+      #expect(
+        captured.value.contains(
+          .updateGateUpdateTapped(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: unreachableVersion)))
+    }
+  }
+
+  @Test
+  func testDuplicatePresentDoesNotDoubleTrackShown() async {
+    @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
+      minimumVersion: "1.0.0", minimumBroadcasterVersion: "9.9.9")
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.broadcasterUpdateDiscovered()
+      await model.broadcasterUpdateDiscovered()
+
+      #expect(model.requiresUpdate == true)
+      #expect(gateShownEvents(captured.value).count == 1)
+    }
+  }
+
+  @Test
+  func testUpdateButtonTappedTracksEvent() async {
+    @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
+      minimumVersion: "1.2.3", minimumBroadcasterVersion: "1.2.3")
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.updateButtonTapped()
+
+      #expect(
+        captured.value == [
+          .updateGateUpdateTapped(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: "1.2.3")
+        ])
+    }
+  }
+}

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
@@ -39,7 +39,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == true)
+      #expect(model.presentedAlert != nil)
       let shown = gateShownEvents(captured.value)
       #expect(shown.count == 1)
       #expect(
@@ -66,7 +66,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == false)
+      #expect(model.presentedAlert == nil)
       #expect(gateShownEvents(captured.value).isEmpty)
     }
   }
@@ -86,7 +86,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == true)
+      #expect(model.presentedAlert != nil)
       let shown = gateShownEvents(captured.value)
       #expect(shown.count == 1)
       #expect(
@@ -113,7 +113,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == false)
+      #expect(model.presentedAlert == nil)
       #expect(gateShownEvents(captured.value).isEmpty)
     }
   }
@@ -132,7 +132,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.checkVersionRequirements()
 
-      #expect(model.requiresUpdate == false)
+      #expect(model.presentedAlert == nil)
       #expect(captured.value.isEmpty)
     }
   }
@@ -149,7 +149,7 @@ struct AppVersionGateModelTests {
       let model = AppVersionGateModel()
       await model.broadcasterUpdateDiscovered()
 
-      #expect(model.requiresUpdate == true)
+      #expect(model.presentedAlert != nil)
       let shown = gateShownEvents(captured.value)
       #expect(shown.count == 1)
       #expect(
@@ -157,6 +157,28 @@ struct AppVersionGateModelTests {
           == .updateGateShown(
             currentVersion: Bundle.main.releaseVersionNumber ?? "",
             requiredVersion: "9.9.9",
+            trigger: .broadcasterDiscovered))
+    }
+  }
+
+  @Test
+  func testBroadcasterDiscoveredWithoutRequirementsReportsEmptyRequiredVersion() async {
+    // Requirements not loaded (fresh empty store): the gate still blocks, but must
+    // not masquerade the current build as the required version.
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.broadcasterUpdateDiscovered()
+
+      #expect(model.presentedAlert != nil)
+      #expect(
+        gateShownEvents(captured.value).first
+          == .updateGateShown(
+            currentVersion: Bundle.main.releaseVersionNumber ?? "",
+            requiredVersion: "",
             trigger: .broadcasterDiscovered))
     }
   }
@@ -200,7 +222,7 @@ struct AppVersionGateModelTests {
       await model.broadcasterUpdateDiscovered()
       await model.broadcasterUpdateDiscovered()
 
-      #expect(model.requiresUpdate == true)
+      #expect(model.presentedAlert != nil)
       #expect(gateShownEvents(captured.value).count == 1)
     }
   }

--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -17,12 +17,9 @@ extension Notification.Name {
 @MainActor
 struct ContentView: View {
   @Shared(.auth) var auth
-  @Shared(.appVersionRequirements) var appVersionRequirements
-  @Shared(.isBroadcaster) var isBroadcaster
-  @Dependency(\.api) var api
   @Dependency(\.analytics) var analytics
   @State private var hasTrackedAppOpen = false
-  @State private var requiresUpdate = false
+  @State private var versionGate = AppVersionGateModel()
 
   @Dependency(\.stationPlayer) private var stationPlayer
   @Dependency(\.nowPlayingUpdater) private var nowPlayingUpdater
@@ -37,10 +34,6 @@ struct ContentView: View {
     _ = nowPlayingUpdater
   }
 
-  private let appStoreURL = URL(
-    string: "itms-apps://itunes.apple.com/app/id6480465361"
-  )!
-
   var body: some View {
     Group {
       if auth.isLoggedIn {
@@ -50,18 +43,21 @@ struct ContentView: View {
       }
     }
     .alert(
-      "Update Required",
-      isPresented: $requiresUpdate
+      versionGate.alertTitle,
+      isPresented: $versionGate.requiresUpdate
     ) {
-      Button("Update") {
-        UIApplication.shared.open(appStoreURL)
-        requiresUpdate = true
+      Button(versionGate.updateButtonTitle) {
+        versionGate.requiresUpdate = true
+        Task {
+          await versionGate.updateButtonTapped()
+          _ = await UIApplication.shared.open(versionGate.appStoreURL)
+        }
       }
     } message: {
-      Text("A new version of Playola Radio is available. Please update to continue.")
+      Text(versionGate.alertMessage)
     }
     .task {
-      await checkVersionRequirements()
+      await versionGate.checkVersionRequirements()
 
       guard !hasTrackedAppOpen else { return }
       hasTrackedAppOpen = true
@@ -73,30 +69,7 @@ struct ContentView: View {
         ))
     }
     .onReceive(NotificationCenter.default.publisher(for: .requiresAppUpdate)) { _ in
-      requiresUpdate = true
-    }
-  }
-
-  private func checkVersionRequirements() async {
-    do {
-      let requirements = try await api.getAppVersionRequirements()
-      $appVersionRequirements.withLock { $0 = requirements }
-
-      guard let currentVersion = Bundle.main.releaseVersionNumber else { return }
-
-      if isVersion(currentVersion, lessThan: requirements.minimumVersion) {
-        requiresUpdate = true
-        return
-      }
-
-      if isBroadcaster,
-        isVersion(currentVersion, lessThan: requirements.minimumBroadcasterVersion)
-      {
-        requiresUpdate = true
-        return
-      }
-    } catch {
-      // Network failure → fail open (allow app)
+      Task { await versionGate.broadcasterUpdateDiscovered() }
     }
   }
 

--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -8,7 +8,6 @@
 import Dependencies
 import Sharing
 import SwiftUI
-import UIKit
 
 extension Notification.Name {
   static let requiresAppUpdate = Notification.Name("requiresAppUpdate")
@@ -42,20 +41,7 @@ struct ContentView: View {
         SignInPage(model: SignInPageModel())
       }
     }
-    .alert(
-      versionGate.alertTitle,
-      isPresented: $versionGate.requiresUpdate
-    ) {
-      Button(versionGate.updateButtonTitle) {
-        versionGate.requiresUpdate = true
-        Task {
-          await versionGate.updateButtonTapped()
-          _ = await UIApplication.shared.open(versionGate.appStoreURL)
-        }
-      }
-    } message: {
-      Text(versionGate.alertMessage)
-    }
+    .playolaAlert($versionGate.presentedAlert)
     .task {
       await versionGate.checkVersionRequirements()
 

--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -17,6 +17,7 @@ extension Notification.Name {
 struct ContentView: View {
   @Shared(.auth) var auth
   @Dependency(\.analytics) var analytics
+  @Environment(\.scenePhase) private var scenePhase
   @State private var hasTrackedAppOpen = false
   @State private var versionGate = AppVersionGateModel()
 
@@ -56,6 +57,9 @@ struct ContentView: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .requiresAppUpdate)) { _ in
       Task { await versionGate.broadcasterUpdateDiscovered() }
+    }
+    .onChange(of: scenePhase) { _, newPhase in
+      versionGate.scenePhaseChanged(newPhase: newPhase)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -206,7 +206,7 @@ class HomePageModel: ViewModel {
   }
 
   func hasUpcomingGiveawayForStation(_ stationId: String) -> Bool {
-    upcomingGiveaways[id: stationId] != nil
+    liveStatusForStation(stationId) != nil && upcomingGiveaways[id: stationId] != nil
   }
 
   // MARK: - Private Helpers

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -767,4 +767,52 @@ struct HomePageTests {
     }
   }
 
+  // MARK: - Giveaway Badge (live-gated) Tests
+
+  @Test
+  func testHasUpcomingGiveawayForStationTrueWhenStationIsLive() {
+    let station = Station.mockWith(id: "live-station", curatorName: "DJ Live")
+    @Shared(.liveStations) var liveStations = [
+      LiveStationInfo(stationId: "live-station", liveStatus: .showAiring, station: station)
+    ]
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e1", stationId: "live-station", prizeName: "Prize", winningNumber: 1,
+          status: .scheduled))
+    ]
+
+    let model = HomePageModel()
+
+    #expect(model.hasUpcomingGiveawayForStation("live-station"))
+  }
+
+  @Test
+  func testHasUpcomingGiveawayForStationFalseWhenStationNotLive() {
+    @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e1", stationId: "not-live-station", prizeName: "Prize", winningNumber: 1,
+          status: .scheduled))
+    ]
+
+    let model = HomePageModel()
+
+    #expect(!model.hasUpcomingGiveawayForStation("not-live-station"))
+  }
+
+  @Test
+  func testHasUpcomingGiveawayForStationFalseWhenLiveButNoGiveaway() {
+    let station = Station.mockWith(id: "live-station", curatorName: "DJ Live")
+    @Shared(.liveStations) var liveStations = [
+      LiveStationInfo(stationId: "live-station", liveStatus: .voicetracking, station: station)
+    ]
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = []
+
+    let model = HomePageModel()
+
+    #expect(!model.hasUpcomingGiveawayForStation("live-station"))
+  }
+
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModel.swift
@@ -15,6 +15,7 @@ class UpcomingGiveawayBannerModel: ViewModel {
   @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
   @ObservationIgnored @Shared(.activeGiveaway) var activeGiveaway
   @ObservationIgnored @Shared(.upcomingGiveaways) var upcomingGiveaways
+  @ObservationIgnored @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
 
   // MARK: - Initialization
   override init() {
@@ -41,9 +42,10 @@ class UpcomingGiveawayBannerModel: ViewModel {
 
   // MARK: - View Helpers
 
-  /// Visible only while the now-playing station has an upcoming giveaway and its contest has not yet
-  /// opened. Reading `activeGiveaway` is what lets the banner self-hide the instant the tap overlay
-  /// takes over.
+  /// Visible only while the now-playing station is live and has an upcoming giveaway whose contest has
+  /// not yet opened. Gating on `liveStations` mirrors the station-list / Home badge, so the banner
+  /// won't surface a giveaway that's still hours/days out. Reading `activeGiveaway` is what lets the
+  /// banner self-hide the instant the tap overlay takes over.
   var isVisible: Bool { upcomingGiveaway != nil }
 
   var bannerOpacity: Double { isVisible ? 1 : 0 }
@@ -72,6 +74,7 @@ class UpcomingGiveawayBannerModel: ViewModel {
 
   private var upcomingGiveaway: UpcomingGiveawayInfo? {
     guard let stationId = currentStation?.id,
+      liveStations.contains(where: { $0.stationId == stationId }),
       let info = upcomingGiveaways[id: stationId]
     else { return nil }
     if let active = activeGiveaway, active.status == .open, active.stationId == stationId {

--- a/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/UpcomingGiveawayBannerModelTests.swift
@@ -42,6 +42,12 @@ struct UpcomingGiveawayBannerModelTests {
         airingId: airingId))
   }
 
+  private func makeLiveStations(_ ids: String...) -> [LiveStationInfo] {
+    ids.map {
+      LiveStationInfo(stationId: $0, liveStatus: .showAiring, station: Station.mockWith(id: $0))
+    }
+  }
+
   /// Builds the model and simulates the once-a-minute tick having fired at `referenceNow`.
   private func makeModel() -> UpcomingGiveawayBannerModel {
     let model = UpcomingGiveawayBannerModel()
@@ -51,6 +57,7 @@ struct UpcomingGiveawayBannerModelTests {
 
   @Test func hiddenWhenNotPlayingAStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1")
     ]
@@ -62,6 +69,7 @@ struct UpcomingGiveawayBannerModelTests {
 
   @Test func hiddenWhenNoUpcomingForCurrentStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e2", station: "other")
     ]
@@ -69,9 +77,23 @@ struct UpcomingGiveawayBannerModelTests {
     #expect(model.isVisible == false)
   }
 
+  @Test func hiddenWhenCurrentStationNotLive() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
+    @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      scheduled(id: "e1", station: "s1")
+    ]
+    let model = makeModel()
+    #expect(model.isVisible == false)
+    #expect(model.bannerOpacity == 0)
+    #expect(model.bannerText == "")
+  }
+
   @Test func visibleWithBannerTextWhenUpcomingForCurrentStation() {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", prize: "Two tickets")
     ]
@@ -85,6 +107,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = GiveawayEvent(
       id: "e1", stationId: "s1", prizeName: "Two tickets", winningNumber: 9, status: .open)
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1")
     ]
@@ -96,6 +119,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(id: "s1")
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = GiveawayEvent(
       id: "eOther", stationId: "other", prizeName: "x", winningNumber: 9, status: .open)
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1")
     ]
@@ -107,6 +131,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(38 * 60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -124,6 +149,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(38 * 60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -136,6 +162,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(43 * 60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -148,6 +175,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(90))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -160,6 +188,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "other-airing", endTime: Self.referenceNow.addingTimeInterval(38 * 60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -171,6 +200,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: nil)
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]
@@ -182,6 +212,7 @@ struct UpcomingGiveawayBannerModelTests {
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = playolaNowPlaying(
       airingId: "a1", endTime: Self.referenceNow.addingTimeInterval(-60))
     @Shared(.activeGiveaway) var activeGiveaway: GiveawayEvent? = nil
+    @Shared(.liveStations) var liveStations = makeLiveStations("s1")
     @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
       scheduled(id: "e1", station: "s1", airingId: "a1")
     ]

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRow.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRow.swift
@@ -11,17 +11,13 @@ struct EpisodeRow: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 8) {
-      // Episode Title row with optional Originally Aired badge
+      // Episode Title row
       HStack {
         Text(model.airing.episode?.title ?? "Unknown Episode")
           .font(.custom(FontNames.Inter_600_SemiBold, size: 15))
           .foregroundColor(.white)
 
         Spacer()
-
-        if model.hasAiredBefore {
-          OriginallyAiredBadge(dateText: model.originallyAiredDateText)
-        }
       }
 
       // Calendar badge and tune in text
@@ -95,22 +91,6 @@ struct CalendarDateBadge: View {
   }
 }
 
-// MARK: - Originally Aired Badge
-
-struct OriginallyAiredBadge: View {
-  let dateText: String
-
-  var body: some View {
-    Text("First Aired \(dateText)")
-      .font(.custom(FontNames.Inter_500_Medium, size: 11))
-      .foregroundColor(Color(hex: "#bababa"))
-      .padding(.horizontal, 8)
-      .padding(.vertical, 4)
-      .background(Color(hex: "#2a2a2a"))
-      .cornerRadius(4)
-  }
-}
-
 // MARK: - Preview
 
 #Preview {
@@ -125,28 +105,22 @@ struct OriginallyAiredBadge: View {
       )
     )
 
-    // Previously aired episode (next week)
+    // Upcoming episode (next week)
     EpisodeRow(
       model: EpisodeRowModel(
         airing: .mockWith(
           airtime: Date().addingTimeInterval(86400 * 10),
-          episode: .mockWith(
-            title: "Nashville Sessions",
-            createdAt: Date().addingTimeInterval(-86400 * 14)
-          )
+          episode: .mockWith(title: "Nashville Sessions")
         )
       )
     )
 
-    // Another episode (beyond next week)
+    // Upcoming episode (beyond next week)
     EpisodeRow(
       model: EpisodeRowModel(
         airing: .mockWith(
           airtime: Date().addingTimeInterval(86400 * 20),
-          episode: .mockWith(
-            title: "Texas Country Vibes",
-            createdAt: Date().addingTimeInterval(-86400 * 7)
-          )
+          episode: .mockWith(title: "Texas Country Vibes")
         )
       )
     )

--- a/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/EpisodeRow/EpisodeRowModel.swift
@@ -23,11 +23,6 @@ class EpisodeRowModel: ViewModel {
     airing.airtime > now
   }
 
-  var hasAiredBefore: Bool {
-    guard let episode = airing.episode else { return false }
-    return episode.createdAt < airing.airtime.addingTimeInterval(-86400)
-  }
-
   var tuneInText: String {
     let time = formattedTime
     let dayOfWeek = dayOfWeekString
@@ -40,13 +35,6 @@ class EpisodeRowModel: ViewModel {
       let dayWithOrdinal = dayOfMonthWithOrdinal
       return "Tune in \(dayOfWeek) the \(dayWithOrdinal) at \(time)"
     }
-  }
-
-  var originallyAiredDateText: String {
-    guard let createdAt = airing.episode?.createdAt else { return "" }
-    let formatter = DateFormatter()
-    formatter.dateFormat = "M/d/yy"
-    return formatter.string(from: createdAt)
   }
 
   // MARK: - Private Helpers

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListLiveSortTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListLiveSortTests.swift
@@ -188,4 +188,90 @@ struct StationListLiveSortTests {
 
     expectNoDifference(model.cancellables.count, 3)
   }
+
+  // MARK: - Giveaway Badge (live-gated) Tests
+
+  @Test
+  func testGiveawayBadgeShowsOnlyOnLiveStations() async {
+    @Shared(.showSecretStations) var showSecretStations = false
+    let now = Date()
+
+    let liveStation = Station.mockWith(id: "live-station", name: "Live Station")
+    let offlineStation = Station.mockWith(id: "offline-station", name: "Offline Station")
+
+    let list = StationList(
+      id: "test-list",
+      name: "Test List",
+      slug: "test-list",
+      hidden: false,
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+      items: [
+        APIStationItem(sortOrder: 0, visibility: .visible, station: liveStation, urlStation: nil),
+        APIStationItem(
+          sortOrder: 1, visibility: .visible, station: offlineStation, urlStation: nil),
+      ]
+    )
+    @Shared(.stationLists) var stationLists = IdentifiedArray(uniqueElements: [list])
+    @Shared(.liveStations) var liveStations: [LiveStationInfo] = [
+      LiveStationInfo(stationId: "live-station", liveStatus: .showAiring, station: liveStation)
+    ]
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e-live", stationId: "live-station", prizeName: "Prize", winningNumber: 1,
+          status: .scheduled)),
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e-offline", stationId: "offline-station", prizeName: "Prize", winningNumber: 2,
+          status: .scheduled)),
+    ]
+
+    let model = StationListModel()
+    await model.viewAppeared()
+
+    let rows = model.displayedSections[0].rows
+    #expect(rows.first { $0.id == "live-station" }?.hasUpcomingGiveaway == true)
+    #expect(rows.first { $0.id == "offline-station" }?.hasUpcomingGiveaway == false)
+  }
+
+  @Test
+  func testGiveawayBadgeAppearsWhenStationGoesLive() async {
+    @Shared(.showSecretStations) var showSecretStations = false
+    let now = Date()
+
+    let station = Station.mockWith(id: "station-1", name: "Station 1")
+    let list = StationList(
+      id: "test-list",
+      name: "Test List",
+      slug: "test-list",
+      hidden: false,
+      sortOrder: 0,
+      createdAt: now,
+      updatedAt: now,
+      items: [
+        APIStationItem(sortOrder: 0, visibility: .visible, station: station, urlStation: nil)
+      ]
+    )
+    @Shared(.stationLists) var stationLists = IdentifiedArray(uniqueElements: [list])
+    @Shared(.liveStations) var liveStations: [LiveStationInfo] = []
+    @Shared(.upcomingGiveaways) var upcomingGiveaways: IdentifiedArrayOf<UpcomingGiveawayInfo> = [
+      UpcomingGiveawayInfo(
+        event: GiveawayEvent(
+          id: "e1", stationId: "station-1", prizeName: "Prize", winningNumber: 1,
+          status: .scheduled))
+    ]
+
+    let model = StationListModel()
+    await model.viewAppeared()
+
+    #expect(model.displayedSections[0].rows.first?.hasUpcomingGiveaway == false)
+
+    $liveStations.withLock {
+      $0 = [LiveStationInfo(stationId: "station-1", liveStatus: .showAiring, station: station)]
+    }
+
+    #expect(model.displayedSections[0].rows.first?.hasUpcomingGiveaway == true)
+  }
 }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -617,10 +617,12 @@ class StationListModel: ViewModel {
         id: list.id,
         title: list.title,
         rows: liveSortedStationItems(for: list, liveStations: liveStations).map { item in
-          DisplayedStationSection.Row(
+          let liveStatus = liveStations.first { $0.stationId == item.anyStation.id }?.liveStatus
+          return DisplayedStationSection.Row(
             item: item,
-            liveStatus: liveStations.first { $0.stationId == item.anyStation.id }?.liveStatus,
-            hasUpcomingGiveaway: upcomingGiveaways[id: item.anyStation.id] != nil
+            liveStatus: liveStatus,
+            hasUpcomingGiveaway: liveStatus != nil
+              && upcomingGiveaways[id: item.anyStation.id] != nil
           )
         }
       )

--- a/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
+++ b/PlayolaRadio/Views/Reusable Components/PlayolaAlert.swift
@@ -45,6 +45,26 @@ struct PlayolaAlert: Equatable, Identifiable, Hashable {
     self.tertiaryAction = nil
   }
 
+  /// A single-button alert whose only action is `primaryAction` and which has no
+  /// dismiss/cancel button. Use for blocking prompts like a forced-update gate.
+  init(
+    title: String,
+    message: String?,
+    primaryButtonText: String,
+    primaryAction: @escaping @MainActor () async -> Void
+  ) {
+    self.title = title
+    self.message = message
+    self.dismissButton = nil
+    self.secondaryButton = nil
+    self.primaryButtonText = primaryButtonText
+    self.secondaryButtonText = nil
+    self.tertiaryButtonText = nil
+    self.primaryAction = primaryAction
+    self.secondaryAction = nil
+    self.tertiaryAction = nil
+  }
+
   init(
     title: String,
     message: String?,

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -41,37 +41,44 @@ def committed_build_number
   File.read(pbxproj).scan(/CURRENT_PROJECT_VERSION = (\d+);/).flatten.map(&:to_i).max || 0
 end
 
+# Highest build number that exists for the app on App Store Connect, across ALL
+# marketing versions and processing states. Deliberately NOT latest_testflight_build_number:
+# that action sorts by uploadedDate and returns the most recently *uploaded* build, which
+# is not necessarily the numeric max — an out-of-order or cross-marketing-version upload
+# could hand back a lower number that then collides. Build.all paginates every build, so
+# taking the numeric max in Ruby is immune to upload order and to API string-sort quirks.
+# Requires Spaceship auth (asc_api_key sets the token via set_spaceship_token).
+def highest_testflight_build_number(app_identifier:)
+  app = Spaceship::ConnectAPI::App.find(app_identifier)
+  UI.user_error!("App #{app_identifier} not found on App Store Connect — check credentials/identifier.") unless app
+  Spaceship::ConnectAPI::Build.all(app_id: app.id).map { |b| b.version.to_i }.max || 0
+end
+
 # Derive the TestFlight build number from App Store Connect instead of trusting the
 # checked-in CURRENT_PROJECT_VERSION. Hotfix and release branches historically drifted
 # out of sync and reused a build number (7.3.0 and 7.3.1 both shipped as build 98,
 # because develop still read 97 when 7.3.1 was cut). Querying ASC for the highest build
 # that exists for THIS app and adding one makes collisions structurally impossible,
 # independent of branch or marketing version.
-def next_testflight_build_number(app_identifier:, api_key:)
-  latest = latest_testflight_build_number(
-    api_key: api_key,
-    app_identifier: app_identifier,
-    initial_build_number: 0
-  ).to_i
+def next_testflight_build_number(app_identifier:)
+  latest = highest_testflight_build_number(app_identifier: app_identifier)
 
-  # Hard guard: a non-positive result means the ASC query failed (auth error, wrong
-  # app, network) — these apps always have upload history. Fail loudly rather than
-  # ship build 1. This is the "did the query actually work" preflight check.
+  # Hard guard: zero means no builds were returned — either the query failed or we are
+  # pointed at the wrong app (these apps always have upload history). Fail loudly rather
+  # than ship build 1. This is the "did the query actually work" preflight check.
   if latest <= 0
     UI.user_error!(
-      "latest_testflight_build_number returned #{latest} for #{app_identifier}. " \
-      "The App Store Connect query likely failed (auth/network/wrong app) — refusing to upload."
+      "No builds found for #{app_identifier} on App Store Connect (query failed or wrong app) — refusing to upload."
     )
   end
 
-  # Use the committed CURRENT_PROJECT_VERSION only as a LOWER BOUND, never as an
-  # equality guard. latest_testflight_build_number returns the most recent upload,
-  # which is not guaranteed to be the numeric max; the committed floor guards against
-  # that under-reporting. It is per-app safe: staging is a separate ASC sequence that
-  # may legitimately trail prod, so this advances its number rather than failing closed.
+  # Keep the committed CURRENT_PROJECT_VERSION as a redundant LOWER BOUND. ASC is the
+  # source of truth, but this cheaply covers eventual-consistency gaps (a just-uploaded
+  # build not yet listed). It is per-app safe: staging is a separate ASC sequence that
+  # may legitimately trail prod, so this only ever advances the number, never blocks it.
   floor = committed_build_number
   nxt = [latest, floor].max + 1
-  UI.message("Build number for #{app_identifier}: #{nxt} (ASC latest #{latest}, committed floor #{floor})")
+  UI.message("Build number for #{app_identifier}: #{nxt} (ASC max #{latest}, committed floor #{floor})")
   nxt
 end
 
@@ -96,7 +103,10 @@ platform :ios do
       key_content: key,
       # A raw PEM always contains the literal "-----BEGIN"; base64 never can
       # (its alphabet has no dashes), so this disambiguates the two reliably.
-      is_key_content_base64: !key.include?("-----BEGIN")
+      is_key_content_base64: !key.include?("-----BEGIN"),
+      # Authorize direct Spaceship::ConnectAPI queries (highest_testflight_build_number)
+      # in addition to returning the key hash for upload_to_testflight.
+      set_spaceship_token: true
     )
   end
 
@@ -113,8 +123,7 @@ platform :ios do
 
     api_key = asc_api_key
     build_number = next_testflight_build_number(
-      app_identifier: "fm.playola.playolaradio.staging",
-      api_key: api_key
+      app_identifier: "fm.playola.playolaradio.staging"
     )
 
     build_app(
@@ -187,8 +196,7 @@ platform :ios do
 
     api_key = asc_api_key
     build_number = next_testflight_build_number(
-      app_identifier: "fm.playola.playolaradio",
-      api_key: api_key
+      app_identifier: "fm.playola.playolaradio"
     )
 
     build_app(

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -33,6 +33,48 @@ def print_failed_tests_summary(output_dir)
   end
 end
 
+# Highest CURRENT_PROJECT_VERSION committed in the project. Used only as a lower
+# bound for the derived build number — never as the shipped value on its own.
+# Returns 0 if the setting can't be parsed so callers can still fall back to ASC.
+def committed_build_number
+  pbxproj = File.expand_path("../PlayolaRadio.xcodeproj/project.pbxproj", __dir__)
+  File.read(pbxproj).scan(/CURRENT_PROJECT_VERSION = (\d+);/).flatten.map(&:to_i).max || 0
+end
+
+# Derive the TestFlight build number from App Store Connect instead of trusting the
+# checked-in CURRENT_PROJECT_VERSION. Hotfix and release branches historically drifted
+# out of sync and reused a build number (7.3.0 and 7.3.1 both shipped as build 98,
+# because develop still read 97 when 7.3.1 was cut). Querying ASC for the highest build
+# that exists for THIS app and adding one makes collisions structurally impossible,
+# independent of branch or marketing version.
+def next_testflight_build_number(app_identifier:, api_key:)
+  latest = latest_testflight_build_number(
+    api_key: api_key,
+    app_identifier: app_identifier,
+    initial_build_number: 0
+  ).to_i
+
+  # Hard guard: a non-positive result means the ASC query failed (auth error, wrong
+  # app, network) — these apps always have upload history. Fail loudly rather than
+  # ship build 1. This is the "did the query actually work" preflight check.
+  if latest <= 0
+    UI.user_error!(
+      "latest_testflight_build_number returned #{latest} for #{app_identifier}. " \
+      "The App Store Connect query likely failed (auth/network/wrong app) — refusing to upload."
+    )
+  end
+
+  # Use the committed CURRENT_PROJECT_VERSION only as a LOWER BOUND, never as an
+  # equality guard. latest_testflight_build_number returns the most recent upload,
+  # which is not guaranteed to be the numeric max; the committed floor guards against
+  # that under-reporting. It is per-app safe: staging is a separate ASC sequence that
+  # may legitimately trail prod, so this advances its number rather than failing closed.
+  floor = committed_build_number
+  nxt = [latest, floor].max + 1
+  UI.message("Build number for #{app_identifier}: #{nxt} (ASC latest #{latest}, committed floor #{floor})")
+  nxt
+end
+
 platform :ios do
   before_all do
     setup_circle_ci if ENV['CI']
@@ -69,12 +111,18 @@ platform :ios do
       readonly: true
     )
 
+    api_key = asc_api_key
+    build_number = next_testflight_build_number(
+      app_identifier: "fm.playola.playolaradio.staging",
+      api_key: api_key
+    )
+
     build_app(
       project: "PlayolaRadio.xcodeproj",
       scheme: "PlayolaRadio-Staging",
       export_method: "app-store",
       output_directory: "./build",
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation",
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation CURRENT_PROJECT_VERSION=#{build_number}",
       export_options: {
         method: "app-store",
         # sentry-cocoa's SwiftPM `Sentry` product links statically (its symbols
@@ -96,8 +144,6 @@ platform :ios do
       project_slug: 'apple-ios',
       include_sources: true
     )
-
-    api_key = asc_api_key
 
     upload_to_testflight(
       api_key: api_key,
@@ -139,12 +185,18 @@ platform :ios do
     print_failed_tests_summary('./fastlane/test_output/xctest') if test_error
     raise test_error if test_error
 
+    api_key = asc_api_key
+    build_number = next_testflight_build_number(
+      app_identifier: "fm.playola.playolaradio",
+      api_key: api_key
+    )
+
     build_app(
       project: "PlayolaRadio.xcodeproj",
       scheme: "PlayolaRadio",
       export_method: "app-store",
       output_directory: "./build",
-      xcargs: "-skipPackagePluginValidation -skipMacroValidation",
+      xcargs: "-skipPackagePluginValidation -skipMacroValidation CURRENT_PROJECT_VERSION=#{build_number}",
       export_options: {
         method: "app-store",
         # See release_staging for rationale: Sentry links statically but Xcode
@@ -164,8 +216,6 @@ platform :ios do
       project_slug: 'apple-ios',
       include_sources: true
     )
-
-    api_key = asc_api_key
 
     upload_to_testflight(
       api_key: api_key,


### PR DESCRIPTION
## Giveaway gating & episode-badge fixes

### Changes
- #368: Re-block forced-upgrade gate after App Store return
- #366: Remove misfiring "First Aired" episode badge
- #365: Gate giveaway 'coming up' surfaces on station being live
- #364: Instrument forced-upgrade gate (Shown/Update-Tapped analytics)
- #363: Derive TestFlight build number from App Store Connect
- #355: Sync main to develop

### Version
`7.3.2` (build `99`)
