### PR TITLE
docs: add LONG_RUNNING.md tracker for multi-PR / soaking work

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,15 @@
+<!-- Keep this light. Delete sections that don't apply. -->
+
+## What & why
+
+
+## Long-running work
+
+- [ ] This PR does **not** advance/start a long-running effort, **or** I updated
+      [`LONG_RUNNING.md`](../LONG_RUNNING.md) in this PR (step / soak / phase).
+
+<!--
+LONG_RUNNING.md tracks anything spanning >1 PR or carrying a production soak.
+If this PR advances a tracked task (or starts one that's clearly multi-PR /
+needs a staged rollout), update the tracker here. One-off PRs: just check the box.
+-->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,7 +6,8 @@
 ## Long-running work
 
 - [ ] This PR does **not** advance/start a long-running effort, **or** I updated
-      [`LONG_RUNNING.md`](../LONG_RUNNING.md) in this PR (step / soak / phase).
+      [`LONG_RUNNING.md`](https://github.com/playola-radio/playola-radio-ios/blob/develop/LONG_RUNNING.md)
+      in this PR (step / soak / phase).
 
 <!--
 LONG_RUNNING.md tracks anything spanning >1 PR or carrying a production soak.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
 <!-- Keep this light. Delete sections that don't apply. -->
 
-## What & why
+# What & why
 
 
 ## Long-running work

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,26 @@
 
 **`develop` must always be in a deployable state.** Both as a matter of policy and so we can ship from it at any time in an emergency. Never merge work into `develop` that doesn't compile, has failing tests, or leaves the app in a broken/half-finished runtime state. If a change can't be made deployable in one PR, keep it on a feature branch until it is (see the gating rule below — do NOT reach for an environment gate).
 
+## Long-Running Work Tracking
+
+`LONG_RUNNING.md` (repo root) is the source of truth for efforts that span **more
+than one PR** or carry a **production soak**. Keep it current:
+
+- **If a PR advances a step, changes a soak state, or completes a phase of a task
+  tracked in `LONG_RUNNING.md`, update `LONG_RUNNING.md` in the *same PR*.** A
+  stale tracker is worse than none.
+- **If a PR *starts* a new effort that is clearly multi-PR or will need a staged
+  rollout, add it to `LONG_RUNNING.md`** in that PR. (One-off PRs with no soak do
+  NOT go there — a normal PR description covers them.)
+- **The soak state is load-bearing:** a task is not done until its soak clears.
+  Don't cut an App Store release for a soaking task before its "Advance when"
+  criteria are met.
+
+Reviewers (including Greptile): flag any PR that clearly advances or completes a
+`LONG_RUNNING.md` task but leaves the tracker untouched. Keep this narrow — only
+flag *obvious* advancement of an *already-tracked* task; whether something new
+*should* be tracked is a human judgment call, not a review gate.
+
 ## NEVER NEVER NEVER gate a feature to an environment
 
 **Do not gate any user-facing feature so that it behaves differently in production than in staging/development.** Absolutely never write code of the form `Config.shared.environment != .production` (or any equivalent) to turn a feature on in staging while leaving it dark in production.

--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -9,7 +9,7 @@ soak gate passes/fails — in the *same PR* that caused the change. Keeping this
 current is the point; a stale tracker is worse than none. (See the "Long-Running
 Work Tracking" rule in `CLAUDE.md`.)
 
-**Status legend:** 🟢 planning · 🔵 in progress · 🟡 soaking (merged, watching prod) · ✅ done · ⏸️ paused
+**Status legend:** 🟢 planning · 🔵 in progress · 🟡 soaking (merged; watching staging → phased prod) · ✅ done · ⏸️ paused
 
 **Soak is a first-class state here on purpose.** "Merged" ≠ "shipped safely."
 Risky changes (especially audio) merge to `develop`, then **soak** on staging /
@@ -27,7 +27,7 @@ _Last updated: 2026-08-02_
 
 | Task | Status | Current step | Soak | Links |
 |------|--------|--------------|------|-------|
-| Host-owned audio → Sonos | 🟡 soaking | Phase 1 merged; staging soak + device matrix | Staging, since `⟨owner: staging build date⟩` | PR #345 · plan |
+| Host-owned audio → Sonos | 🟡 soaking | Phase 1 merged; staging soak + device matrix | Not started (pending first staging build) | PR #345 · plan |
 | Clip share | 🔵 in progress | ⟨owner: current step⟩ | none (standard release) | PR #219 |
 | Rewards → Your Library | 🔵 in progress | Rewards→Profile, Library tab, Presets move | none | PR #372 · `fix-library-requests-ui` |
 | Siri "Play on Playola" (App Intents media schema) | 🟢 planning | Approach B decided (2026-06-14); not started | n/a | — |
@@ -45,6 +45,7 @@ CarPlay teardown, speaker-stuck-after-recording) along the way.
 **Plan doc:** `~/playola/shared/PLAYOLA_AUDIO_OWNERSHIP_PLAN.md` (authoritative).
 
 ### Phases
+
 - [x] **Phase 0 — SDK host-only** (shipped as PlayolaPlayer 0.20.0 → 0.20.2)
 - [x] **Phase 1 — app owns session + interruptions** (PR #345, merged to develop) — 🟡 soaking
 - [ ] **Phase 2 — single Now Playing writer** (low risk, ~1 PR)
@@ -54,13 +55,17 @@ CarPlay teardown, speaker-stuck-after-recording) along the way.
 - [ ] **Phase 5 — Sonos renderer** (AVSampleBuffer render path; big; own plan + server-flag rollout)
 
 ### Current step
+
 Phase 1 merged. Now: run the device-verification matrix on real hardware and
 soak on staging before an App Store release. Phase 2 can proceed on develop in
 parallel — it does not block the Phase 1 release soak.
 
 ### Soak — Phase 1
+
 - **Environment:** staging TestFlight → then App Store 7-day phased rollout.
-- **Soaking since:** `⟨owner: date the staging build ships⟩`
+- **Soaking since:** not started yet — pending the first staging TestFlight build.
+  Fill the date when it ships (the "~1 week clean" advance criterion is measured
+  from here).
 - **Device matrix (must pass before App Store):** phone-call/Siri interruption
   resumes · interruption-without-shouldResume stays paused · headphone unplug
   pauses (not stops) · Bluetooth A2DP + car HFP route · CarPlay connect/play/
@@ -73,10 +78,15 @@ parallel — it does not block the Phase 1 release soak.
 - **Advance when:** device matrix passes AND ~1 week of clean staging dogfooding
   AND Mixpanel session metrics flat. Then cut the release; don't over-soak on
   develop (it just entangles with later changes).
-- **Rollback lever:** revert the PlayolaPlayer SPM pin (0.20.2 → 0.19.x) + revert
-  the app PR = instant return to old session-managed behavior.
+- **Rollback lever:** known-good prior version is PlayolaPlayer **0.19.0**. Rolling
+  back = revert the SPM pin (0.20.2 → 0.19.0) + revert the app PR, then **build and
+  ship a new release** — reverting source does *not* change binaries already
+  installed via TestFlight/App Store. Because Phase 1 hasn't reached production
+  yet, the cheapest rollback right now is simply **not cutting the release**; once
+  it's live, roll back by shipping a build repinned to 0.19.0 (phased release again).
 
 ### Notes
+
 - FRadioPlayer is now a maintained local package (`LocalPackages/FRadioPlayer`),
   isolated from the app's strict build settings.
 - Phase 5 (the actual Sonos-enabling renderer) is the highest-risk item and gets

--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -1,0 +1,137 @@
+# Long-Running Work
+
+Tracks efforts that span **more than one PR** or that carry a **production soak** —
+the things a single PR description can't hold. If a piece of work is one PR and
+merges without a staged rollout, it does **not** belong here; a normal PR covers it.
+
+**When to update:** the moment a task advances a step, changes soak state, or a
+soak gate passes/fails — in the *same PR* that caused the change. Keeping this
+current is the point; a stale tracker is worse than none. (See the "Long-Running
+Work Tracking" rule in `CLAUDE.md`.)
+
+**Status legend:** 🟢 planning · 🔵 in progress · 🟡 soaking (merged, watching prod) · ✅ done · ⏸️ paused
+
+**Soak is a first-class state here on purpose.** "Merged" ≠ "shipped safely."
+Risky changes (especially audio) merge to `develop`, then **soak** on staging /
+phased production while we watch metrics before they reach everyone. A task is
+not ✅ done until its soak clears.
+
+> Entries marked `⟨owner: …⟩` are placeholders the task owner should fill in —
+> I scaffolded them from open PRs/branches but don't know the internal plan.
+
+_Last updated: 2026-08-02_
+
+---
+
+## Active
+
+| Task | Status | Current step | Soak | Links |
+|------|--------|--------------|------|-------|
+| Host-owned audio → Sonos | 🟡 soaking | Phase 1 merged; staging soak + device matrix | Staging, since `⟨owner: staging build date⟩` | PR #345 · plan |
+| Clip share | 🔵 in progress | ⟨owner: current step⟩ | none (standard release) | PR #219 |
+| Rewards → Your Library | 🔵 in progress | Rewards→Profile, Library tab, Presets move | none | PR #372 · `fix-library-requests-ui` |
+| Siri "Play on Playola" (App Intents media schema) | 🟢 planning | Approach B decided (2026-06-14); not started | n/a | — |
+| View/Model pattern cleanup | 🔵 in progress (opportunistic) | ongoing, fix-on-touch | none | `TODO_VIEW_MODEL_VIOLATIONS.md` |
+
+---
+
+## Host-owned audio → Sonos
+
+**Goal:** make the app the single owner of the AVAudioSession / interruptions /
+Now Playing, then swap the Playola render path so stations can cast to Sonos
+(AirPlay 2 long-form). Fixes existing bugs (won't-resume-after-interruption,
+CarPlay teardown, speaker-stuck-after-recording) along the way.
+
+**Plan doc:** `~/playola/shared/PLAYOLA_AUDIO_OWNERSHIP_PLAN.md` (authoritative).
+
+### Phases
+- [x] **Phase 0 — SDK host-only** (shipped as PlayolaPlayer 0.20.0 → 0.20.2)
+- [x] **Phase 1 — app owns session + interruptions** (PR #345, merged to develop) — 🟡 soaking
+- [ ] **Phase 2 — single Now Playing writer** (low risk, ~1 PR)
+- [ ] **Verify URL stations → Sonos** (quick AirPlay-2 check; possible early win)
+- [ ] **Phase 3 — single state-derivation source** (low–med risk, ~1 PR)
+- [ ] **Owned URLStreamBackend** (retire the vendored FRadioPlayer fork; optional)
+- [ ] **Phase 5 — Sonos renderer** (AVSampleBuffer render path; big; own plan + server-flag rollout)
+
+### Current step
+Phase 1 merged. Now: run the device-verification matrix on real hardware and
+soak on staging before an App Store release. Phase 2 can proceed on develop in
+parallel — it does not block the Phase 1 release soak.
+
+### Soak — Phase 1
+- **Environment:** staging TestFlight → then App Store 7-day phased rollout.
+- **Soaking since:** `⟨owner: date the staging build ships⟩`
+- **Device matrix (must pass before App Store):** phone-call/Siri interruption
+  resumes · interruption-without-shouldResume stays paused · headphone unplug
+  pauses (not stops) · Bluetooth A2DP + car HFP route · CarPlay connect/play/
+  interrupt/resume · AirPlay long-form (watch for a `-50` on `.longFormAudio`) ·
+  record voicetrack → stop → play → output not speaker-stuck · URL station
+  interruption pauses/resumes via the coordinator.
+- **Watch (go/no-go metrics):** Mixpanel `listeningSessionStarted` count + session
+  length (the canary — a dip means audio broke in the field without a crash);
+  Sentry for new `AVAudioSession` / `engine.start` error clusters.
+- **Advance when:** device matrix passes AND ~1 week of clean staging dogfooding
+  AND Mixpanel session metrics flat. Then cut the release; don't over-soak on
+  develop (it just entangles with later changes).
+- **Rollback lever:** revert the PlayolaPlayer SPM pin (0.20.2 → 0.19.x) + revert
+  the app PR = instant return to old session-managed behavior.
+
+### Notes
+- FRadioPlayer is now a maintained local package (`LocalPackages/FRadioPlayer`),
+  isolated from the app's strict build settings.
+- Phase 5 (the actual Sonos-enabling renderer) is the highest-risk item and gets
+  its own Codex-architected plan + server-flag (not env-gate) staged rollout.
+
+---
+
+## Clip share
+
+**Goal:** let listeners download and share audio clips of their Q&A airings
+(spin-based clip identity for natural de-duplication). Includes MyAiringsPage,
+push-notification handling, and homepage integration.
+
+- **Status:** 🔵 in progress — PR #219 (open since 2026-03-19).
+- **Steps:** `⟨owner: break into steps / what's left⟩`
+- **Soak:** none expected (feature behind normal release; no process-global risk).
+- **Links:** PR #219.
+
+---
+
+## Rewards → Your Library
+
+**Goal:** replace the Rewards tab with a **Your Library** tab (heart icon); Rewards
+moves to a button on Profile; the Presets carousel moves from Radio Stations to
+the top of Your Library.
+
+- **Status:** 🔵 in progress — PR #372.
+- **Steps:** `⟨owner: is this one PR or a Library-area cluster? (a fix-library-requests-ui branch exists)⟩`
+- **Soak:** none (UI reorg).
+- **Links:** PR #372, branch `fix-library-requests-ui`.
+
+---
+
+## Siri "Play on Playola" (App Intents media schema)
+
+**Goal:** make "Play {station} on Playola" route to Playola instead of Apple Music,
+by adopting the App Intents media Assistant Schema (approach B, decided 2026-06-14).
+
+- **Status:** 🟢 planning — decided, not started.
+- **Steps:** `⟨owner: scope into a plan when prioritized⟩`
+- **Soak:** n/a until built.
+- **Notes:** SSU voice model is processed server-side by Apple; voice lags the
+  install, the action works immediately.
+
+---
+
+## View/Model pattern cleanup
+
+Standing, **opportunistic** cleanup (fix-on-touch, not a scheduled task) —
+tracked in `TODO_VIEW_MODEL_VIOLATIONS.md`. Listed here only for visibility; it
+has no phases or soak. Don't spin up dedicated PRs for it; fix violations when
+you're already in a file.
+
+---
+
+## Done
+
+_(none yet — move tasks here with their completion date once their soak clears)_


### PR DESCRIPTION
## What & why

Adds a repo-level tracker for the work that a single PR description can't hold: efforts that span **more than one PR** or carry a **production soak**. The motivating case is the host-owned-audio → Sonos work, which is *merged but still soaking* — and "merged" is not "shipped safely."

### What's in it
- **`LONG_RUNNING.md`** — source of truth. A scan table + per-task detail, with a first-class **🟡 soaking** status and a dedicated **soak block** per task (environment, soaking-since, the go/no-go metrics to watch, "advance when" criteria, rollback lever).
- **`CLAUDE.md` rule** — "if a PR advances/completes a tracked task, update the tracker in the same PR," plus a *narrow* Greptile-enforcement backstop.
- **`.github/pull_request_template.md`** — a one-checkbox human nudge at PR-creation time (no template existed before; kept minimal).

Deliberately **no standalone skill and no CI gate** — that's more machinery than a handful of concurrent efforts warrants, and it rots too. Four cheap layers matched to the load.

### Seeded tasks (all current long-running efforts I could find)
| Task | Status |
|---|---|
| Host-owned audio → Sonos | 🟡 soaking (Phase 1 merged) |
| Clip share (#219) | 🔵 in progress (open since March) |
| Rewards → Your Library (#372) | 🔵 in progress |
| Siri "Play on Playola" App-Intents media schema | 🟢 planning |
| View/Model pattern cleanup | 🔵 opportunistic |

Entries I scaffolded from open PRs/branches but don't have the internal plan for are marked with an `⟨owner: …⟩` placeholder to fill in — **please review those and prune anything that isn't actually long-running.**

### Follow-up (not in this PR)
The tightest "check before PR creation" hook would live in the ship/`create-release-pr` flow (a gstack skill, not in-repo). Worth adding there so the tracker check runs automatically as part of shipping.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for tracking multi-step work and production validation periods.
  * Added a centralized tracker for active efforts, milestones, monitoring criteria, and rollback steps.
  * Added pull request checklist guidance to keep long-running work status up to date.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->