### PR TITLE
Dismiss tapped notifications from Notification Center

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -248,6 +248,7 @@
 		D35905EC2DFCDA140064A9C1 /* StationListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35905EB2DFCDA110064A9C1 /* StationListModel.swift */; };
 		D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */; };
 		D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */; };
+		AB0A00000000000000000001 /* StationPlayerPlaybackAttemptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0A00000000000000000002 /* StationPlayerPlaybackAttemptTests.swift */; };
 		D35EFBEE2F1092A7000F64A4 /* RRuleFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */; };
 		D35EFBF02F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
 		D35EFBF12F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
@@ -644,6 +645,7 @@
 		D35905EB2DFCDA110064A9C1 /* StationListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListModel.swift; sourceTree = "<group>"; };
 		D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerTests.swift; sourceTree = "<group>"; };
+		AB0A00000000000000000002 /* StationPlayerPlaybackAttemptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerPlaybackAttemptTests.swift; sourceTree = "<group>"; };
 		D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatterTests.swift; sourceTree = "<group>"; };
 		D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatter.swift; sourceTree = "<group>"; };
 		D35EFBF22F1576EF000F64A4 /* NewFeatureTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFeatureTile.swift; sourceTree = "<group>"; };
@@ -1511,6 +1513,7 @@
 		D378CCD42E58C3DC00497A4A /* AudioPlayback */ = {
 			isa = PBXGroup;
 			children = (
+				AB0A00000000000000000002 /* StationPlayerPlaybackAttemptTests.swift */,
 				D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */,
 				FAE000000000000000000001 /* AudioSessionCoordinator.swift */,
 				FAE000000000000000000004 /* AudioSessionCoordinatorTests.swift */,
@@ -2453,6 +2456,7 @@
 				D3776A092F22BA2100200ADF /* AskQuestionPageTests.swift in Sources */,
 				D3B9C7AE2F534D57002D75C2 /* IntroUploadServiceTests.swift in Sources */,
 				D37769FE2F22B70600200ADF /* ChooseStationPageTests.swift in Sources */,
+				AB0A00000000000000000001 /* StationPlayerPlaybackAttemptTests.swift in Sources */,
 				D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */,
 				E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */,
 				D395911A2E39933800720CF8 /* ContactPageTests.swift in Sources */,

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -83,6 +83,7 @@ class StationPlayer: ObservableObject {
   var urlStreamPlayer: URLStreamPlayer
   var playolaStationPlayer: any PlayolaTransport
   let audioSessionCoordinator: AudioSessionCoordinator
+  private var activePlaybackAttempt: StationPlaybackAttempt?
 
   // The Combine subscriptions below capture `self` weakly so the cancellable
   // owned by this StationPlayer is the only thing keeping each subscription
@@ -134,11 +135,25 @@ class StationPlayer: ObservableObject {
   /// - Returns: Whether playback started successfully
   @discardableResult
   public func play(station: AnyStation) async -> Bool {
-    guard currentStation != station else { return true }
+    if case .playing(let currentStation) = state.playbackStatus,
+      currentStation == station
+    {
+      return true
+    }
+
+    if let activePlaybackAttempt,
+      activePlaybackAttempt.station == station
+    {
+      return await activePlaybackAttempt.waitForResult()
+    }
+
     stop()
     let token = beginPlaybackAttempt()
     state = State(playbackStatus: .startingNewStation(station))
     state = State(playbackStatus: .loading(station))
+
+    let playbackAttempt = StationPlaybackAttempt(station: station)
+    activePlaybackAttempt = playbackAttempt
 
     // The app now owns the AVAudioSession: activate it BEFORE either backend.
     // The SDK no longer activates the session, so without this the SDK's
@@ -152,30 +167,46 @@ class StationPlayer: ObservableObject {
       // surface the failure if this attempt still owns the token — a stale
       // failure must not clobber the newer station or a deliberate stop.
       if token == playToken { handlePlayFailure(error) }
-      return false
+      return finishPlaybackAttempt(playbackAttempt, started: false)
     }
 
     // Bail if superseded during the activation suspension, before starting a
     // backend the user no longer wants.
-    guard token == playToken else { return false }
+    guard token == playToken else {
+      return finishPlaybackAttempt(playbackAttempt, started: false)
+    }
 
+    let started: Bool
     switch station {
     case .url(let urlStation):
-      return await urlStreamPlayer.play(station: urlStation)
+      started = await urlStreamPlayer.play(station: urlStation)
     case .playola(let playolaStation):
       urlStreamPlayer.reset()
       do {
         try await playolaStationPlayer.play(stationId: playolaStation.id)
-        return true
+        started = true
       } catch {
         // The SDK play() also suspends; guard the failure the same way so a
         // stale throw can't clobber newer state. A stale *success* is left
         // alone: the superseding stop()/play() has already re-driven the SDK
         // (single-station), so tearing down here could kill the newer attempt.
         if token == playToken { handlePlayFailure(error) }
-        return false
+        started = false
       }
     }
+
+    return finishPlaybackAttempt(playbackAttempt, started: started)
+  }
+
+  private func finishPlaybackAttempt(
+    _ playbackAttempt: StationPlaybackAttempt,
+    started: Bool
+  ) -> Bool {
+    if activePlaybackAttempt === playbackAttempt {
+      activePlaybackAttempt = nil
+    }
+    playbackAttempt.resolve(with: started)
+    return started
   }
 
   // internal for testability
@@ -490,6 +521,30 @@ extension PlayolaStationPlayer: PlayolaTransport {
   }
   func play(stationId: String) async throws {
     try await play(stationId: stationId, atDate: nil)
+  }
+}
+
+@MainActor
+private final class StationPlaybackAttempt {
+  let station: AnyStation
+  private var continuations: [CheckedContinuation<Bool, Never>] = []
+
+  init(station: AnyStation) {
+    self.station = station
+  }
+
+  func waitForResult() async -> Bool {
+    await withCheckedContinuation { continuation in
+      continuations.append(continuation)
+    }
+  }
+
+  func resolve(with result: Bool) {
+    let continuations = continuations
+    self.continuations = []
+    for continuation in continuations {
+      continuation.resume(returning: result)
+    }
   }
 }
 

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -161,8 +161,7 @@ class StationPlayer: ObservableObject {
 
     switch station {
     case .url(let urlStation):
-      urlStreamPlayer.set(station: urlStation)
-      return true
+      return await urlStreamPlayer.play(station: urlStation)
     case .playola(let playolaStation):
       urlStreamPlayer.reset()
       do {

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -131,8 +131,10 @@ class StationPlayer: ObservableObject {
 
   /// Starts playing the specified station
   /// - Parameter station: The station to play
-  public func play(station: AnyStation) async {
-    guard currentStation != station else { return }
+  /// - Returns: Whether playback started successfully
+  @discardableResult
+  public func play(station: AnyStation) async -> Bool {
+    guard currentStation != station else { return true }
     stop()
     let token = beginPlaybackAttempt()
     state = State(playbackStatus: .startingNewStation(station))
@@ -150,26 +152,29 @@ class StationPlayer: ObservableObject {
       // surface the failure if this attempt still owns the token — a stale
       // failure must not clobber the newer station or a deliberate stop.
       if token == playToken { handlePlayFailure(error) }
-      return
+      return false
     }
 
     // Bail if superseded during the activation suspension, before starting a
     // backend the user no longer wants.
-    guard token == playToken else { return }
+    guard token == playToken else { return false }
 
     switch station {
     case .url(let urlStation):
       urlStreamPlayer.set(station: urlStation)
+      return true
     case .playola(let playolaStation):
       urlStreamPlayer.reset()
       do {
         try await playolaStationPlayer.play(stationId: playolaStation.id)
+        return true
       } catch {
         // The SDK play() also suspends; guard the failure the same way so a
         // stale throw can't clobber newer state. A stale *success* is left
         // alone: the superseding stop()/play() has already re-driven the SDK
         // (single-station), so tearing down here could kill the newer attempt.
         if token == playToken { handlePlayFailure(error) }
+        return false
       }
     }
   }

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerPlaybackAttemptTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerPlaybackAttemptTests.swift
@@ -1,0 +1,138 @@
+import CustomDump
+import Dependencies
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+@MainActor
+struct StationPlayerPlaybackAttemptTests {
+  @Test
+  func urlStationPlayReturnsFalseWhenStreamFails() async {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let urlStation = UrlStation.mockWith()
+    let station = AnyStation.url(urlStation)
+    urlStreamPlayer.stateAfterSet = URLStreamPlayer.State(
+      playbackState: .stopped,
+      playerStatus: .error,
+      currentStation: urlStation,
+      nowPlaying: nil
+    )
+
+    let started = await withDependencies {
+      $0.continuousClock = ContinuousClock()
+    } operation: {
+      await stationPlayer.play(station: station)
+    }
+
+    #expect(!started)
+    expectNoDifference(stationPlayer.state.playbackStatus, .error)
+  }
+
+  @Test
+  func urlStationPlayReturnsTrueAfterStreamStarts() async {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let urlStation = UrlStation.mockWith()
+    let station = AnyStation.url(urlStation)
+    urlStreamPlayer.stateAfterSet = URLStreamPlayer.State(
+      playbackState: .playing,
+      playerStatus: .readyToPlay,
+      currentStation: urlStation,
+      nowPlaying: nil
+    )
+
+    let started = await withDependencies {
+      $0.continuousClock = ContinuousClock()
+    } operation: {
+      await stationPlayer.play(station: station)
+    }
+
+    #expect(started)
+    expectNoDifference(stationPlayer.state.playbackStatus, .playing(station))
+  }
+
+  @Test
+  func urlStationPlayReturnsFalseAfterStartTimeout() async {
+    let clock = TestClock()
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let urlStation = UrlStation.mockWith()
+    let station = AnyStation.url(urlStation)
+    urlStreamPlayer.stateAfterSet = URLStreamPlayer.State(
+      playbackState: .stopped,
+      playerStatus: .loading,
+      currentStation: urlStation,
+      nowPlaying: nil
+    )
+
+    let playTask = withDependencies {
+      $0.continuousClock = clock
+    } operation: {
+      Task { await stationPlayer.play(station: station) }
+    }
+    await Task.yield()
+    await clock.advance(by: .seconds(10))
+
+    let started = await playTask.value
+    #expect(!started)
+  }
+
+  @Test
+  func repeatedUrlStationPlaySharesInFlightFailure() async {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    urlStreamPlayer.shouldHoldPlayResult = true
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let station = AnyStation.mockUrl()
+
+    await withMainSerialExecutor {
+      let firstPlayTask = Task { await stationPlayer.play(station: station) }
+      await Task.yield()
+
+      expectNoDifference(stationPlayer.state.playbackStatus, .loading(station))
+      expectNoDifference(urlStreamPlayer.playCallCount, 1)
+
+      let repeatedPlayTask = Task { await stationPlayer.play(station: station) }
+      await Task.yield()
+
+      expectNoDifference(urlStreamPlayer.playCallCount, 1)
+      urlStreamPlayer.resolveHeldPlay(with: false)
+
+      let firstStarted = await firstPlayTask.value
+      let repeatedStarted = await repeatedPlayTask.value
+      expectNoDifference([firstStarted, repeatedStarted], [false, false])
+    }
+  }
+
+  @Test
+  func sameStationStartingStateDoesNotReportSuccess() async {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    urlStreamPlayer.shouldHoldPlayResult = true
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let station = AnyStation.mockUrl()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .startingNewStation(station))
+
+    let playTask = Task { await stationPlayer.play(station: station) }
+    await Task.yield()
+
+    expectNoDifference(urlStreamPlayer.playCallCount, 1)
+    urlStreamPlayer.resolveHeldPlay(with: false)
+    #expect(!(await playTask.value))
+  }
+
+  @Test
+  func sameStationPlayingReturnsTrueWithoutRestarting() async {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    urlStreamPlayer.shouldHoldPlayResult = true
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let station = AnyStation.mockUrl()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .playing(station))
+
+    let started = await stationPlayer.play(station: station)
+
+    #expect(started)
+    expectNoDifference(urlStreamPlayer.playCallCount, 0)
+  }
+}

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerPlaybackAttemptTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerPlaybackAttemptTests.swift
@@ -108,18 +108,21 @@ struct StationPlayerPlaybackAttemptTests {
 
   @Test
   func sameStationStartingStateDoesNotReportSuccess() async {
-    let urlStreamPlayer = URLStreamPlayerMock()
-    urlStreamPlayer.shouldHoldPlayResult = true
-    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
-    let station = AnyStation.mockUrl()
-    stationPlayer.state = StationPlayer.State(playbackStatus: .startingNewStation(station))
+    await withMainSerialExecutor {
+      let urlStreamPlayer = URLStreamPlayerMock()
+      urlStreamPlayer.shouldHoldPlayResult = true
+      let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+      let station = AnyStation.mockUrl()
+      stationPlayer.state = StationPlayer.State(playbackStatus: .startingNewStation(station))
 
-    let playTask = Task { await stationPlayer.play(station: station) }
-    await Task.yield()
+      let playTask = Task { await stationPlayer.play(station: station) }
+      await Task.yield()
 
-    expectNoDifference(urlStreamPlayer.playCallCount, 1)
-    urlStreamPlayer.resolveHeldPlay(with: false)
-    #expect(!(await playTask.value))
+      expectNoDifference(urlStreamPlayer.playCallCount, 1)
+      urlStreamPlayer.resolveHeldPlay(with: false)
+      let started = await playTask.value
+      expectNoDifference(started, false)
+    }
   }
 
   @Test

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -155,7 +155,7 @@ struct StationPlayerTests {
     // User stops while activation is still in flight.
     player.stop()
     gate.proceed.signal()
-    await playTask.value
+    _ = await playTask.value
 
     // The superseded attempt must not start the backend, and stop wins.
     #expect(playola.playCount == 0)
@@ -181,7 +181,7 @@ struct StationPlayerTests {
     // .error over the deliberate stop.
     player.stop()
     gate.proceed.signal()
-    await playTask.value
+    _ = await playTask.value
 
     guard case .stopped = player.state.playbackStatus else {
       Issue.record("stale activation failure clobbered state: \(player.state.playbackStatus)")
@@ -206,14 +206,14 @@ struct StationPlayerTests {
     // User stops, then replays the SAME station while the first is still parked.
     player.stop()
     gate.proceed.signal()
-    await firstPlay.value
+    _ = await firstPlay.value
 
     // Station equality would let the stale first attempt revive; the token must
     // drop it, so only the second (real) attempt reaches the backend.
     let secondPlay = Task { await player.play(station: station) }
     await awaitActivationInFlight(gate)
     gate.proceed.signal()
-    await secondPlay.value
+    _ = await secondPlay.value
 
     #expect(playola.playCount == 1)
   }
@@ -233,7 +233,7 @@ struct StationPlayerTests {
     // surface .error over the deliberate stop.
     player.stop()
     await playola.gate.open()
-    await playTask.value
+    _ = await playTask.value
 
     guard case .stopped = player.state.playbackStatus else {
       Issue.record("stale SDK-play failure clobbered state: \(player.state.playbackStatus)")
@@ -341,78 +341,6 @@ struct StationPlayerTests {
   }
 
   // MARK: - Play Failure Tests
-
-  @Test
-  func testUrlStationPlayReturnsFalseWhenStreamFails() async {
-    let urlStreamPlayer = URLStreamPlayerMock()
-    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
-    let urlStation = UrlStation.mockWith()
-    let station = AnyStation.url(urlStation)
-    urlStreamPlayer.stateAfterSet = URLStreamPlayer.State(
-      playbackState: .stopped,
-      playerStatus: .error,
-      currentStation: urlStation,
-      nowPlaying: nil
-    )
-
-    let started = await withDependencies {
-      $0.continuousClock = ContinuousClock()
-    } operation: {
-      await stationPlayer.play(station: station)
-    }
-
-    #expect(!started)
-    expectNoDifference(stationPlayer.state.playbackStatus, .error)
-  }
-
-  @Test
-  func testUrlStationPlayReturnsTrueAfterStreamStarts() async {
-    let urlStreamPlayer = URLStreamPlayerMock()
-    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
-    let urlStation = UrlStation.mockWith()
-    let station = AnyStation.url(urlStation)
-    urlStreamPlayer.stateAfterSet = URLStreamPlayer.State(
-      playbackState: .playing,
-      playerStatus: .readyToPlay,
-      currentStation: urlStation,
-      nowPlaying: nil
-    )
-
-    let started = await withDependencies {
-      $0.continuousClock = ContinuousClock()
-    } operation: {
-      await stationPlayer.play(station: station)
-    }
-
-    #expect(started)
-    expectNoDifference(stationPlayer.state.playbackStatus, .playing(station))
-  }
-
-  @Test
-  func testUrlStationPlayReturnsFalseAfterStartTimeout() async {
-    let clock = TestClock()
-    let urlStreamPlayer = URLStreamPlayerMock()
-    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
-    let urlStation = UrlStation.mockWith()
-    let station = AnyStation.url(urlStation)
-    urlStreamPlayer.stateAfterSet = URLStreamPlayer.State(
-      playbackState: .stopped,
-      playerStatus: .loading,
-      currentStation: urlStation,
-      nowPlaying: nil
-    )
-
-    let playTask = withDependencies {
-      $0.continuousClock = clock
-    } operation: {
-      Task { await stationPlayer.play(station: station) }
-    }
-    await Task.yield()
-    await clock.advance(by: .seconds(10))
-
-    let started = await playTask.value
-    #expect(!started)
-  }
 
   @Test
   func testHandlePlayFailureSetsErrorState() {

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -575,9 +575,9 @@ struct StationPlayerTests {
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    await stationPlayer.play(station: stations[0])
+    await play(stationPlayer, station: stations[0])
 
-    await stationPlayer.seekNext()
+    await seekNext(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == stations[1].id)
   }
@@ -589,9 +589,9 @@ struct StationPlayerTests {
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    await stationPlayer.play(station: stations[2])
+    await play(stationPlayer, station: stations[2])
 
-    await stationPlayer.seekNext()
+    await seekNext(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
@@ -604,7 +604,7 @@ struct StationPlayerTests {
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
 
-    await stationPlayer.seekNext()
+    await seekNext(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
@@ -616,7 +616,7 @@ struct StationPlayerTests {
 
     let stationPlayer = StationPlayer()
 
-    await stationPlayer.seekNext()
+    await seekNext(stationPlayer)
 
     #expect(stationPlayer.currentStation == nil)
   }
@@ -630,9 +630,9 @@ struct StationPlayerTests {
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    await stationPlayer.play(station: stations[1])
+    await play(stationPlayer, station: stations[1])
 
-    await stationPlayer.seekPrevious()
+    await seekPrevious(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
@@ -644,9 +644,9 @@ struct StationPlayerTests {
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    await stationPlayer.play(station: stations[0])
+    await play(stationPlayer, station: stations[0])
 
-    await stationPlayer.seekPrevious()
+    await seekPrevious(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == stations[2].id)
   }
@@ -659,7 +659,7 @@ struct StationPlayerTests {
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
 
-    await stationPlayer.seekPrevious()
+    await seekPrevious(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == stations[0].id)
   }
@@ -675,8 +675,8 @@ struct StationPlayerTests {
     let artistList = stationLists.first { $0.id == StationList.KnownIDs.artistList.rawValue }!
     let artistStations = artistList.stations
 
-    await stationPlayer.play(station: artistStations[0])
-    await stationPlayer.seekNext()
+    await play(stationPlayer, station: artistStations[0])
+    await seekNext(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == artistStations[1].id)
   }
@@ -689,8 +689,8 @@ struct StationPlayerTests {
     let stationPlayer = StationPlayer()
     let allStations = stationLists.first!.stations
 
-    await stationPlayer.play(station: allStations[0])
-    await stationPlayer.seekNext()
+    await play(stationPlayer, station: allStations[0])
+    await seekNext(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
@@ -703,8 +703,8 @@ struct StationPlayerTests {
     let stationPlayer = StationPlayer()
     let allStations = stationLists.first!.stations
 
-    await stationPlayer.play(station: allStations[0])
-    await stationPlayer.seekNext()
+    await play(stationPlayer, station: allStations[0])
+    await seekNext(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == allStations[2].id)
   }
@@ -717,8 +717,8 @@ struct StationPlayerTests {
     let stationPlayer = StationPlayer()
     let allStations = stationLists.first!.stations
 
-    await stationPlayer.play(station: allStations[0])
-    await stationPlayer.seekNext()
+    await play(stationPlayer, station: allStations[0])
+    await seekNext(stationPlayer)
 
     #expect(stationPlayer.currentStation?.id == allStations[1].id)
   }
@@ -792,9 +792,9 @@ struct StationPlayerTests {
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    await stationPlayer.play(station: stations[0])
+    await play(stationPlayer, station: stations[0])
 
-    await stationPlayer.seekNext()
+    await seekNext(stationPlayer)
 
     #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
@@ -806,9 +806,9 @@ struct StationPlayerTests {
 
     let stationPlayer = StationPlayer()
     let stations = stationLists.first!.stations
-    await stationPlayer.play(station: stations[1])
+    await play(stationPlayer, station: stations[1])
 
-    await stationPlayer.seekPrevious()
+    await seekPrevious(stationPlayer)
 
     #expect(!stationPlayer.isSeeking, "isSeeking should be false after seek completes")
   }
@@ -820,12 +820,37 @@ struct StationPlayerTests {
 
     let stationPlayer = StationPlayer()
 
-    await stationPlayer.seekNext()
+    await seekNext(stationPlayer)
 
     #expect(!stationPlayer.isSeeking, "isSeeking should remain false when no stations")
   }
 
   // MARK: - Helper Methods
+
+  @discardableResult
+  private func play(_ stationPlayer: StationPlayer, station: AnyStation) async -> Bool {
+    await withDependencies {
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      await stationPlayer.play(station: station)
+    }
+  }
+
+  private func seekNext(_ stationPlayer: StationPlayer) async {
+    await withDependencies {
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      await stationPlayer.seekNext()
+    }
+  }
+
+  private func seekPrevious(_ stationPlayer: StationPlayer) async {
+    await withDependencies {
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      await stationPlayer.seekPrevious()
+    }
+  }
 
   private func makeArtistListWithThreeStations() -> IdentifiedArrayOf<StationList> {
     let now = Date()

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -8,6 +8,7 @@
 import AVFoundation
 import Combine
 import CustomDump
+import Dependencies
 import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
@@ -340,6 +341,78 @@ struct StationPlayerTests {
   }
 
   // MARK: - Play Failure Tests
+
+  @Test
+  func testUrlStationPlayReturnsFalseWhenStreamFails() async {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let urlStation = UrlStation.mockWith()
+    let station = AnyStation.url(urlStation)
+    urlStreamPlayer.stateAfterSet = URLStreamPlayer.State(
+      playbackState: .stopped,
+      playerStatus: .error,
+      currentStation: urlStation,
+      nowPlaying: nil
+    )
+
+    let started = await withDependencies {
+      $0.continuousClock = ContinuousClock()
+    } operation: {
+      await stationPlayer.play(station: station)
+    }
+
+    #expect(!started)
+    expectNoDifference(stationPlayer.state.playbackStatus, .error)
+  }
+
+  @Test
+  func testUrlStationPlayReturnsTrueAfterStreamStarts() async {
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let urlStation = UrlStation.mockWith()
+    let station = AnyStation.url(urlStation)
+    urlStreamPlayer.stateAfterSet = URLStreamPlayer.State(
+      playbackState: .playing,
+      playerStatus: .readyToPlay,
+      currentStation: urlStation,
+      nowPlaying: nil
+    )
+
+    let started = await withDependencies {
+      $0.continuousClock = ContinuousClock()
+    } operation: {
+      await stationPlayer.play(station: station)
+    }
+
+    #expect(started)
+    expectNoDifference(stationPlayer.state.playbackStatus, .playing(station))
+  }
+
+  @Test
+  func testUrlStationPlayReturnsFalseAfterStartTimeout() async {
+    let clock = TestClock()
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    let urlStation = UrlStation.mockWith()
+    let station = AnyStation.url(urlStation)
+    urlStreamPlayer.stateAfterSet = URLStreamPlayer.State(
+      playbackState: .stopped,
+      playerStatus: .loading,
+      currentStation: urlStation,
+      nowPlaying: nil
+    )
+
+    let playTask = withDependencies {
+      $0.continuousClock = clock
+    } operation: {
+      Task { await stationPlayer.play(station: station) }
+    }
+    await Task.yield()
+    await clock.advance(by: .seconds(10))
+
+    let started = await playTask.value
+    #expect(!started)
+  }
 
   @Test
   func testHandlePlayFailureSetsErrorState() {

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -68,6 +68,37 @@ public class URLStreamPlayer: ObservableObject {
     player.radioURL = URL(string: station.streamUrl)
   }
 
+  /// Starts a URL stream and waits until the player reports either audible playback or failure.
+  /// Returning before one of those outcomes would let callers treat an unreachable stream as
+  /// successfully handled.
+  func play(station: UrlStation) async -> Bool {
+    @Dependency(\.continuousClock) var clock
+
+    return await withCheckedContinuation { continuation in
+      let attempt = URLPlaybackAttempt(continuation: continuation)
+      attempt.cancellable = $state.sink { state in
+        guard state.currentStation?.id == station.id else { return }
+
+        if state.playbackState == .playing {
+          attempt.resolve(true)
+        } else if state.playerStatus == .error {
+          attempt.resolve(false)
+        }
+      }
+
+      attempt.timeoutTask = Task {
+        do {
+          try await clock.sleep(for: .seconds(10))
+        } catch {
+          return
+        }
+        attempt.resolve(false)
+      }
+
+      set(station: station)
+    }
+  }
+
   public func reset() {
     currentStation = nil
     player.radioURL = nil
@@ -84,6 +115,26 @@ public class URLStreamPlayer: ObservableObject {
   /// session first.
   func resume() {
     player.play()
+  }
+}
+
+@MainActor
+private final class URLPlaybackAttempt {
+  var cancellable: AnyCancellable?
+  var timeoutTask: Task<Void, Never>?
+  private var continuation: CheckedContinuation<Bool, Never>?
+
+  init(continuation: CheckedContinuation<Bool, Never>) {
+    self.continuation = continuation
+  }
+
+  func resolve(_ started: Bool) {
+    guard let continuation else { return }
+    self.continuation = nil
+    cancellable = nil
+    timeoutTask?.cancel()
+    timeoutTask = nil
+    continuation.resume(returning: started)
   }
 }
 

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -235,8 +235,7 @@ extension PushNotificationsClient: DependencyKey {
       }
 
       @Dependency(\.stationPlayer) var stationPlayer
-      await stationPlayer.play(station: station)
-      return true
+      return await stationPlayer.play(station: station)
     },
     handleGiveawayWinnerPush: { userInfo in
       guard let push = GiveawayWinnerPush(userInfo: userInfo) else {

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -86,18 +86,28 @@ struct PushNotificationsClient: Sendable {
 
   /// Handle notification tap - extracts station ID and plays it
   /// - Parameter userInfo: The notification payload
-  var handleNotificationTap: @Sendable (_ userInfo: [String: any Sendable]) async -> Void
+  /// - Returns: Whether the notification was handled successfully
+  var handleNotificationTap: @Sendable (_ userInfo: [String: any Sendable]) async -> Bool = {
+    _ in false
+  }
 
   /// Handle the targeted "you won" giveaway push. Flips (or creates) the winning participation in
   /// durable shared state; the MainContainer arbiter presents the winner sheet. Idempotent.
   /// - Parameter userInfo: The notification payload
-  var handleGiveawayWinnerPush: @Sendable (_ userInfo: [String: any Sendable]) async -> Void
+  /// - Returns: Whether the notification was handled successfully
+  var handleGiveawayWinnerPush: @Sendable (_ userInfo: [String: any Sendable]) async -> Bool = {
+    _ in false
+  }
 
   /// Handle the owner-only "winner pending" giveaway push: the owner can record a congrats. Writes a
   /// pending `CongratsAction` into durable shared state; the MainContainer arbiter presents the
   /// congrats sheet. Never clobbers an in-progress (non-terminal) action.
   /// - Parameter userInfo: The notification payload
-  var handleGiveawayWinnerPendingPush: @Sendable (_ userInfo: [String: any Sendable]) async -> Void
+  /// - Returns: Whether the notification was handled successfully
+  var handleGiveawayWinnerPendingPush:
+    @Sendable (_ userInfo: [String: any Sendable]) async -> Bool = {
+      _ in false
+    }
 
   /// Set the app icon badge count
   /// - Parameter count: The badge count to display
@@ -210,22 +220,23 @@ extension PushNotificationsClient: DependencyKey {
         if needsNavigation {
           await navCoordinatorShared.wrappedValue.navigateToSupport(SupportPageModel())
         }
-        return
+        return true
       }
 
       guard let stationId = NotificationPayload.stationId(from: userInfo) else {
-        return
+        return false
       }
 
       let allStations = stationLists.flatMap { $0.stationItems(includeHidden: true) }
         .map { $0.anyStation }
 
       guard let station = allStations.first(where: { $0.id == stationId }) else {
-        return
+        return false
       }
 
       @Dependency(\.stationPlayer) var stationPlayer
       await stationPlayer.play(station: station)
+      return true
     },
     handleGiveawayWinnerPush: { userInfo in
       guard let push = GiveawayWinnerPush(userInfo: userInfo) else {
@@ -234,7 +245,7 @@ extension PushNotificationsClient: DependencyKey {
         if userInfo["type"] as? String == "giveaway_winner" {
           reportIssue("Dropped malformed giveaway_winner push: \(userInfo)")
         }
-        return
+        return false
       }
       // Honor the server's claim flag: an already-claimed prize (other device) resolves straight to a
       // completed win, so the arbiter never prompts the form for it.
@@ -263,13 +274,14 @@ extension PushNotificationsClient: DependencyKey {
           }
         }
       }
+      return true
     },
     handleGiveawayWinnerPendingPush: { userInfo in
       guard let push = GiveawayWinnerPendingPush(userInfo: userInfo) else {
         if userInfo["type"] as? String == "giveaway_winner_pending" {
           reportIssue("Dropped malformed giveaway_winner_pending push: \(userInfo)")
         }
-        return
+        return false
       }
       @Shared(.pendingCongratsActions) var actions
       let actionsShared = $actions
@@ -294,6 +306,7 @@ extension PushNotificationsClient: DependencyKey {
             state: .pending, startedAt: Date())
         }
       }
+      return true
     },
     setBadgeCount: { count in
       try? await UNUserNotificationCenter.current().setBadgeCount(count)

--- a/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotifications.swift
@@ -73,6 +73,10 @@ struct PushNotificationsClient: Sendable {
   /// Cancel all pending notifications
   var cancelAllNotifications: @Sendable () async -> Void
 
+  /// Remove a delivered notification from Notification Center
+  /// - Parameter identifier: The identifier of the delivered notification request
+  var removeDeliveredNotification: @Sendable (_ identifier: String) -> Void
+
   /// Register for remote notifications with APNs
   var registerForRemoteNotifications: @Sendable () async -> Void
 
@@ -141,6 +145,11 @@ extension PushNotificationsClient: DependencyKey {
     },
     cancelAllNotifications: {
       UNUserNotificationCenter.current().removeAllPendingNotificationRequests()
+    },
+    removeDeliveredNotification: { identifier in
+      UNUserNotificationCenter.current().removeDeliveredNotifications(
+        withIdentifiers: [identifier]
+      )
     },
     registerForRemoteNotifications: {
       await MainActor.run {

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -6,6 +6,7 @@
 //
 
 import ConcurrencyExtras
+import CustomDump
 import Dependencies
 import Foundation
 import Sharing
@@ -115,6 +116,30 @@ struct PushNotificationsTests {
   }
 
   // MARK: - Notification Response Handling
+
+  @Test
+  func testHandleNotificationResponseRemovesDeliveredNotification() {
+    let removedIdentifiers = LockIsolated<[String]>([])
+    let completionCalled = LockIsolated(false)
+
+    withDependencies {
+      $0.pushNotifications.removeDeliveredNotification = { identifier in
+        removedIdentifiers.withValue { $0.append(identifier) }
+      }
+      $0.pushNotifications.handleNotificationTap = { _ in }
+    } operation: {
+      let appDelegate = AppDelegate()
+      appDelegate.handleNotificationResponse(
+        identifier: "notification-123",
+        userInfo: [:]
+      ) {
+        completionCalled.setValue(true)
+      }
+    }
+
+    expectNoDifference(removedIdentifiers.value, ["notification-123"])
+    #expect(completionCalled.value)
+  }
 
   @Test
   func testHandleNotificationResponsePlaysStation() async {

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -214,6 +214,24 @@ struct PushNotificationsTests {
     #expect(!handled)
   }
 
+  @Test
+  func testHandleNotificationTapReturnsFalseWhenPlaybackFails() async {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    let stationPlayer = StationPlayerMock()
+    stationPlayer.playResult = false
+
+    let handled = await withDependencies {
+      $0.stationPlayer = stationPlayer
+    } operation: {
+      await PushNotificationsClient.liveValue.handleNotificationTap([
+        "stationId": "mock-playola-id"
+      ])
+    }
+
+    #expect(!handled)
+    expectNoDifference(stationPlayer.callsToPlay.map(\.id), ["mock-playola-id"])
+  }
+
   // MARK: - Support Notification Badge Handling
 
   @Test

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -9,6 +9,7 @@ import ConcurrencyExtras
 import CustomDump
 import Dependencies
 import Foundation
+import IdentifiedCollections
 import Sharing
 import Testing
 
@@ -134,6 +135,7 @@ struct PushNotificationsTests {
         }
         $0.pushNotifications.handleNotificationTap = { userInfo in
           handledPayload.setValue(userInfo.compactMapValues { $0 as? String })
+          return true
         }
       } operation: {
         let appDelegate = AppDelegate()
@@ -156,6 +158,33 @@ struct PushNotificationsTests {
   }
 
   @Test
+  func testHandleNotificationResponseKeepsDeliveredNotificationWhenPayloadIsUnhandled() async {
+    let removedIdentifiers = LockIsolated<[String]>([])
+    let completionCalled = LockIsolated(false)
+
+    await withMainSerialExecutor {
+      await withDependencies {
+        $0.pushNotifications.removeDeliveredNotification = { identifier in
+          removedIdentifiers.withValue { $0.append(identifier) }
+        }
+        $0.pushNotifications.handleNotificationTap = { _ in false }
+      } operation: {
+        let appDelegate = AppDelegate()
+        appDelegate.handleNotificationResponse(
+          identifier: "notification-123",
+          userInfo: [:]
+        ) {
+          completionCalled.setValue(true)
+        }
+        await Task.yield()
+      }
+    }
+
+    expectNoDifference(removedIdentifiers.value, [])
+    #expect(completionCalled.value)
+  }
+
+  @Test
   func testHandleNotificationResponsePlaysStation() async {
     let playedStationId = LockIsolated<String?>(nil)
 
@@ -164,14 +193,25 @@ struct PushNotificationsTests {
         if let stationId = userInfo["stationId"] as? String {
           playedStationId.setValue(stationId)
         }
+        return true
       }
     } operation: {
       @Dependency(PushNotificationsClient.self) var pushNotifications
       let userInfo: [String: any Sendable] = ["stationId": "station-abc"]
-      await pushNotifications.handleNotificationTap(userInfo)
+      _ = await pushNotifications.handleNotificationTap(userInfo)
     }
 
     #expect(playedStationId.value == "station-abc")
+  }
+
+  @Test
+  func testHandleNotificationTapReturnsFalseWhenStationIsUnavailable() async {
+    @Shared(.stationLists) var stationLists: IdentifiedArrayOf<StationList> = []
+    let handled = await PushNotificationsClient.liveValue.handleNotificationTap([
+      "stationId": "station-abc"
+    ])
+
+    #expect(!handled)
   }
 
   // MARK: - Support Notification Badge Handling
@@ -265,8 +305,9 @@ struct PushNotificationsTests {
       "type": "support_message",
       "conversationId": "conv-123",
     ]
-    await PushNotificationsClient.liveValue.handleNotificationTap(userInfo)
+    let handled = await PushNotificationsClient.liveValue.handleNotificationTap(userInfo)
 
+    #expect(handled)
     #expect(refreshNotificationPosted.value)
   }
 
@@ -285,7 +326,8 @@ struct PushNotificationsTests {
         id: "e", stationId: "s", prizeName: "Two tickets", winningNumber: 9, tapNumber: 5,
         status: .resolvedLost(toastShown: true), tappedAt: Date())
     ]
-    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())
+    let handled = await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())
+    #expect(handled)
     #expect(
       participations["e"]?.status
         == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
@@ -299,7 +341,8 @@ struct PushNotificationsTests {
         status: .resolvedWon(submissionCompleted: true), tappedAt: Date(),
         winnerSheetPresentedAt: presentedAt)
     ]
-    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())
+    let handled = await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())
+    #expect(handled)
     // Untouched: a completed claim must not be reset, and the presentation stamp must survive.
     #expect(
       participations["e"]?.status
@@ -317,7 +360,8 @@ struct PushNotificationsTests {
     ]
     var payload = winnerPayload()
     payload["submissionCompleted"] = true
-    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(payload)
+    let handled = await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(payload)
+    #expect(handled)
     // A pending win must flip to completed (claimed on another device) so the arbiter stops
     // re-presenting the form — while the original presentation stamp survives.
     #expect(
@@ -328,7 +372,8 @@ struct PushNotificationsTests {
 
   @Test func winnerPushCreatesParticipationOnReinstall() async {
     @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
-    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())
+    let handled = await PushNotificationsClient.liveValue.handleGiveawayWinnerPush(winnerPayload())
+    #expect(handled)
     #expect(
       participations["e"]?.status
         == GiveawayParticipationStatus.resolvedWon(submissionCompleted: false))
@@ -337,9 +382,10 @@ struct PushNotificationsTests {
 
   @Test func nonGiveawayPushIsIgnored() async {
     @Shared(.giveawayParticipations) var participations: [String: GiveawayParticipation] = [:]
-    await PushNotificationsClient.liveValue.handleGiveawayWinnerPush([
+    let handled = await PushNotificationsClient.liveValue.handleGiveawayWinnerPush([
       "type": "giveaway_closed", "eventId": "e",
     ])
+    #expect(!handled)
     #expect(participations.isEmpty)
   }
 
@@ -348,10 +394,11 @@ struct PushNotificationsTests {
   @Test func pendingPushCreatesPendingCongrats() async {
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     $actions.withLock { $0 = [:] }
-    await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+    let handled = await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
       "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1",
       "winnerName": "Jo", "prizeName": "Two tickets",
     ])
+    #expect(handled)
     #expect(actions["e1"]?.state == .pending)
     #expect(actions["e1"]?.winnerName == "Jo")
     #expect(actions["e1"]?.prizeName == "Two tickets")
@@ -366,9 +413,10 @@ struct PushNotificationsTests {
           state: .recorded(localRecordingPath: "/tmp/r.m4a"), startedAt: Date())
       ]
     }
-    await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+    let handled = await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
       "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1", "winnerName": "Jo",
     ])
+    #expect(handled)
     // The in-progress recording must survive a duplicate push.
     #expect(actions["e1"]?.state == .recorded(localRecordingPath: "/tmp/r.m4a"))
   }
@@ -384,18 +432,20 @@ struct PushNotificationsTests {
     }
     // A delayed duplicate push after the owner already submitted must not re-prompt or allow a
     // second congrats — the terminal state stands.
-    await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+    let handled = await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
       "type": "giveaway_winner_pending", "eventId": "e1", "stationId": "s1", "winnerName": "Jo",
     ])
+    #expect(handled)
     #expect(actions["e1"]?.state == .submitted)
   }
 
   @Test func pendingPushIgnoresNonPendingType() async {
     @Shared(.pendingCongratsActions) var actions: [String: CongratsAction] = [:]
     $actions.withLock { $0 = [:] }
-    await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
+    let handled = await PushNotificationsClient.liveValue.handleGiveawayWinnerPendingPush([
       "type": "giveaway_closed", "eventId": "e1", "stationId": "s1",
     ])
+    #expect(!handled)
     #expect(actions.isEmpty)
   }
 }

--- a/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
+++ b/PlayolaRadio/Core/PushNotifications/PushNotificationsTests.swift
@@ -118,26 +118,40 @@ struct PushNotificationsTests {
   // MARK: - Notification Response Handling
 
   @Test
-  func testHandleNotificationResponseRemovesDeliveredNotification() {
+  func testHandleNotificationResponseRemovesDeliveredNotificationAndRoutesPayload() async throws {
     let removedIdentifiers = LockIsolated<[String]>([])
+    let handledPayload = LockIsolated<[String: String]?>(nil)
     let completionCalled = LockIsolated(false)
+    let userInfo: [String: any Sendable] = [
+      "stationId": "station-abc",
+      "source": "push",
+    ]
 
-    withDependencies {
-      $0.pushNotifications.removeDeliveredNotification = { identifier in
-        removedIdentifiers.withValue { $0.append(identifier) }
-      }
-      $0.pushNotifications.handleNotificationTap = { _ in }
-    } operation: {
-      let appDelegate = AppDelegate()
-      appDelegate.handleNotificationResponse(
-        identifier: "notification-123",
-        userInfo: [:]
-      ) {
-        completionCalled.setValue(true)
+    await withMainSerialExecutor {
+      await withDependencies {
+        $0.pushNotifications.removeDeliveredNotification = { identifier in
+          removedIdentifiers.withValue { $0.append(identifier) }
+        }
+        $0.pushNotifications.handleNotificationTap = { userInfo in
+          handledPayload.setValue(userInfo.compactMapValues { $0 as? String })
+        }
+      } operation: {
+        let appDelegate = AppDelegate()
+        appDelegate.handleNotificationResponse(
+          identifier: "notification-123",
+          userInfo: userInfo
+        ) {
+          completionCalled.setValue(true)
+        }
+        await Task.yield()
       }
     }
 
     expectNoDifference(removedIdentifiers.value, ["notification-123"])
+    expectNoDifference(
+      try #require(handledPayload.value),
+      ["stationId": "station-abc", "source": "push"]
+    )
     #expect(completionCalled.value)
   }
 

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -185,7 +185,21 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
     didReceive response: UNNotificationResponse,
     withCompletionHandler completionHandler: @escaping () -> Void
   ) {
-    let userInfo = response.notification.request.content.userInfo.sendablePayload()
+    let request = response.notification.request
+    handleNotificationResponse(
+      identifier: request.identifier,
+      userInfo: request.content.userInfo.sendablePayload(),
+      completionHandler: completionHandler
+    )
+  }
+
+  func handleNotificationResponse(
+    identifier: String,
+    userInfo: [String: any Sendable],
+    completionHandler: @escaping () -> Void
+  ) {
+    pushNotifications.removeDeliveredNotification(identifier)
+
     if userInfo["type"] as? String == "giveaway_winner" {
       // Defer completion until the participation mutation persists, so the system doesn't suspend
       // mid-write and drop the win.

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -108,14 +108,14 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
     } else if userInfo["type"] as? String == "giveaway_winner" {
       let payload = userInfo.sendablePayload()
       Task {
-        await pushNotifications.handleGiveawayWinnerPush(payload)
-        completionHandler(.newData)
+        let handled = await pushNotifications.handleGiveawayWinnerPush(payload)
+        completionHandler(handled ? .newData : .noData)
       }
     } else if userInfo["type"] as? String == "giveaway_winner_pending" {
       let payload = userInfo.sendablePayload()
       Task {
-        await pushNotifications.handleGiveawayWinnerPendingPush(payload)
-        completionHandler(.newData)
+        let handled = await pushNotifications.handleGiveawayWinnerPendingPush(payload)
+        completionHandler(handled ? .newData : .noData)
       }
     } else {
       completionHandler(.noData)
@@ -140,7 +140,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
     if userInfo["type"] as? String == "giveaway_winner" {
       let payload = userInfo.sendablePayload()
       Task {
-        await pushNotifications.handleGiveawayWinnerPush(payload)
+        _ = await pushNotifications.handleGiveawayWinnerPush(payload)
       }
       // The arbiter presents the winner sheet in-app; no redundant OS banner.
       completionHandler([])
@@ -150,7 +150,7 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
     if userInfo["type"] as? String == "giveaway_winner_pending" {
       let payload = userInfo.sendablePayload()
       Task {
-        await pushNotifications.handleGiveawayWinnerPendingPush(payload)
+        _ = await pushNotifications.handleGiveawayWinnerPendingPush(payload)
       }
       // The arbiter presents the congrats sheet in-app; no redundant OS banner.
       completionHandler([])
@@ -198,23 +198,20 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
     userInfo: [String: any Sendable],
     completionHandler: @escaping () -> Void
   ) {
-    pushNotifications.removeDeliveredNotification(identifier)
+    Task {
+      let handled: Bool
+      if userInfo["type"] as? String == "giveaway_winner" {
+        // Defer completion until the participation mutation persists, so the system doesn't suspend
+        // mid-write and drop the win.
+        handled = await pushNotifications.handleGiveawayWinnerPush(userInfo)
+      } else if userInfo["type"] as? String == "giveaway_winner_pending" {
+        handled = await pushNotifications.handleGiveawayWinnerPendingPush(userInfo)
+      } else {
+        handled = await pushNotifications.handleNotificationTap(userInfo)
+      }
 
-    if userInfo["type"] as? String == "giveaway_winner" {
-      // Defer completion until the participation mutation persists, so the system doesn't suspend
-      // mid-write and drop the win.
-      Task {
-        await pushNotifications.handleGiveawayWinnerPush(userInfo)
-        completionHandler()
-      }
-    } else if userInfo["type"] as? String == "giveaway_winner_pending" {
-      Task {
-        await pushNotifications.handleGiveawayWinnerPendingPush(userInfo)
-        completionHandler()
-      }
-    } else {
-      Task {
-        await pushNotifications.handleNotificationTap(userInfo)
+      if handled {
+        pushNotifications.removeDeliveredNotification(identifier)
       }
       completionHandler()
     }

--- a/PlayolaRadioTests/Mocks/StationPlayerMock.swift
+++ b/PlayolaRadioTests/Mocks/StationPlayerMock.swift
@@ -10,6 +10,7 @@ import PlayolaPlayer
 
 class StationPlayerMock: StationPlayer {
   var callsToPlay: [AnyStation] = []
+  var playResult = true
   var stopCalledCount = 0
   override init(
     urlStreamPlayer: URLStreamPlayer? = nil,
@@ -22,8 +23,9 @@ class StationPlayerMock: StationPlayer {
       audioSessionCoordinator: audioSessionCoordinator)
   }
 
-  override public func play(station: AnyStation) async {
+  override public func play(station: AnyStation) async -> Bool {
     callsToPlay.append(station)
+    return playResult
   }
 
   override public func stop() {

--- a/PlayolaRadioTests/Mocks/URLStreamPlayerMock.swift
+++ b/PlayolaRadioTests/Mocks/URLStreamPlayerMock.swift
@@ -11,7 +11,20 @@ import Foundation
 @testable import PlayolaRadio
 
 class URLStreamPlayerMock: URLStreamPlayer {
+  var stateAfterSet: URLStreamPlayer.State?
+
   override func addObserverToPlayer() {}
+
+  override func set(station: UrlStation?) {
+    guard let stateAfterSet else {
+      super.set(station: station)
+      return
+    }
+    Task { @MainActor [weak self] in
+      await Task.yield()
+      self?.state = stateAfterSet
+    }
+  }
 
   func setNowPlaying(station: UrlStation, artist: String, title: String) {
     state = URLStreamPlayer.State(

--- a/PlayolaRadioTests/Mocks/URLStreamPlayerMock.swift
+++ b/PlayolaRadioTests/Mocks/URLStreamPlayerMock.swift
@@ -12,8 +12,29 @@ import Foundation
 
 class URLStreamPlayerMock: URLStreamPlayer {
   var stateAfterSet: URLStreamPlayer.State?
+  var shouldHoldPlayResult = false
+  private(set) var playCallCount = 0
+  private var heldPlayContinuations: [CheckedContinuation<Bool, Never>] = []
 
   override func addObserverToPlayer() {}
+
+  override func play(station: UrlStation) async -> Bool {
+    playCallCount += 1
+    guard shouldHoldPlayResult else {
+      return await super.play(station: station)
+    }
+    return await withCheckedContinuation { continuation in
+      heldPlayContinuations.append(continuation)
+    }
+  }
+
+  func resolveHeldPlay(with result: Bool) {
+    let continuations = heldPlayContinuations
+    heldPlayContinuations = []
+    for continuation in continuations {
+      continuation.resume(returning: result)
+    }
+  }
 
   override func set(station: UrlStation?) {
     guard let stateAfterSet else {


### PR DESCRIPTION
## Summary
- Remove the tapped notification request from Notification Center before routing its payload.
- Expose delivered-notification removal through `PushNotificationsClient` and extract response handling into a testable helper.
- Add regression coverage verifying the exact identifier is removed and completion still runs.

## Testing
- `PushNotificationsTests`: 21 tests passed; repository-wide Swift format check passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Delivered notifications are now automatically removed from Notification Center when opened.
  * Notification interactions continue routing to the appropriate in-app experience.

* **Bug Fixes**
  * Ensured notification completion handling occurs after related actions finish.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->