### PR TITLE
Release 7.4.2: Mini-player polish

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2544,7 +2544,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2564,7 +2564,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.4.1;
+				MARKETING_VERSION = 7.4.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2589,7 +2589,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2609,7 +2609,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.4.1;
+				MARKETING_VERSION = 7.4.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2634,7 +2634,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2654,7 +2654,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.4.1;
+				MARKETING_VERSION = 7.4.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2800,7 +2800,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = CTFSB7Y8TD;
@@ -2822,7 +2822,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.4.1;
+				MARKETING_VERSION = 7.4.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2847,7 +2847,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2869,7 +2869,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.4.1;
+				MARKETING_VERSION = 7.4.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2889,7 +2889,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2910,7 +2910,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -3000,7 +3000,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = CTFSB7Y8TD;
@@ -3022,7 +3022,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.4.1;
+				MARKETING_VERSION = 7.4.2;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3042,7 +3042,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 101;
+				CURRENT_PROJECT_VERSION = 102;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;

--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -259,6 +259,11 @@ struct PlayolaRadioApp: App {
         EmptyView()
       } else {
         ContentView()
+          // Playola is a dark-only app (every screen draws on black). Lock the
+          // interface style so system semantic colors (e.g. the glass mini
+          // player's `.primary`/`.secondary` text) resolve to the dark palette
+          // on light-mode devices instead of rendering black-on-black.
+          .preferredColorScheme(.dark)
           .onOpenURL { url in
             GIDSignIn.sharedInstance.handle(url)
           }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -31,7 +31,7 @@ struct MainContainer: View {
     }
     .accentColor(.white)  // Makes the selected tab icon white
     .playolaTabBarChrome()
-    .playolaTabBarMinimize()
+    .playolaTabBarMinimize(isEnabled: model.shouldShowSmallPlayer)
     .playolaBottomAccessory(isEnabled: model.shouldShowSmallPlayer) {
       smallPlayer(isGlassAccessory: true)
     }

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
@@ -31,6 +31,7 @@ struct MainContainer: View {
     }
     .accentColor(.white)  // Makes the selected tab icon white
     .playolaTabBarChrome()
+    .playolaTabBarMinimize()
     .playolaBottomAccessory(isEnabled: model.shouldShowSmallPlayer) {
       smallPlayer(isGlassAccessory: true)
     }

--- a/PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift
@@ -81,13 +81,15 @@ extension View {
     }
   }
 
-  /// Minimizes the tab bar on scroll-down (Apple Music style).
-  /// - iOS 26.1+: `.tabBarMinimizeBehavior(.onScrollDown)`.
+  /// Minimizes the tab bar on scroll-down (Apple Music style), but only while the
+  /// mini player is present — collapsing the bar when there's nothing to squeeze
+  /// into the inline slot just leaves a lone tab pill, so keep the bar full then.
+  /// - iOS 26.1+: `.onScrollDown` when `isEnabled`, else `.never`.
   /// - Legacy: no-op (no glass tab bar to minimize).
   @ViewBuilder
-  func playolaTabBarMinimize() -> some View {
+  func playolaTabBarMinimize(isEnabled: Bool) -> some View {
     if #available(iOS 26.1, *) {
-      self.tabBarMinimizeBehavior(.onScrollDown)
+      self.tabBarMinimizeBehavior(isEnabled ? .onScrollDown : .never)
     } else {
       self
     }

--- a/PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift
@@ -80,4 +80,43 @@ extension View {
       }
     }
   }
+
+  /// Minimizes the tab bar on scroll-down (Apple Music style).
+  /// - iOS 26.1+: `.tabBarMinimizeBehavior(.onScrollDown)`.
+  /// - Legacy: no-op (no glass tab bar to minimize).
+  @ViewBuilder
+  func playolaTabBarMinimize() -> some View {
+    if #available(iOS 26.1, *) {
+      self.tabBarMinimizeBehavior(.onScrollDown)
+    } else {
+      self
+    }
+  }
+}
+
+/// Hands `content` a plain `isInline` bool so `SmallPlayer` (deployment target
+/// 18.1, also used in the legacy embed) never references an iOS 26 symbol.
+/// - iOS 26.1+: `isInline == true` when the bottom accessory has squeezed inline
+///   with a minimized tab bar.
+/// - Legacy: always `false`.
+struct PlayolaAccessoryPlacementReader<Content: View>: View {
+  @ViewBuilder let content: (_ isInline: Bool) -> Content
+
+  var body: some View {
+    if #available(iOS 26.1, *) {
+      PlacementEnvReader(content: content)
+    } else {
+      content(false)
+    }
+  }
+}
+
+@available(iOS 26.1, *)
+private struct PlacementEnvReader<Content: View>: View {
+  @Environment(\.tabViewBottomAccessoryPlacement) private var placement
+  @ViewBuilder let content: (_ isInline: Bool) -> Content
+
+  var body: some View {
+    content(placement == .inline)
+  }
 }

