### PR TITLE
feat(player): Liquid Glass tab bar and mini player on iOS 26.1

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -153,6 +153,7 @@
 		D30F008D2E8592F0007BCC73 /* URLStreamPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E56C2BFD2FAB00B9E35B /* URLStreamPlayer.swift */; };
 		D30F008E2E8592F0007BCC73 /* StationListPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E5662BFD10AE00B9E35B /* StationListPage.swift */; };
 		D30F008F2E8592F0007BCC73 /* MainContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C82DFA247A001BC6F9 /* MainContainer.swift */; };
+		ABCDEF010000000000000002 /* TabBarPlatformChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */; };
 		D30F00902E8592F0007BCC73 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257752E6342C600F4228B /* ToastView.swift */; };
 		D30F00912E8592F0007BCC73 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E5682BFD1C0800B9E35B /* APIClient.swift */; };
 		D30F00922E8592F0007BCC73 /* SmallPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D382671B2E00C13E0006BAC2 /* SmallPlayer.swift */; };
@@ -311,6 +312,7 @@
 		D37257C42DF8F885001BC6F9 /* circleBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C32DF8F87F001BC6F9 /* circleBackground.swift */; };
 		D37257C62DF9F064001BC6F9 /* HomePageStationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C52DF9EF8D001BC6F9 /* HomePageStationList.swift */; };
 		D37257C92DFA247D001BC6F9 /* MainContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C82DFA247A001BC6F9 /* MainContainer.swift */; };
+		ABCDEF010000000000000003 /* TabBarPlatformChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */; };
 		D37257CC2DFA3F83001BC6F9 /* FontNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */; };
 		D37257D02DFB4368001BC6F9 /* PlayerPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */; };
 		D37769F92F22B38700200ADF /* ChooseStationPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37769F62F22B38700200ADF /* ChooseStationPageModel.swift */; };
@@ -682,6 +684,7 @@
 		D37257C32DF8F87F001BC6F9 /* circleBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = circleBackground.swift; sourceTree = "<group>"; };
 		D37257C52DF9EF8D001BC6F9 /* HomePageStationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageStationList.swift; sourceTree = "<group>"; };
 		D37257C82DFA247A001BC6F9 /* MainContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContainer.swift; sourceTree = "<group>"; };
+		ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPlatformChrome.swift; sourceTree = "<group>"; };
 		D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontNames.swift; sourceTree = "<group>"; };
 		D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPage.swift; sourceTree = "<group>"; };
 		D37769F62F22B38700200ADF /* ChooseStationPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationPageModel.swift; sourceTree = "<group>"; };
@@ -1378,6 +1381,7 @@
 				D31CD5252DFBB47D009B9780 /* MainContainerTests.swift */,
 				FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */,
 				D37257C82DFA247A001BC6F9 /* MainContainer.swift */,
+				ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */,
 			);
 			path = MainContainer;
 			sourceTree = "<group>";
@@ -2103,6 +2107,7 @@
 				D3B9C7A62F534CE0002D75C2 /* IntroPresignedURLResponse.swift in Sources */,
 				D30F008E2E8592F0007BCC73 /* StationListPage.swift in Sources */,
 				D30F008F2E8592F0007BCC73 /* MainContainer.swift in Sources */,
+				ABCDEF010000000000000002 /* TabBarPlatformChrome.swift in Sources */,
 				D3776A3B2F2918DE00200ADF /* WaveformViews.swift in Sources */,
 				D39728712F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */,
 				D30F00902E8592F0007BCC73 /* ToastView.swift in Sources */,
@@ -2299,6 +2304,7 @@
 				D3B9C7A72F534CE0002D75C2 /* IntroPresignedURLResponse.swift in Sources */,
 				D339E5672BFD10AE00B9E35B /* StationListPage.swift in Sources */,
 				D37257C92DFA247D001BC6F9 /* MainContainer.swift in Sources */,
+				ABCDEF010000000000000003 /* TabBarPlatformChrome.swift in Sources */,
 				D3776A3C2F2918DE00200ADF /* WaveformViews.swift in Sources */,
 				D39728722F60DCCC008591E3 /* ArtistSuggestion.swift in Sources */,
 				D30257762E6342C900F4228B /* ToastView.swift in Sources */,

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -29,16 +29,10 @@ struct MainContainer: View {
         profileTab
       }
     }
