### PR TITLE
Add iPad layouts for Home, Sign In, and Profile screens

### DIFF
--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -32,7 +32,7 @@ _Last updated: 2026-08-06_
 | Rewards → Your Library | 🔵 in progress | Rewards→Profile, Library tab, Presets move | none | PR #372 · `fix-library-requests-ui` |
 | Siri "Play on Playola" (App Intents media schema) | 🟢 planning | Approach B decided (2026-06-14); not started | n/a | — |
 | View/Model pattern cleanup | 🔵 in progress (opportunistic) | ongoing, fix-on-touch | none | `TODO_VIEW_MODEL_VIOLATIONS.md` |
-| Prettify iPad screens | 🔵 in progress | Radio Stations (screen 1 of N) | none (standard release) | spec: `docs/superpowers/specs/2026-08-05-ipad-radio-stations-design.md` |
+| Prettify iPad screens | 🔵 in progress | Profile (screen 4 of N) | none (standard release) | specs in `docs/superpowers/specs/2026-08-0*-ipad-*-design.md` |
 
 ---
 
@@ -53,11 +53,22 @@ iPhone) is acceptable. Any iPad file may be deleted wholesale without touching i
 
 - [ ] **Radio Stations** — 2-col grid, top search, right-aligned suggest button.
       Spec: `docs/superpowers/specs/2026-08-05-ipad-radio-stations-design.md`. 🔵 in progress.
+- [ ] **Home** — logo+welcome header, 2-col compact reward/listening tiles, 2-col station
+      card grid (reuses the shared `StationCardView`). `HomePagePadView.swift`.
+      Spec: `docs/superpowers/specs/2026-08-06-ipad-home-design.md`. 🔵 in progress.
+- [ ] **Sign In** — centered, width-constrained auth card on the gradient (logo, wordmark,
+      welcome text, Google + Apple buttons, terms footer). `SignInPadView.swift`.
+      Spec: `docs/superpowers/specs/2026-08-06-ipad-sign-in-design.md`. 🔵 in progress.
+- [ ] **Profile** ("Your Profile" tab = `ContactPageView`) — centered profile card + 2-col
+      action-button grid, outlined Log out below. `ContactPagePadView.swift`.
+      Spec: `docs/superpowers/specs/2026-08-06-ipad-profile-design.md`. 🔵 in progress.
 - [ ] (further screens added as they're tackled)
 
 ### Current step
 
-Radio Stations: design approved (Codex-reviewed), implementing `StationListPadView`.
+Profile: `ContactPagePadView` implemented (branched on `horizontalSizeClass` in
+`ContactPageView`); no model change (all text/flags already existed). iPhone path untouched.
+Verified via `ImageRenderer` throwaway render.
 
 ---
 

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -163,6 +163,12 @@
 		D30F008E2E8592F0007BCC73 /* StationListPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E5662BFD10AE00B9E35B /* StationListPage.swift */; };
 		ABCDEF020000000000000002 /* StationListPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF020000000000000001 /* StationListPadView.swift */; };
 		ABCDEF020000000000000003 /* StationListPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF020000000000000001 /* StationListPadView.swift */; };
+		ABCDEF030000000000000002 /* HomePagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF030000000000000001 /* HomePagePadView.swift */; };
+		ABCDEF030000000000000003 /* HomePagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF030000000000000001 /* HomePagePadView.swift */; };
+		ABCDEF040000000000000002 /* SignInPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF040000000000000001 /* SignInPadView.swift */; };
+		ABCDEF040000000000000003 /* SignInPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF040000000000000001 /* SignInPadView.swift */; };
+		ABCDEF050000000000000002 /* ContactPagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF050000000000000001 /* ContactPagePadView.swift */; };
+		ABCDEF050000000000000003 /* ContactPagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF050000000000000001 /* ContactPagePadView.swift */; };
 		D30F008F2E8592F0007BCC73 /* MainContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C82DFA247A001BC6F9 /* MainContainer.swift */; };
 		ABCDEF010000000000000002 /* TabBarPlatformChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */; };
 		D30F00902E8592F0007BCC73 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257752E6342C600F4228B /* ToastView.swift */; };
@@ -627,6 +633,9 @@
 		D3367C002F097D0D00AF87FA /* PushNotificationSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationSubscription.swift; sourceTree = "<group>"; };
 		D339E5662BFD10AE00B9E35B /* StationListPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPage.swift; sourceTree = "<group>"; };
 		ABCDEF020000000000000001 /* StationListPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPadView.swift; sourceTree = "<group>"; };
+		ABCDEF030000000000000001 /* HomePagePadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePagePadView.swift; sourceTree = "<group>"; };
+		ABCDEF040000000000000001 /* SignInPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPadView.swift; sourceTree = "<group>"; };
+		ABCDEF050000000000000001 /* ContactPagePadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPagePadView.swift; sourceTree = "<group>"; };
 		D339E5682BFD1C0800B9E35B /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		D339E56C2BFD2FAB00B9E35B /* URLStreamPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLStreamPlayer.swift; sourceTree = "<group>"; };
 		D339E56E2BFD306600B9E35B /* FRadioPlayerMetadata+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FRadioPlayerMetadata+Equatable.swift"; sourceTree = "<group>"; };
@@ -1373,6 +1382,7 @@
 				D37257B32DF88BD9001BC6F9 /* HomePageTests.swift */,
 				D37257B12DF88BBD001BC6F9 /* HomePageModel.swift */,
 				D37257AF2DF88BB2001BC6F9 /* HomePageView.swift */,
