### PR TITLE
Revert "Remove Invite Your Friends home tile"

### DIFF
--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -34,6 +34,7 @@ class HomePageModel: ViewModel {
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
   @ObservationIgnored @Shared(.unreadSupportCount) var unreadSupportCount
+  @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
   @ObservationIgnored @Shared(.welcomeMessageEligible) var welcomeMessageEligible: Bool = false
   @ObservationIgnored @Shared(.welcomeMessageShownThisSession)
   var welcomeMessageShownThisSession: Bool = false
@@ -51,6 +52,14 @@ class HomePageModel: ViewModel {
 
   var hasUpcomingQuestionAiring: Bool {
     upcomingQuestionAiring != nil
+  }
+
+  var canInviteFriends: Bool {
+    guard let totalMSListened = listeningTracker?.totalListenTimeMS, totalMSListened > 0 else {
+      return false
+    }
+    let totalHours = Double(totalMSListened) / 1000.0 / 3600.0
+    return totalHours >= 2.0
   }
 
   var welcomeMessage: String {
@@ -125,6 +134,20 @@ class HomePageModel: ViewModel {
       buttonAction: { [weak self] in
         guard let self = self else { return }
         await self.shareQuestionAiringButtonTapped()
+      }
+    )
+
+  @ObservationIgnored lazy var inviteFriendsTileModel: NewFeatureTileModel =
+    NewFeatureTileModel(
+      iconName: "person.2.fill",
+      isSystemImage: true,
+      label: "Power Listener Reward",
+      content: "Invite Your Friends",
+      paragraph: "You've unlocked the ability to invite friends to Playola!",
+      buttonText: "Invite",
+      buttonAction: { [weak self] in
+        guard let self = self else { return }
+        await self.inviteFriendsButtonTapped()
       }
     )
 
@@ -268,6 +291,11 @@ class HomePageModel: ViewModel {
   }
 
   private static let appStoreUrl = "https://apps.apple.com/us/app/playola-radio/id6480465361"
+
+  private func inviteFriendsButtonTapped() async {
+    let shareModel = ShareSheetModel(items: [Self.appStoreUrl])
+    mainContainerNavigationCoordinator.presentedSheet = .share(shareModel)
+  }
 
   private func shareQuestionAiringButtonTapped() async {
     guard let airing = upcomingQuestionAiring else { return }

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageTests.swift
@@ -724,6 +724,74 @@ struct HomePageTests {
     }
   }
 
+  // MARK: - Invite Friends Tile Tests
+
+  @Test
+  func testCanInviteFriendsIsTrueWhenUserHasTwoOrMoreHours() {
+    let rewardsProfile = RewardsProfile(
+      totalTimeListenedMS: 2 * 60 * 60 * 1000,  // 2 hours
+      totalMSAvailableForRewards: 0,
+      accurateAsOfTime: Date()
+    )
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = ListeningTracker(
+      rewardsProfile: rewardsProfile)
+
+    let model = HomePageModel()
+
+    #expect(model.canInviteFriends)
+  }
+
+  @Test
+  func testCanInviteFriendsIsFalseWhenUserHasLessThanTwoHours() {
+    let rewardsProfile = RewardsProfile(
+      totalTimeListenedMS: 1 * 60 * 60 * 1000,  // 1 hour
+      totalMSAvailableForRewards: 0,
+      accurateAsOfTime: Date()
+    )
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker? = ListeningTracker(
+      rewardsProfile: rewardsProfile)
+
+    let model = HomePageModel()
+
+    #expect(!model.canInviteFriends)
+  }
+
+  @Test
+  func testCanInviteFriendsIsFalseWhenListeningTrackerIsNil() {
+    @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+
+    let model = HomePageModel()
+
+    #expect(!model.canInviteFriends)
+  }
+
+  @Test
+  func testInviteFriendsTileHasCorrectContent() {
+    let model = HomePageModel()
+
+    #expect(model.inviteFriendsTileModel.label == "Power Listener Reward")
+    #expect(model.inviteFriendsTileModel.content == "Invite Your Friends")
+    #expect(model.inviteFriendsTileModel.buttonText == "Invite")
+    #expect(model.inviteFriendsTileModel.paragraph != nil)
+  }
+
+  @Test
+  func testInviteFriendsTilePresentsShareSheetWithAppStoreUrl() async {
+    @Shared(.mainContainerNavigationCoordinator) var navigationCoordinator =
+      MainContainerNavigationCoordinator()
+
+    let model = HomePageModel()
+
+    await model.inviteFriendsTileModel.buttonAction?()
+
+    if case .share(let shareModel) = navigationCoordinator.presentedSheet {
+      #expect(shareModel.items.count == 1)
+      #expect(shareModel.items[0] == Self.appStoreUrl)
+    } else {
+      Issue.record("Expected share sheet to be presented")
+    }
+  }
+
   // MARK: - Giveaway Badge (live-gated) Tests
 
   @Test

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
@@ -59,6 +59,11 @@ struct HomePageView: View {
               .padding(.bottom, 20)
           }
 
+          if model.canInviteFriends {
+            NewFeatureTile(model: model.inviteFriendsTileModel)
+              .padding(.bottom, 20)
+          }
+
           ListeningTimeTile(model: model.listeningTimeTileModel)
 
           HomePageStationList(

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageView.swift
@@ -44,23 +44,8 @@ struct HomePageView: View {
             introMessage: model.introMessage,
             onIconTapped10Times: model.playolaIconTapped10Times)
 
-          if model.hasUnreadSupportMessages {
-            NewFeatureTile(model: model.supportMessageTileModel)
-              .padding(.bottom, 20)
-          }
-
-          if model.hasScheduledShows {
-            NewFeatureTile(model: model.scheduledShowsTileModel)
-              .padding(.bottom, 20)
-          }
-
-          if model.hasUpcomingQuestionAiring {
-            NewFeatureTile(model: model.questionAiringTileModel)
-              .padding(.bottom, 20)
-          }
-
-          if model.canInviteFriends {
-            NewFeatureTile(model: model.inviteFriendsTileModel)
+          ForEach(model.visibleFeatureTileModels, id: \.label) { tile in
+            NewFeatureTile(model: tile)
               .padding(.bottom, 20)
           }
 


### PR DESCRIPTION
Reverts playola-radio/playola-radio-ios#394

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a “Power Listener Reward” tile for listeners who have listened for at least two hours.
  - Eligible listeners can invite friends through a share sheet containing the app’s App Store link.
  - The invitation tile appears automatically on the home page when eligibility requirements are met.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->