### PR TITLE
Add iPad layout for Radio Stations screen

### DIFF
--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -19,7 +19,7 @@ not ✅ done until its soak clears.
 > Entries marked `⟨owner: …⟩` are placeholders the task owner should fill in —
 > I scaffolded them from open PRs/branches but don't know the internal plan.
 
-_Last updated: 2026-08-02_
+_Last updated: 2026-08-06_
 
 ---
 

--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -32,6 +32,32 @@ _Last updated: 2026-08-02_
 | Rewards → Your Library | 🔵 in progress | Rewards→Profile, Library tab, Presets move | none | PR #372 · `fix-library-requests-ui` |
 | Siri "Play on Playola" (App Intents media schema) | 🟢 planning | Approach B decided (2026-06-14); not started | n/a | — |
 | View/Model pattern cleanup | 🔵 in progress (opportunistic) | ongoing, fix-on-touch | none | `TODO_VIEW_MODEL_VIOLATIONS.md` |
+| Prettify iPad screens | 🔵 in progress | Radio Stations (screen 1 of N) | none (standard release) | spec: `docs/superpowers/specs/2026-08-05-ipad-radio-stations-design.md` |
+
+---
+
+## Prettify iPad screens
+
+**Goal:** the app is iPhone-first; on iPad several screens render as a single narrow
+column with large dead space and misplaced controls. Make them "not embarrassing" on
+iPad, **one screen at a time**, without taxing the maintained iPhone path.
+
+**Guiding constraint (load-bearing):** iPad is **not** a maintained priority. Each
+screen's iPad layout must be **quarantined** — the iPhone/compact path stays byte-for-byte
+unchanged and no shared abstraction may couple iPhone changes to iPad. iPad code lives in
+its own `*PadView` file, branched once on `horizontalSizeClass == .regular`, reusing only
+already-shared leaf components + the page model. Design drift (iPad styling lagging
+iPhone) is acceptable. Any iPad file may be deleted wholesale without touching iPhone.
+
+### Screens
+
+- [ ] **Radio Stations** — 2-col grid, top search, right-aligned suggest button.
+      Spec: `docs/superpowers/specs/2026-08-05-ipad-radio-stations-design.md`. 🔵 in progress.
+- [ ] (further screens added as they're tackled)
+
+### Current step
+
+Radio Stations: design approved (Codex-reviewed), implementing `StationListPadView`.
 
 ---
 

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -161,6 +161,8 @@
 		D30F008C2E8592F0007BCC73 /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */; };
 		D30F008D2E8592F0007BCC73 /* URLStreamPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E56C2BFD2FAB00B9E35B /* URLStreamPlayer.swift */; };
 		D30F008E2E8592F0007BCC73 /* StationListPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E5662BFD10AE00B9E35B /* StationListPage.swift */; };
+		ABCDEF020000000000000002 /* StationListPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF020000000000000001 /* StationListPadView.swift */; };
+		ABCDEF020000000000000003 /* StationListPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF020000000000000001 /* StationListPadView.swift */; };
 		D30F008F2E8592F0007BCC73 /* MainContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C82DFA247A001BC6F9 /* MainContainer.swift */; };
 		ABCDEF010000000000000002 /* TabBarPlatformChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */; };
 		D30F00902E8592F0007BCC73 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257752E6342C600F4228B /* ToastView.swift */; };
@@ -624,6 +626,7 @@
 		D3367BF72F08B7DC00AF87FA /* NotificationsSettingsPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsPageView.swift; sourceTree = "<group>"; };
 		D3367C002F097D0D00AF87FA /* PushNotificationSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationSubscription.swift; sourceTree = "<group>"; };
 		D339E5662BFD10AE00B9E35B /* StationListPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPage.swift; sourceTree = "<group>"; };
+		ABCDEF020000000000000001 /* StationListPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPadView.swift; sourceTree = "<group>"; };
 		D339E5682BFD1C0800B9E35B /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		D339E56C2BFD2FAB00B9E35B /* URLStreamPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLStreamPlayer.swift; sourceTree = "<group>"; };
 		D339E56E2BFD306600B9E35B /* FRadioPlayerMetadata+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FRadioPlayerMetadata+Equatable.swift"; sourceTree = "<group>"; };
@@ -1002,6 +1005,7 @@
 				D30F00B52E8718F2007BCC73 /* StationListStationRowView */,
 				D35905EB2DFCDA110064A9C1 /* StationListModel.swift */,
 				D339E5662BFD10AE00B9E35B /* StationListPage.swift */,