+				ABCDEF030000000000000001 /* HomePagePadView.swift */,
 			);
 			path = HomePage;
 			sourceTree = "<group>";
@@ -1602,6 +1612,7 @@
 				D39591182E39932800720CF8 /* ContactPageTests.swift */,
 				D39591162E39932300720CF8 /* ContactPageModel.swift */,
 				D39591142E39931D00720CF8 /* ContactPageView.swift */,
+				ABCDEF050000000000000001 /* ContactPagePadView.swift */,
 			);
 			path = ContactPage;
 			sourceTree = "<group>";
@@ -1665,6 +1676,7 @@
 			children = (
 				D378CCCD2E56011500497A4A /* SignInPageModel.swift */,
 				D3B662692D40103800975D2F /* SignInPageView.swift */,
+				ABCDEF040000000000000001 /* SignInPadView.swift */,
 				D3B662752D41B0C700975D2F /* SignInPageTests.swift */,
 			);
 			path = SignInPage;
@@ -2070,6 +2082,7 @@
 				D3FACE020000000000000003 /* RemoteArtwork.swift in Sources */,
 				D30F00542E8592F0007BCC73 /* ViewModel.swift in Sources */,
 				D30F00552E8592F0007BCC73 /* SignInPageView.swift in Sources */,
+				ABCDEF040000000000000002 /* SignInPadView.swift in Sources */,
 				D30F00562E8592F0007BCC73 /* UrlStation.swift in Sources */,
 				D3C7E5DB2EF0A43000EDD3ED /* SongSearchPageModel.swift in Sources */,
 				D30F00572E8592F0007BCC73 /* Color+Hex.swift in Sources */,
@@ -2129,6 +2142,7 @@
 				D3C7E5E12EF0A44400EDD3ED /* SongSearchPageView.swift in Sources */,
 				D30F00772E8592F0007BCC73 /* UIImage+Cache.swift in Sources */,
 				D30F00782E8592F0007BCC73 /* ContactPageView.swift in Sources */,
+				ABCDEF050000000000000002 /* ContactPagePadView.swift in Sources */,
 				D30F00792E8592F0007BCC73 /* PlayolaTokenProvider.swift in Sources */,
 				D30F007A2E8592F0007BCC73 /* circleBackground.swift in Sources */,
 				D30F007B2E8592F0007BCC73 /* ShareSheet.swift in Sources */,
@@ -2173,6 +2187,7 @@
 				D3B9C7A62F534CE0002D75C2 /* IntroPresignedURLResponse.swift in Sources */,
 				D30F008E2E8592F0007BCC73 /* StationListPage.swift in Sources */,
 				ABCDEF020000000000000002 /* StationListPadView.swift in Sources */,
+				ABCDEF030000000000000002 /* HomePagePadView.swift in Sources */,
 				D30F008F2E8592F0007BCC73 /* MainContainer.swift in Sources */,
 				ABCDEF010000000000000002 /* TabBarPlatformChrome.swift in Sources */,
 				D3776A3B2F2918DE00200ADF /* WaveformViews.swift in Sources */,
@@ -2273,6 +2288,7 @@
 				D3FACE020000000000000002 /* RemoteArtwork.swift in Sources */,
 				D31CD5232DFBA1F2009B9780 /* ViewModel.swift in Sources */,
 				D3B6626A2D40103C00975D2F /* SignInPageView.swift in Sources */,
+				ABCDEF040000000000000003 /* SignInPadView.swift in Sources */,
 				D30AE8A72E75C92700D9FBCA /* UrlStation.swift in Sources */,
 				D3C7E5DC2EF0A43000EDD3ED /* SongSearchPageModel.swift in Sources */,
 				D3536A3B2BFA6520006942D6 /* Color+Hex.swift in Sources */,
@@ -2332,6 +2348,7 @@
 				D3C7E5E22EF0A44400EDD3ED /* SongSearchPageView.swift in Sources */,
 				D3536A3C2BFA6520006942D6 /* UIImage+Cache.swift in Sources */,
 				D39591152E39932000720CF8 /* ContactPageView.swift in Sources */,
+				ABCDEF050000000000000003 /* ContactPagePadView.swift in Sources */,
 				D3BECAC62E201A380009E618 /* PlayolaTokenProvider.swift in Sources */,
 				D37257C42DF8F885001BC6F9 /* circleBackground.swift in Sources */,
 				D378CCD02E57947800497A4A /* ShareSheet.swift in Sources */,
@@ -2376,6 +2393,7 @@
 				D3B9C7A72F534CE0002D75C2 /* IntroPresignedURLResponse.swift in Sources */,
 				D339E5672BFD10AE00B9E35B /* StationListPage.swift in Sources */,
 				ABCDEF020000000000000003 /* StationListPadView.swift in Sources */,
