### PR TITLE
PlayerPage: move hardcoded strings to model, migrate hero off UIScreen.main

### DIFF
--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -55,33 +55,16 @@ struct PlayerPage: View {
       ScrollView {
 
         // Main Image
-        WebImage(
-          url: model.stationArtUrl,
-          context: RemoteArtwork.downsampleContext(
-            CGSize(
-              width: UIScreen.main.bounds.width - 148,
-              height: UIScreen.main.bounds.width - 148),
-            scale: displayScale)
-        ) { image in
-          image
-            .resizable()
-            .aspectRatio(contentMode: .fill)
-        } placeholder: {
-          Color(white: 0.2)
-        }
-        .frame(
-          width: UIScreen.main.bounds.width - 148,
-          height: UIScreen.main.bounds.width - 148
-        )
-        .cornerRadius(14)
-        .padding(.top, 32)
-        .padding(.horizontal, 74)
+        HeroArtwork(url: model.stationArtUrl, displayScale: displayScale)
+          .cornerRadius(14)
+          .padding(.top, 32)
+          .padding(.horizontal, 74)
 
         // Now Playing Section
         VStack(alignment: .leading, spacing: 4) {
           HStack(spacing: 12) {
             VStack(alignment: .leading, spacing: 8) {
-              Text("NOW PLAYING")
+              Text(model.nowPlayingLabel)
                 .font(.custom(FontNames.Inter_600_SemiBold, size: 12))
                 .foregroundColor(Color(hex: "#C7C7C7"))
 
@@ -117,13 +100,13 @@ struct PlayerPage: View {
 
           // Live indicator
           HStack(spacing: 8) {
-            Text("ON AIR")
+            Text(model.onAirLabel)
               .font(.custom(FontNames.Inter_400_Regular, size: 12))
               .foregroundColor(.gray)
 
             Spacer()
 
-            Text("LIVE")
+            Text(model.liveLabel)
               .font(.custom(FontNames.Inter_400_Regular, size: 12))
               .foregroundColor(.gray)
 
@@ -170,7 +153,7 @@ struct PlayerPage: View {
               HStack(spacing: 8) {
                 Image(systemName: "mic.fill")
                   .font(.system(size: 14))
-                Text("Ask the Artist")
+                Text(model.askArtistLabel)
                   .font(.custom(FontNames.Inter_500_Medium, size: 14))
               }
               .foregroundColor(.white)
@@ -210,6 +193,42 @@ struct PlayerPage: View {
     .background(Color.black)
     .onChange(of: scenePhase) { _, newValue in
       model.scenePhaseChanged(newPhase: newValue)
+    }
+  }
+}
+
+// The square station-art hero. `.aspectRatio(1, contentMode: .fit)` sizes it to a
+// square of the proposed (container) width synchronously on first layout, so the
+// slot never collapses to zero and content doesn't jump. The rendered width is
+// captured into `side` and used to size the `WebImage` downsample target; the URL
+// is withheld until `side` is known so the image is never decoded at a zero (i.e.
+// unbounded, full-resolution) size.
+private struct HeroArtwork: View {
+  let url: URL?
+  let displayScale: CGFloat
+
+  @State private var side: CGFloat = 0
+
+  var body: some View {
+    WebImage(
+      url: side > 0 ? url : nil,
+      context: RemoteArtwork.downsampleContext(
+        CGSize(width: side, height: side),
+        scale: displayScale)
+    ) { image in
+      image
+        .resizable()
+        .aspectRatio(contentMode: .fill)
+    } placeholder: {
+      Color(white: 0.2)
+    }
+    .aspectRatio(1, contentMode: .fit)
+    .onGeometryChange(for: CGFloat.self) { proxy in
+      proxy.size.width
+    } action: { width in
+      // Ignore transient zero-width passes so a measured size is never cleared
+      // (which would drop the loaded image back to the placeholder).
+      if width > 0 { side = width }
     }
   }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -124,6 +124,12 @@ class PlayerPageModel: ViewModel {
 
   var _chosenRelatedText: (RelatedText?, String) = (nil, "")
 
+  // MARK: - View Helpers
+  var nowPlayingLabel: String { "NOW PLAYING" }
+  var onAirLabel: String { "ON AIR" }
+  var liveLabel: String { "LIVE" }
+  var askArtistLabel: String { "Ask the Artist" }
+
   // MARK: Callbacks
   var onDismiss: (() -> Void)?
 

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageModel.swift
@@ -124,12 +124,6 @@ class PlayerPageModel: ViewModel {
 
   var _chosenRelatedText: (RelatedText?, String) = (nil, "")
 
-  // MARK: - View Helpers
-  var nowPlayingLabel: String { "NOW PLAYING" }
-  var onAirLabel: String { "ON AIR" }
-  var liveLabel: String { "LIVE" }
-  var askArtistLabel: String { "Ask the Artist" }
-
   // MARK: Callbacks
   var onDismiss: (() -> Void)?
 
@@ -242,4 +236,10 @@ class PlayerPageModel: ViewModel {
     mainContainerNavigationCoordinator.path.append(.askQuestionPage(model))
     onDismiss?()
   }
+
+  // MARK: - View Helpers
+  var nowPlayingLabel: String { "NOW PLAYING" }
+  var onAirLabel: String { "ON AIR" }
+  var liveLabel: String { "LIVE" }
+  var askArtistLabel: String { "Ask the Artist" }
 }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPageTests.swift
@@ -909,4 +909,20 @@ struct PlayerPageTests {
 
     #expect(navCoordinator.path.isEmpty)
   }
+
+  // MARK: - Static Label Tests
+
+  @Test
+  func testStaticLabels() {
+    let model = withDependencies {
+      $0.stationPlayer = StationPlayerMock()
+    } operation: {
+      PlayerPageModel()
+    }
+
+    #expect(model.nowPlayingLabel == "NOW PLAYING")
+    #expect(model.onAirLabel == "ON AIR")
+    #expect(model.liveLabel == "LIVE")
+    #expect(model.askArtistLabel == "Ask the Artist")
+  }
 }


### PR DESCRIPTION
Finishes the MV convention cleanup for **PlayerPage**, the one page intentionally deferred from #316 (it also needed a layout-affecting `UIScreen.main` migration that had to be verified visually).

## Part A — hardcoded strings → model
Moved the four remaining user-facing literals into computed label properties on `PlayerPageModel` (`nowPlayingLabel`, `onAirLabel`, `liveLabel`, `askArtistLabel`), grouped under `// MARK: - View Helpers`, and referenced them from the view. No SF Symbols, `Image("LiveIcon")`, `FontNames.*`, or hex colors touched.

## Part B — `UIScreen.main` → container-relative sizing
The hero station-art image sized itself off the deprecated `UIScreen.main.bounds.width - 148` in **two coupled places** (the `WebImage` downsample `context:` and the `.frame`). `UIScreen.main` emits a deprecation warning, which fails the app target's warnings-as-errors build.

Extracted a `HeroArtwork` subview that:
- sizes a square **synchronously** via `.aspectRatio(1, contentMode: .fit)`, so the slot never collapses to `0×0` and content never jumps on first paint;
- captures the rendered width with `.onGeometryChange` into `@State side`;
- uses `side` for the `WebImage` downsample pixel target so the decode matches the on-screen size;
- **withholds the URL** (`url: side > 0 ? url : nil`) until the width is known, so the image is never decoded at a zero (i.e. unbounded, full-resolution) size — the SDWebImage jetsam trap;
- ignores transient zero-width geometry passes so a measured size is never cleared.

The `- 148` = the existing `.padding(.horizontal, 74)` (74 × 2). The app is **portrait-only** and PlayerPage is a **full-width sheet**, so the measured container width equals the old full-screen width — behavior is identical in the only supported orientation.

## Verification
- **Build + full suite green** under Xcode 26.5.0 (matches CI): **1223 passed / 0 failed**, warnings-as-errors clean (the `UIScreen.main` warning is gone).
- **`make lint`** clean (0 violations).
- **Hero layout** verified with a headless `ImageRenderer` → pixel-sampling throwaway test at iPhone SE (320pt) and Pro Max (440pt) widths: centered square of side `width − 148` (±2px), 74pt clear on each edge, no zero/collapsed render. Throwaway removed before commit.
- **Codex adversarial review** on the final diff: no P1/P2 findings. (An initial pass flagged a possible first-paint layout jump from an earlier `frame`-based guard; the `.aspectRatio` rework here resolves it, and the follow-up review confirmed the fix is sound.)

Added `testStaticLabels` for the new model labels.

## Out of scope
Other pages (done in #316); the 3 pages still on legacy `.alert` (RecordPage, AskQuestionPage, ListenerQuestionDetailPage) — those stay until `PlayolaAlert` gains a single-button-with-action / secondary-button form (a separate follow-up).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Improved station artwork loading for more efficient image display.
  * Updated player labels for now playing, live status, and artist questions.
* **Tests**
  * Added coverage to verify player labels display correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->