### PR TITLE
fix(audio): single MPNowPlayingInfoCenter writer (Phase 2)

### DIFF
--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -96,10 +96,14 @@ projection of `state` (so the two can't drift); NowPlayingUpdater is a pure rend
 + behavioral tests. **Hold the merge until the Phase 1 release branch is cut** so the Phase 1
 soak canary (Mixpanel session metrics) stays attributable to Phase 1 alone.
 
-One intentional cosmetic change to flag at review: for a URL station paused by an
-interruption, in-app now-playing artwork is now the ICY track artwork (a projection of
-`state`) rather than being blanked; previously the shared value carried no URL artwork.
-Lock-screen artwork (station image) is unchanged.
+Behavior change to note: URL stations now surface their ICY track artwork in the in-app
+now-playing UI (SmallPlayer / PlayerPage), consistent with Playola stations. Phase 3 makes
+`nowPlaying` a projection of `state`, and `processAlbumArtworkURLChanged` (the URL artwork
+signal) now routes through the shared writer, so `state` and `nowPlaying` no longer drift
+(previously the artwork lived only in `state` and surfaced only after an interruption). The
+write is guarded to the URL backend so the stale `artworkDidChange(nil)` that every Playola
+play triggers via `reset()` can't blank the active Playola spin's artwork. Lock-screen
+artwork (station image) is unchanged.
 
 ### Soak — Phase 1
 

--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -74,9 +74,9 @@ CarPlay teardown, speaker-stuck-after-recording) along the way.
 
 - [x] **Phase 0 — SDK host-only** (shipped as PlayolaPlayer 0.20.0 → 0.20.2)
 - [x] **Phase 1 — app owns session + interruptions** (PR #345, merged to develop) — 🟡 soaking
-- [ ] **Phase 2 — single Now Playing writer** (low risk, ~1 PR) — 🔵 in PR (removes URLStreamPlayer's MPNowPlayingInfoCenter writes; NowPlayingUpdater sole writer)
+- [ ] **Phase 2 — single Now Playing writer** (low risk) — 🔵 in PR #384 (removes URLStreamPlayer's MPNowPlayingInfoCenter writes; NowPlayingUpdater sole writer)
 - [ ] **Verify URL stations → Sonos** (quick AirPlay-2 check; possible early win)
-- [ ] **Phase 3 — single state-derivation source** (low–med risk, ~1 PR)
+- [ ] **Phase 3 — single state-derivation source** — 🔵 in PR #384 (StationPlayer is the sole `@Shared(.nowPlaying)` writer + single derivation authority; NowPlayingUpdater is now a pure renderer of `stationPlayer.$state`; structural + behavioral tests guard it)
 - [ ] **Owned URLStreamBackend** (retire the vendored FRadioPlayer fork; optional)
 - [ ] **Phase 5 — Sonos renderer** (AVSampleBuffer render path; big; own plan + server-flag rollout)
 
@@ -86,10 +86,20 @@ Phase 1 merged. Now: run the device-verification matrix on real hardware and
 soak on staging before an App Store release. Phase 2 can proceed on develop in
 parallel — it does not block the Phase 1 release soak.
 
-Phase 2 is now in a PR (single MPNowPlayingInfoCenter writer): URLStreamPlayer no
-longer writes the lock screen, NowPlayingUpdater is the sole writer, guarded by a
-structural test. **Hold the merge until the Phase 1 release branch is cut** so the
-Phase 1 soak canary (Mixpanel session metrics) stays attributable to Phase 1 alone.
+Phases 2 and 3 are stacked as two distinct commits on `briankeane/audio-migration-next-step`
+(PR #384). **Phase 2** (single MPNowPlayingInfoCenter writer): URLStreamPlayer no longer
+writes the lock screen, NowPlayingUpdater is the sole writer. **Phase 3** (single
+state-derivation source): StationPlayer is the sole writer of `@Shared(.nowPlaying)` and
+the single derivation authority — its backend processors publish `nowPlaying` as a
+projection of `state` (so the two can't drift); NowPlayingUpdater is a pure renderer of
+`stationPlayer.$state` and no longer subscribes to the backends. Both guarded by structural
++ behavioral tests. **Hold the merge until the Phase 1 release branch is cut** so the Phase 1
+soak canary (Mixpanel session metrics) stays attributable to Phase 1 alone.
+
+One intentional cosmetic change to flag at review: for a URL station paused by an
+interruption, in-app now-playing artwork is now the ICY track artwork (a projection of
+`state`) rather than being blanked; previously the shared value carried no URL artwork.
+Lock-screen artwork (station image) is unchanged.
 
 ### Soak — Phase 1
 

--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -74,7 +74,7 @@ CarPlay teardown, speaker-stuck-after-recording) along the way.
 
 - [x] **Phase 0 — SDK host-only** (shipped as PlayolaPlayer 0.20.0 → 0.20.2)
 - [x] **Phase 1 — app owns session + interruptions** (PR #345, merged to develop) — 🟡 soaking
-- [ ] **Phase 2 — single Now Playing writer** (low risk, ~1 PR)
+- [ ] **Phase 2 — single Now Playing writer** (low risk, ~1 PR) — 🔵 in PR (removes URLStreamPlayer's MPNowPlayingInfoCenter writes; NowPlayingUpdater sole writer)
 - [ ] **Verify URL stations → Sonos** (quick AirPlay-2 check; possible early win)
 - [ ] **Phase 3 — single state-derivation source** (low–med risk, ~1 PR)
 - [ ] **Owned URLStreamBackend** (retire the vendored FRadioPlayer fork; optional)
@@ -85,6 +85,11 @@ CarPlay teardown, speaker-stuck-after-recording) along the way.
 Phase 1 merged. Now: run the device-verification matrix on real hardware and
 soak on staging before an App Store release. Phase 2 can proceed on develop in
 parallel — it does not block the Phase 1 release soak.
+
+Phase 2 is now in a PR (single MPNowPlayingInfoCenter writer): URLStreamPlayer no
+longer writes the lock screen, NowPlayingUpdater is the sole writer, guarded by a
+structural test. **Hold the merge until the Phase 1 release branch is cut** so the
+Phase 1 soak canary (Mixpanel session metrics) stays attributable to Phase 1 alone.
 
 ### Soak — Phase 1
 

--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -19,7 +19,7 @@ not ✅ done until its soak clears.
 > Entries marked `⟨owner: …⟩` are placeholders the task owner should fill in —
 > I scaffolded them from open PRs/branches but don't know the internal plan.
 
-_Last updated: 2026-08-06_
+_Last updated: 2026-08-08_
 
 ---
 
@@ -27,7 +27,7 @@ _Last updated: 2026-08-06_
 
 | Task | Status | Current step | Soak | Links |
 |------|--------|--------------|------|-------|
-| Host-owned audio → Sonos | 🟡 soaking | Phase 1 merged; staging soak + device matrix | Not started (pending first staging build) | PR #345 · plan |
+| Host-owned audio → Sonos | 🟡 soaking | Phase 1 in prod (phased, from 2026-08-08); Phase 2+3 merged to develop, soaking on staging | Phase 1: prod phased rollout · Phase 2+3: staging soak from 2026-08-08 | PR #345 · #384 · plan |
 | Clip share | 🔵 in progress | ⟨owner: current step⟩ | none (standard release) | PR #219 |
 | Rewards → Your Library | 🔵 in progress | Rewards→Profile, Library tab, Presets move | none | PR #372 · `fix-library-requests-ui` |
 | Siri "Play on Playola" (App Intents media schema) | 🟢 planning | Approach B decided (2026-06-14); not started | n/a | — |
@@ -73,28 +73,33 @@ CarPlay teardown, speaker-stuck-after-recording) along the way.
 ### Phases
 
 - [x] **Phase 0 — SDK host-only** (shipped as PlayolaPlayer 0.20.0 → 0.20.2)
-- [x] **Phase 1 — app owns session + interruptions** (PR #345, merged to develop) — 🟡 soaking
-- [ ] **Phase 2 — single Now Playing writer** (low risk) — 🔵 in PR #384 (removes URLStreamPlayer's MPNowPlayingInfoCenter writes; NowPlayingUpdater sole writer)
+- [x] **Phase 1 — app owns session + interruptions** (PR #345) — released to production 2026-08-08 (🟡 phased-rollout soak)
+- [x] **Phase 2 — single Now Playing writer** (low risk, PR #384) — 🟡 merged to develop, soaking on staging (removes URLStreamPlayer's MPNowPlayingInfoCenter writes; NowPlayingUpdater sole writer)
 - [ ] **Verify URL stations → Sonos** (quick AirPlay-2 check; possible early win)
-- [ ] **Phase 3 — single state-derivation source** — 🔵 in PR #384 (StationPlayer is the sole `@Shared(.nowPlaying)` writer + single derivation authority; NowPlayingUpdater is now a pure renderer of `stationPlayer.$state`; structural + behavioral tests guard it)
+- [x] **Phase 3 — single state-derivation source** (PR #384) — 🟡 merged to develop, soaking on staging (StationPlayer is the sole `@Shared(.nowPlaying)` writer + single derivation authority; NowPlayingUpdater is now a pure renderer of `stationPlayer.$state`; structural + behavioral tests guard it)
 - [ ] **Owned URLStreamBackend** (retire the vendored FRadioPlayer fork; optional)
 - [ ] **Phase 5 — Sonos renderer** (AVSampleBuffer render path; big; own plan + server-flag rollout)
 
 ### Current step
 
-Phase 1 merged. Now: run the device-verification matrix on real hardware and
-soak on staging before an App Store release. Phase 2 can proceed on develop in
-parallel — it does not block the Phase 1 release soak.
+Phase 1 **released to production 2026-08-08** (phased rollout under way). That lifted the
+hold on PR #384 — the hold existed so the Phase 1 *staging* soak canary stayed attributable
+to Phase 1 alone; Phase 1 is now off staging, so Phase 2+3 can soak there without
+contaminating it (different metric stream from Phase 1's prod rollout).
 
-Phases 2 and 3 are stacked as two distinct commits on `briankeane/audio-migration-next-step`
-(PR #384). **Phase 2** (single MPNowPlayingInfoCenter writer): URLStreamPlayer no longer
-writes the lock screen, NowPlayingUpdater is the sole writer. **Phase 3** (single
-state-derivation source): StationPlayer is the sole writer of `@Shared(.nowPlaying)` and
-the single derivation authority — its backend processors publish `nowPlaying` as a
-projection of `state` (so the two can't drift); NowPlayingUpdater is a pure renderer of
-`stationPlayer.$state` and no longer subscribes to the backends. Both guarded by structural
-+ behavioral tests. **Hold the merge until the Phase 1 release branch is cut** so the Phase 1
-soak canary (Mixpanel session metrics) stays attributable to Phase 1 alone.
+**Phase 2 + Phase 3 merged to develop together (PR #384) and are now soaking on staging.**
+Phase 2 (single MPNowPlayingInfoCenter writer): URLStreamPlayer no longer writes the lock
+screen, NowPlayingUpdater is the sole writer. Phase 3 (single state-derivation source):
+StationPlayer is the sole writer of `@Shared(.nowPlaying)` and the single derivation
+authority — its backend processors publish `nowPlaying` as a projection of `state` (so the
+two can't drift); NowPlayingUpdater is a pure renderer of `stationPlayer.$state`. Both
+guarded by structural + behavioral tests.
+
+**Next:** cut a staging TestFlight build (`fastlane release_staging` from develop), soak ~1
+week (see "Soak — Phase 2+3"). **Do NOT cut the Phase 2+3 production release while Phase 1's
+phased prod rollout is still in flight** — stacking two audio changes on real listeners
+re-muddies prod attribution. Gate the prod cut on: staging soak clean AND Phase 1 prod
+rollout completed cleanly.
 
 Behavior change to note: URL stations now surface their ICY track artwork in the in-app
 now-playing UI (SmallPlayer / PlayerPage), consistent with Playola stations. Phase 3 makes
@@ -107,28 +112,36 @@ artwork (station image) is unchanged.
 
 ### Soak — Phase 1
 
-- **Environment:** staging TestFlight → then App Store 7-day phased rollout.
-- **Soaking since:** not started yet — pending the first staging TestFlight build.
-  Fill the date when it ships (the "~1 week clean" advance criterion is measured
-  from here).
-- **Device matrix (must pass before App Store):** phone-call/Siri interruption
-  resumes · interruption-without-shouldResume stays paused · headphone unplug
-  pauses (not stops) · Bluetooth A2DP + car HFP route · CarPlay connect/play/
-  interrupt/resume · AirPlay long-form (watch for a `-50` on `.longFormAudio`) ·
-  record voicetrack → stop → play → output not speaker-stuck · URL station
-  interruption pauses/resumes via the coordinator.
+- **Environment:** staging TestFlight (cleared) → App Store phased rollout, **live from 2026-08-08**.
+- **Now:** in production phased rollout. Watch the go/no-go metrics below across the
+  rollout; hold Phase 2+3's *production* cut until this rollout completes cleanly.
 - **Watch (go/no-go metrics):** Mixpanel `listeningSessionStarted` count + session
   length (the canary — a dip means audio broke in the field without a crash);
   Sentry for new `AVAudioSession` / `engine.start` error clusters.
-- **Advance when:** device matrix passes AND ~1 week of clean staging dogfooding
-  AND Mixpanel session metrics flat. Then cut the release; don't over-soak on
-  develop (it just entangles with later changes).
-- **Rollback lever:** known-good prior version is PlayolaPlayer **0.19.0**. Rolling
-  back = revert the SPM pin (0.20.2 → 0.19.0) + revert the app PR, then **build and
-  ship a new release** — reverting source does *not* change binaries already
-  installed via TestFlight/App Store. Because Phase 1 hasn't reached production
-  yet, the cheapest rollback right now is simply **not cutting the release**; once
-  it's live, roll back by shipping a build repinned to 0.19.0 (phased release again).
+- **Rollback lever:** known-good prior version is PlayolaPlayer **0.19.0**. Now that
+  Phase 1 is live, roll back by shipping a build repinned to 0.19.0 (phased release
+  again) — reverting source does *not* change binaries already installed.
+
+### Soak — Phase 2+3
+
+- **Environment:** staging TestFlight (from develop) → later a production phased rollout.
+- **Soaking since:** 2026-08-08 (merged to develop). Cut the staging build with
+  `fastlane release_staging` from develop; the "~1 week clean" clock runs from that build.
+- **Device matrix (must pass before the production cut) — focused on the now-playing
+  surface these phases change:** lock screen shows the correct track/title/artist ·
+  **CarPlay Now Playing is NOT dismissed when a Playola station starts** (the `.urlNotSet`
+  ownership guard) · interruption pause keeps artwork + metadata and the play button
+  resumes · station switch updates the lock screen · **URL station shows ICY track artwork
+  in-app** (new in Phase 3 — confirm it reads as an improvement). Re-run the Phase 1
+  interruption/route/Bluetooth/CarPlay matrix too, since these phases sit on that path.
+- **Watch (go/no-go metrics):** same canary — Mixpanel `listeningSessionStarted` count +
+  session length; Sentry for `AVAudioSession` / `engine.start` clusters and any new
+  MediaPlayer/now-playing errors.
+- **Advance when:** device matrix passes AND ~1 week clean staging dogfooding AND Mixpanel
+  session metrics flat **AND Phase 1's production rollout has completed cleanly**. Then cut
+  the Phase 2+3 production release.
+- **Rollback lever:** revert the PR #384 merge on develop; nothing shipped to production
+  until the gate above is met, so pre-prod rollback is just not cutting the release.
 
 ### Notes
 

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -513,6 +513,7 @@
 		FAE000000000000000000002 /* AudioSessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE000000000000000000001 /* AudioSessionCoordinator.swift */; };
 		FAE000000000000000000003 /* AudioSessionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE000000000000000000001 /* AudioSessionCoordinator.swift */; };
 		FAE000000000000000000005 /* AudioSessionCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE000000000000000000004 /* AudioSessionCoordinatorTests.swift */; };
+		FAE000000000000000000011 /* SingleNowPlayingWriterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAE000000000000000000010 /* SingleNowPlayingWriterTests.swift */; };
 		FAF000000000000000000002 /* AudioRecorderClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF000000000000000000001 /* AudioRecorderClientTests.swift */; };
 		FE01A0C72DFCB368002BAC30 /* SharedStateTestTrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */; };
 		FE110A0000000000000000B2 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
@@ -829,6 +830,7 @@
 		FAD00000000000000000000B /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = "<group>"; };
 		FAE000000000000000000001 /* AudioSessionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionCoordinator.swift; sourceTree = "<group>"; };
 		FAE000000000000000000004 /* AudioSessionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionCoordinatorTests.swift; sourceTree = "<group>"; };
+		FAE000000000000000000010 /* SingleNowPlayingWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleNowPlayingWriterTests.swift; sourceTree = "<group>"; };
 		FAF000000000000000000001 /* AudioRecorderClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderClientTests.swift; sourceTree = "<group>"; };
 		FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateTestTrait.swift; sourceTree = "<group>"; };
 		FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageModel.swift; sourceTree = "<group>"; };
@@ -1536,6 +1538,7 @@
 				D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */,
 				FAE000000000000000000001 /* AudioSessionCoordinator.swift */,
 				FAE000000000000000000004 /* AudioSessionCoordinatorTests.swift */,
+				FAE000000000000000000010 /* SingleNowPlayingWriterTests.swift */,
 				D31C43A72D3C195B0021AAE4 /* StationPlayer.swift */,
 				D3D6CE5E2D5ECECB0059BDCA /* UrlStreamListeningSessionReporter.swift */,
 				D339E56C2BFD2FAB00B9E35B /* URLStreamPlayer.swift */,
@@ -2434,6 +2437,7 @@
 			files = (
 				FAF000000000000000000002 /* AudioRecorderClientTests.swift in Sources */,
 				FAE000000000000000000005 /* AudioSessionCoordinatorTests.swift in Sources */,
+				FAE000000000000000000011 /* SingleNowPlayingWriterTests.swift in Sources */,
 				D35EFC142F1595C5000F64A4 /* SeriesCardTests.swift in Sources */,
 				D3776A1D2F243F8600200ADF /* BroadcastersListenerQuestionPageTests.swift in Sources */,
 				D35EFC532F1A99E6000F64A4 /* ConversationListPageTests.swift in Sources */,

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -214,6 +214,13 @@ class NowPlayingUpdater {
       if !artist.isEmpty {
         info[MPMediaItemPropertyArtist] = artist
       }
+    } else if case .url = station {
+      // URL stream with no ICY track metadata: fall back to the station's own
+      // name/description so the lock screen isn't blank. Mirrors the
+      // `UrlStation.trackName ?? name` / `artistName ?? description` fallback
+      // URLStreamPlayer wrote directly before Phase 2.
+      info[MPMediaItemPropertyTitle] = state.titlePlaying ?? station.name
+      info[MPMediaItemPropertyArtist] = state.artistPlaying ?? station.description
     } else {
       if let artistPlaying = state.artistPlaying {
         info[MPMediaItemPropertyArtist] = artistPlaying

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -9,7 +9,6 @@ import Dependencies
 import Foundation
 import MediaPlayer
 import PlayolaPlayer
-import Sharing
 
 // MARK: - Now Playing Data Structure
 
@@ -37,6 +36,22 @@ struct NowPlaying: Equatable, Codable {
     self.playbackStatus = playbackStatus
   }
 
+  /// Projects the authoritative `StationPlayer.State` into the app-wide shared
+  /// now-playing value. `NowPlaying` is `State` plus `currentStation`, and
+  /// `currentStation` is itself a projection of `playbackStatus`, so this is a
+  /// total, lossless mapping — `StationPlayer` writes `state` and `nowPlaying`
+  /// from the same value, which is what stops them drifting (Phase 3).
+  init(from state: StationPlayer.State) {
+    self.init(
+      artistPlaying: state.artistPlaying,
+      titlePlaying: state.titlePlaying,
+      albumArtworkUrl: state.albumArtworkUrl,
+      playolaSpinPlaying: state.playolaSpinPlaying,
+      currentStation: state.playbackStatus.station,
+      playbackStatus: state.playbackStatus
+    )
+  }
+
   static func mockWith(
     artistPlaying: String? = nil,
     titlePlaying: String? = nil,
@@ -61,7 +76,6 @@ struct NowPlaying: Equatable, Codable {
 class NowPlayingUpdater {
   var stationPlayer: StationPlayer
 
-  @ObservationIgnored @Shared(.nowPlaying) var nowPlaying
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.date.now) var now
@@ -360,174 +374,6 @@ class NowPlayingUpdater {
       }
       .store(in: &disposeBag)
     setupRemoteControlCenter()
-    setupSharedStateObservation()
-  }
-
-  // MARK: - Shared State Management
-
-  private func setupSharedStateObservation() {
-    @Dependency(\.urlStreamPlayer) var urlStreamPlayer
-
-    stationPlayer.playolaStationPlayer.statePublisher
-      .sink { [weak self] playolaState in
-        self?.processPlayolaStationPlayerState(playolaState)
-      }
-      .store(in: &disposeBag)
-
-    urlStreamPlayer.$state
-      .sink { [weak self] urlStreamState in
-        self?.processUrlStreamStateChanged(urlStreamState)
-      }
-      .store(in: &disposeBag)
-  }
-
-  // MARK: - State Processing Methods (duplicated from StationPlayer)
-
-  func processPlayolaStationPlayerState(
-    _ playolaState: PlayolaStationPlayer.State?
-  ) {
-    // Backend ownership: while a URL station is active, ignore all Playola events
-    // (stale `.idle`/`.error`/`.loading`/`.playing`) so they cannot clobber the
-    // shared now-playing state. Mirrors StationPlayer.processPlayolaStationPlayerState.
-    if case .url = stationPlayer.currentStation { return }
-    switch playolaState {
-    case .idle:
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: nil,
-          playbackStatus: .stopped
-        )
-      }
-    case .loading(let progress):
-      guard let currentStation = stationPlayer.currentStation else { return }
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: currentStation,
-          playbackStatus: .loading(currentStation, progress)
-        )
-      }
-    case .playing(let nowPlayingData):
-      publishPlayolaSpin(nowPlayingData, paused: false)
-    // `.paused` is published by the SDK when the host pauses for an interruption.
-    // Keep the interrupted spin's metadata so the lock screen keeps showing what
-    // was playing with a play button to resume. Mirrors StationPlayer.
-    case .paused(let spin):
-      publishPlayolaSpin(spin, paused: true)
-    // `.error` is PlayolaPlayer 0.19.0's terminal failure (e.g. the schedule
-    // fetch exhausted its retries); `.none` is an unexpected empty state. Both
-    // publish the recoverable `.error` status so the lock screen shows the
-    // error and the user can tap play again to retry.
-    case .error, .none:
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: nil,
-          playbackStatus: .error
-        )
-      }
-    }
-  }
-
-  func processUrlStreamStateChanged(
-    _ urlStreamPlayerState: URLStreamPlayer.State
-  ) {
-    // Backend ownership: while a Playola station is active, ignore all URL events
-    // (a late `.urlNotSet` from the `reset()` every Playola play performs, or a
-    // stale `.readyToPlay`/`.error`) so they cannot clobber the shared now-playing
-    // state. Mirrors StationPlayer.processUrlStreamStateChanged.
-    if case .playola = stationPlayer.currentStation { return }
-    // A URL stream paused for an interruption reports playbackState == .paused
-    // while playerStatus stays .loadingFinished; map it to .paused so the lock
-    // screen reflects paused (rate 0) instead of playing. Mirrors StationPlayer.
-    if urlStreamPlayerState.playbackState == .paused,
-      let currentStation = stationPlayer.currentStation
-    {
-      publishUrlNowPlaying(urlStreamPlayerState, currentStation: currentStation, paused: true)
-      return
-    }
-    switch urlStreamPlayerState.playerStatus {
-    case .loading:
-      guard let currentStation = stationPlayer.currentStation else { return }
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: currentStation,
-          playbackStatus: .loading(currentStation)
-        )
-      }
-    case .loadingFinished, .readyToPlay:
-      guard let currentStation = stationPlayer.currentStation else { return }
-      publishUrlNowPlaying(urlStreamPlayerState, currentStation: currentStation, paused: false)
-    case .error:
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: nil,
-          playbackStatus: .error
-        )
-      }
-    case .urlNotSet, .none:
-      $nowPlaying.withLock {
-        $0 = NowPlaying(
-          artistPlaying: nil,
-          titlePlaying: nil,
-          albumArtworkUrl: nil,
-          playolaSpinPlaying: nil,
-          currentStation: nil,
-          playbackStatus: .stopped
-        )
-      }
-    }
-  }
-
-  /// Publishes shared now-playing for a Playola spin in either the playing or
-  /// paused status, keeping the spin metadata identical across the two.
-  private func publishPlayolaSpin(_ spin: Spin, paused: Bool) {
-    guard let currentStation = stationPlayer.currentStation else { return }
-    $nowPlaying.withLock {
-      $0 = NowPlaying(
-        artistPlaying: spin.audioBlock.artist,
-        titlePlaying: spin.audioBlock.title,
-        albumArtworkUrl: spin.audioBlock.imageUrl,
-        playolaSpinPlaying: spin,
-        currentStation: currentStation,
-        playbackStatus: paused ? .paused(currentStation) : .playing(currentStation)
-      )
-    }
-  }
-
-  /// Publishes shared now-playing for a URL stream in either the playing or
-  /// paused status. A pause preserves existing artwork across the transition.
-  private func publishUrlNowPlaying(
-    _ state: URLStreamPlayer.State, currentStation: AnyStation, paused: Bool
-  ) {
-    $nowPlaying.withLock {
-      $0 = NowPlaying(
-        artistPlaying: state.nowPlaying?.artistName,
-        titlePlaying: state.nowPlaying?.trackName,
-        albumArtworkUrl: paused ? $0?.albumArtworkUrl : nil,
-        playolaSpinPlaying: nil,
-        currentStation: currentStation,
-        playbackStatus: paused ? .paused(currentStation) : .playing(currentStation)
-      )
-    }
   }
 
   func setupRemoteControlCenter() {

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -143,6 +143,27 @@ struct NowPlayingUpdaterTests {
   }
 
   @Test
+  func testUrlStationWithoutTrackMetadataFallsBackToStationNameAndDescription() {
+    let urlStation = AnyStation.mockUrl()  // name "Mock FM", description "Mock FM Station"
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer()
+      // Playing URL station whose stream reported no ICY track metadata.
+      stationPlayer.state = StationPlayer.State(playbackStatus: .playing(urlStation))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    // Regression (Phase 2): after URLStreamPlayer stopped writing the lock screen
+    // directly, NowPlayingUpdater must still fall back to the station's own
+    // name/description instead of leaving the lock-screen title/artist blank.
+    #expect(updater.currentNowPlayingInfo[MPMediaItemPropertyTitle] as? String == "Mock FM")
+    #expect(
+      updater.currentNowPlayingInfo[MPMediaItemPropertyArtist] as? String == "Mock FM Station")
+  }
+
+  @Test
   func testIsStillCurrentTrueForPlayingStationFalseAfterSwitch() {
     let updater = withDependencies {
       $0.analytics.track = { _ in }

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -60,87 +60,11 @@ struct NowPlayingUpdaterTests {
 
   // MARK: - Playola State Processing Tests
 
-  @Test
-  func testProcessPlayolaErrorStatePublishesRecoverableErrorStatus() {
-    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .loading(.mock))
-    let updater = withDependencies {
-      $0.analytics.track = { _ in }
-      $0.date = .constant(Date())
-    } operation: {
-      NowPlayingUpdater()
-    }
-
-    // PlayolaPlayer 0.19.0's terminal `.error` must publish the recoverable
-    // `.error` status into shared state, not leave the UI stuck on .loading.
-    updater.processPlayolaStationPlayerState(.error(.networkError("boom")))
-
-    #expect(nowPlaying?.playbackStatus == .error)
-  }
-
-  // MARK: - Backend Ownership Regression Tests
-
-  // Same CarPlay/lock-screen "instantly dismissed" regression as in
-  // StationPlayer, but for the shared `nowPlaying` state NowPlayingUpdater
-  // publishes. NowPlayingUpdater independently observes both audio backends, so
-  // the spurious cross-backend `.stopped` must be guarded here too.
-
-  @Test
-  func testUrlStreamUrlNotSetDoesNotClobberActivePlayolaNowPlaying() {
-    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
-    let playolaStation = AnyStation.mockPlayola()
-    let updater = withDependencies {
-      $0.analytics.track = { _ in }
-      $0.date = .constant(Date())
-    } operation: {
-      let stationPlayer = StationPlayer()
-      stationPlayer.state = StationPlayer.State(playbackStatus: .loading(playolaStation))
-      return NowPlayingUpdater(stationPlayer: stationPlayer)
-    }
-
-    // Establish a real Playola baseline (last writer wins over init echoes).
-    updater.processPlayolaStationPlayerState(.loading(0.5))
-    // A late URL-backend `.urlNotSet` (FRadioPlayer's response to reset() during
-    // the Playola play) must not clobber shared state back to .stopped.
-    updater.processUrlStreamStateChanged(
-      URLStreamPlayer.State(
-        playbackState: .stopped,
-        playerStatus: .urlNotSet,
-        currentStation: nil,
-        nowPlaying: nil
-      )
-    )
-
-    expectNoDifference(nowPlaying?.playbackStatus, .loading(playolaStation, 0.5))
-  }
-
-  @Test
-  func testPlayolaIdleDoesNotClobberActiveUrlNowPlaying() {
-    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
-    let urlStation = AnyStation.mockUrl()
-    let updater = withDependencies {
-      $0.analytics.track = { _ in }
-      $0.date = .constant(Date())
-    } operation: {
-      let stationPlayer = StationPlayer()
-      stationPlayer.state = StationPlayer.State(playbackStatus: .playing(urlStation))
-      return NowPlayingUpdater(stationPlayer: stationPlayer)
-    }
-
-    // Establish a real URL baseline.
-    updater.processUrlStreamStateChanged(
-      URLStreamPlayer.State(
-        playbackState: .playing,
-        playerStatus: .readyToPlay,
-        currentStation: nil,
-        nowPlaying: nil
-      )
-    )
-    // A stray Playola `.idle` (emitted by stop() while switching) must not
-    // clobber the active URL station back to .stopped.
-    updater.processPlayolaStationPlayerState(.idle)
-
-    expectNoDifference(nowPlaying?.playbackStatus, .playing(urlStation))
-  }
+  // Phase 3: shared `nowPlaying` writing (Playola `.error` recovery, and the
+  // cross-backend ownership guards for shared state) moved to `StationPlayer`,
+  // the single writer of `@Shared(.nowPlaying)`. Those assertions now live in
+  // StationPlayerTests. NowPlayingUpdater is a pure renderer of
+  // `stationPlayer.$state` and no longer observes the backends directly.
 
   @Test
   func testUrlStationWithoutTrackMetadataFallsBackToStationNameAndDescription() {

--- a/PlayolaRadio/Core/AudioPlayback/SingleNowPlayingWriterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/SingleNowPlayingWriterTests.swift
@@ -1,0 +1,52 @@
+//
+//  SingleNowPlayingWriterTests.swift
+//  PlayolaRadio
+//
+//  Structural guard for Phase 2 of the audio-ownership refactor: NowPlayingUpdater
+//  is the ONLY writer of MPNowPlayingInfoCenter. A second writer (historically
+//  URLStreamPlayer) clobbers the Now Playing dict and produces the wrong lock
+//  screen. This scans the app source tree and fails if MPNowPlayingInfoCenter is
+//  referenced anywhere except NowPlayingUpdater.swift.
+//
+
+import Foundation
+import Testing
+
+@Suite(.freshSharedState)
+struct SingleNowPlayingWriterTests {
+  @Test
+  func onlyNowPlayingUpdaterReferencesNowPlayingCenter() throws {
+    // This file lives at PlayolaRadio/Core/AudioPlayback/<file>; walk up three
+    // levels to the PlayolaRadio app-source root and scan every Swift file under it.
+    let appSourceRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // AudioPlayback
+      .deletingLastPathComponent()  // Core
+      .deletingLastPathComponent()  // PlayolaRadio
+
+    let enumerator = try #require(
+      FileManager.default.enumerator(at: appSourceRoot, includingPropertiesForKeys: nil),
+      "Could not enumerate app source root at \(appSourceRoot.path)")
+
+    // Allowlist by resolved relative path, not basename — a basename match would
+    // silently skip any other file named NowPlayingUpdater.swift elsewhere in the
+    // tree, letting a second writer slip past the guard.
+    let allowedRelativePaths: Set<String> = [
+      "Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift"
+    ]
+
+    var offenders: [String] = []
+    for case let url as URL in enumerator where url.pathExtension == "swift" {
+      guard !url.lastPathComponent.hasSuffix("Tests.swift") else { continue }
+      let relativePath = url.path.replacingOccurrences(of: appSourceRoot.path + "/", with: "")
+      guard !allowedRelativePaths.contains(relativePath) else { continue }
+      let content = try String(contentsOf: url, encoding: .utf8)
+      if content.contains("MPNowPlayingInfoCenter") {
+        offenders.append(relativePath)
+      }
+    }
+
+    #expect(
+      offenders.isEmpty,
+      "MPNowPlayingInfoCenter must be written only by NowPlayingUpdater; found in: \(offenders)")
+  }
+}

--- a/PlayolaRadio/Core/AudioPlayback/SingleNowPlayingWriterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/SingleNowPlayingWriterTests.swift
@@ -13,37 +13,13 @@ import Foundation
 import Testing
 
 @Suite(.freshSharedState)
+@MainActor
 struct SingleNowPlayingWriterTests {
   @Test
   func onlyNowPlayingUpdaterReferencesNowPlayingCenter() throws {
-    // This file lives at PlayolaRadio/Core/AudioPlayback/<file>; walk up three
-    // levels to the PlayolaRadio app-source root and scan every Swift file under it.
-    let appSourceRoot = URL(fileURLWithPath: #filePath)
-      .deletingLastPathComponent()  // AudioPlayback
-      .deletingLastPathComponent()  // Core
-      .deletingLastPathComponent()  // PlayolaRadio
-
-    let enumerator = try #require(
-      FileManager.default.enumerator(at: appSourceRoot, includingPropertiesForKeys: nil),
-      "Could not enumerate app source root at \(appSourceRoot.path)")
-
-    // Allowlist by resolved relative path, not basename — a basename match would
-    // silently skip any other file named NowPlayingUpdater.swift elsewhere in the
-    // tree, letting a second writer slip past the guard.
-    let allowedRelativePaths: Set<String> = [
-      "Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift"
-    ]
-
-    var offenders: [String] = []
-    for case let url as URL in enumerator where url.pathExtension == "swift" {
-      guard !url.lastPathComponent.hasSuffix("Tests.swift") else { continue }
-      let relativePath = url.path.replacingOccurrences(of: appSourceRoot.path + "/", with: "")
-      guard !allowedRelativePaths.contains(relativePath) else { continue }
-      let content = try String(contentsOf: url, encoding: .utf8)
-      if content.contains("MPNowPlayingInfoCenter") {
-        offenders.append(relativePath)
-      }
-    }
+    let offenders = try appSwiftFilesContaining(
+      "MPNowPlayingInfoCenter",
+      allowedRelativePaths: ["Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift"])
 
     #expect(
       offenders.isEmpty,
@@ -57,6 +33,29 @@ struct SingleNowPlayingWriterTests {
   // if `$nowPlaying.withLock` appears anywhere except StationPlayer.swift.
   @Test
   func onlyStationPlayerWritesSharedNowPlaying() throws {
+    let offenders = try appSwiftFilesContaining(
+      "$nowPlaying.withLock",
+      allowedRelativePaths: ["Core/AudioPlayback/StationPlayer.swift"])
+
+    #expect(
+      offenders.isEmpty,
+      "@Shared(.nowPlaying) must be written only by StationPlayer; found in: \(offenders)")
+  }
+
+  /// Relative paths of every app-source Swift file (excluding `*Tests.swift` and
+  /// the allowlist) that contains `needle`. This file lives at
+  /// `PlayolaRadio/Core/AudioPlayback/<file>`; walk up three levels to the
+  /// app-source root. Allowlisting by resolved relative path — not basename —
+  /// avoids silently skipping a same-named file elsewhere in the tree.
+  ///
+  /// The needle is the exact write idiom (`$nowPlaying.withLock` /
+  /// `MPNowPlayingInfoCenter`), not the `@Shared` key: several files legitimately
+  /// declare `@Shared(.nowPlaying)` to *read* it (and some also `.withLock` other
+  /// keys), so a key-based match would false-positive on readers.
+  private func appSwiftFilesContaining(
+    _ needle: String,
+    allowedRelativePaths: Set<String>
+  ) throws -> [String] {
     let appSourceRoot = URL(fileURLWithPath: #filePath)
       .deletingLastPathComponent()  // AudioPlayback
       .deletingLastPathComponent()  // Core
@@ -66,24 +65,16 @@ struct SingleNowPlayingWriterTests {
       FileManager.default.enumerator(at: appSourceRoot, includingPropertiesForKeys: nil),
       "Could not enumerate app source root at \(appSourceRoot.path)")
 
-    // Allowlist by resolved relative path, not basename — see the sibling test.
-    let allowedRelativePaths: Set<String> = [
-      "Core/AudioPlayback/StationPlayer.swift"
-    ]
-
     var offenders: [String] = []
     for case let url as URL in enumerator where url.pathExtension == "swift" {
       guard !url.lastPathComponent.hasSuffix("Tests.swift") else { continue }
       let relativePath = url.path.replacingOccurrences(of: appSourceRoot.path + "/", with: "")
       guard !allowedRelativePaths.contains(relativePath) else { continue }
       let content = try String(contentsOf: url, encoding: .utf8)
-      if content.contains("$nowPlaying.withLock") {
+      if content.contains(needle) {
         offenders.append(relativePath)
       }
     }
-
-    #expect(
-      offenders.isEmpty,
-      "@Shared(.nowPlaying) must be written only by StationPlayer; found in: \(offenders)")
+    return offenders
   }
 }

--- a/PlayolaRadio/Core/AudioPlayback/SingleNowPlayingWriterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/SingleNowPlayingWriterTests.swift
@@ -49,4 +49,41 @@ struct SingleNowPlayingWriterTests {
       offenders.isEmpty,
       "MPNowPlayingInfoCenter must be written only by NowPlayingUpdater; found in: \(offenders)")
   }
+
+  // Structural guard for Phase 3: StationPlayer is the ONLY writer of
+  // `@Shared(.nowPlaying)`. A second writer (historically NowPlayingUpdater's
+  // duplicated backend processors) can drift from `StationPlayer.state`, so the
+  // lock screen and in-app UI disagree. This scans the app source tree and fails
+  // if `$nowPlaying.withLock` appears anywhere except StationPlayer.swift.
+  @Test
+  func onlyStationPlayerWritesSharedNowPlaying() throws {
+    let appSourceRoot = URL(fileURLWithPath: #filePath)
+      .deletingLastPathComponent()  // AudioPlayback
+      .deletingLastPathComponent()  // Core
+      .deletingLastPathComponent()  // PlayolaRadio
+
+    let enumerator = try #require(
+      FileManager.default.enumerator(at: appSourceRoot, includingPropertiesForKeys: nil),
+      "Could not enumerate app source root at \(appSourceRoot.path)")
+
+    // Allowlist by resolved relative path, not basename — see the sibling test.
+    let allowedRelativePaths: Set<String> = [
+      "Core/AudioPlayback/StationPlayer.swift"
+    ]
+
+    var offenders: [String] = []
+    for case let url as URL in enumerator where url.pathExtension == "swift" {
+      guard !url.lastPathComponent.hasSuffix("Tests.swift") else { continue }
+      let relativePath = url.path.replacingOccurrences(of: appSourceRoot.path + "/", with: "")
+      guard !allowedRelativePaths.contains(relativePath) else { continue }
+      let content = try String(contentsOf: url, encoding: .utf8)
+      if content.contains("$nowPlaying.withLock") {
+        offenders.append(relativePath)
+      }
+    }
+
+    #expect(
+      offenders.isEmpty,
+      "@Shared(.nowPlaying) must be written only by StationPlayer; found in: \(offenders)")
+  }
 }

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -73,11 +73,11 @@ class StationPlayer: ObservableObject {
   /// from one derivation is what keeps them from drifting — and makes
   /// `StationPlayer` the single writer of `@Shared(.nowPlaying)` (Phase 3).
   ///
-  /// Only the backend processors and `handlePlayFailure` route through this.
-  /// `play()`/`stop()`/`processAlbumArtworkURLChanged` deliberately set `state`
-  /// directly: today the shared loading/stopped/artwork transitions are driven
-  /// by the backend events those processors handle, and routing them here would
-  /// change observable behavior.
+  /// The backend processors (including `processAlbumArtworkURLChanged`) and
+  /// `handlePlayFailure` route through this. `play()`/`stop()` deliberately set
+  /// `state` directly: their `.startingNewStation`/`.loading`/`.stopped`
+  /// transitions are echoed by the backend events the processors handle, so the
+  /// shared value is published there and routing them here would double-write.
   private func setState(_ newState: State) {
     state = newState
     // Skip the shared write only for the init-time subscription echoes (see
@@ -424,11 +424,7 @@ class StationPlayer: ObservableObject {
           playbackStatus: .paused(currentStation),
           artistPlaying: urlStreamPlayerState.nowPlaying?.artistName,
           titlePlaying: urlStreamPlayerState.nowPlaying?.trackName,
-          // Keep the current artwork across the pause. Since Phase 3 projects
-          // `nowPlaying` from `state`, this carries `state.albumArtworkUrl` (the
-          // ICY artwork `processAlbumArtworkURLChanged` tracks) into shared state,
-          // keeping the two consistent rather than blanking it on pause.
-          albumArtworkUrl: state.albumArtworkUrl
+          albumArtworkUrl: state.albumArtworkUrl  // keep artwork across the pause
         ))
       return
     }