+				ABCDEF020000000000000001 /* StationListPadView.swift */,
 				D3137DC12D39B4FC0070033A /* StationListPageTests.swift */,
 				BFF0E48DF7714364A04B11B2 /* Presets */,
 				3B83C3893A771EB211B3AF8F /* StationListLiveSortTests.swift */,
@@ -2168,6 +2172,7 @@
 				D35EFC122F1595BE000F64A4 /* SeriesCardModel.swift in Sources */,
 				D3B9C7A62F534CE0002D75C2 /* IntroPresignedURLResponse.swift in Sources */,
 				D30F008E2E8592F0007BCC73 /* StationListPage.swift in Sources */,
+				ABCDEF020000000000000002 /* StationListPadView.swift in Sources */,
 				D30F008F2E8592F0007BCC73 /* MainContainer.swift in Sources */,
 				ABCDEF010000000000000002 /* TabBarPlatformChrome.swift in Sources */,
 				D3776A3B2F2918DE00200ADF /* WaveformViews.swift in Sources */,
@@ -2370,6 +2375,7 @@
 				D35EFC102F1595BE000F64A4 /* SeriesCardModel.swift in Sources */,
 				D3B9C7A72F534CE0002D75C2 /* IntroPresignedURLResponse.swift in Sources */,
 				D339E5672BFD10AE00B9E35B /* StationListPage.swift in Sources */,
