### PR TITLE
Stop double-triggered release pipeline from double-uploading builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,17 @@
 version: 2.1
 
+parameters:
+  # Set to true only by the auto-tag GitHub Action's API trigger (see
+  # .github/workflows/auto-tag-release.yml). CircleCI's native tag webhook is
+  # unreliable — it fires on some release tags and not others — so the API POST is
+  # the real release trigger. Gating the release workflow on this parameter makes
+  # the API-triggered pipeline the SINGLE deterministic release path: a webhook tag
+  # pipeline arrives without the parameter (default false) and skips the release,
+  # instead of racing the API pipeline and double-uploading the same build (ITMS-90189).
+  run_release:
+    type: boolean
+    default: false
+
 jobs:
   swiftlint_check:
     macos:
@@ -161,6 +173,10 @@ workflows:
             - build-and-test
 
   release:
+    # Only run on the API-triggered pipeline that carries run_release: true. A native
+    # tag webhook pipeline lacks the parameter and is skipped, so exactly one pipeline
+    # per tag uploads a build. See the run_release parameter definition above.
+    when: << pipeline.parameters.run_release >>
     jobs:
       - release_build:
           context: ios-release

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -9,11 +9,16 @@ permissions:
   contents: write
 
 concurrency:
-  # Serialize auto-tag runs so two overlapping runs for main can't both pass the
-  # idempotency check and double-trigger the release. cancel-in-progress: false lets a
-  # queued run still execute afterward (by which time the first run's API pipeline is
-  # visible to the idempotency check), so a genuinely-failed trigger can still recover.
-  group: ${{ github.workflow }}-${{ github.ref }}
+  # Serialize only runs for the SAME commit (e.g. a manual re-run of this workflow) so
+  # they can't both pass the idempotency check and double-trigger the release. Keyed by
+  # github.sha, NOT github.ref: a ref-wide group would put every main push in one group,
+  # and GitHub keeps only one running + one pending run per group, so a third push would
+  # cancel the pending second and that commit would never get tagged/triggered. Per-sha
+  # groups let every distinct commit run while still de-duping same-commit re-runs.
+  # cancel-in-progress: false lets a queued re-run still execute afterward (by which time
+  # the first run's API pipeline is visible to the idempotency check), so a genuinely
+  # failed trigger can still recover.
+  group: ${{ github.workflow }}-${{ github.sha }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/auto-tag-release.yml
+++ b/.github/workflows/auto-tag-release.yml
@@ -8,6 +8,14 @@ on:
 permissions:
   contents: write
 
+concurrency:
+  # Serialize auto-tag runs so two overlapping runs for main can't both pass the
+  # idempotency check and double-trigger the release. cancel-in-progress: false lets a
+  # queued run still execute afterward (by which time the first run's API pipeline is
+  # visible to the idempotency check), so a genuinely-failed trigger can still recover.
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
   create-tag:
     runs-on: ubuntu-latest
@@ -72,12 +80,16 @@ jobs:
             exit 1
           fi
           # Idempotency: page through the CircleCI pipeline list (most-recent-first)
-          # looking for an existing pipeline for this tag. Combined with the HEAD
-          # check above, a re-run RECOVERS a failed trigger but never duplicates a
-          # successful one. FAIL CLOSED — if the pipeline state can't be
-          # determined, do NOT POST (re-running retries the check), so a flaky API
-          # never causes a duplicate release build/upload. Paginating (not just the
-          # first page) keeps this correct even if other pipelines ran in between.
+          # looking for an existing API-triggered pipeline for this tag. Combined with
+          # the HEAD check above, a re-run RECOVERS a failed trigger but never duplicates
+          # a successful one. We match trigger.type == "api" ONLY: the release workflow
+          # runs solely on our API trigger (it carries run_release: true), so a native
+          # tag-webhook pipeline for this tag does NOT release and must not be mistaken
+          # for a successful trigger — otherwise we'd skip the POST and never release.
+          # FAIL CLOSED — if the pipeline state can't be determined, do NOT POST
+          # (re-running retries the check), so a flaky API never causes a duplicate
+          # release build/upload. Paginating (not just the first page) keeps this correct
+          # even if other pipelines ran in between.
           PAGE_TOKEN=""
           FOUND=0
           for _ in $(seq 1 10); do
@@ -94,7 +106,7 @@ jobs:
               echo "::error::Unexpected response while checking existing pipelines; refusing to trigger. Re-run this job to retry."
               cat "$LIST"; exit 1
             fi
-            MATCH=$(jq -r --arg t "$TAG" '[.items[] | select(((.vcs // {}).tag // "") == $t)] | length' "$LIST")
+            MATCH=$(jq -r --arg t "$TAG" '[.items[] | select(((.vcs // {}).tag // "") == $t and (.trigger.type // "") == "api")] | length' "$LIST")
             if [ "$MATCH" != "0" ]; then FOUND=1; break; fi
             PAGE_TOKEN=$(jq -r '.next_page_token // ""' "$LIST")
             [ -z "$PAGE_TOKEN" ] && break
@@ -104,7 +116,10 @@ jobs:
             exit 0
           fi
           echo "Triggering CircleCI release pipeline for tag $TAG"
-          PAYLOAD=$(jq -nc --arg t "$TAG" '{tag: $t}')
+          # run_release: true gates the release workflow on in the config, so ONLY this
+          # API-triggered pipeline uploads a build (the native tag-webhook pipeline, which
+          # lacks the parameter, skips the release).
+          PAYLOAD=$(jq -nc --arg t "$TAG" '{tag: $t, parameters: {run_release: true}}')
           HTTP=$(curl -sS -o /tmp/cci-response.json -w '%{http_code}' \
             -X POST "https://circleci.com/api/v2/project/gh/playola-radio/playola-radio-ios/pipeline" \
             -H "Circle-Token: $CIRCLECI_TOKEN" \


### PR DESCRIPTION
A release tag was launching two CircleCI pipelines — CircleCI's flaky native tag webhook and the auto-tag Action's explicit API POST — and both computed and uploaded the same build number, so Apple rejected the second with ITMS-90189 (Redundant Binary Upload), as seen on v7.3.2 build 100 for both prod and staging (confirmed via the CircleCI API: pipelines 1252 `webhook` and 1254 `api`, 3s apart). This gates the `release` workflow on a new `run_release` pipeline parameter that only the API POST sets, so a webhook tag pipeline skips the release and exactly one pipeline uploads per tag. The Action now passes `run_release: true`, its idempotency check counts only `api`-triggered pipelines (so the webhook pipeline can't fool it into skipping the essential POST), and a workflow `concurrency` guard prevents two overlapping Action runs from both triggering. Build numbers are unchanged — still ASC-derived, so the next release is 101. Known limitation: if a first API trigger ever creates a pipeline that never actually releases, later re-runs skip it as "already triggered" — recover by re-cutting/re-pushing the tag.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release automation to prevent duplicate release jobs from running.
  * Ensured releases run only for explicitly triggered release pipelines.
  * Added safeguards to serialize release workflow runs without canceling queued runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->