### PR TITLE
feat(congrats): make the winner's name the hero of the shout-out recording screen

### DIFF
--- a/PlayolaRadio/Models/GiveawayWinnerPendingPush.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPendingPush.swift
@@ -19,9 +19,16 @@ struct GiveawayWinnerPendingPush: Equatable, Sendable {
     self.eventId = eventId
     self.stationId = stationId
     self.giveawayId = userInfo["giveawayId"] as? String
-    self.winnerName = userInfo["winnerName"] as? String
-    self.prizeName = userInfo["prizeName"] as? String
+    // The server sends "" (not absent) when a name is unknown — normalize so the UI's fallback copy
+    // kicks in instead of rendering a blank.
+    self.winnerName = Self.nonEmpty(userInfo["winnerName"] as? String)
+    self.prizeName = Self.nonEmpty(userInfo["prizeName"] as? String)
     self.congratsExpiresAt = (userInfo["congratsExpiresAt"] as? String).flatMap(Self.parseISO8601)
+  }
+
+  private static func nonEmpty(_ string: String?) -> String? {
+    guard let string, !string.isEmpty else { return nil }
+    return string
   }
 
   /// Robust ISO-8601 parse: the server sends fractional seconds, but tolerate a value without them.

--- a/PlayolaRadio/Models/GiveawayWinnerPendingPush.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPendingPush.swift
@@ -27,8 +27,10 @@ struct GiveawayWinnerPendingPush: Equatable, Sendable {
   }
 
   private static func nonEmpty(_ string: String?) -> String? {
-    guard let string, !string.isEmpty else { return nil }
-    return string
+    guard let trimmed = string?.trimmingCharacters(in: .whitespaces), !trimmed.isEmpty else {
+      return nil
+    }
+    return trimmed
   }
 
   /// Robust ISO-8601 parse: the server sends fractional seconds, but tolerate a value without them.