+				ABCDEF020000000000000003 /* StationListPadView.swift in Sources */,
 				D37257C92DFA247D001BC6F9 /* MainContainer.swift in Sources */,
 				ABCDEF010000000000000003 /* TabBarPlatformChrome.swift in Sources */,
 				D3776A3C2F2918DE00200ADF /* WaveformViews.swift in Sources */,

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -65,6 +65,7 @@ class StationListModel: ViewModel {
   var presentedAlert: PlayolaAlert?
   let navigationTitle = "Radio Stations"
   let suggestArtistButtonText = "Don't see your artist? Suggest a station"
+  let suggestStationShortText = "Suggest a station"
   let searchBarPlaceholder = "Search stations"
   let noResultsIconName = "music.note.list"
   let noResultsMessage = "No stations found"

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListModel.swift
@@ -138,6 +138,10 @@ class StationListModel: ViewModel {
     presentedAlert = nil
   }
 
+  func clearSearchTapped() {
+    searchText = ""
+  }
+
   func suggestArtistTapped() {
     let model = StationSuggestionPageModel()
     model.onDismiss = { [weak self] in

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPadView.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPadView.swift
@@ -71,7 +71,7 @@ struct StationListPadView: View {
         .textInputAutocapitalization(.never)
 
       Button {
-        model.searchText = ""
+        model.clearSearchTapped()
       } label: {
         Image(systemName: "xmark.circle.fill")
           .font(.system(size: 16))
@@ -183,6 +183,10 @@ struct StationListPadView: View {
         isPreset: isPreset, stationName: rowModel.titleText),
       onTogglePreset: { await model.presetsModel.starTapped(for: item) }
     )
+    // At half width, cap title/subtitle to one line so long names truncate instead of
+    // shoving the live/giveaway badges and preset star out of the cell. Applied here via
+    // the environment so the shared row (and the iPhone layout) stay untouched.
+    .lineLimit(1)
   }
 
   @ViewBuilder
@@ -206,7 +210,7 @@ struct StationListPadView: View {
   }
 }
 
-#Preview {
+#Preview(traits: .fixedLayout(width: 1024, height: 768)) {
   NavigationStack {
     StationListPadView(model: StationListModel())
   }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPadView.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPadView.swift
@@ -1,0 +1,214 @@
+//
+//  StationListPadView.swift
+//  PlayolaRadio
+//
+//  iPad-only (regular horizontal size class) layout for the Radio Stations screen.
+//
+//  QUARANTINED ON PURPOSE. iPad is not a maintained priority. This view is a dumb
+//  layout over `StationListModel` — it holds zero business logic and reuses only the
+//  shared `StationListStationRowView`. It deliberately duplicates the small chip / search
+//  styling rather than sharing components with the iPhone layout, so that future iPhone
+//  changes never have to account for iPad. Design drift is acceptable; this whole file can
+//  be deleted without touching the iPhone path. See
+//  docs/superpowers/specs/2026-08-05-ipad-radio-stations-design.md.
+//
+
+import SwiftUI
+
+struct StationListPadView: View {
+  @Bindable var model: StationListModel
+
+  private let contentMaxWidth: CGFloat = 1100
+  private let columns = [
+    GridItem(.flexible(), spacing: 24),
+    GridItem(.flexible(), spacing: 24),
+  ]
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      stationsScroll
+    }
+    .background(Color.black)
+  }
+
+  // MARK: - Header (title + search, then filter row)
+
+  private var header: some View {
+    VStack(spacing: 20) {
+      HStack(alignment: .center) {
+        Text(model.navigationTitle)
+          .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 32))
+          .foregroundColor(.white)
+        Spacer(minLength: 24)
+        searchField
+          .frame(width: 320)
+      }
+
+      HStack(spacing: 12) {
+        segmentControl
+        Spacer(minLength: 16)
+        suggestButton
+      }
+    }
+    .frame(maxWidth: contentMaxWidth)
+    .frame(maxWidth: .infinity, alignment: .center)
+    .padding(.horizontal, 32)
+    .padding(.top, 20)
+    .padding(.bottom, 16)
+  }
+
+  private var searchField: some View {
+    HStack(spacing: 8) {
+      Image(systemName: "magnifyingglass")
+        .font(.system(size: 16))
+        .foregroundColor(.playolaGray)
+
+      TextField(model.searchBarPlaceholder, text: $model.searchText)
+        .font(.custom(FontNames.Inter_400_Regular, size: 16))
+        .foregroundColor(.white)
+        .autocorrectionDisabled()
+        .textInputAutocapitalization(.never)
+
+      Button {
+        model.searchText = ""
+      } label: {
+        Image(systemName: "xmark.circle.fill")
+          .font(.system(size: 16))
+          .foregroundColor(.playolaGray)
+      }
+      .opacity(model.searchText.isEmpty ? 0 : 1)
+      .disabled(model.searchText.isEmpty)
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 10)
+    .background(Color(hex: "#333333"))
+    .clipShape(.rect(cornerRadius: 8))
+  }
+
+  private var segmentControl: some View {
+    ScrollView(.horizontal, showsIndicators: false) {
+      HStack(spacing: 8) {
+        ForEach(model.segmentTitles, id: \.self) { segment in
+          Button {
+            Task { await model.segmentSelected(segment) }
+          } label: {
+            Text(segment)
+              .font(.custom(FontNames.Inter_500_Medium, size: 16))
+              .foregroundColor(.white)
+              .padding(.horizontal, 16)
+              .padding(.vertical, 8)
+              .background(
+                model.selectedSegment == segment
+                  ? Color.playolaRed
+                  : Color(hex: "#333333")
+              )
+              .cornerRadius(20)
+          }
+        }
+      }
+    }
+  }
+
+  private var suggestButton: some View {
+    Button {
+      model.suggestArtistTapped()
+    } label: {
+      HStack(spacing: 8) {
+        Image(systemName: "plus")
+          .font(.system(size: 14, weight: .bold))
+        Text(model.suggestStationShortText)
+          .font(.custom(FontNames.Inter_700_Bold, size: 15))
+          .lineLimit(1)
+          .fixedSize()
+      }
+      .foregroundColor(.playolaRed)
+      .padding(.horizontal, 16)
+      .padding(.vertical, 10)
+      .overlay(
+        RoundedRectangle(cornerRadius: 20)
+          .strokeBorder(Color.playolaRed.opacity(0.6), lineWidth: 1)
+      )
+    }
+  }
+
+  // MARK: - Stations
+
+  private var stationsScroll: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 28) {
+        noResults
+        ForEach(model.displayedSections) { section in
+          gridSection(section)
+        }
+      }
+      .frame(maxWidth: contentMaxWidth, alignment: .leading)
+      .frame(maxWidth: .infinity, alignment: .center)
+      .padding(.horizontal, 32)
+      .padding(.top, 8)
+      .padding(.bottom, 24)
+    }
+  }
+
+  @ViewBuilder
+  private func gridSection(_ section: DisplayedStationSection) -> some View {
+    let rows = model.displayedRows(for: section)
+    if !rows.isEmpty {
+      VStack(alignment: .leading, spacing: 12) {
+        Text(section.title)
+          .font(.custom(FontNames.Inter_600_SemiBold, size: 14))
+          .foregroundColor(.white)
+
+        LazyVGrid(columns: columns, alignment: .leading, spacing: 4) {
+          ForEach(rows) { row in
+            stationRow(row)
+          }
+        }
+      }
+    }
+  }
+
+  private func stationRow(_ row: DisplayedStationSection.Row) -> some View {
+    let item = row.item
+    let rowModel = StationListStationRowModel(
+      item: item,
+      liveStatus: row.liveStatus,
+      hasUpcomingGiveaway: row.hasUpcomingGiveaway)
+    let isPreset = model.presetsModel.isPreset(stationId: item.anyStation.id)
+    return StationListStationRowView(
+      model: rowModel,
+      action: { Task { await model.stationSelected(item) } },
+      isPreset: isPreset,
+      presetAccessibilityLabel: model.presetsModel.presetStarAccessibilityLabel(
+        isPreset: isPreset, stationName: rowModel.titleText),
+      onTogglePreset: { await model.presetsModel.starTapped(for: item) }
+    )
+  }
+
+  @ViewBuilder
+  private var noResults: some View {
+    if model.isShowingNoResults {
+      VStack(spacing: 12) {
+        Image(systemName: model.noResultsIconName)
+          .font(.system(size: 40, weight: .light))
+          .foregroundColor(.playolaGray)
+        Text(model.noResultsMessage)
+          .font(.custom(FontNames.Inter_600_SemiBold, size: 18))
+          .foregroundColor(.white)
+        Text(model.noResultsHint)
+          .font(.custom(FontNames.Inter_400_Regular, size: 14))
+          .foregroundColor(.playolaGray)
+          .multilineTextAlignment(.center)
+      }
+      .frame(maxWidth: .infinity)
+      .padding(.top, 64)
+    }
+  }
+}
+
+#Preview {
+  NavigationStack {
+    StationListPadView(model: StationListModel())
+  }
+  .preferredColorScheme(.dark)
+}

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift
@@ -12,8 +12,27 @@ struct StationListPage: View {
   // MARK: - Model
   @Bindable var model: StationListModel
 
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
   // MARK: - View
   var body: some View {
+    Group {
+      if horizontalSizeClass == .regular {
+        StationListPadView(model: model)
+      } else {
+        compactBody
+      }
+    }
+    .toolbarBackground(.hidden, for: .navigationBar)
+    .navigationBarTitleDisplayMode(.inline)
+    .background(Color.black)
+    .onAppear { Task { await model.viewAppeared() } }
+    .playolaAlert($model.presentedAlert)
+    .playolaAlert(Bindable(model.presetsModel).presentedAlert)
+  }
+
+  // MARK: - Compact (iPhone) layout — unchanged
+  private var compactBody: some View {
     VStack(spacing: 0) {
       // Header
       VStack(spacing: 0) {
@@ -102,12 +121,6 @@ struct StationListPage: View {
     .safeAreaInset(edge: .bottom) {
       searchBar
     }
-    .toolbarBackground(.hidden, for: .navigationBar)
-    .navigationBarTitleDisplayMode(.inline)
-    .background(Color.black)
-    .onAppear { Task { await model.viewAppeared() } }
-    .playolaAlert($model.presentedAlert)
-    .playolaAlert(Bindable(model.presetsModel).presentedAlert)
   }
 
   private var searchBar: some View {

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListPageTests.swift
@@ -170,6 +170,18 @@ struct StationListPageTests {
     #expect(model.segmentTitles == ["All"] + stationLists.map { $0.title })
   }
 
+  @Test
+  func testClearSearchTappedClearsSearchText() async {
+    @Shared(.stationLists) var stationLists = StationList.mocks
+    let model = StationListModel()
+    await model.viewAppeared()
+    model.searchText = "reckless"
+
+    model.clearSearchTapped()
+
+    #expect(model.searchText == "")
+  }
+
   // MARK: - Player Interaction Tests
 
   @Test

--- a/docs/superpowers/specs/2026-08-05-ipad-radio-stations-design.md
+++ b/docs/superpowers/specs/2026-08-05-ipad-radio-stations-design.md
@@ -1,0 +1,106 @@
+# iPad Radio Stations layout — design
+
+_Date: 2026-08-05 · First screen of the multi-PR "Prettify iPad screens" effort (see `LONG_RUNNING.md`)._
+
+## Goal
+
+On iPad the Radio Stations screen renders as a single narrow full-width column with a
+vast empty right half and the search bar stranded at the very bottom. Make it "not
+embarrassing" on iPad by matching the provided mockup: title + search on the top row, a
+filter row with a right-aligned suggest button, and a 2-column grid of stations.
+
+**Explicit non-goal:** the iPad layout must never tax future iPhone work. iPhone is the
+only maintained path. iPad is disposable and may lag iPhone in styling (design drift is
+acceptable).
+
+## Scope
+
+- iPad / **regular** horizontal size class only.
+- iPhone / **compact** stays **byte-for-byte identical** to today.
+- Content-area only. Global nav (the top Home/Radio Stations/Your Library/Your Profile
+  bar) is already handled by iOS and is out of scope.
+
+## Architecture — quarantine, don't share
+
+Reviewed with Codex (consult). Codex initially recommended extracting shared components
+(DRY). Given the "iPad must not tax iPhone" constraint, we deliberately chose the
+opposite — **isolation over DRY** — and Codex concurred: sharing components would turn
+every future iPhone change into an implicit iPad change (coupling), which is exactly the
+tech debt the owner is refusing.
+
+`StationListPage`:
+
+```swift
+@Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
+var body: some View {
+  if horizontalSizeClass == .regular {
+    StationListPadView(model: model)   // new, self-contained
+  } else {
+    compactBody                        // today's body, moved verbatim
+  }
+  // shared modifiers (.playolaAlert, .onAppear, .background) wrap both
+}
+
+private var compactBody: some View { /* exact current body */ }
+```
+
+- The current body content moves into `compactBody` **unchanged** — no refactor of the
+  maintained path, no iPhone regression risk, nothing new in iPhone diffs.
+- The single size-class branch is genuine **view geometry** (device knowledge), so it
+  stays in the view, never in the model. This is a deliberate, isolated bend of the
+  project's "no control flow in page Views" rule, approved for this one branch.
+- `StationListPadView` lives in its own file. It can be ignored in every iPhone PR or
+  deleted wholesale.
+
+### What `StationListPadView` may and may not do
+
+- **May** reuse `StationListStationRowView` (already the shared semantic row unit — low
+  coupling risk; if iPhone changes row behavior, iPad inheriting it is desirable) and the
+  shared `StationListModel` (same inputs/actions).
+- **May** duplicate the small chip-pill and search-field styling (~40 lines).
+- **Must NOT** copy any filtering / business logic. All of it stays in the model
+  (`displayedSections`, `displayedRows(for:)`, `segmentTitles`, `selectedSegment`,
+  `searchText`, `isShowingNoResults`, `suggestArtistTapped()`, `stationSelected(_:)`,
+  preset toggling). The iPad view is a dumb layout over model state.
+
+## iPad layout (matches mockup)
+
+- **Header row:** `navigationTitle` left (SpaceGrotesk 700, 32) · search field right,
+  fixed ~320pt, `#333333` rounded field with magnifying glass + clear button, bound to
+  `model.searchText`.
+- **Filter row:** All / Artist Stations / FM Stations chips left (same pill styling as
+  compact) · compact "+ Suggest a station" pill right (playolaRed text + red border),
+  calls `model.suggestArtistTapped()`.
+- **Grid:** 2 columns (`GridItem(.flexible())` ×2), reusing `StationListStationRowView`
+  per row. Section header (`section.title`) spans the full width above each section's
+  grid. Empty sections skipped (driven by `model.displayedRows(for:)`).
+- **No-results state:** reuse the model's no-results strings
+  (`noResultsMessage` / `noResultsHint` / `noResultsIconName`) in a simple centered block.
+- **Width cap:** content capped ~1100pt, centered, standard horizontal padding, so it
+  doesn't stretch grotesquely on a 13" iPad.
+- **Row polish for half width:** `lineLimit` + truncation on title/subtitle so long names
+  don't crush the trailing badges/star; verify the preset star hit area stays ≥44×44.
+
+## Model
+
+**Unchanged.** Only the View layer changes.
+
+## Testing
+
+No new model behavior → existing `StationListModel` and `StationListStationRowView` tests
+stay green (run them to confirm the `compactBody` move didn't regress). New code is
+layout-only:
+
+- Add a `#Preview` at regular width for the iPad layout.
+- Verify against the mockup via an iPad simulator screenshot.
+- Confirm iPhone renders identically after the `compactBody` extraction.
+
+## Files
+
+- `PlayolaRadio/Views/Pages/StationListPage/StationListPage.swift` — add branch + move
+  current body into `compactBody` (no content change).
+- `PlayolaRadio/Views/Pages/StationListPage/StationListPadView.swift` — **new**,
+  self-contained iPad layout. Register in `project.pbxproj`.
+- `LONG_RUNNING.md` — add the "Prettify iPad screens" effort with Radio Stations as
+  the first screen.


### PR DESCRIPTION
# What & why

On iPad (regular width) the Radio Stations screen was a single narrow column with a huge empty right half and search stranded at the bottom; this adds a self-contained `StationListPadView` — 2-column grid, search top-right, right-aligned "Suggest a station" pill — matching the mockup. The iPhone/compact path is byte-for-byte unchanged: the old body moved verbatim into `compactBody` behind a single `horizontalSizeClass` branch. The iPad view is deliberately quarantined (reuses only the shared row view and page model, holds zero business logic) so it never taxes future iPhone work and can be deleted wholesale. Verified: builds on Xcode 26.5, 47 StationList tests pass, `make lint` clean, and a Codex adversarial review found no issues.

## Long-running work

- [x] This PR does **not** advance/start a long-running effort, **or** I updated
      [`LONG_RUNNING.md`](https://github.com/playola-radio/playola-radio-ios/blob/develop/LONG_RUNNING.md)
      in this PR (step / soak / phase).

<!-- Starts the multi-PR "Prettify iPad screens" effort; tracker + spec added in this PR. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an iPad-optimized Radio Stations layout for regular-width screens.
  - Introduced station search, segment filters, station suggestions, preset toggles, and a two-column station grid.
  - Added an empty-state message when no stations match the search or filters.
  - Preserved the existing compact layout for smaller screens.
- **Documentation**
  - Added design and implementation guidance for the iPad Radio Stations experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->