-    //        .tabBarMinimizeBehavior(.onScrollDown)  // add in iOS 26
     .accentColor(.white)  // Makes the selected tab icon white
-    .onAppear {
-      let tabBarAppearance = UITabBarAppearance()
-      tabBarAppearance.configureWithOpaqueBackground()
-      tabBarAppearance.backgroundColor = .black
-
-      UITabBar.appearance().standardAppearance = tabBarAppearance
-      UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
-      UITabBar.appearance().unselectedItemTintColor = UIColor(white: 0.7, alpha: 1.0)
+    .playolaTabBarChrome()
+    .playolaBottomAccessory(isEnabled: model.shouldShowSmallPlayer) {
+      smallPlayer(isGlassAccessory: true)
     }
     .playolaAlert($model.presentedAlert)
     .onChange(of: model.activeTab) {
@@ -303,18 +297,17 @@ struct MainContainer: View {
   private func tabContentWithSmallPlayer<Content: View>(@ViewBuilder content: () -> Content)
     -> some View
   {
-    VStack(spacing: 0) {
-      content()
-
-      if model.shouldShowSmallPlayer {
-        SmallPlayer()
-          .onTapGesture {
-            model.onSmallPlayerTapped()
-          }
-          .transition(.move(edge: .bottom))
-          .zIndex(1)
+    content()
+      .playolaLegacySmallPlayer(isEnabled: model.shouldShowSmallPlayer) {
+        smallPlayer(isGlassAccessory: false)
       }
-    }
+  }
+
+  private func smallPlayer(isGlassAccessory: Bool) -> some View {
+    SmallPlayer(isGlassAccessory: isGlassAccessory)
+      .onTapGesture {
+        model.onSmallPlayerTapped()
+      }
   }
 
   private var activeTabBinding: Binding<MainContainerModel.ActiveTab> {

--- a/PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift
@@ -1,0 +1,83 @@
+//
+//  TabBarPlatformChrome.swift
+//  PlayolaRadio
+//
+//  Compatibility boundary for the tab bar + mini player.
+//
+//  iOS 26.1+ renders a native Liquid Glass tab bar and hosts the mini player as
+//  a `tabViewBottomAccessory`. Everything below that floor (iOS 18 through
+//  iOS 26.0) keeps the opaque-black UIKit tab bar and embeds the mini player
+//  beneath each tab's content.
+//
+//  All three modifiers MUST use the same availability floor so a device never
+//  gets a mismatched combination (e.g. glass tab bar with no mini player). The
+//  floor is iOS 26.1 because `tabViewBottomAccessory(isEnabled:)` is unavailable
+//  before 26.1; iOS 26.0 therefore falls to the fully-consistent legacy path.
+//
+//  Every OS fork for this feature lives in THIS file. When the legacy OSes are
+//  dropped, delete the `else` branches below (and the two `playolaLegacy*` call
+//  sites in MainContainer) and the app is left on the pure Liquid Glass path.
+//
+
+import SwiftUI
+import UIKit
+
+extension View {
+  /// Tab bar chrome appropriate to the OS.
+  /// - iOS 26.1+: no-op, so the system renders its native Liquid Glass tab bar.
+  /// - Legacy: installs the opaque-black `UITabBarAppearance`.
+  @ViewBuilder
+  func playolaTabBarChrome() -> some View {
+    if #available(iOS 26.1, *) {
+      self
+    } else {
+      self.onAppear {
+        let tabBarAppearance = UITabBarAppearance()
+        tabBarAppearance.configureWithOpaqueBackground()
+        tabBarAppearance.backgroundColor = .black
+
+        UITabBar.appearance().standardAppearance = tabBarAppearance
+        UITabBar.appearance().scrollEdgeAppearance = tabBarAppearance
+        UITabBar.appearance().unselectedItemTintColor = UIColor(white: 0.7, alpha: 1.0)
+      }
+    }
+  }
+
+  /// Attaches the mini player as the tab view's floating bottom accessory.
+  /// - iOS 26.1+: hosts `content` via `tabViewBottomAccessory`, shown/hidden by `isEnabled`.
+  /// - Legacy: no-op (the mini player is embedded per-tab via `playolaLegacySmallPlayer`).
+  @ViewBuilder
+  func playolaBottomAccessory<Accessory: View>(
+    isEnabled: Bool,
+    @ViewBuilder content: () -> Accessory
+  ) -> some View {
+    if #available(iOS 26.1, *) {
+      self.tabViewBottomAccessory(isEnabled: isEnabled, content: content)
+    } else {
+      self
+    }
+  }
+
+  /// Embeds the mini player beneath a tab's content.
+  /// - iOS 26.1+: no-op (the mini player is the tab view bottom accessory instead).
+  /// - Legacy: stacks `content` under the tab content when `isEnabled`.
+  @ViewBuilder
+  func playolaLegacySmallPlayer<Accessory: View>(
+    isEnabled: Bool,
+    @ViewBuilder content: () -> Accessory
+  ) -> some View {
+    if #available(iOS 26.1, *) {
+      self
+    } else {
+      VStack(spacing: 0) {
+        self
+
+        if isEnabled {
+          content()
+            .transition(.move(edge: .bottom))
+            .zIndex(1)
+        }
+      }
+    }
+  }
+}

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -18,6 +18,27 @@ struct SmallPlayer: View {
   @Dependency(\.likesManager) var likesManager
   @Dependency(\.stationPlayer) var stationPlayer
 
+  /// `true` when hosted in the iOS 26.1+ Liquid Glass `tabViewBottomAccessory`:
+  /// the player draws no background (system glass shows through), and shows the
+  /// station artwork inset and smaller, Apple-Music style. `false` keeps the
+  /// legacy opaque-black bar embedded above the tab bar (full-bleed art).
+  var isGlassAccessory = false
+
+  private var artworkSize: CGFloat { isGlassAccessory ? 40 : 64 }
+
+  // Glass content uses vibrant hierarchical styles so it stays legible on the
+  // system glass surface — a hardcoded white vanishes on light glass.
+  private var titleStyle: AnyShapeStyle {
+    isGlassAccessory ? AnyShapeStyle(.primary) : AnyShapeStyle(Color.white)
+  }
+  private var subtitleStyle: AnyShapeStyle {
+    isGlassAccessory ? AnyShapeStyle(.secondary) : AnyShapeStyle(Color(hex: "#C7C7C7"))
+  }
+  private var heartStyle: AnyShapeStyle {
+    if isCurrentSongLiked { return AnyShapeStyle(Color(hex: "#EF6962")) }
+    return isGlassAccessory ? AnyShapeStyle(.secondary) : AnyShapeStyle(Color(hex: "#BABABA"))
+  }
+
   // Computed properties from nowPlaying data
   var mainTitle: String {
     nowPlaying?.currentStation?.name ?? ""
@@ -37,7 +58,13 @@ struct SmallPlayer: View {
   }
 
   var artworkURL: URL {
-    nowPlaying?.albumArtworkUrl
+    if isGlassAccessory {
+      // Glass mini player represents the station, so lead with the station art.
+      return nowPlaying?.currentStation?.processedImageURL()
+        ?? nowPlaying?.albumArtworkUrl
+        ?? URL(string: "https://example.com")!
+    }
+    return nowPlaying?.albumArtworkUrl
       ?? nowPlaying?.currentStation?.processedImageURL()
       ?? URL(string: "https://example.com")!
   }
@@ -51,16 +78,33 @@ struct SmallPlayer: View {
     return likesManager.isLiked(audioBlock.id)
   }
 
+  // Glass: a small plain glyph like Apple Music. Legacy: black icon on a white circle.
+  @ViewBuilder
+  private var stopButtonLabel: some View {
+    if isGlassAccessory {
+      Image(systemName: "stop.fill")
+        .font(.system(size: 22))
+        .foregroundStyle(.primary)
+        .frame(width: 28, height: 28)
+    } else {
+      Image(systemName: "stop.fill")
+        .foregroundColor(.black)
+        .frame(width: 34, height: 34)
+        .background(.white)
+        .clipShape(Circle())
+    }
+  }
+
   // MARK: - Body
   var body: some View {
     VStack(spacing: 0) {
       // Player bar
-      HStack(spacing: 16) {
+      HStack(spacing: isGlassAccessory ? 10 : 16) {
         // Artwork
         WebImage(
           url: artworkURL,
           context: RemoteArtwork.downsampleContext(
-            CGSize(width: 64, height: 64), scale: displayScale)
+            CGSize(width: artworkSize, height: artworkSize), scale: displayScale)
         ) { image in
           image
             .resizable()
@@ -68,20 +112,25 @@ struct SmallPlayer: View {
         } placeholder: {
           Color.gray.opacity(0.3)
         }
-        .frame(width: 64, height: 64)
+        .frame(width: artworkSize, height: artworkSize)
         .clipped()
-        .clipShape(RoundedRectangle(cornerRadius: 6))
+        .clipShape(RoundedRectangle(cornerRadius: isGlassAccessory ? 8 : 6))
+        .padding(.vertical, isGlassAccessory ? 8 : 0)
+        .padding(.leading, isGlassAccessory ? 6 : 0)
 
         // Title & subtitle
         VStack(alignment: .leading, spacing: 4) {
           Text(mainTitle)
-            .font(.custom(FontNames.Inter_500_Medium, size: 16))
-            .foregroundColor(.white)
+            .font(.custom(FontNames.Inter_500_Medium, size: isGlassAccessory ? 13 : 16))
+            .foregroundStyle(titleStyle)
+            .lineLimit(isGlassAccessory ? 1 : nil)
           Text(secondaryTitle)
-            .font(.custom(FontNames.Inter_400_Regular, size: 14))
-            .foregroundColor(Color(hex: "#C7C7C7"))
+            .font(.custom(FontNames.Inter_400_Regular, size: isGlassAccessory ? 11 : 14))
+            .foregroundStyle(subtitleStyle)
+            .lineLimit(isGlassAccessory ? 2 : nil)
+            .fixedSize(horizontal: false, vertical: isGlassAccessory)
         }
-        .padding(.vertical, 12)
+        .padding(.vertical, isGlassAccessory ? 4 : 12)
 
         Spacer()
 
@@ -93,7 +142,7 @@ struct SmallPlayer: View {
             },
             label: {
               Image(systemName: isCurrentSongLiked ? "heart.fill" : "heart")
-                .foregroundColor(isCurrentSongLiked ? Color(hex: "#EF6962") : Color(hex: "#BABABA"))
+                .foregroundStyle(heartStyle)
                 .font(.system(size: 20))
                 .frame(width: 20, height: 20)
             }
@@ -103,19 +152,13 @@ struct SmallPlayer: View {
 
         Button(
           action: { stationPlayer.stop() },
-          label: {
-            Image(systemName: "stop.fill")
-              .foregroundColor(.black)
-              .frame(width: 34, height: 34)
-              .background(.white)
-              .clipShape(Circle())
-          }
+          label: { stopButtonLabel }
         )
-        .padding(.trailing, 24)
+        .padding(.trailing, isGlassAccessory ? 16 : 24)
       }
       .padding(.horizontal)
       .padding(.vertical, 8)
-      .background(Color.black.opacity(0.85))
+      .background(isGlassAccessory ? Color.clear : Color.black.opacity(0.85))
 
       // Progress bar
       GeometryReader { geo in
@@ -127,7 +170,7 @@ struct SmallPlayer: View {
       }
       .frame(height: 2)
     }
-    .background(Color.black)
+    .background(isGlassAccessory ? Color.clear : Color.black)
   }
 }
 


### PR DESCRIPTION
Adopts the native iOS 26.1 Liquid Glass tab bar and moves the persistent mini player into a `tabViewBottomAccessory`, with every OS fork isolated in a new `TabBarPlatformChrome.swift` so the pre-26.1 path (opaque `UITabBar` + embedded player) can be deleted in one motion when iOS 18 support is dropped. On the glass path, `SmallPlayer` drops its opaque background so the system glass shows through, uses smaller inset station artwork, a small plain transport glyph, vibrant `.primary`/`.secondary` text (fixing the white-on-glass contrast), and wraps the artist/title to two rows when long. iOS 18 and iOS 26.0 render exactly as before. Verified: builds on the iOS 26.5 SDK, `make lint` clean, all 1205 tests pass, and the glass tab bar + mini player confirmed on an iOS 26.1 simulator.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a compact mini-player accessory to the main tab view on supported systems.
  * Introduced a modern Liquid Glass tab bar and mini-player appearance on newer operating systems.
  * Added an adaptive compact mini-player design with updated artwork, typography, spacing, and controls.

* **Bug Fixes**
  * Preserved the existing tab bar and mini-player presentation on older operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->