### PR TITLE
Move Suggest Station into Artist Stations list

### DIFF
--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -15,6 +15,7 @@ import SwiftUI
 struct DisplayedStationSection: Identifiable {
   let id: String
   let title: String
+  let isArtistList: Bool
   let rows: [Row]
 
   struct Row: Identifiable {
@@ -63,11 +64,11 @@ class StationListModel: ViewModel {
   var searchText = ""
   var presentedAlert: PlayolaAlert?
   let navigationTitle = "Radio Stations"
-  let suggestArtistButtonText = "Suggest Station"
+  let suggestArtistButtonText = "Don't see your artist? Suggest a station"
   let searchBarPlaceholder = "Search stations"
   let noResultsIconName = "music.note.list"
   let noResultsMessage = "No stations found"
-  let noResultsHint = "Try a different search, or tap Suggest Station to request one."
+  let noResultsHint = "Try a different search, or suggest a station to request one."
 
   // MARK: - Initialization
 
@@ -288,6 +289,7 @@ class StationListModel: ViewModel {
       DisplayedStationSection(
         id: list.id,
         title: list.title,
+        isArtistList: list.slug == StationList.artistListSlug,
         rows: liveSortedStationItems(for: list, liveStations: liveStations).map { item in
           let liveStatus = liveStations.first { $0.stationId == item.anyStation.id }?.liveStatus
           return DisplayedStationSection.Row(

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -79,6 +79,13 @@ struct StationListPage: View {
               .foregroundColor(.playolaGray)
               .multilineTextAlignment(.center)
               .padding(.horizontal, 32)
+
+            SuggestStationRow(
+              isVisible: true,
+              text: model.suggestArtistButtonText,
+              action: { model.suggestArtistTapped() }
+            )
+            .padding(.top, 4)
           }
           .frame(maxWidth: .infinity)
           .padding(.top, 64)

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -23,21 +23,6 @@ struct StationListPage: View {
             .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 32))
             .foregroundColor(.white)
           Spacer()
-          Button {
-            model.suggestArtistTapped()
-          } label: {
-            HStack(spacing: 4) {
-              Image(systemName: "plus")
-                .font(.system(size: 11, weight: .bold))
-              Text(model.suggestArtistButtonText)
-                .font(.custom(FontNames.Inter_500_Medium, size: 12))
-            }
-            .foregroundColor(.white)
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
-            .background(Color.playolaRed)
-            .cornerRadius(16)
-          }
         }
         .padding(.horizontal, 16)
         .padding(.top, 20)
@@ -161,6 +146,12 @@ struct StationListPage: View {
           .padding(.horizontal)
           .padding(.bottom, 8)
 
+        SuggestStationRow(
+          isVisible: section.isArtistList,
+          text: model.suggestArtistButtonText,
+          action: { model.suggestArtistTapped() }
+        )
+
         VStack(spacing: 1) {
           ForEach(rows) { row in
             let item = row.item
@@ -180,6 +171,43 @@ struct StationListPage: View {
             )
           }
         }
+      }
+    }
+  }
+}
+
+// MARK: - Suggest Station Row
+
+private struct SuggestStationRow: View {
+  let isVisible: Bool
+  let text: String
+  let action: () -> Void
+
+  var body: some View {
+    if isVisible {
+      Button(action: action) {
+        HStack(spacing: 12) {
+          Image(systemName: "plus")
+            .font(.system(size: 15, weight: .bold))
+          Text(text)
+            .font(.custom(FontNames.Inter_700_Bold, size: 15))
+            .lineLimit(1)
+            .minimumScaleFactor(0.5)
+          Spacer(minLength: 0)
+        }
+        .foregroundColor(.playolaRed)
+        .padding(.horizontal, 16)
+        .padding(.vertical, 22)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .overlay(
+          RoundedRectangle(cornerRadius: 12)
+            .strokeBorder(
+              Color(hex: "#4D4D4D"),
+              style: StrokeStyle(lineWidth: 1, dash: [4])
+            )
+        )
+        .padding(.horizontal, 16)
+        .padding(.bottom, 12)
       }
     }
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -33,6 +33,33 @@ struct StationListPageTests {
     #expect(model.selectedSegment == "All")
   }
 
+  @Test
+  func testArtistSectionFlaggedBySlugNotId() async {
+    // Real server data gives each list a UUID id and identifies the artist list
+    // by its slug, so the flag must key off slug — not the mock-only id value.
+    let now = Date()
+    @Shared(.showSecretStations) var showSecretStations = false
+    @Shared(.stationLists) var stationLists = IdentifiedArray(uniqueElements: [
+      StationList(
+        id: "8f051a90-067d-4c98-aab8-019d1292377d", name: "Artist Stations",
+        slug: StationList.artistListSlug, hidden: false, sortOrder: 0,
+        createdAt: now, updatedAt: now,
+        items: [APIStationItem(sortOrder: 0, station: nil, urlStation: .mock)]),
+      StationList(
+        id: "b1234567-0000-0000-0000-000000000000", name: "FM Stations",
+        slug: "fm-stations", hidden: false, sortOrder: 1,
+        createdAt: now, updatedAt: now,
+        items: [APIStationItem(sortOrder: 0, station: nil, urlStation: .mock)]),
+    ])
+    let model = StationListModel()
+    await model.viewAppeared()
+
+    let flaggedSlugs = model.displayedSections
+      .filter(\.isArtistList)
+      .compactMap { section in stationLists[id: section.id]?.slug }
+    #expect(flaggedSlugs == [StationList.artistListSlug])
+  }
+
   // MARK: - Segment Selection Tests
 
   @Test


### PR DESCRIPTION
# What & why

Replaces the red "Suggest Station" pill in the Radio Stations header with a full-width, dashed-border **"Don't see your artist? Suggest a station"** row rendered at the top of the Artist Stations section (matching the requested design), with the label pinned to a single line that shrinks to fit rather than wrapping. The section is identified by slug (`"artist-list"`) — the same way the rest of the app finds it — because keying off the mock-only `id` left the row hidden against real (UUID-`id`) server data. Adds a regression test asserting the artist section is flagged by slug, not id.

## Long-running work

- [x] This PR does **not** advance/start a long-running effort, **or** I updated
      [`LONG_RUNNING.md`](https://github.com/playola-radio/playola-radio-ios/blob/develop/LONG_RUNNING.md)
      in this PR (step / soak / phase).