### PR TITLE
Re-block forced-upgrade gate after App Store return

### DIFF
--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -135,7 +135,14 @@ class AppVersionGateModel: ViewModel {
       primaryAction: { [weak self] in
         guard let self else { return }
         await self.updateButtonTapped()
-        _ = await UIApplication.shared.open(self.appStoreURL)
+        let opened = await UIApplication.shared.open(self.appStoreURL)
+        // Normally the App Store foregrounds and `scenePhaseChanged` re-blocks on
+        // return. If it fails to open there is no foreground transition to re-block on,
+        // and the app is still active (no background race), so re-present immediately
+        // rather than let a too-old build slip through the dismissed gate.
+        if !opened {
+          self.presentedAlert = self.makeUpdateRequiredAlert()
+        }
       })
   }
 }

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -87,6 +87,17 @@ class AppVersionGateModel: ViewModel {
       trigger: .broadcasterDiscovered)
   }
 
+  /// Re-presents the gate when the app returns to the foreground. Tapping "Update"
+  /// dismisses the alert (SwiftUI clears `presentedAlert`) and opens the App Store, but
+  /// `UIApplication.open` returns immediately rather than waiting for the user to come
+  /// back, and `checkVersionRequirements()` only runs on cold launch. Without this, a
+  /// user who taps "Update" and returns without updating could keep using an unsupported
+  /// build. Reuses the existing `activeGate`, so it does not re-track a "shown" event.
+  func scenePhaseChanged(newPhase: ScenePhase) {
+    guard newPhase == .active, activeGate != nil, presentedAlert == nil else { return }
+    presentedAlert = makeUpdateRequiredAlert()
+  }
+
   /// Tracks the tap. Called from the alert action before opening the App Store,
   /// so the event is enqueued before the app is backgrounded and the event lost.
   func updateButtonTapped() async {
@@ -125,17 +136,6 @@ class AppVersionGateModel: ViewModel {
         guard let self else { return }
         await self.updateButtonTapped()
         _ = await UIApplication.shared.open(self.appStoreURL)
-        self.reblockAfterAppStoreReturn()
       })
-  }
-
-  /// Re-presents the blocking gate once the App Store is dismissed. `open()` suspends
-  /// while the App Store is foregrounded, so this runs the moment the user returns.
-  /// `checkVersionRequirements()` only runs on cold launch, so without re-presenting, a
-  /// user who taps "Update" and backs out without updating could keep using an
-  /// unsupported build. Reuses the existing `activeGate`, so it does not re-track a
-  /// "shown" event.
-  func reblockAfterAppStoreReturn() {
-    presentedAlert = makeUpdateRequiredAlert()
   }
 }

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModel.swift
@@ -31,10 +31,11 @@ class AppVersionGateModel: ViewModel {
 
   var presentedAlert: PlayolaAlert?
 
-  let alertTitle = "Update Required"
-  let alertMessage = "A new version of Playola Radio is available. Please update to continue."
-  let updateButtonTitle = "Update"
-  let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id6480465361")!
+  private let alertTitle = "Update Required"
+  private let alertMessage =
+    "A new version of Playola Radio is available. Please update to continue."
+  private let updateButtonTitle = "Update"
+  private let appStoreURL = URL(string: "itms-apps://itunes.apple.com/app/id6480465361")!
 
   /// The versions the currently-shown gate was presented with, so the
   /// "Update Tapped" event reports the same required_version as its "Shown"
@@ -124,6 +125,17 @@ class AppVersionGateModel: ViewModel {
         guard let self else { return }
         await self.updateButtonTapped()
         _ = await UIApplication.shared.open(self.appStoreURL)
+        self.reblockAfterAppStoreReturn()
       })
+  }
+
+  /// Re-presents the blocking gate once the App Store is dismissed. `open()` suspends
+  /// while the App Store is foregrounded, so this runs the moment the user returns.
+  /// `checkVersionRequirements()` only runs on cold launch, so without re-presenting, a
+  /// user who taps "Update" and backs out without updating could keep using an
+  /// unsupported build. Reuses the existing `activeGate`, so it does not re-track a
+  /// "shown" event.
+  func reblockAfterAppStoreReturn() {
+    presentedAlert = makeUpdateRequiredAlert()
   }
 }

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
@@ -228,6 +228,34 @@ struct AppVersionGateModelTests {
   }
 
   @Test
+  func testGateReblocksAfterAppStoreReturnWithoutRetrackingShown() async {
+    // Tapping "Update" clears the alert (SwiftUI sets isPresented = false, which the
+    // binding maps to presentedAlert = nil). checkVersionRequirements() only runs on
+    // cold launch, so the gate must re-present itself when the user returns from the
+    // App Store without updating — without inflating the "shown" analytics count.
+    @Shared(.isBroadcaster) var isBroadcaster = false
+    let captured = LockIsolated<[AnalyticsEvent]>([])
+
+    await withDependencies {
+      $0.api.getAppVersionRequirements = { [unreachableVersion, ancientVersion] in
+        AppVersionRequirements(
+          minimumVersion: unreachableVersion, minimumBroadcasterVersion: ancientVersion)
+      }
+      $0.analytics.track = { event in captured.withValue { $0.append(event) } }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.checkVersionRequirements()
+      #expect(model.presentedAlert != nil)
+
+      model.presentedAlert = nil
+      model.reblockAfterAppStoreReturn()
+
+      #expect(model.presentedAlert != nil)
+      #expect(gateShownEvents(captured.value).count == 1)
+    }
+  }
+
+  @Test
   func testUpdateButtonTappedTracksEvent() async {
     @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
       minimumVersion: "1.2.3", minimumBroadcasterVersion: "1.2.3")