--- a/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
+++ b/PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift
@@ -108,6 +108,14 @@ struct SmallPlayer: View {
 
   // MARK: - Body
   var body: some View {
+    PlayolaAccessoryPlacementReader { isInline in
+      playerBody(hidesHeart: isGlassAccessory && isInline)
+    }
+  }
+
+  // swiftlint:disable function_body_length
+  @ViewBuilder
+  private func playerBody(hidesHeart: Bool) -> some View {
     VStack(spacing: 0) {
       // Player bar
       HStack(spacing: isGlassAccessory ? 12 : 16) {
@@ -150,8 +158,8 @@ struct SmallPlayer: View {
 
         Spacer()
 
-        // Heart button (only for songs)
-        if let audioBlock = currentAudioBlock, audioBlock.type == "song" {
+        // Heart button (only for songs; hidden when the glass player is squeezed inline)
+        if !hidesHeart, let audioBlock = currentAudioBlock, audioBlock.type == "song" {
           Button(
             action: {
               likesManager.toggleLike(audioBlock)
@@ -188,6 +196,7 @@ struct SmallPlayer: View {
     }
     .background(isGlassAccessory ? Color.clear : Color.black)
   }
+  // swiftlint:enable function_body_length
 }
 
 struct SmallPlayer_Previews: PreviewProvider {

--- a/docs/superpowers/plans/2026-08-04-tabbar-minimize-player-squeeze.md
+++ b/docs/superpowers/plans/2026-08-04-tabbar-minimize-player-squeeze.md
@@ -1,0 +1,259 @@
+# Tab-Bar Minimize + Mini-Player Squeeze Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** On iOS 26.1+, minimize the Liquid Glass tab bar on scroll-down and let the glass mini-player squeeze into the inline slot, dropping only its heart button in that state.
+
+**Architecture:** All iOS-26 API forking stays inside the existing compat boundary `TabBarPlatformChrome.swift`. A new `playolaTabBarMinimize()` shim applies `.tabBarMinimizeBehavior(.onScrollDown)`, and a `PlayolaAccessoryPlacementReader` wrapper reads `tabViewBottomAccessoryPlacement` and hands `SmallPlayer` a plain `Bool isInline`. `SmallPlayer` never references an iOS 26 symbol, so the 18.1-deployment view and the legacy embed stay clean.
+
+**Tech Stack:** SwiftUI, iOS 26 tab APIs (`tabBarMinimizeBehavior`, `tabViewBottomAccessoryPlacement`), existing `@Observable` MV pattern.
+
+## Global Constraints
+
+- iOS 26.1+ for all new behavior; legacy (iOS 18.0 through 26.0) path byte-for-byte unchanged.
+- Deployment target iOS 18.1. `SmallPlayer` must contain NO direct iOS 26 API reference (it is compiled at 18.1 and reused in the legacy embed).
+- `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES` on app + staging targets (tests target excluded). Availability isolation must be exact or the build fails.
+- Must compile under Xcode 26.5 (CI) **and** local Xcode 27 beta. Build with `DEVELOPER_DIR=Xcode-26.5.0` locally to match CI.
+- Pre-commit hook runs swift-format only; run `make lint` (SwiftLint) manually before pushing or CI fails.
+- No environment gates. Feature ships on for all qualifying (26.1+) users.
+- Presentation-only change: no model logic, no new model tests. `hidesHeart` is a view-layer/OS-placement concern and correctly lives in the view.
+
+---
+
+### Task 1: Add minimize shim + placement reader to the compat boundary, and wire the call site
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift` (add one shim + two wrapper views)
+- Modify: `PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift:33` (add `.playolaTabBarMinimize()`)
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces:
+  - `func playolaTabBarMinimize() -> some View` (View extension)
+  - `struct PlayolaAccessoryPlacementReader<Content: View>: View` with initializer taking `@ViewBuilder content: @escaping (_ isInline: Bool) -> Content` — renders `content(true)` only when the glass accessory is squeezed inline, else `content(false)`. Task 2 consumes this.
+
+- [ ] **Step 1: Add the `playolaTabBarMinimize()` shim inside the existing `extension View` in `TabBarPlatformChrome.swift`**
+
+Place it after `playolaTabBarChrome()`:
+
+```swift
+  /// Minimizes the tab bar on scroll-down (Apple Music style).
+  /// - iOS 26.1+: `.tabBarMinimizeBehavior(.onScrollDown)`.
+  /// - Legacy: no-op (no glass tab bar to minimize).
+  @ViewBuilder
+  func playolaTabBarMinimize() -> some View {
+    if #available(iOS 26.1, *) {
+      self.tabBarMinimizeBehavior(.onScrollDown)
+    } else {
+      self
+    }
+  }
+```
+
+- [ ] **Step 2: Add the placement reader wrapper views at the bottom of `TabBarPlatformChrome.swift`, after the closing brace of `extension View`**
+
+```swift
+/// Hands `content` a plain `isInline` bool so `SmallPlayer` (deployment target
+/// 18.1, also used in the legacy embed) never references an iOS 26 symbol.
+/// - iOS 26.1+: `isInline == true` when the bottom accessory has squeezed inline
+///   with a minimized tab bar.
+/// - Legacy: always `false`.
+struct PlayolaAccessoryPlacementReader<Content: View>: View {
+  @ViewBuilder let content: (_ isInline: Bool) -> Content
+
+  var body: some View {
+    if #available(iOS 26.1, *) {
+      PlacementEnvReader(content: content)
+    } else {
+      content(false)
+    }
+  }
+}
+
+@available(iOS 26.1, *)
+private struct PlacementEnvReader<Content: View>: View {
+  @Environment(\.tabViewBottomAccessoryPlacement) private var placement
+  @ViewBuilder let content: (_ isInline: Bool) -> Content
+
+  var body: some View {
+    content(placement == .inline)
+  }
+}
+```
+
+- [ ] **Step 3: Wire the call site in `MainContainer.swift`**
+
+Insert `.playolaTabBarMinimize()` between `.playolaTabBarChrome()` and `.playolaBottomAccessory(...)` on the root `TabView` (currently line 33):
+
+```swift
+    .accentColor(.white)  // Makes the selected tab icon white
+    .playolaTabBarChrome()
+    .playolaTabBarMinimize()
+    .playolaBottomAccessory(isEnabled: model.shouldShowSmallPlayer) {
+      smallPlayer(isGlassAccessory: true)
+    }
+```
+
+- [ ] **Step 4: Build to verify compilation on the CI SDK (and confirm availability isolation)**
+
+Run:
+```bash
+DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer \
+xcodebuild build -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
+  -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation
+```
+Expected: BUILD SUCCEEDED. `SmallPlayer` isn't changed yet, so `PlayolaAccessoryPlacementReader` compiles as unused — that's fine (it's referenced in Task 2). No warnings (warnings are errors).
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint`
+Expected: no violations.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift \
+        PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift
+git commit -m "feat: add tab bar minimize-on-scroll shim + accessory placement reader (iOS 26.1+)"
+```
+
+---
+
+### Task 2: Hide the heart when the mini-player is squeezed inline
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift` (body + heart gate)
+
+**Interfaces:**
+- Consumes: `PlayolaAccessoryPlacementReader` from Task 1.
+- Produces: nothing new for later tasks.
+
+- [ ] **Step 1: Extract the current body into a `playerBody(hidesHeart:)` method and wrap `body` in the placement reader**
+
+Replace the current `body` (lines 110-190) so that `body` delegates to the reader, and the existing content moves verbatim into `playerBody(hidesHeart:)`:
+
+```swift
+  // MARK: - Body
+  var body: some View {
+    PlayolaAccessoryPlacementReader { isInline in
+      playerBody(hidesHeart: isGlassAccessory && isInline)
+    }
+  }
+
+  @ViewBuilder
+  private func playerBody(hidesHeart: Bool) -> some View {
+    VStack(spacing: 0) {
+      // Player bar
+      HStack(spacing: isGlassAccessory ? 12 : 16) {
+        // ... existing artwork + title/subtitle block UNCHANGED ...
+```
+
+Everything from the `VStack(spacing: 0)` down to its closing `.background(...)` moves into `playerBody(hidesHeart:)` unchanged EXCEPT the heart gate in the next step.
+
+- [ ] **Step 2: Gate the heart button on `!hidesHeart`**
+
+Change the heart condition (currently line 154) from:
+
+```swift
+        // Heart button (only for songs)
+        if let audioBlock = currentAudioBlock, audioBlock.type == "song" {
+```
+
+to:
+
+```swift
+        // Heart button (only for songs; hidden when the glass player is squeezed inline)
+        if !hidesHeart, let audioBlock = currentAudioBlock, audioBlock.type == "song" {
+```
+
+- [ ] **Step 3: Build on the CI SDK**
+
+Run:
+```bash
+DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer \
+xcodebuild build -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
+  -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation
+```
+Expected: BUILD SUCCEEDED, no warnings.
+
+- [ ] **Step 4: Run the test suite (regression — nothing should break)**
+
+Run the existing tests to confirm no regression (use a concrete booted simulator id; `-skipPackagePluginValidation` required):
+```bash
+DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer \
+xcodebuild test -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
+  -destination 'platform=iOS Simulator,name=iPhone 16' -skipPackagePluginValidation
+```
+Expected: all existing tests pass. (No new tests — presentation-only change.)
+
+- [ ] **Step 5: Lint**
+
+Run: `make lint`
+Expected: no violations.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift"
+git commit -m "feat: drop heart button when glass mini-player squeezes inline"
+```
+
+---
+
+### Task 3: Runtime verification + legacy regression + adversarial review
+
+**Files:** none (verification only). Any fix discovered here appends to Task 2's commit or a new small commit.
+
+**Interfaces:** none.
+
+- [ ] **Step 1: Runtime check on iOS 26.1+ (feature visible)**
+
+Boot an iOS 26.1 simulator, run the app, start playback so the mini-player shows, open a tab with vertical scroll (Home / Stations / Your Library), and scroll down. Confirm:
+  - Tab bar minimizes to a pill.
+  - Glass mini-player squeezes into the inline slot.
+  - Heart button disappears in the squeezed state; artwork/title/subtitle/stop remain.
+  - Scrolling back up restores the full-width player WITH the heart (for a song).
+
+- [ ] **Step 2: Judge the heart transition; add a scoped transition ONLY if it pops**
+
+If the heart blinks out harshly (rather than the surrounding layout sliding smoothly), add `.transition(.opacity)` to just the heart `Button`. If it already looks clean via the OS morph, add nothing. Do NOT add a blanket `.animation(...)`.
+
+If you add the transition, rebuild + relint + amend the Task 2 commit:
+```bash
+DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer \
+xcodebuild build -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
+  -destination 'generic/platform=iOS Simulator' -skipPackagePluginValidation
+make lint
+git add "PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift"
+git commit --amend --no-edit
+```
+
+- [ ] **Step 3: Legacy regression on iOS 18**
+
+Boot an iOS 18 simulator, run the app, start playback. Confirm the embedded opaque-black mini-player is identical to before: full-bleed 64pt artwork, heart present for songs, stop button as a white circle, no tab-bar minimize behavior.
+
+- [ ] **Step 4: Adversarial Codex review of the final diff**
+
+Per the project's Architect-with-Codex pipeline, run `/codex review` then `/codex challenge` on the branch diff (this touches real product view logic, so it clears the triviality threshold). Fix anything surfaced; re-run if fixes are non-trivial.
+
+- [ ] **Step 5: Final confirmation**
+
+Confirm: builds clean on Xcode 26.5, `make lint` clean, tests pass, iOS 26.1 behavior correct, iOS 18 unchanged, Codex clear. Ready for PR against `develop`.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Minimize trigger (`.onScrollDown`, 26.1-gated) → Task 1, Steps 1 & 3. ✅
+- Expanded state unchanged → Task 2 preserves all styling; only the heart gate changes. ✅
+- Inline state = expanded minus heart → Task 2, Step 2 (`hidesHeart = isGlassAccessory && isInline`). ✅
+- Legacy untouched → `PlayolaAccessoryPlacementReader` returns `content(false)` on legacy; verified in Task 3, Step 3. ✅
+- iOS 26 API isolated from `SmallPlayer` → placement read lives in `PlacementEnvReader` in the compat file. ✅
+- OS-driven animation, transition only if needed → Task 3, Step 2. ✅
+- Scrollable-tab verification → already confirmed pre-plan (recorded in spec Risks #1). ✅
+- Build under both Xcode versions, warnings-as-errors, lint → Tasks 1-3 build/lint steps. ✅
+
+**Placeholder scan:** No TBD/TODO; all code shown verbatim; the one conditional step (heart transition) has explicit criteria and exact commands. ✅
+
+**Type consistency:** `PlayolaAccessoryPlacementReader` / `playolaTabBarMinimize()` names match between Task 1 (produce) and Task 2 (consume). `playerBody(hidesHeart:)` used consistently in Task 2 Steps 1-2. `hidesHeart` bool threads correctly. ✅

--- a/docs/superpowers/plans/2026-08-04-tabbar-minimize-player-squeeze.md
+++ b/docs/superpowers/plans/2026-08-04-tabbar-minimize-player-squeeze.md
@@ -8,12 +8,20 @@
 
 **Tech Stack:** SwiftUI, iOS 26 tab APIs (`tabBarMinimizeBehavior`, `tabViewBottomAccessoryPlacement`), existing `@Observable` MV pattern.
 
+## Post-review updates (2026-08-05)
+
+Reconciling this plan with what shipped after runtime testing:
+
+- The minimize shim gained an `isEnabled:` parameter: `playolaTabBarMinimize(isEnabled: Bool)` applies `.onScrollDown` only when the mini player is showing and `.never` otherwise, wired as `.playolaTabBarMinimize(isEnabled: model.shouldShowSmallPlayer)`. This prevents the bar collapsing to a lone tab pill when nothing is playing. The snippets below show the original no-arg form; the shipped form takes `isEnabled`.
+- Added an app-wide `.preferredColorScheme(.dark)` on the root view: the app is dark-only but never declared it, so the glass player's `.primary`/`.secondary` text resolved black-on-black on light-mode devices.
+- CI Xcode is **26.2** (see `.circleci/config.yml`), not 26.5; local builds used an available stable 26.x.
+
 ## Global Constraints
 
-- iOS 26.1+ for all new behavior; legacy (iOS 18.0 through 26.0) path byte-for-byte unchanged.
+- iOS 26.1+ for all new behavior; legacy (iOS 18.1 through 26.0) path byte-for-byte unchanged.
 - Deployment target iOS 18.1. `SmallPlayer` must contain NO direct iOS 26 API reference (it is compiled at 18.1 and reused in the legacy embed).
 - `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES` on app + staging targets (tests target excluded). Availability isolation must be exact or the build fails.
-- Must compile under Xcode 26.5 (CI) **and** local Xcode 27 beta. Build with `DEVELOPER_DIR=Xcode-26.5.0` locally to match CI.
+- Must compile under Xcode 26.2 (CI) **and** the local Xcode 27 beta. Build locally with a stable Xcode 26.x (never the 27 beta), e.g. `DEVELOPER_DIR=/Applications/Xcode-26.5.0.app/Contents/Developer`, to approximate CI (which pins Xcode 26.2).
 - Pre-commit hook runs swift-format only; run `make lint` (SwiftLint) manually before pushing or CI fails.
 - No environment gates. Feature ships on for all qualifying (26.1+) users.
 - Presentation-only change: no model logic, no new model tests. `hidesHeart` is a view-layer/OS-placement concern and correctly lives in the view.
@@ -24,12 +32,12 @@
 
 **Files:**
 - Modify: `PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift` (add one shim + two wrapper views)
-- Modify: `PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift:33` (add `.playolaTabBarMinimize()`)
+- Modify: `PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift:33` (add `.playolaTabBarMinimize(isEnabled:)`)
 
 **Interfaces:**
 - Consumes: nothing new.
 - Produces:
-  - `func playolaTabBarMinimize() -> some View` (View extension)
+  - `func playolaTabBarMinimize(isEnabled: Bool) -> some View` (View extension; shipped form — see Post-review updates)
   - `struct PlayolaAccessoryPlacementReader<Content: View>: View` with initializer taking `@ViewBuilder content: @escaping (_ isInline: Bool) -> Content` — renders `content(true)` only when the glass accessory is squeezed inline, else `content(false)`. Task 2 consumes this.
 
 - [ ] **Step 1: Add the `playolaTabBarMinimize()` shim inside the existing `extension View` in `TabBarPlatformChrome.swift`**
@@ -37,13 +45,14 @@
 Place it after `playolaTabBarChrome()`:
 
 ```swift
-  /// Minimizes the tab bar on scroll-down (Apple Music style).
-  /// - iOS 26.1+: `.tabBarMinimizeBehavior(.onScrollDown)`.
+  /// Minimizes the tab bar on scroll-down (Apple Music style), only while the
+  /// mini player is present so the bar never collapses to a lone tab pill.
+  /// - iOS 26.1+: `.onScrollDown` when `isEnabled`, else `.never`.
   /// - Legacy: no-op (no glass tab bar to minimize).
   @ViewBuilder
-  func playolaTabBarMinimize() -> some View {
+  func playolaTabBarMinimize(isEnabled: Bool) -> some View {
     if #available(iOS 26.1, *) {
-      self.tabBarMinimizeBehavior(.onScrollDown)
+      self.tabBarMinimizeBehavior(isEnabled ? .onScrollDown : .never)
     } else {
       self
     }
@@ -88,7 +97,7 @@ Insert `.playolaTabBarMinimize()` between `.playolaTabBarChrome()` and `.playola
 ```swift
     .accentColor(.white)  // Makes the selected tab icon white
     .playolaTabBarChrome()
-    .playolaTabBarMinimize()
+    .playolaTabBarMinimize(isEnabled: model.shouldShowSmallPlayer)
     .playolaBottomAccessory(isEnabled: model.shouldShowSmallPlayer) {
       smallPlayer(isGlassAccessory: true)
     }

--- a/docs/superpowers/specs/2026-08-04-tabbar-minimize-player-squeeze-design.md
+++ b/docs/superpowers/specs/2026-08-04-tabbar-minimize-player-squeeze-design.md
@@ -1,0 +1,206 @@
+# Tab-Bar Minimize + Mini-Player Squeeze (Apple Music style)
+
+**Date:** 2026-08-04
+**Branch:** `briankeane/apple-music-player-squeeze`
+**Status:** Design approved, ready for implementation plan
+
+## Goal
+
+Match Apple Music's behavior on the phone: when the user scrolls down, the Liquid
+Glass tab bar minimizes (truncates to a pill), and the persistent glass mini-player
+"squeezes" into the inline slot beside the minimized tab bar. In that squeezed
+(inline) state the mini-player drops its Favorites (heart) button; everything else
+stays exactly as it is today.
+
+This is an **additive iOS 26.1+ enhancement**. The pre-iOS-26 (legacy) path — opaque
+black tab bar with the mini-player embedded beneath each tab's content — is untouched.
+
+## Scope (decided with the user — do not relitigate)
+
+- **Trigger:** `.tabBarMinimizeBehavior(.onScrollDown)` on the root `TabView`, gated to
+  the existing iOS 26.1+ floor.
+- **Expanded accessory state:** exactly today's glass mini-player (station artwork +
+  title + subtitle + heart (songs only) + stop).
+- **Inline (minimized) accessory state:** identical to expanded **except the heart
+  button is removed**. Nothing else changes.
+- **Legacy (pre-26):** no glass tab bar exists, so minimize never applies. Byte-for-byte
+  unchanged.
+
+Out of scope: converting the app's search field to the iOS 26 glass search style. Search
+is a custom `TextField` in a full-screen-cover modal (`SongSearchPageView`); it is not a
+tab and does not interact with the tab bar. It is a separate future project.
+
+## Architecture
+
+All OS-version forking stays inside the existing compatibility boundary,
+`PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift`. `SmallPlayer`
+never references any iOS 26 API directly — it receives a plain `Bool`. This is what
+keeps the 18.1-deployment-target view and the legacy embed path clean.
+
+API availability note: `tabBarMinimizeBehavior` and `tabViewBottomAccessoryPlacement`
+are iOS 26.0 APIs (verified against the Xcode 26.5 and Xcode 27 beta SwiftUI
+`.swiftinterface` files). We still gate this feature at **iOS 26.1** to match the
+existing glass floor — iOS 26.0 is intentionally on the legacy path in this app because
+`tabViewBottomAccessory(isEnabled:)` is 26.1+. Consistency over theoretical availability.
+
+### 1. New minimize shim — `TabBarPlatformChrome.swift`
+
+```swift
+/// Minimizes the tab bar on scroll (Apple Music style).
+/// - iOS 26.1+: `.tabBarMinimizeBehavior(.onScrollDown)`.
+/// - Legacy: no-op.
+@ViewBuilder
+func playolaTabBarMinimize() -> some View {
+  if #available(iOS 26.1, *) {
+    self.tabBarMinimizeBehavior(.onScrollDown)
+  } else {
+    self
+  }
+}
+```
+
+Call site in `MainContainer.swift` (root `TabView`, ~line 33), between chrome and
+accessory:
+
+```swift
+.accentColor(.white)
+.playolaTabBarChrome()
+.playolaTabBarMinimize()          // new
+.playolaBottomAccessory(isEnabled: model.shouldShowSmallPlayer) {
+  smallPlayer(isGlassAccessory: true)
+}
+```
+
+Ordering relative to the accessory is not functionally significant; keep the three
+tab-bar chrome modifiers adjacent for readability.
+
+### 2. Placement reader — `TabBarPlatformChrome.swift`
+
+A small wrapper view isolates the iOS 26 environment read and hands the content a plain
+`Bool isInline`. Defined as a proper wrapper view (not a `View` extension that ignores
+its subject — that was a smell in the draft snippet):
+
+```swift
+/// Reads the tab view bottom-accessory placement and hands `isInline` to `content`.
+/// - iOS 26.1+: `isInline == true` when the accessory has squeezed inline with a
+///   minimized tab bar.
+/// - Legacy: always `isInline == false` (no glass accessory exists).
+struct PlayolaAccessoryPlacementReader<Content: View>: View {
+  @ViewBuilder let content: (_ isInline: Bool) -> Content
+
+  var body: some View {
+    if #available(iOS 26.1, *) {
+      PlacementEnvReader(content: content)
+    } else {
+      content(false)
+    }
+  }
+}
+
+@available(iOS 26.1, *)
+private struct PlacementEnvReader<Content: View>: View {
+  @Environment(\.tabViewBottomAccessoryPlacement) private var placement
+  @ViewBuilder let content: (_ isInline: Bool) -> Content
+
+  var body: some View {
+    content(placement == .inline)
+  }
+}
+```
+
+The environment value propagates into the `.tabViewBottomAccessory` content closure
+(that is the documented, supported way to adapt inline vs expanded). On the legacy embed
+path the env is never installed, and the wrapper short-circuits to `content(false)`, so
+the heart logic there is unchanged.
+
+### 3. `SmallPlayer.swift` — one behavioral change
+
+Today the body is a `VStack` containing the player-bar `HStack` and the progress
+`Rectangle`, with the heart rendered at lines 154-167 whenever
+`currentAudioBlock.type == "song"`.
+
+Change:
+- Extract the current `body` contents into a private `playerBody(hidesHeart:)` method.
+- Wrap the body in the placement reader:
+
+```swift
+var body: some View {
+  PlayolaAccessoryPlacementReader { isInline in
+    playerBody(hidesHeart: isGlassAccessory && isInline)
+  }
+}
+```
+
+- Gate the heart on `!hidesHeart`:
+
+```swift
+if !hidesHeart, let audioBlock = currentAudioBlock, audioBlock.type == "song" {
+  // existing heart Button, unchanged
+}
+```
+
+Result: `hidesHeart` is `true` only in the glass accessory's inline state. Expanded
+glass and the legacy embed both pass `hidesHeart == false`, so their heart behavior is
+identical to today. All other styling (artwork, title/subtitle, stop, progress, spacing,
+`subtitleIsMultiline` state) is unchanged.
+
+### 4. Animation — rely on the OS, add a transition only if needed
+
+The tab-bar collapse and the accessory's expanded↔inline morph are OS-driven and
+animated; the placement change is delivered inside the system's animation transaction.
+The layout reflow of the remaining elements rides along for free — **do not add a
+blanket `.animation(...)`**, which can fight the system's timing.
+
+The one element that may pop (a conditionally-removed view has no implicit transition) is
+the heart itself. Verify at runtime. **If** the heart's removal pops harshly, add a
+scoped transition to just the heart:
+
+```swift
+.transition(.opacity)
+```
+
+Nothing more.
+
+## Testing / Verification
+
+- **Runtime (primary):** on an iOS 26.1 simulator/device, scroll a tab with real
+  scrollable content and confirm: tab bar minimizes, mini-player squeezes inline, heart
+  disappears, remaining layout reflows cleanly, and scrolling back up restores the
+  expanded player with the heart. Check the heart pop and add `.transition(.opacity)`
+  only if needed.
+- **Legacy regression:** on an iOS 18 simulator, confirm the embedded mini-player is
+  visually and behaviorally identical to before (heart present for songs, no minimize).
+- **Build:** must compile under Xcode 26.5 (CI) and the local Xcode 27 beta, with
+  `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES` — so the availability isolation must be exact.
+- **Unit tests:** this is presentation-only (no model logic changes), so no new model
+  tests are expected. If we later move the "should the heart show" decision into a
+  computed value, add a test then.
+
+## Risks / things to verify during implementation
+
+1. **Scrollable tab content — VERIFIED.** `.onScrollDown` only triggers on tabs whose
+   content is a real `ScrollView`/`List`. Confirmed all primary tabs qualify:
+   `HomePageView` (ScrollView), `StationListPage` (vertical ScrollView), `YourLibraryPageView`
+   (ScrollView), `ContactPageView` = Profile/Settings (ScrollView), `LibraryPageView` (List),
+   `BroadcastPageView` (List). Note `StationListPage` also has a *horizontal* ScrollView at
+   top which will not drive minimize; the main vertical ScrollView beneath it will. Feature
+   will be visible on every tab.
+2. **iPhone-only:** tab-bar minimization is a phone behavior; do not expect inline on
+   iPad/sidebar-adapted layouts. Not a concern for this phone-first app but worth noting.
+3. **`safeAreaInset(edge: .bottom)` search bar:** lives inside a full-screen cover that
+   owns its own presentation/safe area, so interaction risk with root tab-bar minimize is
+   low. Sanity-check anyway.
+4. **`TabViewBottomAccessoryPlacement` equality/optionality:** `placement == .inline`
+   works whether the env value is optional or not; confirm it compiles against both SDKs.
+
+## Files touched
+
+- `PlayolaRadio/Views/Pages/MainContainer/TabBarPlatformChrome.swift` — add
+  `playolaTabBarMinimize()` shim + `PlayolaAccessoryPlacementReader` (and private
+  `PlacementEnvReader`).
+- `PlayolaRadio/Views/Pages/MainContainer/MainContainer.swift` — add
+  `.playolaTabBarMinimize()` to the root `TabView`.
+- `PlayolaRadio/Views/Reusable Components/SmallPlayer/SmallPlayer.swift` — wrap body in
+  the placement reader, extract `playerBody(hidesHeart:)`, gate the heart.
+
+No new files, so no `project.pbxproj` registration needed.

--- a/docs/superpowers/specs/2026-08-04-tabbar-minimize-player-squeeze-design.md
+++ b/docs/superpowers/specs/2026-08-04-tabbar-minimize-player-squeeze-design.md
@@ -4,6 +4,15 @@
 **Branch:** `briankeane/apple-music-player-squeeze`
 **Status:** Design approved, ready for implementation plan
 
+## Post-review updates (2026-08-05)
+
+Two changes landed after runtime testing that this design predates:
+
+- The minimize trigger is gated on player visibility: `playolaTabBarMinimize(isEnabled: model.shouldShowSmallPlayer)` applies `.onScrollDown` only while the mini player shows, `.never` otherwise (so an empty tab bar never collapses to a lone pill). Snippets below show the original no-arg form.
+- Added app-wide `.preferredColorScheme(.dark)`: the app is dark-only but never declared it, so the glass player's `.primary`/`.secondary` text rendered black-on-black on light-mode devices.
+
+Legacy range throughout means **iOS 18.1 through 26.0** (the feature floor is iOS 26.1). CI compiles on Xcode 26.2.
+
 ## Goal
 
 Match Apple Music's behavior on the phone: when the user scrolls down, the Liquid
@@ -12,8 +21,9 @@ Glass tab bar minimizes (truncates to a pill), and the persistent glass mini-pla
 (inline) state the mini-player drops its Favorites (heart) button; everything else
 stays exactly as it is today.
 
-This is an **additive iOS 26.1+ enhancement**. The pre-iOS-26 (legacy) path — opaque
-black tab bar with the mini-player embedded beneath each tab's content — is untouched.
+This is an **additive iOS 26.1+ enhancement**. The pre-iOS-26.1 legacy path (iOS 18.1
+through 26.0) — opaque black tab bar with the mini-player embedded beneath each tab's
+content — is untouched.
 
 ## Scope (decided with the user — do not relitigate)
 
@@ -23,8 +33,8 @@ black tab bar with the mini-player embedded beneath each tab's content — is un
   title + subtitle + heart (songs only) + stop).
 - **Inline (minimized) accessory state:** identical to expanded **except the heart
   button is removed**. Nothing else changes.
-- **Legacy (pre-26):** no glass tab bar exists, so minimize never applies. Byte-for-byte
-  unchanged.
+- **Legacy (pre-26.1, iOS 18.1–26.0):** no glass tab bar exists, so minimize never
+  applies. Byte-for-byte unchanged.
 
 Out of scope: converting the app's search field to the iOS 26 glass search style. Search
 is a custom `TextField` in a full-screen-cover modal (`SongSearchPageView`); it is not a
@@ -46,13 +56,14 @@ existing glass floor — iOS 26.0 is intentionally on the legacy path in this ap
 ### 1. New minimize shim — `TabBarPlatformChrome.swift`
 
 ```swift
-/// Minimizes the tab bar on scroll (Apple Music style).
-/// - iOS 26.1+: `.tabBarMinimizeBehavior(.onScrollDown)`.
+/// Minimizes the tab bar on scroll (Apple Music style), only while the mini
+/// player is present so the bar never collapses to a lone tab pill.
+/// - iOS 26.1+: `.onScrollDown` when `isEnabled`, else `.never`.
 /// - Legacy: no-op.
 @ViewBuilder
-func playolaTabBarMinimize() -> some View {
+func playolaTabBarMinimize(isEnabled: Bool) -> some View {
   if #available(iOS 26.1, *) {
-    self.tabBarMinimizeBehavior(.onScrollDown)
+    self.tabBarMinimizeBehavior(isEnabled ? .onScrollDown : .never)
   } else {
     self
   }
@@ -65,7 +76,7 @@ accessory:
 ```swift
 .accentColor(.white)
 .playolaTabBarChrome()
-.playolaTabBarMinimize()          // new
+.playolaTabBarMinimize(isEnabled: model.shouldShowSmallPlayer)   // new
 .playolaBottomAccessory(isEnabled: model.shouldShowSmallPlayer) {
   smallPlayer(isGlassAccessory: true)
 }
@@ -170,7 +181,7 @@ Nothing more.
   only if needed.
 - **Legacy regression:** on an iOS 18 simulator, confirm the embedded mini-player is
   visually and behaviorally identical to before (heart present for songs, no minimize).
-- **Build:** must compile under Xcode 26.5 (CI) and the local Xcode 27 beta, with
+- **Build:** must compile under Xcode 26.2 (CI) and the local Xcode 27 beta, with
   `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES` — so the availability isolation must be exact.
 - **Unit tests:** this is presentation-only (no model logic changes), so no new model
   tests are expected. If we later move the "should the heart show" decision into a


### PR DESCRIPTION
## Mini-player polish

### Changes
- #388: Apple Music-style tab bar minimize + mini-player squeeze (iOS 26.1+)

### Version
`7.4.2` (build `102`)