+				ABCDEF030000000000000003 /* HomePagePadView.swift in Sources */,
 				D37257C92DFA247D001BC6F9 /* MainContainer.swift in Sources */,
 				ABCDEF010000000000000003 /* TabBarPlatformChrome.swift in Sources */,
 				D3776A3C2F2918DE00200ADF /* WaveformViews.swift in Sources */,

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPagePadView.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPagePadView.swift
@@ -1,0 +1,275 @@
+//
+//  ContactPagePadView.swift
+//  PlayolaRadio
+//
+//  iPad-only (regular horizontal size class) layout for the "Your Profile" screen.
+//
+//  QUARANTINED ON PURPOSE. iPad is not a maintained priority. This view is a dumb
+//  layout over `ContactPageModel` — it holds zero business logic and wires every button
+//  to the same model actions the compact layout uses. It deliberately duplicates the
+//  small card / button styling rather than sharing components with the iPhone layout, so
+//  future iPhone changes never have to account for iPad. Design drift is acceptable; this
+//  whole file can be deleted without touching the iPhone path. See
+//  docs/superpowers/specs/2026-08-06-ipad-profile-design.md.
+//
+
+import Sharing
+import SwiftUI
+
+struct ContactPagePadView: View {
+  @Bindable var model: ContactPageModel
+  @Shared(.unreadSupportCount) var unreadSupportCount
+
+  private let contentMaxWidth: CGFloat = 720
+  private let columns = [
+    GridItem(.flexible(), spacing: 16),
+    GridItem(.flexible(), spacing: 16),
+  ]
+
+  var body: some View {
+    VStack(spacing: 0) {
+      header
+      ScrollView {
+        VStack(alignment: .leading, spacing: 20) {
+          profileCard
+          modeButtons
+          actionGrid
+          logOutButton
+        }
+        .frame(maxWidth: contentMaxWidth, alignment: .leading)
+        .frame(maxWidth: .infinity, alignment: .center)
+        .padding(.horizontal, 32)
+        .padding(.top, 8)
+        .padding(.bottom, 40)
+      }
+    }
+    .background(Color.black)
+  }
+
+  // MARK: - Header
+
+  private var header: some View {
+    HStack {
+      Text(model.navigationTitle)
+        .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 32))
+        .foregroundColor(.white)
+      Spacer()
+    }
+    .frame(maxWidth: contentMaxWidth)
+    .frame(maxWidth: .infinity, alignment: .center)
+    .padding(.horizontal, 32)
+    .padding(.top, 20)
+    .padding(.bottom, 24)
+    .background(Color.black)
+  }
+
+  // MARK: - Profile card
+
+  private var profileCard: some View {
+    ZStack {
+      VStack(spacing: 16) {
+        ZStack {
+          Circle()
+            .fill(Color.gray700)
+            .frame(width: 112, height: 112)
+
+          Image("empty-profile-avatar")
+            .frame(width: 72, height: 72)
+            .foregroundColor(Color.gray400)
+        }
+
+        VStack(spacing: 4) {
+          Text(model.name)
+            .font(.custom(FontNames.Inter_500_Medium, size: 20))
+            .foregroundColor(.white)
+
+          Text(verbatim: model.email)
+            .font(.custom(FontNames.Inter_400_Regular, size: 14))
+            .foregroundColor(Color.textSecondary)
+        }
+      }
+      .padding(.vertical, 24)
+      .frame(maxWidth: .infinity)
+      .background(Color.gray900)
+      .cornerRadius(6)
+
+      VStack {
+        HStack {
+          Spacer()
+          Button {
+            model.onEditProfileTapped()
+          } label: {
+            Image("pencil")
+              .font(.system(size: 16, weight: .medium))
+              .foregroundColor(.white)
+              .padding(8)
+          }
+          .padding(.trailing, 16)
+          .padding(.top, 16)
+        }
+        Spacer()
+      }
+    }
+  }
+
+  // MARK: - Conditional mode buttons
+
+  @ViewBuilder
+  private var modeButtons: some View {
+    if model.isInBroadcastMode {
+      ProfilePadActionButton(
+        icon: "headphones", label: model.switchToListeningModeLabel, background: Color.info
+      ) {
+        model.switchToListeningMode()
+      }
+    }
+    if model.myStationButtonVisible {
+      ProfilePadActionButton(
+        icon: "antenna.radiowaves.left.and.right",
+        label: model.switchToBroadcastingModeLabel, background: Color.info
+      ) {
+        Task { await model.onMyStationTapped() }
+      }
+    }
+  }
+
+  // MARK: - Action grid
+
+  private var actionGrid: some View {
+    LazyVGrid(columns: columns, spacing: 16) {
+      ProfilePadActionButton(
+        icon: "gift.fill", label: model.rewardsLabel, background: .playolaRed
+      ) {
+        model.onRewardsTapped()
+      }
+
+      ProfilePadActionButton(
+        icon: "bell.fill", label: model.notificationsLabel, background: .playolaRed
+      ) {
+        model.onNotificationsTapped()
+      }
+
+      contactUsButton
+
+      ProfilePadActionButton(
+        icon: "mic.fill", label: model.askArtistLabel, background: .playolaRed
+      ) {
+        model.callIntoStationButtonTapped()
+      }
+    }
+  }
+
+  private var contactUsButton: some View {
+    Button {
+      Task { await model.onContactUsTapped() }
+    } label: {
+      HStack(spacing: 12) {
+        contactUsIcon
+
+        Text(model.contactUsLabel)
+          .font(.custom(FontNames.Inter_500_Medium, size: 16))
+          .foregroundColor(.white)
+
+        Spacer(minLength: 8)
+
+        Image(systemName: "chevron.right")
+          .foregroundColor(.white)
+          .font(.system(size: 14))
+      }
+      .frame(maxWidth: .infinity)
+      .frame(height: 56)
+      .padding(.horizontal, 16)
+      .background(Color.playolaRed)
+      .cornerRadius(6)
+    }
+    .disabled(model.isCheckingSupport)
+  }
+
+  @ViewBuilder
+  private var contactUsIcon: some View {
+    if model.isCheckingSupport {
+      ProgressView()
+        .tint(.white)
+        .frame(width: 16, height: 16)
+    } else {
+      ZStack(alignment: .topTrailing) {
+        Image(systemName: "bubble.left.fill")
+          .foregroundColor(.white)
+          .font(.system(size: 16))
+
+        if unreadSupportCount > 0 {
+          Text("\(unreadSupportCount)")
+            .font(.system(size: 10, weight: .bold))
+            .foregroundColor(Color.playolaRed)
+            .frame(minWidth: 16, minHeight: 16)
+            .background(Circle().fill(Color.white))
+            .offset(x: 8, y: -8)
+        }
+      }
+    }
+  }
+
+  // MARK: - Log out
+
+  private var logOutButton: some View {
+    Button {
+      Task { await model.onLogOutTapped() }
+    } label: {
+      HStack(spacing: 8) {
+        Image("signout-icon")
+          .renderingMode(.template)
+          .foregroundColor(.white)
+
+        Text(model.logOutLabel)
+          .font(.custom(FontNames.Inter_500_Medium, size: 16))
+          .foregroundColor(.white)
+      }
+      .frame(maxWidth: .infinity)
+      .frame(height: 56)
+      .overlay(
+        RoundedRectangle(cornerRadius: 6)
+          .stroke(Color.gray600, lineWidth: 1)
+      )
+    }
+    .padding(.top, 4)
+  }
+}
+
+// MARK: - Reusable colored action button (duplicated styling, quarantined)
+
+private struct ProfilePadActionButton: View {
+  let icon: String
+  let label: String
+  let background: Color
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: 12) {
+        Image(systemName: icon)
+          .foregroundColor(.white)
+          .font(.system(size: 16))
+
+        Text(label)
+          .font(.custom(FontNames.Inter_500_Medium, size: 16))
+          .foregroundColor(.white)
+
+        Spacer(minLength: 8)
+
+        Image(systemName: "chevron.right")
+          .foregroundColor(.white)
+          .font(.system(size: 14))
+      }
+      .frame(maxWidth: .infinity)
+      .frame(height: 56)
+      .padding(.horizontal, 16)
+      .background(background)
+      .cornerRadius(6)
+    }
+  }
+}
+
+#Preview(traits: .fixedLayout(width: 1024, height: 768)) {
+  ContactPagePadView(model: ContactPageModel())
+    .preferredColorScheme(.dark)
+}

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
@@ -12,7 +12,25 @@ struct ContactPageView: View {
   @Bindable var model: ContactPageModel
   @Shared(.unreadSupportCount) var unreadSupportCount
 
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
   var body: some View {
+    Group {
+      if horizontalSizeClass == .regular {
+        ContactPagePadView(model: model)
+      } else {
+        compactBody
+      }
+    }
+    .background(Color.black)
+    .task {
+      await model.onViewAppeared()
+    }
+    .playolaAlert($model.presentedAlert)
+  }
+
+  // MARK: - Compact (iPhone) layout — unchanged
+  private var compactBody: some View {
     VStack(spacing: 0) {
       // Title
       HStack {
@@ -311,11 +329,6 @@ struct ContactPageView: View {
         .padding(.bottom, 100)  // Account for tab bar
       }
     }
-    .background(Color.black)
-    .task {
-      await model.onViewAppeared()
-    }
-    .playolaAlert($model.presentedAlert)
   }
 }
 

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -218,6 +218,22 @@ class HomePageModel: ViewModel {
     liveStatusForStation(stationId) != nil && upcomingGiveaways[id: stationId] != nil
   }
 
+  // MARK: - iPad Layout Helpers
+
+  /// Ordered feature tiles currently visible on the Home screen, mirroring the compact
+  /// layout's conditional tiles. Consumed only by the quarantined iPad layout
+  /// (`HomePagePadView`) so it can render the tile row without duplicating the
+  /// visibility logic. The always-present listening-time tile is intentionally excluded
+  /// (it lives outside this list because it drives a live ticking timer).
+  var visibleFeatureTileModels: [NewFeatureTileModel] {
+    var tiles: [NewFeatureTileModel] = []
+    if hasUnreadSupportMessages { tiles.append(supportMessageTileModel) }
+    if hasScheduledShows { tiles.append(scheduledShowsTileModel) }
+    if hasUpcomingQuestionAiring { tiles.append(questionAiringTileModel) }
+    if canInviteFriends { tiles.append(inviteFriendsTileModel) }
+    return tiles
+  }
+
   // MARK: - Private Helpers
 
   private func stationItem(for station: AnyStation) -> APIStationItem? {

--- a/PlayolaRadio/Views/Pages/HomePage/HomePagePadView.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePagePadView.swift
@@ -1,0 +1,165 @@
+//
+//  HomePagePadView.swift
+//  PlayolaRadio
+//
+//  iPad-only (regular horizontal size class) layout for the Home screen.
+//
+//  QUARANTINED ON PURPOSE. iPad is not a maintained priority. This view is a dumb
+//  layout over `HomePageModel` — it holds zero business logic and reuses only the
+//  shared `StationCardView` leaf plus the existing tile models. It deliberately
+//  duplicates the small tile styling rather than sharing components with the iPhone
+//  layout, so future iPhone changes never have to account for iPad. Design drift is
+//  acceptable; this whole file can be deleted without touching the iPhone path. See
+//  docs/superpowers/specs/2026-08-06-ipad-home-design.md.
+//
+
+import SwiftUI
+
+struct HomePagePadView: View {
+  @Bindable var model: HomePageModel
+
+  private let contentMaxWidth: CGFloat = 1100
+  private let columns = [
+    GridItem(.flexible(), spacing: 24),
+    GridItem(.flexible(), spacing: 24),
+  ]
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 32) {
+        header
+        tilesGrid
+        stationsSection
+      }
+      .frame(maxWidth: contentMaxWidth, alignment: .leading)
+      .frame(maxWidth: .infinity, alignment: .center)
+      .padding(.horizontal, 32)
+      .padding(.vertical, 24)
+    }
+    .scrollIndicators(.hidden)
+    .background(Color.black)
+  }
+
+  // MARK: - Header (logo + welcome)
+
+  private var header: some View {
+    HStack(alignment: .center, spacing: 24) {
+      Image("LogoMark")
+        .resizable()
+        .scaledToFit()
+        .frame(width: 96, height: 124)
+        .onTapGesture(count: 10, perform: model.playolaIconTapped10Times)
+
+      VStack(alignment: .leading, spacing: 8) {
+        Text(model.welcomeMessage)
+          .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 40))
+          .foregroundColor(.white)
+
+        Text(model.introMessage)
+          .font(.custom(FontNames.Inter_400_Regular, size: 18))
+          .foregroundColor(.playolaGray)
+      }
+
+      Spacer(minLength: 0)
+    }
+  }
+
+  // MARK: - Feature + Listening tiles
+
+  private var tilesGrid: some View {
+    LazyVGrid(columns: columns, alignment: .leading, spacing: 20) {
+      ForEach(model.visibleFeatureTileModels, id: \.label) { tile in
+        HomePadTile(
+          label: tile.label,
+          value: tile.content,
+          buttonText: tile.buttonText ?? "",
+          action: { await tile.onButtonTapped() })
+      }
+
+      HomePadTile(
+        label: model.listeningTimeTileModel.titleText,
+        value: model.listeningTimeTileModel.listeningTimeDisplayString,
+        buttonText: model.listeningTimeTileModel.buttonText ?? "",
+        action: { await model.listeningTimeTileModel.onButtonTapped() }
+      )
+      .onAppear { model.listeningTimeTileModel.viewAppeared() }
+      .onDisappear { model.listeningTimeTileModel.viewDisappeared() }
+    }
+  }
+
+  // MARK: - Stations grid
+
+  private var stationsSection: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text(model.stationListTitle)
+        .font(.custom(FontNames.SpaceGrotesk_700_Bold, size: 28))
+        .foregroundColor(.white)
+
+      LazyVGrid(columns: columns, alignment: .leading, spacing: 16) {
+        ForEach(model.forYouStations) { station in
+          StationCardView(
+            station: station,
+            liveStatus: model.liveStatusForStation(station.id),
+            hasUpcomingGiveaway: model.hasUpcomingGiveawayForStation(station.id),
+            onRadioStationSelected: { tapped in
+              Task { await model.stationTapped(tapped) }
+            }
+          )
+        }
+      }
+    }
+  }
+}
+
+// MARK: - Compact iPad tile (duplicated styling, quarantined)
+
+private struct HomePadTile: View {
+  let label: String
+  let value: String
+  let buttonText: String
+  let action: () async -> Void
+
+  var body: some View {
+    HStack(alignment: .center, spacing: 16) {
+      VStack(alignment: .leading, spacing: 4) {
+        Text(label)
+          .font(.custom(FontNames.SpaceGrotesk_500_Medium, size: 15))
+          .foregroundColor(.playolaGray)
+
+        Text(value)
+          .font(.custom(FontNames.Inter_700_Bold, size: 24))
+          .foregroundColor(.white)
+          .lineLimit(1)
+          .minimumScaleFactor(0.6)
+      }
+
+      Spacer(minLength: 12)
+
+      Button {
+        Task { await action() }
+      } label: {
+        Text(buttonText)
+          .font(.custom(FontNames.Inter_500_Medium, size: 16))
+          .foregroundColor(.white)
+          .lineLimit(1)
+          .fixedSize()
+          .padding(.horizontal, 28)
+          .padding(.vertical, 12)
+          .background(Color(red: 0.8, green: 0.4, blue: 0.4))
+          .cornerRadius(24)
+      }
+    }
+    .padding(.horizontal, 20)
+    .padding(.vertical, 18)
+    .frame(maxWidth: .infinity, minHeight: 96, alignment: .leading)
+    .background(Color(white: 0.15))
+    .cornerRadius(12)
+  }
+}
+
+#Preview(traits: .fixedLayout(width: 1024, height: 768)) {
+  NavigationStack {
+    HomePagePadView(model: HomePageModel())
+  }
+  .preferredColorScheme(.dark)
+}

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
@@ -10,7 +10,23 @@ import SwiftUI
 struct HomePageView: View {
   @Bindable var model: HomePageModel
 
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
   var body: some View {
+    Group {
+      if horizontalSizeClass == .regular {
+        HomePagePadView(model: model)
+      } else {
+        compactBody
+      }
+    }
+    .background(Color.black.ignoresSafeArea())
+    .playolaAlert($model.presentedAlert)
+    .onAppear { Task { await model.viewAppeared() } }
+  }
+
+  // MARK: - Compact (iPhone) layout — unchanged
+  private var compactBody: some View {
     VStack {
       VStack {
         Text(model.welcomeMessage)
@@ -64,9 +80,6 @@ struct HomePageView: View {
       }
       .circleBackground(offsetY: -180)
     }
-    .background(Color.black.ignoresSafeArea())
-    .playolaAlert($model.presentedAlert)
-    .onAppear { Task { await model.viewAppeared() } }
   }
 }
 

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPadView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPadView.swift
@@ -1,0 +1,130 @@
+//
+//  SignInPadView.swift
+//  PlayolaRadio
+//
+//  iPad-only (regular horizontal size class) layout for the Sign In screen.
+//
+//  QUARANTINED ON PURPOSE. iPad is not a maintained priority. This view is a dumb
+//  layout over `SignInPageModel` — it holds zero business logic and reuses only the
+//  shared `CustomGoogleSignInButton` plus the system `SignInWithAppleButton`, wiring
+//  both to the same model actions the compact layout uses. It deliberately duplicates
+//  the small card styling rather than sharing components with the iPhone layout, so
+//  future iPhone changes never have to account for iPad. Design drift is acceptable;
+//  this whole file can be deleted without touching the iPhone path. See
+//  docs/superpowers/specs/2026-08-06-ipad-sign-in-design.md.
+//
+
+import AuthenticationServices
+import SwiftUI
+
+struct SignInPadView: View {
+  @Bindable var model: SignInPageModel
+
+  var body: some View {
+    ZStack {
+      LinearGradient(
+        gradient: Gradient(colors: [Color.black, Color(hex: "#1C1C1E")]),
+        startPoint: .top,
+        endPoint: .bottom
+      )
+      .ignoresSafeArea()
+
+      card
+        .frame(width: 460)
+    }
+  }
+
+  // MARK: - Centered auth card
+
+  private var card: some View {
+    VStack(spacing: 32) {
+      logo
+      welcome
+      authButtons
+      footer
+    }
+    .padding(40)
+    .frame(maxWidth: .infinity)
+    .background(Color.white.opacity(0.05))
+    .clipShape(.rect(cornerRadius: 24))
+    .overlay(
+      RoundedRectangle(cornerRadius: 24)
+        .stroke(Color.white.opacity(0.08), lineWidth: 1)
+    )
+  }
+
+  private var logo: some View {
+    VStack(spacing: 16) {
+      Image("LogoMark")
+        .resizable()
+        .scaledToFit()
+        .frame(height: 96)
+
+      Image("PlayolaWordLogo")
+        .resizable()
+        .scaledToFit()
+        .frame(width: 220)
+    }
+    .padding(.bottom, 8)
+  }
+
+  private var welcome: some View {
+    VStack(spacing: 12) {
+      Text(model.welcomeTitle)
+        .font(.system(size: 32, weight: .bold))
+        .foregroundColor(.white)
+
+      Text(model.welcomeSubtitle)
+        .font(.system(size: 17))
+        .foregroundColor(.white.opacity(0.7))
+        .multilineTextAlignment(.center)
+    }
+  }
+
+  private var authButtons: some View {
+    VStack(spacing: 16) {
+      CustomGoogleSignInButton(title: model.googleSignInButtonTitle) {
+        Task { await model.signInWithGoogleButtonTapped() }
+      }
+
+      SignInWithAppleButton(.signIn) { request in
+        model.signInWithAppleButtonTapped(request: request)
+      } onCompletion: { result in
+        Task { await model.signInWithAppleCompleted(result: result) }
+      }
+      .signInWithAppleButtonStyle(.white)
+      .frame(height: 56)
+      .cornerRadius(12)
+    }
+  }
+
+  private var footer: some View {
+    VStack(spacing: 8) {
+      Text(model.termsAgreementText)
+        .font(.footnote)
+        .foregroundColor(Color.white.opacity(0.6))
+
+      HStack(spacing: 4) {
+        Text(model.termsOfServiceText)
+          .font(.footnote)
+          .foregroundColor(.playolaRed)
+          .underline()
+
+        Text(model.termsConjunctionText)
+          .font(.footnote)
+          .foregroundColor(Color.white.opacity(0.6))
+
+        Text(model.privacyPolicyText)
+          .font(.footnote)
+          .foregroundColor(.playolaRed)
+          .underline()
+      }
+    }
+    .padding(.top, 8)
+  }
+}
+
+#Preview(traits: .fixedLayout(width: 1024, height: 768)) {
+  SignInPadView(model: SignInPageModel())
+    .preferredColorScheme(.dark)
+}

