### PR TITLE
PlayerPage: remove control flow from view body

### DIFF
--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -5,6 +5,7 @@
 //  Created by Brian D Keane on 6/12/25.
 //
 
+import PlayolaPlayer
 import SDWebImageSwiftUI
 import SwiftUI
 
@@ -79,17 +80,8 @@ struct PlayerPage: View {
 
             Spacer()
 
-            if model.heartState != .hidden {
-              Button(
-                action: { model.heartButtonTapped() },
-                label: {
-                  Image(systemName: model.heartState.imageName)
-                    .foregroundColor(Color(hex: model.heartState.imageColorHex))
-                    .font(.system(size: 24))
-                }
-              )
+            HeartButton(state: model.heartState, onTap: { model.heartButtonTapped() })
               .layoutPriority(0)
-            }
           }
 
           ProgressView(value: model.loadingPercentage)
@@ -145,46 +137,14 @@ struct PlayerPage: View {
         )
         .padding(.top, 32)
 
-        // Ask Question Button
-        if model.canAskQuestion {
-          Button(
-            action: { model.askQuestionButtonTapped() },
-            label: {
-              HStack(spacing: 8) {
-                Image(systemName: "mic.fill")
-                  .font(.system(size: 14))
-                Text(model.askArtistLabel)
-                  .font(.custom(FontNames.Inter_500_Medium, size: 14))
-              }
-              .foregroundColor(.white)
-              .padding(.horizontal, 20)
-              .padding(.vertical, 12)
-              .background(Color(hex: "#333333"))
-              .cornerRadius(20)
-            }
-          )
-          .padding(.top, 16)
-        }
+        // Ask Question Button (hidden unless the now-playing station is a Playola station)
+        AskArtistButton(
+          isVisible: model.canAskQuestion,
+          label: model.askArtistLabel,
+          onTap: { model.askQuestionButtonTapped() })
 
-        if let relatedText = model.relatedText {
-
-          VStack(alignment: .leading, spacing: 16) {
-            Text(relatedText.title)
-              .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 18))
-              .foregroundColor(.white)
-
-            Text(relatedText.body)
-              .font(.custom(FontNames.Inter_400_Regular, size: 14))
-              .foregroundColor(.gray)
-              .lineSpacing(4)
-          }
-          .frame(maxWidth: .infinity, alignment: .leading)
-          .padding(.horizontal, 16)
-          .padding(.vertical, 16)
-          .background(Color(hex: "#333333"))
-          .padding(.horizontal, 24)
-          .padding(.top, 32)
-        }
+        // Related-text card (hidden when the current spin has no related text)
+        RelatedTextCard(relatedText: model.relatedText)
       }
       .scrollIndicators(.hidden)
 
@@ -229,6 +189,85 @@ private struct HeroArtwork: View {
       // Ignore transient zero-width passes so a measured size is never cleared
       // (which would drop the loaded image back to the placeholder).
       if width > 0 { side = width }
+    }
+  }
+}
+
+// The like/unlike heart, shown only while a Playola song is playing. Collapses to nothing
+// (occupying no space after the now-playing `Spacer()`) when `state` is `.hidden`.
+private struct HeartButton: View {
+  let state: PlayerPageModel.HeartState
+  let onTap: () -> Void
+
+  var body: some View {
+    if state != .hidden {
+      Button(
+        action: onTap,
+        label: {
+          Image(systemName: state.imageName)
+            .foregroundColor(Color(hex: state.imageColorHex))
+            .font(.system(size: 24))
+        }
+      )
+    }
+  }
+}
+
+// The "Ask the Artist" button, shown only when the now-playing station is a Playola station.
+// Collapses to nothing (no button, no top padding) when `isVisible` is false.
+private struct AskArtistButton: View {
+  let isVisible: Bool
+  let label: String
+  let onTap: () -> Void
+
+  var body: some View {
+    if isVisible {
+      Button(
+        action: onTap,
+        label: {
+          HStack(spacing: 8) {
+            Image(systemName: "mic.fill")
+              .font(.system(size: 14))
+            Text(label)
+              .font(.custom(FontNames.Inter_500_Medium, size: 14))
+          }
+          .foregroundColor(.white)
+          .padding(.horizontal, 20)
+          .padding(.vertical, 12)
+          .background(Color(hex: "#333333"))
+          .cornerRadius(20)
+        }
+      )
+      .padding(.top, 16)
+    }
+  }
+}
+
+// The related-text card ("Why I chose this song" / artist notes). Collapses to nothing (no card,
+// no top padding) when there's no related text for the current spin. The optional is evaluated
+// once at the call site and passed in, because `PlayerPageModel.relatedText` memoizes a random
+// pick per spin and must not be read repeatedly.
+private struct RelatedTextCard: View {
+  let relatedText: RelatedText?
+
+  var body: some View {
+    if let relatedText {
+      VStack(alignment: .leading, spacing: 16) {
+        Text(relatedText.title)
+          .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 18))
+          .foregroundColor(.white)
+
+        Text(relatedText.body)
+          .font(.custom(FontNames.Inter_400_Regular, size: 14))
+          .foregroundColor(.gray)
+          .lineSpacing(4)
+      }
+      .frame(maxWidth: .infinity, alignment: .leading)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 16)
+      .background(Color(hex: "#333333"))
+      .padding(.horizontal, 24)
+      .padding(.top, 32)
     }
   }
 }


### PR DESCRIPTION
Follow-up to #375: makes `PlayerPage`'s view body control-flow-free, per the repo convention that page views contain zero `if`/`if let`/ternary/`switch`. Extracts the three conditional render sites (heart button, ask-artist button, related-text card) into private, self-hiding subviews in the same file, mirroring the existing `UpcomingGiveawayBanner` / `GiveawayPlayerOverlayView` pattern — each renders its content when applicable and collapses to nothing otherwise. `relatedText` is evaluated once at the call site and passed into its subview, preserving its memoized-per-spin semantics. This is view-only restructuring, so the rendered result is unchanged in all states (song playing/not, Playola vs URL station, related text present/absent) and no new tests are needed. Verified: full suite green (1223 tests, 0 failures) under Xcode 26.5.0, `make lint` clean, and Codex review passed with no findings.