### PR TITLE
fix: tighten glass mini-player title/subtitle spacing on wrap

### DIFF
--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -24,7 +24,18 @@ struct SmallPlayer: View {
   /// legacy opaque-black bar embedded above the tab bar (full-bleed art).
   var isGlassAccessory = false
 
+  /// `true` once the glass subtitle has wrapped past a single line. When it has,
+  /// the title/subtitle gap tightens so the extra line doesn't push the block
+  /// apart; a single-line subtitle keeps the roomier default spacing.
+  @State private var subtitleIsMultiline = false
+
   private var artworkSize: CGFloat { isGlassAccessory ? 40 : 64 }
+
+  /// Gap between the title and subtitle. Tightens for a wrapped glass subtitle.
+  private var titleSubtitleSpacing: CGFloat {
+    guard isGlassAccessory else { return 4 }
+    return subtitleIsMultiline ? 1 : 4
+  }
 
   // Glass content uses vibrant hierarchical styles so it stays legible on the
   // system glass surface — a hardcoded white vanishes on light glass.
@@ -99,7 +110,7 @@ struct SmallPlayer: View {
   var body: some View {
     VStack(spacing: 0) {
       // Player bar
-      HStack(spacing: isGlassAccessory ? 10 : 16) {
+      HStack(spacing: isGlassAccessory ? 12 : 16) {
         // Artwork
         WebImage(
           url: artworkURL,
@@ -115,11 +126,10 @@ struct SmallPlayer: View {
         .frame(width: artworkSize, height: artworkSize)
         .clipped()
         .clipShape(RoundedRectangle(cornerRadius: isGlassAccessory ? 8 : 6))
-        .padding(.vertical, isGlassAccessory ? 8 : 0)
         .padding(.leading, isGlassAccessory ? 6 : 0)
 
         // Title & subtitle
-        VStack(alignment: .leading, spacing: 4) {
+        VStack(alignment: .leading, spacing: titleSubtitleSpacing) {
           Text(mainTitle)
             .font(.custom(FontNames.Inter_500_Medium, size: isGlassAccessory ? 13 : 16))
             .foregroundStyle(titleStyle)
@@ -129,8 +139,14 @@ struct SmallPlayer: View {
             .foregroundStyle(subtitleStyle)
             .lineLimit(isGlassAccessory ? 2 : nil)
             .fixedSize(horizontal: false, vertical: isGlassAccessory)
+            .onGeometryChange(for: CGFloat.self) {
+              $0.size.height
+            } action: { height in
+              // A single 11pt line is ~15pt tall; two lines clear 20pt.
+              subtitleIsMultiline = height > 20
+            }
         }
-        .padding(.vertical, isGlassAccessory ? 4 : 12)
+        .padding(.vertical, isGlassAccessory ? 0 : 12)
 
         Spacer()
 
@@ -157,7 +173,7 @@ struct SmallPlayer: View {
         .padding(.trailing, isGlassAccessory ? 16 : 24)
       }
       .padding(.horizontal)
-      .padding(.vertical, 8)
+      .padding(.vertical, isGlassAccessory ? 12 : 8)
       .background(isGlassAccessory ? Color.clear : Color.black.opacity(0.85))
 
       // Progress bar


### PR DESCRIPTION
## What

The Liquid Glass mini player (`tabViewBottomAccessory`, iOS 26.1+) left a large empty band between the station title and the `artist - song` subtitle whenever the subtitle wrapped to **two lines** — the block looked loose and cramped at the same time. A single-line subtitle looked great.

## Change

`SmallPlayer.swift` (glass path only):
- Measure the subtitle's rendered height via `onGeometryChange` → `subtitleIsMultiline`.
- Tighten the title↔subtitle gap **only when it wraps**: `4pt` for one line (the roomier look we liked), `1pt` for two lines.
- Nudged the artwork↔text gap (`10→12`) and normalized the pill's vertical padding (single fixed `12pt` glass / `8pt` legacy) after an earlier variable-padding experiment that had no visible effect.

The legacy opaque black-bar player is unchanged (all edits are gated on `isGlassAccessory`).

## Notes

- No feedback loop: subtitle height depends on width, not on the spacing it drives.
- View-only change; no test coverage exists for `SmallPlayer` layout.

## Testing

- Builds clean on Xcode 26.5 (warnings-as-errors on).
- `make lint` → 0 violations; swift-format check passes.
- Verified on device: two-line subtitle now sits tight to the title; one-line keeps the original spacing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the small player layout when subtitles wrap onto multiple lines.
  * Reduced excessive spacing between titles and subtitles for a more compact appearance.
  * Adjusted artwork, glass layout, and vertical padding for better visual alignment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->