--- a/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
+++ b/PlayolaRadio/Views/Pages/SignInPage/SignInPageView.swift
@@ -15,7 +15,21 @@ import SwiftUI
 struct SignInPage: View {
   @Bindable var model: SignInPageModel
 
+  @Environment(\.horizontalSizeClass) private var horizontalSizeClass
+
   var body: some View {
+    Group {
+      if horizontalSizeClass == .regular {
+        SignInPadView(model: model)
+      } else {
+        compactBody
+      }
+    }
+    .playolaAlert($model.presentedAlert)
+  }
+
+  // MARK: - Compact (iPhone) layout — unchanged
+  private var compactBody: some View {
     NavigationView {
       ZStack {
         // Background gradient
@@ -107,7 +121,6 @@ struct SignInPage: View {
       .navigationBarHidden(true)
     }
     .navigationViewStyle(StackNavigationViewStyle())
-    .playolaAlert($model.presentedAlert)
   }
 }
 

--- a/docs/superpowers/specs/2026-08-06-ipad-home-design.md
+++ b/docs/superpowers/specs/2026-08-06-ipad-home-design.md
@@ -1,0 +1,40 @@
+# iPad Home screen design (2026-08-06)
+
+Screen 2 of the "Prettify iPad screens" effort (see `LONG_RUNNING.md`). Same
+**quarantine pattern** as Radio Stations: a self-contained `HomePagePadView` branched
+once on `horizontalSizeClass == .regular` inside `HomePageView`; the iPhone/compact path
+is byte-for-byte unchanged and the iPad file is disposable.
+
+## Layout (regular size class)
+
+Single vertical `ScrollView`, content capped at `maxWidth: 1100`, centered, `.horizontal, 32`
+padding:
+
+1. **Header** — `HStack`: the `LogoMark` (96×124, keeps the 10-tap easter-egg gesture) to the
+   left of a left-aligned `VStack` with `welcomeMessage` (SpaceGrotesk bold 40) and
+   `introMessage` (Inter 18, gray). iPhone stacks these centered; iPad puts them side by side.
+2. **Tiles** — 2-col `LazyVGrid` of compact `HomePadTile`s: label (gray) + bold value on the
+   left, a red pill button on the right. Driven by the model's existing tile models — the
+   conditional feature tiles come from the new `visibleFeatureTileModel`s computed, and the
+   always-present listening-time tile is appended separately (it drives a live ticking timer,
+   so it stays bound to `listeningTimeTileModel` and forwards `viewAppeared`/`viewDisappeared`).
+3. **Stations** — `stationListTitle` + a 2-col `LazyVGrid` of the shared **`StationCardView`**
+   leaf (image left, text right), one per `forYouStations` entry, tapping through to
+   `stationTapped`.
+
+## Constraints honored
+
+- **Zero business logic in the iPad view.** Which tiles show is decided by
+  `HomePageModel.visibleFeatureTileModels` (mirrors the compact layout's order:
+  support → scheduled shows → question airing → invite). The view just `ForEach`es.
+- **Reuses only shared leaves + the model.** `StationCardView` (shared), the existing tile
+  models. `HomePadTile` is a private, duplicated compact style — not extracted/shared.
+- **Design drift accepted.** The compact tile styling and the reused iPhone `StationCardView`
+  text ordering differ slightly from the mock; the bar is "not embarrassing," and the whole
+  file can be deleted without touching iPhone.
+
+## Verification
+
+App is OAuth-gated, so verified with an `ImageRenderer`→PNG throwaway test (ScrollView renders
+blank under `ImageRenderer`, so the header + `HomePadTile`s + `StationCardView`s were rendered
+in plain non-lazy stacks). Composition matched the target mock. All 41 `HomePageTests` pass.

--- a/docs/superpowers/specs/2026-08-06-ipad-profile-design.md
+++ b/docs/superpowers/specs/2026-08-06-ipad-profile-design.md
@@ -1,0 +1,49 @@
+# iPad Profile screen design (2026-08-06)
+
+Screen 4 of the "Prettify iPad screens" effort (see `LONG_RUNNING.md`). The "Your Profile"
+tab renders `ContactPageView` (there is no separate `ProfilePage`). Same **quarantine
+pattern** as the earlier screens: a self-contained `ContactPagePadView` branched once on
+`horizontalSizeClass == .regular` inside `ContactPageView`; the iPhone/compact path is
+byte-for-byte unchanged and the iPad file is disposable.
+
+## Problem
+
+The iPhone profile is a single full-width column of action buttons (Rewards, Notifications,
+Contact Us, Ask an Artist, Log out, plus conditional mode-switch buttons). On iPad each button
+stretches across the whole width, which reads as a blown-up phone screen.
+
+## Layout (regular size class)
+
+`ContactPagePadView`: a left-aligned title header, then a `ScrollView` whose content is capped
+at `maxWidth: 720` and centered:
+
+1. **Profile card** — avatar circle, `model.name`, `model.email`, and the edit-pencil button
+   (top-right), wired to `onEditProfileTapped`. Duplicated from the iPhone card styling.
+2. **Conditional mode buttons** — "Switch to Listening Mode" (when `isInBroadcastMode`) and
+   "Switch to Broadcasting Mode" (when `myStationButtonVisible`), full width, `Color.info`.
+   These two `if`s mirror the iPhone view exactly (that page already renders them conditionally).
+3. **Action grid** — a 2-col `LazyVGrid` of four `ProfilePadActionButton`s: Rewards,
+   Notifications, Contact Us, Ask an Artist. Contact Us keeps its loading spinner
+   (`isCheckingSupport`) and unread badge (`@Shared(.unreadSupportCount)`), same as iPhone.
+4. **Log out** — full-width outlined button below the grid.
+
+Every button calls the exact same `ContactPageModel` action the compact layout uses.
+
+## Constraints honored
+
+- **Zero business logic in the iPad view.** All labels/flags come from the model; buttons call
+  existing model actions. **No model change was needed.**
+- **Reuses only the model + duplicated local styling.** `ProfilePadActionButton` is a private,
+  local helper (not extracted/shared). The card and special buttons duplicate iPhone styling.
+- **iPhone path untouched.** The old body became `compactBody` verbatim; the size-class branch
+  and the shared `.background`/`.task`/`.playolaAlert` wrap both. The whole file can be deleted
+  without touching iPhone.
+- **Control flow:** only the two mode-switch `if`s (matching the iPhone view) plus the leaf-level
+  Contact Us spinner/badge conditionals — no new business branching beyond what iPhone already has.
+
+## Verification
+
+App is OAuth-gated, so verified with an `ImageRenderer`→PNG throwaway test. Because `ScrollView`
+content blanks under `ImageRenderer`, the header + card + a non-lazy 2-col arrangement of the real
+`ProfilePadActionButton` were rendered directly. Composition looked clean and intentional. All 26
+`ContactPageTests` pass.

--- a/docs/superpowers/specs/2026-08-06-ipad-sign-in-design.md
+++ b/docs/superpowers/specs/2026-08-06-ipad-sign-in-design.md
@@ -1,0 +1,46 @@
+# iPad Sign In screen design (2026-08-06)
+
+Screen 3 of the "Prettify iPad screens" effort (see `LONG_RUNNING.md`). Same
+**quarantine pattern** as the earlier screens: a self-contained `SignInPadView` branched
+once on `horizontalSizeClass == .regular` inside `SignInPage`; the iPhone/compact path is
+byte-for-byte unchanged and the iPad file is disposable.
+
+## Problem
+
+The iPhone sign-in is a single full-width centered column. On iPad it stretches to the full
+width — the Google / Apple buttons span ~960pt and the subtitle line runs edge to edge, which
+reads as a blown-up phone screen rather than an intentional layout.
+
+## Layout (regular size class)
+
+`SignInPadView` reuses the same gradient background, then centers a fixed-width (460pt) **auth
+card** on it:
+
+- **Logo** — `LogoMark` (96pt tall) over the `PlayolaWordLogo` (220pt wide).
+- **Welcome** — `welcomeTitle` (system 32 bold) + `welcomeSubtitle` (system 17, 70% white).
+- **Auth buttons** — the shared `CustomGoogleSignInButton` and the system
+  `SignInWithAppleButton`, both wired to the exact same `SignInPageModel` actions the compact
+  layout calls (`signInWithGoogleButtonTapped`, `signInWithAppleButtonTapped(request:)`,
+  `signInWithAppleCompleted(result:)`).
+- **Footer** — the terms-of-service / privacy-policy line, unchanged text from the model.
+
+The card has a faint translucent fill (`Color.white.opacity(0.05)`), 24pt corner radius, and a
+hairline white stroke so it reads as a deliberate panel.
+
+## Constraints honored
+
+- **Zero business logic in the iPad view.** All text comes from the model; both buttons call
+  existing model actions. No model change was needed.
+- **Reuses only shared leaves + the model.** `CustomGoogleSignInButton` (shared, defined in
+  `SignInPageView.swift`) and the system Apple button. The card styling is duplicated locally,
+  not extracted.
+- **iPhone path untouched.** The old body became `compactBody` verbatim; the size-class branch
+  and the shared `.playolaAlert` wrap both. The whole `SignInPadView` file can be deleted
+  without touching iPhone.
+
+## Verification
+
+App is OAuth-gated, so verified with an `ImageRenderer`→PNG throwaway test. The card, logo,
+text, and Google button render correctly; the system `SignInWithAppleButton` shows a placeholder
+under `ImageRenderer` (it's a UIKit-backed control that `ImageRenderer` can't materialize) — it
+renders normally in the real app, identical to the iPhone path. All 23 `SignInPageTests` pass.


### PR DESCRIPTION
# What & why

iPad layouts for the Home, Sign In, and "Your Profile" (ContactPage) screens, continuing the "Prettify iPad screens" effort. Each screen gets a self-contained, disposable `*PadView` branched once on `horizontalSizeClass == .regular`, so the iPhone/compact path is byte-for-byte unchanged (moved verbatim into `compactBody`) — and since iPhone is portrait-locked it never reaches the `.regular` branch. Home reuses the shared `StationCardView` and adds a `visibleFeatureTileModels` model computed so the iPad view carries no visibility logic; Sign In centers a width-constrained auth card on the gradient; Profile centers the profile card over a 2-column action grid with an outlined Log out. No iPhone behavior changes.

## Long-running work

- [x] Updated [`LONG_RUNNING.md`](https://github.com/playola-radio/playola-radio-ios/blob/develop/LONG_RUNNING.md) — this advances the **Prettify iPad screens** effort (Home, Sign In, Profile = screens 2–4) and adds their design specs.