--- a/PlayolaRadio/Models/GiveawayWinnerPendingPushTests.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPendingPushTests.swift
@@ -25,10 +25,18 @@ struct GiveawayWinnerPendingPushTests {
     // treated as a real name or the UI renders a blank where the winner's name belongs.
     let push = GiveawayWinnerPendingPush(userInfo: [
       "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",
-      "winnerName": "", "prizeName": "",
+      "winnerName": "", "prizeName": "   ",
     ])
     expectNoDifference(push?.winnerName, nil)
     expectNoDifference(push?.prizeName, nil)
+  }
+
+  @Test func trimsPaddedWinnerName() {
+    let push = GiveawayWinnerPendingPush(userInfo: [
+      "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",
+      "winnerName": " Jo ",
+    ])
+    expectNoDifference(push?.winnerName, "Jo")
   }
 
   @Test func parsesExpiryWithoutFractionalSeconds() {

--- a/PlayolaRadio/Models/GiveawayWinnerPendingPushTests.swift
+++ b/PlayolaRadio/Models/GiveawayWinnerPendingPushTests.swift
@@ -20,6 +20,17 @@ struct GiveawayWinnerPendingPushTests {
     #expect(push?.congratsExpiresAt != nil)
   }
 
+  @Test func treatsEmptyWinnerAndPrizeNamesAsMissing() {
+    // The server sends `winnerName: ""` when it can't resolve a name — an empty string must not be
+    // treated as a real name or the UI renders a blank where the winner's name belongs.
+    let push = GiveawayWinnerPendingPush(userInfo: [
+      "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",
+      "winnerName": "", "prizeName": "",
+    ])
+    expectNoDifference(push?.winnerName, nil)
+    expectNoDifference(push?.prizeName, nil)
+  }
+
   @Test func parsesExpiryWithoutFractionalSeconds() {
     let push = GiveawayWinnerPendingPush(userInfo: [
       "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModel.swift
@@ -203,10 +203,12 @@ class GiveawayCongratsSheetModel: ViewModel {
   }
 
   // MARK: - View Helpers
+  // The name is the hero of this screen — the curator reads it out loud while recording, so it must
+  // be unmissable rather than buried inside a sentence.
+  var winnerNameText: String { winnerName ?? "Your winner" }
   var headline: String {
-    let who = winnerName ?? "your winner"
-    if let prizeName { return "Congratulate \(who) on winning \(prizeName)!" }
-    return "Congratulate \(who)!"
+    if let prizeName { return "just won \(prizeName)!" }
+    return "just won your giveaway!"
   }
   var subtitle: String { "Record a short message — we'll play it on your station." }
   var skipButtonTitle: String { "Skip" }

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -26,6 +26,15 @@ struct GiveawayCongratsSheetModelTests {
     expectNoDifference(model.headline, "just won Two tickets!")
   }
 
+  @Test func winnerNameWithoutPrizeUsesGiveawayHeadline() {
+    let action = CongratsAction(
+      eventId: "e1", stationId: "s1", winnerName: "Jo", prizeName: nil,
+      congratsExpiresAt: nil, state: .pending, startedAt: Date())
+    let model = GiveawayCongratsSheetModel(action: action, onClose: {})
+    expectNoDifference(model.winnerNameText, "Jo")
+    expectNoDifference(model.headline, "just won your giveaway!")
+  }
+
   @Test func winnerNameFallsBackWhenMissing() {
     let action = CongratsAction(
       eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil,

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetModelTests.swift
@@ -20,9 +20,19 @@ struct GiveawayCongratsSheetModelTests {
       congratsExpiresAt: nil, state: .recorded(localRecordingPath: "/tmp/r.m4a"), startedAt: Date())
   }
 
-  @Test func headlineUsesWinnerAndPrize() {
+  @Test func winnerNameIsTheHeroText() {
     let model = GiveawayCongratsSheetModel(action: recordedAction(), onClose: {})
-    #expect(model.headline == "Congratulate Jo on winning Two tickets!")
+    expectNoDifference(model.winnerNameText, "Jo")
+    expectNoDifference(model.headline, "just won Two tickets!")
+  }
+
+  @Test func winnerNameFallsBackWhenMissing() {
+    let action = CongratsAction(
+      eventId: "e1", stationId: "s1", winnerName: nil, prizeName: nil,
+      congratsExpiresAt: nil, state: .pending, startedAt: Date())
+    let model = GiveawayCongratsSheetModel(action: action, onClose: {})
+    expectNoDifference(model.winnerNameText, "Your winner")
+    expectNoDifference(model.headline, "just won your giveaway!")
   }
 
   @Test func sendUploadsThenSubmitsAndMarksSubmitted() async {

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
@@ -8,10 +8,17 @@ struct GiveawayCongratsSheetView: View {
       Color.black.ignoresSafeArea()
 
       VStack(spacing: 16) {
-        Text(model.headline)
-          .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 24))
-          .foregroundColor(.white)
-          .multilineTextAlignment(.center)
+        VStack(spacing: 4) {
+          Text(model.winnerNameText)
+            .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 34))
+            .foregroundColor(.white)
+            .multilineTextAlignment(.center)
+
+          Text(model.headline)
+            .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 20))
+            .foregroundColor(.white)
+            .multilineTextAlignment(.center)
+        }
 
         Text(model.subtitle)
           .font(.custom(FontNames.Inter_400_Regular, size: 14))

--- a/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
+++ b/PlayolaRadio/Views/Pages/GiveawayCongratsSheet/GiveawayCongratsSheetView.swift
@@ -10,8 +10,8 @@ struct GiveawayCongratsSheetView: View {
       VStack(spacing: 16) {
         VStack(spacing: 4) {
           Text(model.winnerNameText)
-            .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 34))
-            .foregroundColor(.white)
+            .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 40))
+            .foregroundColor(.playolaRed)
             .multilineTextAlignment(.center)
 
           Text(model.headline)


### PR DESCRIPTION
## Why

During the July 15 live giveaway, the artist recording the congrats shout-out reported not seeing the winner's name. Investigation showed the whole data path worked — the push carried the name, the app parsed it, and the headline rendered it — but the name was buried mid-sentence in a single 24pt headline ("Congratulate Janell Wicht on winning …!"), easy to read past while focused on recording.

There was also one real data hole: the server's documented contract sends `winnerName: ""` (empty string, not absent) when a name can't be resolved, and the app treated `""` as a valid name — rendering a blank gap in the sentence.

## What

- The winner's name is now the hero of the recording screen: standalone 40pt SpaceGrotesk bold in Playola red, with "just won \<prize\>!" in white beneath it. Fallback copy when the name is missing: "Your winner / just won your giveaway!"
- `GiveawayWinnerPendingPush` normalizes empty-string `winnerName`/`prizeName` to `nil` so fallback copy kicks in instead of a blank.

<img width="393" alt="congrats sheet" src="" />

## Screenshot

| Before | After |
|---|---|
| Name inline in a 24pt sentence | 40pt red standalone name |

## Testing

- New tests: `winnerNameIsTheHeroText`, `winnerNameFallsBackWhenMissing`, `treatsEmptyWinnerAndPrizeNamesAsMissing`
- All 24 tests in the two affected suites pass; layout verified via headless `ImageRenderer` snapshot
- `make lint` and swift-format clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)