### PR TITLE
ci: nightly staging TestFlight build from develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,15 @@ parameters:
     type: boolean
     default: false
 
+  # Set to true only by the nightly GitHub Action (.github/workflows/nightly-staging.yml),
+  # which POSTs this pipeline on develop. Gates the nightly-staging workflow ON and gates the
+  # ordinary lint/build-test workflows OFF, so a scheduled run does exactly one thing: build
+  # the develop tip to the STAGING TestFlight app. An ordinary develop push lacks the
+  # parameter (default false) and behaves as before.
+  run_nightly_staging:
+    type: boolean
+    default: false
+
 jobs:
   swiftlint_check:
     macos:
@@ -159,10 +168,18 @@ jobs:
 
 workflows:
   lint-codebase:
+    # Skip on the nightly pipeline — it only builds the staging app, nothing to lint.
+    when:
+      not: << pipeline.parameters.run_nightly_staging >>
     jobs:
       - swiftlint_check
 
   build-test-adhoc:
+    # Skip on the nightly pipeline so a scheduled run does exactly one thing (staging build).
+    # develop is already kept green by per-PR CI, so re-running the full suite nightly is
+    # redundant.
+    when:
+      not: << pipeline.parameters.run_nightly_staging >>
     jobs:
       - build-and-test
       - adhoc:
@@ -171,6 +188,16 @@ workflows:
               only: development
           requires:
             - build-and-test
+
+  nightly-staging:
+    # Triggered only by .github/workflows/nightly-staging.yml, which POSTs this pipeline on
+    # develop with run_nightly_staging: true. Builds the develop tip to the STAGING TestFlight
+    # app (internal only — the release_staging lane sets distribute_external: false and
+    # notify_external_testers: false). Reuses the same job as the release-time staging build.
+    when: << pipeline.parameters.run_nightly_staging >>
+    jobs:
+      - release_staging_build:
+          context: ios-release
 
   release:
     # Only run on the API-triggered pipeline that carries run_release: true. A native

--- a/.github/workflows/nightly-staging.yml
+++ b/.github/workflows/nightly-staging.yml
@@ -1,0 +1,69 @@
+name: Nightly Staging Build
+
+# Builds the current develop tip to the STAGING TestFlight app once a day, so internal
+# testers/soak always run the latest develop. Triggering CircleCI from a GitHub Action
+# (rather than a CircleCI-side schedule) keeps the schedule version-controlled and reuses
+# the existing CCI_TOKEN + API-trigger pattern from auto-tag-release.yml.
+#
+# Scheduled workflows only run from the repository default branch (develop), so this file
+# must live on develop for the cron to fire.
+
+on:
+  schedule:
+    # 08:00 UTC daily (~1am PT). Testers wake up to a fresh build.
+    - cron: '0 8 * * *'
+  # Manual "build develop now" button — always builds, bypassing the no-new-commits gate.
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+jobs:
+  trigger:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout develop
+        uses: actions/checkout@v4
+        with:
+          ref: develop
+          fetch-depth: 0
+
+      - name: Decide whether to build
+        id: gate
+        run: |
+          # A manual run always builds. A scheduled run builds only if develop actually
+          # moved in the last day — quiet days produce zero builds, which directly keeps
+          # the staging TestFlight list from filling with identical rebuilds.
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -n "$(git log --since='25 hours ago' --oneline HEAD)" ]; then
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "build=false" >> "$GITHUB_OUTPUT"
+            echo "No new commits on develop in the last 25h — skipping nightly staging build."
+          fi
+
+      - name: Trigger CircleCI staging build
+        if: steps.gate.outputs.build == 'true'
+        env:
+          CIRCLECI_TOKEN: ${{ secrets.CCI_TOKEN }}
+        run: |
+          if [ -z "$CIRCLECI_TOKEN" ]; then
+            echo "::error::CCI_TOKEN secret is not set — cannot trigger the staging build."
+            exit 1
+          fi
+          PAYLOAD=$(jq -nc '{branch: "develop", parameters: {run_nightly_staging: true}}')
+          HTTP=$(curl -sS -o /tmp/cci-response.json -w '%{http_code}' \
+            -X POST "https://circleci.com/api/v2/project/gh/playola-radio/playola-radio-ios/pipeline" \
+            -H "Circle-Token: $CIRCLECI_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$PAYLOAD")
+          echo "CircleCI responded HTTP $HTTP:"
+          cat /tmp/cci-response.json
+          echo
+          if [ "$HTTP" != "200" ] && [ "$HTTP" != "201" ]; then
+            echo "::error::CircleCI staging trigger failed (HTTP $HTTP)"
+            exit 1
+          fi


### PR DESCRIPTION
# What & why

Wires a once-a-day **staging** TestFlight build from `develop`, so internal/soak testers always run the latest develop tip without anyone bumping or shipping by hand. A scheduled GitHub Action (`nightly-staging.yml`, ~1am PT) POSTs the CircleCI API with a new `run_nightly_staging` parameter, which gates a `nightly-staging` workflow that reuses the existing `release_staging_build` job (internal only) and gates the ordinary lint/build-test workflows off so a scheduled run does exactly one thing. It no-ops when `develop` had no commits in the last 25h, so quiet days produce no redundant builds (manual `workflow_dispatch` runs bypass that gate). Production TestFlight and its `v*-b*` release tags are completely untouched, so "which build is in production" is still answered by the existing release tags.

## Long-running work

- [x] This PR does **not** advance/start a long-running effort, **or** I updated
      [`LONG_RUNNING.md`](https://github.com/playola-radio/playola-radio-ios/blob/develop/LONG_RUNNING.md)
      in this PR (step / soak / phase).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated nightly staging builds, scheduled to run daily and available for manual triggering.
  * Nightly builds now run only when recent code changes are detected, reducing unnecessary build activity.
  * Staging release pipelines are triggered automatically when nightly build conditions are met.

* **Chores**
  * Added validation and failure reporting for nightly staging build requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->