--- a/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
+++ b/PlayolaRadio/Views/Pages/AppVersionGate/AppVersionGateModelTests.swift
@@ -7,6 +7,7 @@ import ConcurrencyExtras
 import Dependencies
 import Foundation
 import Sharing
+import SwiftUI
 import Testing
 
 @testable import PlayolaRadio
@@ -228,11 +229,12 @@ struct AppVersionGateModelTests {
   }
 
   @Test
-  func testGateReblocksAfterAppStoreReturnWithoutRetrackingShown() async {
+  func testGateReblocksWhenAppReturnsToForegroundWithoutRetrackingShown() async {
     // Tapping "Update" clears the alert (SwiftUI sets isPresented = false, which the
-    // binding maps to presentedAlert = nil). checkVersionRequirements() only runs on
-    // cold launch, so the gate must re-present itself when the user returns from the
-    // App Store without updating — without inflating the "shown" analytics count.
+    // binding maps to presentedAlert = nil) and opens the App Store. UIApplication.open
+    // returns immediately, and checkVersionRequirements() only runs on cold launch, so
+    // the gate must re-present when the app returns to the foreground — without
+    // inflating the "shown" analytics count.
     @Shared(.isBroadcaster) var isBroadcaster = false
     let captured = LockIsolated<[AnalyticsEvent]>([])
 
@@ -248,10 +250,38 @@ struct AppVersionGateModelTests {
       #expect(model.presentedAlert != nil)
 
       model.presentedAlert = nil
-      model.reblockAfterAppStoreReturn()
+      model.scenePhaseChanged(newPhase: .active)
 
       #expect(model.presentedAlert != nil)
       #expect(gateShownEvents(captured.value).count == 1)
+    }
+  }
+
+  @Test
+  func testScenePhaseActiveDoesNotPresentGateWhenNoGateIsActive() async {
+    // Returning to the foreground on a supported build must not conjure a gate.
+    let model = AppVersionGateModel()
+    model.scenePhaseChanged(newPhase: .active)
+    #expect(model.presentedAlert == nil)
+  }
+
+  @Test
+  func testScenePhaseChangeToBackgroundLeavesShownGateVisible() async {
+    // Backgrounding while the gate is up (without tapping Update) must not clear it.
+    @Shared(.appVersionRequirements) var appVersionRequirements = AppVersionRequirements(
+      minimumVersion: "1.0.0", minimumBroadcasterVersion: "9.9.9")
+
+    await withDependencies {
+      $0.analytics.track = { _ in }
+    } operation: {
+      let model = AppVersionGateModel()
+      await model.broadcasterUpdateDiscovered()
+      let presented = model.presentedAlert
+      #expect(presented != nil)
+
+      model.scenePhaseChanged(newPhase: .background)
+
+      #expect(model.presentedAlert == presented)
     }
   }
 

--- a/PlayolaRadio/Views/Pages/ContentView.swift
+++ b/PlayolaRadio/Views/Pages/ContentView.swift
@@ -17,6 +17,7 @@ extension Notification.Name {
 struct ContentView: View {
   @Shared(.auth) var auth
   @Dependency(\.analytics) var analytics
+  @Environment(\.scenePhase) private var scenePhase
   @State private var hasTrackedAppOpen = false
   @State private var versionGate = AppVersionGateModel()
 
@@ -56,6 +57,9 @@ struct ContentView: View {
     }
     .onReceive(NotificationCenter.default.publisher(for: .requiresAppUpdate)) { _ in
       Task { await versionGate.broadcasterUpdateDiscovered() }
+    }
+    .onChange(of: scenePhase) { _, newPhase in
+      versionGate.scenePhaseChanged(newPhase: newPhase)
     }
   }
 


### PR DESCRIPTION
Addresses the two good points from Greptile's review on #367.

## P1 — Forced-update gate no longer re-blocks after "Update" is tapped

The forced-upgrade alert is driven by `PlayolaAlert`, whose `playolaAlert` binding sets `presentedAlert = nil` when its single button is tapped (SwiftUI sets `isPresented = false`, the binding maps that to `nil`). Nothing re-presented the gate, and `checkVersionRequirements()` only runs once per cold launch. So a user who tapped **Update**, closed the App Store *without* updating, and returned to the app could keep using an unsupported build until the next cold launch — the old `ContentView` path re-set `requiresUpdate = true` inside the button action and did not have this hole.

Fix: after `UIApplication.shared.open(appStoreURL)` returns (it suspends while the App Store is foregrounded, so this runs the moment the user returns), re-present the gate via `reblockAfterAppStoreReturn()`. It reuses the existing `activeGate`, so it does **not** re-track a "shown" analytics event.

## P2 — Scope gate display-text constants to `private`

`alertTitle`, `alertMessage`, `updateButtonTitle`, and `appStoreURL` are only consumed by the private `makeUpdateRequiredAlert()`, so they're now `private let`.

## Testing

Added `testGateReblocksAfterAppStoreReturnWithoutRetrackingShown`: presents the gate, simulates SwiftUI clearing the alert on tap, calls `reblockAfterAppStoreReturn()`, and asserts the gate re-presents while the "shown" count stays at 1.

All 11 `AppVersionGateModelTests` pass (Xcode 26.5, iPhone 17 Pro sim). `make lint` clean. Codex review: no findings.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The required app update prompt now reappears when you return from the App Store without dismissing the update requirement.
  * Returning to the app no longer records duplicate “shown” analytics events for the same update prompt.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->