### PR TITLE
fix(audio): activate AVAudioSession off the main thread

### DIFF
--- a/PlayolaRadio/Core/AudioPlayback/AudioSessionCoordinator.swift
+++ b/PlayolaRadio/Core/AudioPlayback/AudioSessionCoordinator.swift
@@ -11,8 +11,10 @@ import Foundation
 
 /// Thin seam over `AVAudioSession` so the coordinator is unit-testable.
 /// NOT `@MainActor`: `AVAudioSession`'s members are nonisolated; isolation lives
-/// on the coordinator, which is the only caller.
-protocol AudioSessionProtocol {
+/// on the coordinator, which is the only caller. `Sendable` so the coordinator
+/// can hand the seam to the detached task that runs `setActive` off the main
+/// thread (see `AudioSessionCoordinator.activate`).
+protocol AudioSessionProtocol: Sendable {
   func setCategory(
     _ category: AVAudioSession.Category, mode: AVAudioSession.Mode,
     policy: AVAudioSession.RouteSharingPolicy, options: AVAudioSession.CategoryOptions
@@ -58,17 +60,63 @@ protocol AudioInterruptionDelegate: AnyObject {
   func audioSessionShouldResume()
 }
 
+/// Serializes the real `AVAudioSession` mutations on a single executor OFF the
+/// main actor. This is an `actor` (not inline detached tasks) for two reasons:
+///
+/// 1. Off-main: `AVAudioSession.setActive` blocks, and calling it on the main
+///    thread trips a runtime warning ("This method can lead to UI
+///    unresponsiveness..."). iOS's own async activate/deactivate API is iOS 27+
+///    only (our floor is iOS 18.1), so we run the calls on the actor's executor,
+///    which is never the main thread. Unlike a `nonisolated async` seam method,
+///    actor isolation is unaffected by the Swift concurrency mode
+///    (`NonisolatedNonsendingByDefault` would run a `nonisolated async` call back
+///    on the caller's MainActor and silently reintroduce the warning).
+/// 2. Atomic + ordered: each `setCategory` + `setActive` pair runs without
+///    interleaving, so a concurrent playback/recording configure can't activate
+///    the session under the other flow's category. The old fully-synchronous
+///    `@MainActor` path had this guarantee for free; moving activation off-main
+///    would lose it without a single serial owner.
+private actor SessionConfigurator {
+  private let session: any AudioSessionProtocol
+
+  init(_ session: any AudioSessionProtocol) { self.session = session }
+
+  /// Sets the category and activates the session as one atomic unit.
+  func activate(
+    category: AVAudioSession.Category, mode: AVAudioSession.Mode,
+    policy: AVAudioSession.RouteSharingPolicy, options: AVAudioSession.CategoryOptions
+  ) throws {
+    try session.setCategory(category, mode: mode, policy: policy, options: options)
+    try session.setActive(true, options: [])
+  }
+
+  /// Sets the category WITHOUT activating (post-recording restore).
+  func setCategory(
+    _ category: AVAudioSession.Category, mode: AVAudioSession.Mode,
+    policy: AVAudioSession.RouteSharingPolicy, options: AVAudioSession.CategoryOptions
+  ) throws {
+    try session.setCategory(category, mode: mode, policy: policy, options: options)
+  }
+
+  /// Deactivates the session.
+  func deactivate(options: AVAudioSession.SetActiveOptions) throws {
+    try session.setActive(false, options: options)
+  }
+}
+
 /// THE single owner of the process-global `AVAudioSession` for the whole app.
 /// The Playola SDK (host-owned, 0.20.0+), the vendored FRadioPlayer, and the
 /// recorder all defer to this. Also the single owner of interruption/route
 /// policy (see the observer wiring below).
 @MainActor
 final class AudioSessionCoordinator {
-  private let session: AudioSessionProtocol
+  /// All real session mutations funnel through here so they run off-main,
+  /// atomically, and serialized (see `SessionConfigurator`).
+  private let configurator: SessionConfigurator
   weak var delegate: AudioInterruptionDelegate?
 
   init(session: AudioSessionProtocol = LiveAudioSession()) {
-    self.session = session
+    self.configurator = SessionConfigurator(session)
     registerObservers()
   }
 
@@ -83,30 +131,28 @@ final class AudioSessionCoordinator {
   /// already routes Bluetooth A2DP, and adding `.allowBluetooth` /
   /// `.allowBluetoothA2DP` to a `.longFormAudio` category can throw OSStatus
   /// `-50`. Activates the session.
-  func configureForPlayback() throws {
-    try session.setCategory(
-      .playback, mode: .default, policy: .longFormAudio, options: [])
-    try session.setActive(true, options: [])
+  func configureForPlayback() async throws {
+    try await configurator.activate(
+      category: .playback, mode: .default, policy: .longFormAudio, options: [])
   }
 
   /// Voicetrack recording. Activates the session.
-  func configureForRecording() throws {
-    try session.setCategory(
-      .playAndRecord, mode: .default, policy: .default,
+  func configureForRecording() async throws {
+    try await configurator.activate(
+      category: .playAndRecord, mode: .default, policy: .default,
       options: [.defaultToSpeaker, .allowBluetoothHFP])
-    try session.setActive(true, options: [])
   }
 
   /// Restores the playback category after recording WITHOUT activating —
   /// resuming playback (and therefore activation) is an explicit user/app
   /// decision, not a side effect of stopping a recording.
-  func restorePlaybackCategory() throws {
-    try session.setCategory(
+  func restorePlaybackCategory() async throws {
+    try await configurator.setCategory(
       .playback, mode: .default, policy: .longFormAudio, options: [])
   }
 
-  func deactivate() throws {
-    try session.setActive(false, options: [.notifyOthersOnDeactivation])
+  func deactivate() async throws {
+    try await configurator.deactivate(options: [.notifyOthersOnDeactivation])
   }
 
   // MARK: - Interruption / route policy

--- a/PlayolaRadio/Core/AudioPlayback/AudioSessionCoordinator.swift
+++ b/PlayolaRadio/Core/AudioPlayback/AudioSessionCoordinator.swift
@@ -12,8 +12,8 @@ import Foundation
 /// Thin seam over `AVAudioSession` so the coordinator is unit-testable.
 /// NOT `@MainActor`: `AVAudioSession`'s members are nonisolated; isolation lives
 /// on the coordinator, which is the only caller. `Sendable` so the coordinator
-/// can hand the seam to the detached task that runs `setActive` off the main
-/// thread (see `AudioSessionCoordinator.activate`).
+/// can hand the seam to the `SessionConfigurator` actor, which runs `setActive`
+/// off the main thread (see `SessionConfigurator.activate`).
 protocol AudioSessionProtocol: Sendable {
   func setCategory(
     _ category: AVAudioSession.Category, mode: AVAudioSession.Mode,

--- a/PlayolaRadio/Core/AudioPlayback/AudioSessionCoordinatorTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/AudioSessionCoordinatorTests.swift
@@ -9,8 +9,12 @@ import Testing
 @testable import PlayolaRadio
 
 /// Plain class (not `@MainActor`) — the protocol is nonisolated; tests run on
-/// the main actor anyway via the suite annotation.
-final class SpyAudioSession: AudioSessionProtocol {
+/// the main actor anyway via the suite annotation. `@unchecked Sendable` because
+/// the coordinator hands the seam to a detached task that calls `setActive`
+/// off-main, so the seam must be `Sendable`; the recorded arrays are only read
+/// after the caller `await`s the coordinator method, so there is no concurrent
+/// access to guard.
+final class SpyAudioSession: AudioSessionProtocol, @unchecked Sendable {
   struct CategoryCall {
     let category: AVAudioSession.Category
     let mode: AVAudioSession.Mode
@@ -37,7 +41,7 @@ struct AudioSessionConfigError: Error {}
 
 /// Session double whose category/activation calls always throw — used to prove
 /// callers surface session-config failures instead of swallowing them.
-final class FailingAudioSession: AudioSessionProtocol {
+final class FailingAudioSession: AudioSessionProtocol, @unchecked Sendable {
   func setCategory(
     _ category: AVAudioSession.Category, mode: AVAudioSession.Mode,
     policy: AVAudioSession.RouteSharingPolicy, options: AVAudioSession.CategoryOptions
@@ -68,11 +72,11 @@ final class SpyInterruptionDelegate: AudioInterruptionDelegate {
 @MainActor
 struct AudioSessionCoordinatorTests {
   @Test
-  func playbackConfigUsesLongFormAudioAndActivates() throws {
+  func playbackConfigUsesLongFormAudioAndActivates() async throws {
     let spy = SpyAudioSession()
     let coordinator = AudioSessionCoordinator(session: spy)
 
-    try coordinator.configureForPlayback()
+    try await coordinator.configureForPlayback()
 
     #expect(spy.categories.last?.category == .playback)
     #expect(spy.categories.last?.policy == .longFormAudio)
@@ -81,26 +85,26 @@ struct AudioSessionCoordinatorTests {
   }
 
   @Test
-  func recordingConfigUsesPlayAndRecordAndActivates() throws {
+  func recordingConfigUsesPlayAndRecordAndActivates() async throws {
     let spy = SpyAudioSession()
     let coordinator = AudioSessionCoordinator(session: spy)
 
-    try coordinator.configureForRecording()
+    try await coordinator.configureForRecording()
 
     #expect(spy.categories.last?.category == .playAndRecord)
     #expect(spy.activations.last == true)
   }
 
   @Test
-  func recordingThenRestoreReturnsToPlaybackWithoutActivating() throws {
+  func recordingThenRestoreReturnsToPlaybackWithoutActivating() async throws {
     let spy = SpyAudioSession()
     let coordinator = AudioSessionCoordinator(session: spy)
 
-    try coordinator.configureForRecording()
+    try await coordinator.configureForRecording()
     #expect(spy.categories.last?.category == .playAndRecord)
 
     spy.activations = []
-    try coordinator.restorePlaybackCategory()  // category only — no auto-activate
+    try await coordinator.restorePlaybackCategory()  // category only — no auto-activate
 
     #expect(spy.categories.last?.category == .playback)
     #expect(spy.categories.last?.policy == .longFormAudio)
@@ -108,11 +112,11 @@ struct AudioSessionCoordinatorTests {
   }
 
   @Test
-  func deactivateDeactivatesTheSession() throws {
+  func deactivateDeactivatesTheSession() async throws {
     let spy = SpyAudioSession()
     let coordinator = AudioSessionCoordinator(session: spy)
 
-    try coordinator.deactivate()
+    try await coordinator.deactivate()
 
     #expect(spy.activations.last == false)
   }

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -127,11 +127,22 @@ class StationPlayer: ObservableObject {
     // engine.start() would throw deep in playback. A config failure must surface
     // as .error, not be swallowed.
     do {
-      try audioSessionCoordinator.configureForPlayback()
+      try await audioSessionCoordinator.configureForPlayback()
     } catch {
-      handlePlayFailure(error)
+      // Activation now hops off the main actor (see AudioSessionCoordinator), so
+      // this method suspended above and another play()/stop() may have run. Only
+      // surface the failure if this attempt is still current — a stale failure
+      // must not clobber the newer station or a deliberate stop with .error.
+      if currentStation == station { handlePlayFailure(error) }
       return
     }
+
+    // Same staleness check for the success path: if a stop() or a play() for a
+    // different station landed during the activation suspension, this attempt is
+    // stale — bail before starting a backend the user no longer wants. The happy
+    // path is unaffected: nothing mutates state during activation, so
+    // currentStation is still `station` here.
+    guard currentStation == station else { return }
 
     switch station {
     case .url(let urlStation):
@@ -191,16 +202,20 @@ class StationPlayer: ObservableObject {
     // Clearing here also covers the manual lock-screen resume path, so a stale
     // interruption-ended event can't trigger a second resume.
     pausedBySystem = false
-    guard currentStation != nil else { return }
+    // Snapshot the station: activation hops off the main actor (see
+    // AudioSessionCoordinator), so this method suspends below. If a stop() or a
+    // switch to a different station lands in that window, this resume is stale
+    // and must not reactivate/resume against state the user has moved on from.
+    guard let station = currentStation else { return }
     do {
-      try audioSessionCoordinator.configureForPlayback()
-      switch currentStation {
-      case .some(.playola): try await playolaStationPlayer.resumeAfterInterruption()
-      case .some(.url): urlStreamPlayer.resume()
-      case .none: break
+      try await audioSessionCoordinator.configureForPlayback()
+      guard currentStation == station else { return }
+      switch station {
+      case .playola: try await playolaStationPlayer.resumeAfterInterruption()
+      case .url: urlStreamPlayer.resume()
       }
     } catch {
-      handlePlayFailure(error)
+      if currentStation == station { handlePlayFailure(error) }
     }
   }
 

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -47,6 +47,21 @@ class StationPlayer: ObservableObject {
   /// user explicitly stopped, and never double-resume on repeated events.
   private var pausedBySystem = false
 
+  /// Monotonic supersession token. `play()`/`resume()` claim a fresh token via
+  /// `beginPlaybackAttempt()`; `stop()` bumps it to invalidate anything in
+  /// flight. Because session activation now suspends off the main actor, an
+  /// attempt can be superseded mid-flight (a stop, or a *same-station* replay);
+  /// each attempt re-checks its token after every suspension so a stale one can't
+  /// start a backend or clobber newer state. Station equality alone can't tell
+  /// two attempts for the same station apart.
+  private var playToken = 0
+
+  /// Claims and returns a fresh token for a new playback attempt.
+  private func beginPlaybackAttempt() -> Int {
+    playToken += 1
+    return playToken
+  }
+
   /// The currently playing radio station, if any
   public var currentStation: AnyStation? {
     switch state.playbackStatus {
@@ -119,6 +134,7 @@ class StationPlayer: ObservableObject {
   public func play(station: AnyStation) async {
     guard currentStation != station else { return }
     stop()
+    let token = beginPlaybackAttempt()
     state = State(playbackStatus: .startingNewStation(station))
     state = State(playbackStatus: .loading(station))
 
@@ -129,20 +145,17 @@ class StationPlayer: ObservableObject {
     do {
       try await audioSessionCoordinator.configureForPlayback()
     } catch {
-      // Activation now hops off the main actor (see AudioSessionCoordinator), so
-      // this method suspended above and another play()/stop() may have run. Only
-      // surface the failure if this attempt is still current — a stale failure
-      // must not clobber the newer station or a deliberate stop with .error.
-      if currentStation == station { handlePlayFailure(error) }
+      // Activation hops off the main actor (see AudioSessionCoordinator), so this
+      // method suspended above and a stop()/play() may have superseded it. Only
+      // surface the failure if this attempt still owns the token — a stale
+      // failure must not clobber the newer station or a deliberate stop.
+      if token == playToken { handlePlayFailure(error) }
       return
     }
 
-    // Same staleness check for the success path: if a stop() or a play() for a
-    // different station landed during the activation suspension, this attempt is
-    // stale — bail before starting a backend the user no longer wants. The happy
-    // path is unaffected: nothing mutates state during activation, so
-    // currentStation is still `station` here.
-    guard currentStation == station else { return }
+    // Bail if superseded during the activation suspension, before starting a
+    // backend the user no longer wants.
+    guard token == playToken else { return }
 
     switch station {
     case .url(let urlStation):
@@ -152,7 +165,11 @@ class StationPlayer: ObservableObject {
       do {
         try await playolaStationPlayer.play(stationId: playolaStation.id)
       } catch {
-        handlePlayFailure(error)
+        // The SDK play() also suspends; guard the failure the same way so a
+        // stale throw can't clobber newer state. A stale *success* is left
+        // alone: the superseding stop()/play() has already re-driven the SDK
+        // (single-station), so tearing down here could kill the newer attempt.
+        if token == playToken { handlePlayFailure(error) }
       }
     }
   }
@@ -179,6 +196,9 @@ class StationPlayer: ObservableObject {
 
   /// Stops the currently playing station
   public func stop() {
+    // Invalidate any in-flight play()/resume() so a superseded attempt resuming
+    // from its activation await can't restart a backend or clobber .stopped.
+    playToken += 1
     pausedBySystem = false
     urlStreamPlayer.reset()
     playolaStationPlayer.stop()
@@ -202,20 +222,21 @@ class StationPlayer: ObservableObject {
     // Clearing here also covers the manual lock-screen resume path, so a stale
     // interruption-ended event can't trigger a second resume.
     pausedBySystem = false
-    // Snapshot the station: activation hops off the main actor (see
-    // AudioSessionCoordinator), so this method suspends below. If a stop() or a
-    // switch to a different station lands in that window, this resume is stale
-    // and must not reactivate/resume against state the user has moved on from.
+    // Snapshot the station and claim a token: activation hops off the main actor
+    // (see AudioSessionCoordinator), so this method suspends below. If a stop()
+    // or another play()/resume() lands in that window, this resume is stale and
+    // must not reactivate/resume against state the user has moved on from.
     guard let station = currentStation else { return }
+    let token = beginPlaybackAttempt()
     do {
       try await audioSessionCoordinator.configureForPlayback()
-      guard currentStation == station else { return }
+      guard token == playToken else { return }
       switch station {
       case .playola: try await playolaStationPlayer.resumeAfterInterruption()
       case .url: urlStreamPlayer.resume()
       }
     } catch {
-      if currentStation == station { handlePlayFailure(error) }
+      if token == playToken { handlePlayFailure(error) }
     }
   }
 

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -5,6 +5,7 @@
 //  Created by Claude on 1/8/26.
 //
 
+import AVFoundation
 import Combine
 import CustomDump
 import Foundation
@@ -39,9 +40,92 @@ final class SpyPlayolaStationPlayer: PlayolaTransport {
   func resumeAfterInterruption() async throws { resumeAfterInterruptionCount += 1 }
 }
 
+/// Session double whose `setActive` blocks until the test releases it, so a test
+/// can deterministically interleave a `stop()`/`play()` during the off-main
+/// activation window without `Task.sleep`. `@unchecked Sendable`: the coordinator
+/// runs `setActive` on its serial actor (off-main); the semaphores are the sync
+/// primitives that make the hand-off deterministic.
+final class GatedAudioSession: AudioSessionProtocol, @unchecked Sendable {
+  let entered = DispatchSemaphore(value: 0)
+  let proceed = DispatchSemaphore(value: 0)
+  private let throwOnActivate: Bool
+
+  init(throwOnActivate: Bool) { self.throwOnActivate = throwOnActivate }
+
+  func setCategory(
+    _ category: AVAudioSession.Category, mode: AVAudioSession.Mode,
+    policy: AVAudioSession.RouteSharingPolicy, options: AVAudioSession.CategoryOptions
+  ) throws {}
+  func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
+    entered.signal()
+    proceed.wait()
+    if throwOnActivate { throw AudioSessionConfigError() }
+  }
+}
+
 @Suite(.freshSharedState)
 @MainActor
 struct StationPlayerTests {
+
+  /// Waits (off the main actor) until the gated session's `setActive` has been
+  /// entered, i.e. `play()`/`resume()` is suspended inside activation.
+  private func awaitActivationInFlight(_ gate: GatedAudioSession) async {
+    await withCheckedContinuation { continuation in
+      DispatchQueue.global().async {
+        gate.entered.wait()
+        continuation.resume()
+      }
+    }
+  }
+
+  @Test
+  func stopDuringActivationDropsStalePlayBeforeBackendStart() async {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    let gate = GatedAudioSession(throwOnActivate: false)
+    let coordinator = AudioSessionCoordinator(session: gate)
+    let playola = SpyPlayolaStationPlayer()
+    let player = StationPlayer(
+      playolaStationPlayer: playola, audioSessionCoordinator: coordinator)
+
+    let playTask = Task { await player.play(station: .mockPlayola()) }
+    await awaitActivationInFlight(gate)
+
+    // User stops while activation is still in flight.
+    player.stop()
+    gate.proceed.signal()
+    await playTask.value
+
+    // The superseded attempt must not start the backend, and stop wins.
+    #expect(playola.playCount == 0)
+    guard case .stopped = player.state.playbackStatus else {
+      Issue.record("stale play started a backend: \(player.state.playbackStatus)")
+      return
+    }
+  }
+
+  @Test
+  func staleActivationFailureDoesNotClobberNewerState() async {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    let gate = GatedAudioSession(throwOnActivate: true)
+    let coordinator = AudioSessionCoordinator(session: gate)
+    let playola = SpyPlayolaStationPlayer()
+    let player = StationPlayer(
+      playolaStationPlayer: playola, audioSessionCoordinator: coordinator)
+
+    let playTask = Task { await player.play(station: .mockPlayola()) }
+    await awaitActivationInFlight(gate)
+
+    // User stops before activation fails; the stale failure must not surface as
+    // .error over the deliberate stop.
+    player.stop()
+    gate.proceed.signal()
+    await playTask.value
+
+    guard case .stopped = player.state.playbackStatus else {
+      Issue.record("stale activation failure clobbered state: \(player.state.playbackStatus)")
+      return
+    }
+  }
 
   // MARK: - Session Ownership Tests
 

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -63,6 +63,56 @@ final class GatedAudioSession: AudioSessionProtocol, @unchecked Sendable {
   }
 }
 
+/// One-shot async gate: `wait()` suspends until `open()` is called (or returns
+/// immediately if already opened). Lets a test hold an async call suspended
+/// without blocking a thread.
+actor AsyncGate {
+  private var opened = false
+  private var continuation: CheckedContinuation<Void, Never>?
+
+  func wait() async {
+    if opened { return }
+    await withCheckedContinuation { continuation = $0 }
+  }
+
+  func open() {
+    guard !opened else { return }
+    opened = true
+    continuation?.resume()
+    continuation = nil
+  }
+}
+
+/// PlayolaTransport double whose `play` suspends on an async gate until the test
+/// opens it, so a test can interleave a `stop()`/`play()` while the SDK play call
+/// is in flight (the second await inside `StationPlayer.play`).
+@MainActor
+final class GatedPlayolaStationPlayer: PlayolaTransport {
+  private let stateSubject = CurrentValueSubject<PlayolaStationPlayer.State, Never>(.idle)
+  var statePublisher: AnyPublisher<PlayolaStationPlayer.State, Never> {
+    stateSubject.eraseToAnyPublisher()
+  }
+
+  /// Signaled (off-actor safe: a `let` Sendable) when `play` has been entered.
+  let entered = DispatchSemaphore(value: 0)
+  let gate = AsyncGate()
+  private let throwOnPlay: Bool
+  var playCount = 0
+
+  init(throwOnPlay: Bool) { self.throwOnPlay = throwOnPlay }
+
+  func configure(authProvider: PlayolaAuthenticationProvider, baseURL: URL) {}
+  func play(stationId: String) async throws {
+    playCount += 1
+    entered.signal()
+    await gate.wait()
+    if throwOnPlay { throw PlayFailureTestError() }
+  }
+  func stop() {}
+  func pauseForInterruption() {}
+  func resumeAfterInterruption() async throws {}
+}
+
 @Suite(.freshSharedState)
 @MainActor
 struct StationPlayerTests {
@@ -73,6 +123,17 @@ struct StationPlayerTests {
     await withCheckedContinuation { continuation in
       DispatchQueue.global().async {
         gate.entered.wait()
+        continuation.resume()
+      }
+    }
+  }
+
+  /// Waits until the gated Playola double's `play` has been entered, i.e.
+  /// `StationPlayer.play` is suspended inside the backend (second) await.
+  private func awaitBackendPlayInFlight(_ playola: GatedPlayolaStationPlayer) async {
+    await withCheckedContinuation { continuation in
+      DispatchQueue.global().async {
+        playola.entered.wait()
         continuation.resume()
       }
     }
@@ -123,6 +184,58 @@ struct StationPlayerTests {
 
     guard case .stopped = player.state.playbackStatus else {
       Issue.record("stale activation failure clobbered state: \(player.state.playbackStatus)")
+      return
+    }
+  }
+
+  @Test
+  func sameStationReplayDuringActivationDoesNotReviveStaleAttempt() async {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    let gate = GatedAudioSession(throwOnActivate: false)
+    let coordinator = AudioSessionCoordinator(session: gate)
+    let playola = SpyPlayolaStationPlayer()
+    let player = StationPlayer(
+      playolaStationPlayer: playola, audioSessionCoordinator: coordinator)
+    let station = AnyStation.mockPlayola()
+
+    // First attempt suspends inside activation.
+    let firstPlay = Task { await player.play(station: station) }
+    await awaitActivationInFlight(gate)
+
+    // User stops, then replays the SAME station while the first is still parked.
+    player.stop()
+    gate.proceed.signal()
+    await firstPlay.value
+
+    // Station equality would let the stale first attempt revive; the token must
+    // drop it, so only the second (real) attempt reaches the backend.
+    let secondPlay = Task { await player.play(station: station) }
+    await awaitActivationInFlight(gate)
+    gate.proceed.signal()
+    await secondPlay.value
+
+    #expect(playola.playCount == 1)
+  }
+
+  @Test
+  func stalePlayolaPlayFailureDoesNotClobberNewerState() async {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    let coordinator = AudioSessionCoordinator(session: SpyAudioSession())
+    let playola = GatedPlayolaStationPlayer(throwOnPlay: true)
+    let player = StationPlayer(
+      playolaStationPlayer: playola, audioSessionCoordinator: coordinator)
+
+    let playTask = Task { await player.play(station: .mockPlayola()) }
+    await awaitBackendPlayInFlight(playola)
+
+    // User stops while the SDK play() is suspended; the later throw must not
+    // surface .error over the deliberate stop.
+    player.stop()
+    await playola.gate.open()
+    await playTask.value
+
+    guard case .stopped = player.state.playbackStatus else {
+      Issue.record("stale SDK-play failure clobbered state: \(player.state.playbackStatus)")
       return
     }
   }

--- a/PlayolaRadio/Core/SiriIntents/PlayStationAction.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlayStationAction.swift
@@ -17,7 +17,7 @@ struct PlayStationAction {
     let catalog = StationVoiceCatalog()
     guard let station = catalog.station(id: stationID) else { return .notFound }
     let label = catalog.match(id: stationID)?.label ?? station.stationName
-    PlaybackBootstrap().prepareForPlayback()
+    await PlaybackBootstrap().prepareForPlayback()
     await stationPlayer.play(station: station)
     return .playing(stationName: label)
   }

--- a/PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift
+++ b/PlayolaRadio/Core/SiriIntents/PlaybackBootstrap.swift
@@ -9,9 +9,9 @@ import IssueReporting
 struct PlaybackBootstrap {
   @Dependency(\.audioSessionCoordinator) var audioSessionCoordinator
 
-  func prepareForPlayback() {
+  func prepareForPlayback() async {
     do {
-      try audioSessionCoordinator.configureForPlayback()
+      try await audioSessionCoordinator.configureForPlayback()
     } catch {
       reportIssue("PlaybackBootstrap failed to configure the audio session: \(error)")
     }


### PR DESCRIPTION
# What & why

`AVAudioSession.setActive` ran synchronously on the main thread, tripping the "This method can lead to UI unresponsiveness" runtime warning; Apple's async activate/deactivate API is iOS 27+ (unavailable on our iOS 18.1 floor), so this routes all session mutations through a private serial `SessionConfigurator` actor that runs `setCategory`+`setActive` off-main and atomically. Because activation now suspends, `play()`/`resume()` gained staleness guards so a superseding `stop()`/`play()` can't start a stale backend or clobber newer state with `.error`. All session-config methods became `async throws` (call sites in `StationPlayer`, `PlaybackBootstrap`, `PlayStationAction`, and the recorder already await), and two deterministic (semaphore-gated) regression tests were added. Verified: builds under CI Xcode 26.5.0 with warnings-as-errors, 47 audio-suite tests pass, `make lint` clean.

## Long-running work

- [x] This PR does **not** advance/start a long-running effort, **or** I updated
      [`LONG_RUNNING.md`](https://github.com/playola-radio/playola-radio-ios/blob/develop/LONG_RUNNING.md)
      in this PR (step / soak / phase).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio session handling during playback, recording, restoration, and deactivation.
  * Prevented stale playback or error states when users stop playback or switch stations during activation.
  * Improved reliability of Siri-initiated playback preparation.

* **Tests**
  * Added coverage for interrupted activation, activation failures, and asynchronous audio session operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->