@@ -459,13 +455,23 @@ class StationPlayer: ObservableObject {
   }
 
   private func processAlbumArtworkURLChanged(_ albumArtworkURL: URL?) {
-    state = State(
-      playbackStatus: state.playbackStatus,
-      artistPlaying: state.artistPlaying,
-      titlePlaying: state.titlePlaying,
-      albumArtworkUrl: albumArtworkURL,
-      playolaSpinPlaying: state.playolaSpinPlaying
-    )
+    // Album artwork is a URL-backend signal (`urlStreamPlayer.$albumArtworkURL`).
+    // Backend ownership: only apply it while a URL station is active. Every
+    // Playola play calls `urlStreamPlayer.reset()`, which sets `radioURL = nil`
+    // and makes FRadioPlayer emit `artworkDidChange(nil)`; without this guard that
+    // stale event would blank the active Playola spin's artwork. Routing through
+    // `setState` publishes the artwork so `state` and shared `nowPlaying` stay
+    // consistent (previously `state` carried URL artwork the shared value never
+    // saw, so it surfaced only after an interruption).
+    guard case .url = currentStation else { return }
+    setState(
+      State(
+        playbackStatus: state.playbackStatus,
+        artistPlaying: state.artistPlaying,
+        titlePlaying: state.titlePlaying,
+        albumArtworkUrl: albumArtworkURL,
+        playolaSpinPlaying: state.playolaSpinPlaying
+      ))
   }
 }
 

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -64,19 +64,36 @@ class StationPlayer: ObservableObject {
 
   /// The currently playing radio station, if any
   public var currentStation: AnyStation? {
-    switch state.playbackStatus {
-    case .startingNewStation(let station):
-      return station
-    case .playing(let station):
-      return station
-    case .paused(let station):
-      return station
-    case .loading(let station, _):
-      return station
-    case .error, .stopped:
-      return nil
-    }
+    state.playbackStatus.station
   }
+
+  /// Sets the authoritative `state` and republishes `@Shared(.nowPlaying)` as a
+  /// projection of that same value. `state` drives the lock screen (via
+  /// `NowPlayingUpdater`); `nowPlaying` is the app-wide UI truth. Writing both
+  /// from one derivation is what keeps them from drifting — and makes
+  /// `StationPlayer` the single writer of `@Shared(.nowPlaying)` (Phase 3).
+  ///
+  /// Only the backend processors and `handlePlayFailure` route through this.
+  /// `play()`/`stop()`/`processAlbumArtworkURLChanged` deliberately set `state`
+  /// directly: today the shared loading/stopped/artwork transitions are driven
+  /// by the backend events those processors handle, and routing them here would
+  /// change observable behavior.
+  private func setState(_ newState: State) {
+    state = newState
+    // Skip the shared write only for the init-time subscription echoes (see
+    // `publishesSharedNowPlaying`): construction must set `state` without
+    // clobbering `@Shared(.nowPlaying)`, matching the pre-Phase-3 contract.
+    guard publishesSharedNowPlaying else { return }
+    $nowPlaying.withLock { $0 = NowPlaying(from: newState) }
+  }
+
+  /// False only while `init` wires the backend subscriptions, which replay their
+  /// current values synchronously. Those init-time echoes must set `state` (as
+  /// they always have) without publishing `@Shared(.nowPlaying)` — historically
+  /// `StationPlayer` never wrote the shared value on construction (the updater
+  /// did), and app-wide code seeds `nowPlaying` around building the player.
+  /// Flipped true at the end of `init`, so every real transition publishes.
+  private var publishesSharedNowPlaying = false
 
   // MARK: Dependencies
 
@@ -126,6 +143,10 @@ class StationPlayer: ObservableObject {
     // SDK configure are in place — so an interruption arriving mid-init can't
     // drive pause/resume before global state is coherent.
     self.audioSessionCoordinator.delegate = self
+
+    // Construction (and its initial subscription echoes) is done; from here on
+    // every derived state also publishes `@Shared(.nowPlaying)`.
+    self.publishesSharedNowPlaying = true
   }
 
   // MARK: Public Interface
@@ -225,8 +246,7 @@ class StationPlayer: ObservableObject {
   /// superseded this attempt and owns the current state.
   func handlePlayFailure(_ error: Error) {
     if error is CancellationError { return }
-    state = State(playbackStatus: .error)
-    $nowPlaying.withLock { $0 = NowPlaying(playbackStatus: .error) }
+    setState(State(playbackStatus: .error))
   }
 
   /// Stops the currently playing station
@@ -342,31 +362,20 @@ class StationPlayer: ObservableObject {
     if case .url = currentStation { return }
     switch playolaState {
     case .idle:
-      state = .init(
-        playbackStatus: .stopped,
-        artistPlaying: nil,
-        titlePlaying: nil,
-        albumArtworkUrl: nil,
-        playolaSpinPlaying: nil
-      )
+      setState(.init(playbackStatus: .stopped))
     case .loading(let progress):
       guard let currentStation else { return }
-      state = .init(
-        playbackStatus: .loading(currentStation, progress),
-        artistPlaying: nil,
-        titlePlaying: nil,
-        albumArtworkUrl: nil,
-        playolaSpinPlaying: nil
-      )
+      setState(.init(playbackStatus: .loading(currentStation, progress)))
     case .playing(let nowPlaying):
       if let currentStation {
-        state = .init(
-          playbackStatus: .playing(currentStation),
-          artistPlaying: nowPlaying.audioBlock.artist,
-          titlePlaying: nowPlaying.audioBlock.title,
-          albumArtworkUrl: nowPlaying.audioBlock.imageUrl,
-          playolaSpinPlaying: nowPlaying
-        )
+        setState(
+          .init(
+            playbackStatus: .playing(currentStation),
+            artistPlaying: nowPlaying.audioBlock.artist,
+            titlePlaying: nowPlaying.audioBlock.title,
+            albumArtworkUrl: nowPlaying.audioBlock.imageUrl,
+            playolaSpinPlaying: nowPlaying
+          ))
       }
 
     // `.paused` is published by the SDK when the host pauses playback for an
@@ -375,13 +384,14 @@ class StationPlayer: ObservableObject {
     // play button to resume.
     case .paused(let spin):
       if let currentStation {
-        state = .init(
-          playbackStatus: .paused(currentStation),
-          artistPlaying: spin.audioBlock.artist,
-          titlePlaying: spin.audioBlock.title,
-          albumArtworkUrl: spin.audioBlock.imageUrl,
-          playolaSpinPlaying: spin
-        )
+        setState(
+          .init(
+            playbackStatus: .paused(currentStation),
+            artistPlaying: spin.audioBlock.artist,
+            titlePlaying: spin.audioBlock.title,
+            albumArtworkUrl: spin.audioBlock.imageUrl,
+            playolaSpinPlaying: spin
+          ))
       }
 
     // `.error` is PlayolaPlayer 0.19.0's terminal failure (e.g. the schedule
@@ -389,13 +399,7 @@ class StationPlayer: ObservableObject {
     // surface the recoverable `.error` state so the user sees the error and can
     // tap play again to retry.
     case .error, .none:
-      state = .init(
-        playbackStatus: .error,
-        artistPlaying: nil,
-        titlePlaying: nil,
-        albumArtworkUrl: nil,
-        playolaSpinPlaying: nil
-      )
+      setState(.init(playbackStatus: .error))
     }
   }
 
@@ -415,12 +419,17 @@ class StationPlayer: ObservableObject {
     // it to .paused here instead of letting the playerStatus switch below report
     // .playing with a rate of 1.0.
     if urlStreamPlayerState.playbackState == .paused, let currentStation {
-      state = State(
-        playbackStatus: .paused(currentStation),
-        artistPlaying: urlStreamPlayerState.nowPlaying?.artistName,
-        titlePlaying: urlStreamPlayerState.nowPlaying?.trackName,
-        albumArtworkUrl: state.albumArtworkUrl  // keep artwork across the pause
-      )
+      setState(
+        State(
+          playbackStatus: .paused(currentStation),
+          artistPlaying: urlStreamPlayerState.nowPlaying?.artistName,
+          titlePlaying: urlStreamPlayerState.nowPlaying?.trackName,
+          // Keep the current artwork across the pause. Since Phase 3 projects
+          // `nowPlaying` from `state`, this carries `state.albumArtworkUrl` (the
+          // ICY artwork `processAlbumArtworkURLChanged` tracks) into shared state,
+          // keeping the two consistent rather than blanking it on pause.
+          albumArtworkUrl: state.albumArtworkUrl
+        ))
       return
     }
     switch urlStreamPlayerState.playerStatus {
@@ -429,22 +438,23 @@ class StationPlayer: ObservableObject {
         // Log error: currentStation is nil while URLStreamPlayer.state.playerStatus is .loading
         return
       }
-      state = State(playbackStatus: .loading(currentStation))
+      setState(State(playbackStatus: .loading(currentStation)))
     case .loadingFinished, .readyToPlay:
       guard let currentStation else {
         // Log error: currentStation is nil while URLStreamPlayer.state.playerStatus is .loadingFinished
         return
       }
-      state = State(
-        playbackStatus: .playing(currentStation),
-        artistPlaying: urlStreamPlayerState.nowPlaying?.artistName,
-        titlePlaying: urlStreamPlayerState.nowPlaying?.trackName,
-        albumArtworkUrl: nil
-      )
+      setState(
+        State(
+          playbackStatus: .playing(currentStation),
+          artistPlaying: urlStreamPlayerState.nowPlaying?.artistName,
+          titlePlaying: urlStreamPlayerState.nowPlaying?.trackName,
+          albumArtworkUrl: nil
+        ))
     case .error:
-      state = State(playbackStatus: .error)
+      setState(State(playbackStatus: .error))
     case .urlNotSet, .none:
-      state = State(playbackStatus: .stopped)
+      setState(State(playbackStatus: .stopped))
     }
   }
 
@@ -456,6 +466,23 @@ class StationPlayer: ObservableObject {
       albumArtworkUrl: albumArtworkURL,
       playolaSpinPlaying: state.playolaSpinPlaying
     )
+  }
+}
+
+extension StationPlayer.PlaybackStatus {
+  /// The station this status refers to, if any. `.stopped`/`.error` carry none.
+  /// The single source for deriving `currentStation` / `NowPlaying.currentStation`
+  /// from a status, so a status and its station can never disagree.
+  var station: AnyStation? {
+    switch self {
+    case .startingNewStation(let station),
+      .playing(let station),
+      .paused(let station),
+      .loading(let station, _):
+      return station
+    case .error, .stopped:
+      return nil
+    }
   }
 }
 

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -406,6 +406,11 @@ struct StationPlayerTests {
     expectNoDifference(nowPlaying?.playbackStatus, .playing(urlStation))
     #expect(nowPlaying?.artistPlaying == "ICY Artist")
     #expect(nowPlaying?.titlePlaying == "ICY Track")
+
+    // ICY artwork (URL backend) publishes to shared state too — no state/nowPlaying drift.
+    let artwork = URL(string: "https://example.com/icy.jpg")
+    urlStreamPlayer.albumArtworkURL = artwork
+    expectNoDifference(nowPlaying?.albumArtworkUrl, artwork)
   }
 
   // MARK: - Playola State Processing Tests
@@ -454,8 +459,7 @@ struct StationPlayerTests {
 
   @Test
   func testUrlStreamUrlNotSetDoesNotClobberPlayingPlayolaStation() {
-    // Also asserts the guard protects shared `nowPlaying` (migrated from the old
-    // NowPlayingUpdater ownership test): StationPlayer is now the sole writer.
+    // Also asserts the guard protects shared `nowPlaying` (sole-writer migration).
     let playolaStation = AnyStation.mockPlayola()
     @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .playing(playolaStation))
     let urlStreamPlayer = URLStreamPlayerMock()
@@ -471,6 +475,11 @@ struct StationPlayerTests {
 
     expectNoDifference(stationPlayer.state.playbackStatus, .playing(playolaStation))
     expectNoDifference(nowPlaying?.playbackStatus, .playing(playolaStation))
+
+    // A stale URL-backend artwork event (the `artworkDidChange(nil)` every Playola
+    // play triggers via `reset()`) must not clobber the Playola artwork — the guard.
+    urlStreamPlayer.albumArtworkURL = URL(string: "https://example.com/stale.jpg")
+    #expect(nowPlaying?.albumArtworkUrl == nil)
   }
 
   // Covers the brief `.startingNewStation` window between `stop()` and
@@ -498,8 +507,7 @@ struct StationPlayerTests {
   // station's playback could be wiped the same way.
   @Test
   func testPlayolaIdleDoesNotClobberActiveUrlStation() {
-    // Also asserts the guard protects shared `nowPlaying` (migrated from the old
-    // NowPlayingUpdater ownership test): StationPlayer is now the sole writer.
+    // Also asserts the guard protects shared `nowPlaying` (sole-writer migration).
     let urlStation = AnyStation.mockUrl()
     @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .playing(urlStation))
     let stationPlayer = StationPlayer()

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -459,9 +459,10 @@ struct StationPlayerTests {
 
   @Test
   func testUrlStreamUrlNotSetDoesNotClobberPlayingPlayolaStation() {
-    // Also asserts the guard protects shared `nowPlaying` (sole-writer migration).
     let playolaStation = AnyStation.mockPlayola()
-    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .playing(playolaStation))
+    let playolaArtwork = URL(string: "https://example.com/playola-spin.jpg")
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(
+      albumArtworkUrl: playolaArtwork, playbackStatus: .playing(playolaStation))
     let urlStreamPlayer = URLStreamPlayerMock()
     let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
     stationPlayer.state = StationPlayer.State(playbackStatus: .playing(playolaStation))
@@ -476,10 +477,10 @@ struct StationPlayerTests {
     expectNoDifference(stationPlayer.state.playbackStatus, .playing(playolaStation))
     expectNoDifference(nowPlaying?.playbackStatus, .playing(playolaStation))
 
-    // A stale URL-backend artwork event (the `artworkDidChange(nil)` every Playola
-    // play triggers via `reset()`) must not clobber the Playola artwork — the guard.
-    urlStreamPlayer.albumArtworkURL = URL(string: "https://example.com/stale.jpg")
-    #expect(nowPlaying?.albumArtworkUrl == nil)
+    // The stale `artworkDidChange(nil)` a Playola play triggers via `reset()` must
+    // not clear the Playola station's artwork — the URL-backend ownership guard.
+    urlStreamPlayer.albumArtworkURL = nil
+    expectNoDifference(nowPlaying?.albumArtworkUrl, playolaArtwork)
   }
 
   // Covers the brief `.startingNewStation` window between `stop()` and

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerTests.swift
@@ -9,6 +9,7 @@ import AVFoundation
 import Combine
 import CustomDump
 import Dependencies
+import FRadioPlayer
 import Foundation
 import IdentifiedCollections
 import PlayolaPlayer
@@ -367,6 +368,46 @@ struct StationPlayerTests {
     expectNoDifference(nowPlaying?.playbackStatus, .loading(.mock))
   }
 
+  // MARK: - Shared Now Playing Writer Tests
+
+  // Phase 3: StationPlayer is the sole writer of `@Shared(.nowPlaying)`, writing
+  // it as a projection of the authoritative `state` so the two can't drift.
+
+  @Test
+  func stationPlayerIsSoleWriterOfSharedNowPlaying() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    let playolaStation = AnyStation.mockPlayola()
+    let stationPlayer = StationPlayer()
+    stationPlayer.state = StationPlayer.State(playbackStatus: .loading(playolaStation))
+
+    stationPlayer.processPlayolaStationPlayerState(.playing(.mock))
+
+    expectNoDifference(nowPlaying?.playbackStatus, .playing(playolaStation))
+    #expect(nowPlaying?.playolaSpinPlaying?.id == Spin.mock.id)
+    #expect(nowPlaying?.artistPlaying == Spin.mock.audioBlock.artist)
+  }
+
+  @Test
+  func processUrlStreamPlayingWritesSharedNowPlaying() {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    let urlStreamPlayer = URLStreamPlayerMock()
+    let urlStation = AnyStation.mockUrl()
+    let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
+    stationPlayer.state = StationPlayer.State(playbackStatus: .loading(urlStation))
+
+    urlStreamPlayer.state = URLStreamPlayer.State(
+      playbackState: .playing,
+      playerStatus: .readyToPlay,
+      currentStation: nil,
+      nowPlaying: FRadioPlayer.Metadata(
+        artistName: "ICY Artist", trackName: "ICY Track", rawValue: nil, groups: [])
+    )
+
+    expectNoDifference(nowPlaying?.playbackStatus, .playing(urlStation))
+    #expect(nowPlaying?.artistPlaying == "ICY Artist")
+    #expect(nowPlaying?.titlePlaying == "ICY Track")
+  }
+
   // MARK: - Playola State Processing Tests
 
   @Test
@@ -380,10 +421,8 @@ struct StationPlayerTests {
     stationPlayer.processPlayolaStationPlayerState(.error(.networkError("boom")))
 
     expectNoDifference(stationPlayer.state.playbackStatus, .error)
-    // StationPlayer.processPlayolaStationPlayerState drives only `state`; the
-    // shared `nowPlaying` is NowPlayingUpdater's responsibility and must be
-    // left untouched here.
-    expectNoDifference(nowPlaying?.playbackStatus, .loading(.mock))
+    // Phase 3: sole writer of shared `nowPlaying`, so `.error` reaches the UI too.
+    expectNoDifference(nowPlaying?.playbackStatus, .error)
   }
 
   // MARK: - Backend Ownership Regression Tests
@@ -415,9 +454,12 @@ struct StationPlayerTests {
 
   @Test
   func testUrlStreamUrlNotSetDoesNotClobberPlayingPlayolaStation() {
+    // Also asserts the guard protects shared `nowPlaying` (migrated from the old
+    // NowPlayingUpdater ownership test): StationPlayer is now the sole writer.
+    let playolaStation = AnyStation.mockPlayola()
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .playing(playolaStation))
     let urlStreamPlayer = URLStreamPlayerMock()
     let stationPlayer = StationPlayer(urlStreamPlayer: urlStreamPlayer)
-    let playolaStation = AnyStation.mockPlayola()
     stationPlayer.state = StationPlayer.State(playbackStatus: .playing(playolaStation))
 
     urlStreamPlayer.state = URLStreamPlayer.State(
@@ -428,6 +470,7 @@ struct StationPlayerTests {
     )
 
     expectNoDifference(stationPlayer.state.playbackStatus, .playing(playolaStation))
+    expectNoDifference(nowPlaying?.playbackStatus, .playing(playolaStation))
   }
 
   // Covers the brief `.startingNewStation` window between `stop()` and
@@ -455,13 +498,17 @@ struct StationPlayerTests {
   // station's playback could be wiped the same way.
   @Test
   func testPlayolaIdleDoesNotClobberActiveUrlStation() {
-    let stationPlayer = StationPlayer()
+    // Also asserts the guard protects shared `nowPlaying` (migrated from the old
+    // NowPlayingUpdater ownership test): StationPlayer is now the sole writer.
     let urlStation = AnyStation.mockUrl()
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .playing(urlStation))
+    let stationPlayer = StationPlayer()
     stationPlayer.state = StationPlayer.State(playbackStatus: .playing(urlStation))
 
     stationPlayer.processPlayolaStationPlayerState(.idle)
 
     expectNoDifference(stationPlayer.state.playbackStatus, .playing(urlStation))
+    expectNoDifference(nowPlaying?.playbackStatus, .playing(urlStation))
   }
 
   // Ownership also covers non-`.stopped` terminal events: an inactive backend's

--- a/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/URLStreamPlayer.swift
@@ -9,8 +9,6 @@ import Combine
 import Dependencies
 import FRadioPlayer
 import Foundation
-import MediaPlayer
-import UIKit
 
 @MainActor
 public class URLStreamPlayer: ObservableObject {
@@ -138,46 +136,6 @@ private final class URLPlaybackAttempt {
   }
 }
 
-// MARK: - MPNowPlayingInfoCenter (Lock screen)
-
-extension URLStreamPlayer {
-  private func resetArtwork(with station: UrlStation?) {
-    guard let station else {
-      updateLockScreen(with: nil)
-      return
-    }
-
-    Task { [weak self] in
-      let image = await station.getImage()
-      self?.updateLockScreen(with: image)
-    }
-  }
-
-  private func updateLockScreen(with artworkImage: UIImage?) {
-    // Define Now Playing Info
-    var nowPlayingInfo = [String: Any]()
-
-    if let image = artworkImage {
-      nowPlayingInfo[MPMediaItemPropertyArtwork] = MPMediaItemArtwork(
-        boundsSize: image.size,
-        requestHandler: { _ -> UIImage in
-          return image
-        })
-    }
-
-    if let artistName = currentStation?.artistName {
-      nowPlayingInfo[MPMediaItemPropertyArtist] = artistName
-    }
-
-    if let trackName = currentStation?.trackName {
-      nowPlayingInfo[MPMediaItemPropertyTitle] = trackName
-    }
-
-    // Set the metadata
-    MPNowPlayingInfoCenter.default().nowPlayingInfo = nowPlayingInfo
-  }
-}
-
 // MARK: - FRadioPlayerObserver
 
 extension URLStreamPlayer: @preconcurrency FRadioPlayerObserver {
@@ -189,24 +147,14 @@ extension URLStreamPlayer: @preconcurrency FRadioPlayerObserver {
       playerStatus: FRadioPlayer.shared.state,
       currentStation: currentStation,
       nowPlaying: player.currentMetadata)
-    resetArtwork(with: currentStation)
   }
 
+  // URLStreamPlayer only publishes metadata; NowPlayingUpdater is the single
+  // writer of the system Now Playing info center. `$albumArtworkURL` feeds the
+  // in-app now-playing UI (via StationPlayer); the lock screen uses station
+  // artwork by design. See SingleNowPlayingWriterTests.
   public func radioPlayer(_: FRadioPlayer, artworkDidChange artworkURL: URL?) {
     albumArtworkURL = artworkURL
-    guard let artworkURL else {
-      resetArtwork(with: currentStation)
-      return
-    }
-
-    Task { [weak self] in
-      let image = await UIImage.image(from: artworkURL)
-      guard let image else {
-        self?.resetArtwork(with: self?.currentStation)
-        return
-      }
-      self?.updateLockScreen(with: image)
-    }
   }
 
   public func radioPlayer(


### PR DESCRIPTION
## Phase 2 of the audio-ownership refactor (Host-owned audio → Sonos)

Makes **NowPlayingUpdater the single writer of `MPNowPlayingInfoCenter`**. Previously both `NowPlayingUpdater` and `URLStreamPlayer` wrote the system Now Playing dict, and they clobbered each other — producing the wrong lock screen for URL stations (one of the named defects in the plan).

### What changed
- **`URLStreamPlayer`**: removed the direct lock-screen writes (`resetArtwork`/`updateLockScreen`) and the `MediaPlayer`/`UIKit` imports. It now only publishes metadata (`state` + `albumArtworkURL`); `NowPlayingUpdater` renders the lock screen from those.
- **`NowPlayingUpdater`**: preserved the URL-station title/artist fallback (station `name`/`description`) for streams that send no ICY track metadata, matching the prior `UrlStation.trackName ?? name` / `artistName ?? description` behavior — so the lock screen never goes blank.
- **Tests**: a structural guard (`SingleNowPlayingWriterTests`, allowlisted by resolved path) asserting the single-writer invariant, plus a behavioral regression test for the metadata fallback.

### Intentional behavior change
Per-track album art (iTunes lookup) is **no longer** shown on the URL-station lock screen — it now uses **station art**, consistent with CarPlay and the plan's documented policy. Before this change that per-track art only appeared *racily* (URLStreamPlayer wrote it straight to the system center, NowPlayingUpdater clobbered it back). Per-track art still shows **in-app** via `albumArtworkURL`.

### Review
- TDD (RED confirmed `URLStreamPlayer` as offender → GREEN).
- Full app suite green (1239 tests).
- Codex adversarial review (review + challenge): surfaced the blank-metadata regression, which is fixed + tested; re-review **PASS**, no P1/P2.

### ⚠️ Merge sequencing
**Hold merge until the Phase 1 release branch is cut.** Phase 1 (session ownership, PR #345) is soaking; keeping this out of the Phase 1 release binary keeps that soak's Mixpanel session-metrics canary attributable to Phase 1 alone. Phase 2 carries no soak of its own. Tracked in `LONG_RUNNING.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Now Playing details for URL stations without track metadata by using stream information or station details as a fallback.
  * Paused URL stations retain their in-app ICY artwork.
  * Artwork updates preserve other Now Playing information.

* **Bug Fixes**
  * Fixed missing title and artist information for stations without spin metadata.
  * Improved consistency of Now Playing updates across playback sources.
  * Lock-screen artwork behavior remains unchanged.

* **Tests**
  * Added coverage for Now Playing metadata, artwork, and playback-state behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->