### PR TITLE
fix(sentry): stop auto-capturing Cloudflare 520–524 edge noise on listeningSessions

### DIFF
--- a/PlayolaRadio/PlayolaRadioApp.swift
+++ b/PlayolaRadio/PlayolaRadioApp.swift
@@ -47,6 +47,19 @@ class AppDelegate: NSObject, UIApplicationDelegate, @preconcurrency UNUserNotifi
           }
           options.enableLogs = true
 
+          // Skip auto-capturing the Cloudflare edge-error band (520–524) as
+          // failed HTTP requests. A 520–524 is emitted by Cloudflare's edge —
+          // not our origin — when a response can't be delivered cleanly back to
+          // a backgrounded/suspended app. It's transient connection noise on the
+          // high-frequency listening-session heartbeat (verified: origin logged
+          // 200s for the matching requests). Genuine origin 5xx (500–519, 525+)
+          // still report here, and real backend errors still surface via our
+          // explicit APIError reporting. (Sentry APPLE-IOS-A / APPLE-IOS-20.)
+          options.failedRequestStatusCodes = [
+            HttpStatusCodeRange(min: 500, max: 519),
+            HttpStatusCodeRange(min: 525, max: 599),
+          ]
+
           // App Hang Tracking: capture the real main-thread blocking stack so
           // hangs resolve to named functions instead of collapsing into the
           // generic `$main` bucket (Sentry APPLE-IOS-V / 7460768272).


### PR DESCRIPTION
# What & why

Sentry issues APPLE-IOS-A / APPLE-IOS-20 (~1,900 events) report `HTTPClientError: status code 520` on `POST /v1/listeningSessions`, but these aren't real failures — 520–524 is a Cloudflare *edge* status emitted when a response can't be delivered cleanly back to a backgrounded/suspended app (verified: the origin logged 200s for the matching heartbeats). They're auto-captured by the Sentry Cocoa SDK's URLSession swizzling, governed by `failedRequestStatusCodes` (default 500–599). This narrows that range to `[500–519, 525–599]`, dropping the Cloudflare edge-noise band while keeping genuine origin 5xx reporting; real backend errors still surface via explicit APIError reporting. No server or listening-session data-path changes.

## Long-running work

- [x] This PR does **not** advance/start a long-running effort, **or** I updated
      [`LONG_RUNNING.md`](https://github.com/playola-radio/playola-radio-ios/blob/develop/LONG_RUNNING.md)
      in this PR (step / soak / phase).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting by excluding expected Cloudflare service-status responses from failed-request reports.
  * Origin server errors continue to be reported for monitoring.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->