### PR TITLE
Koozie-only rewards for new users (inline tile + shipping-address claim)

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -10,13 +10,19 @@
 		03D9929612C3E595D9BD88D5 /* GiveawayParticipationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5283C7C8C9FAF45659BA98E /* GiveawayParticipationTests.swift */; };
 		0574C4A160288D8AE401D4C9 /* UpcomingGiveawayInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36EB0D70D43F1CF6504F637E /* UpcomingGiveawayInfo.swift */; };
 		086EF07946AAF32C92DE834A /* UpcomingGiveawayBannerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3C275E61DA6CA4C482EC79 /* UpcomingGiveawayBannerModelTests.swift */; };
+		0A6E6C233E85A650521A5331 /* YourLibraryPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903A1DE2476388DF8FCC8874 /* YourLibraryPageView.swift */; };
 		0F528AC0AC6E8A8043556CEC /* GiveawayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */; };
 		100DEE4C2F7441167117CC58 /* GiveawayCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F408E712B42EAED9BE68 /* GiveawayCoordinatorTests.swift */; };
 		1D674687C98A493790039AA2 /* GiveawayCongratsSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1493664DBC23415D4EE04C91 /* GiveawayCongratsSheetView.swift */; };
 		1DBE6EEE6CD7879ED93BB12C /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
+		1DFA251ED9768A3CF235AF92 /* PresetsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4951B01E879591B4AC3CDA52 /* PresetsModelTests.swift */; };
 		1E09F417B01F258C6D38D660 /* GiveawayPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */; };
+		1E1FEF5BE44432473298C8CB /* KoozieShippingAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC624A968B0E0DA09E64702 /* KoozieShippingAddress.swift */; };
 		1F6F57E01E254F5483BD939B /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
+		23D5CA2938294DB58EB23395 /* KoozieShippingAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC624A968B0E0DA09E64702 /* KoozieShippingAddress.swift */; };
+		24801FB664BFA5B73E518BC3 /* RewardsExperience.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD876AFF9DD0588179EB37B /* RewardsExperience.swift */; };
 		2613B751F316B4688367E6D7 /* UpcomingGiveawayBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73585D96F0A0EB79FFD39F8E /* UpcomingGiveawayBadge.swift */; };
+		2891A2D21D67E32129F5F2ED /* YourLibraryPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5384ED9FE3A984F23C18BA /* YourLibraryPageTests.swift */; };
 		2ADE71F9A72B59B6B6C727B5 /* GiveawayWinnerPendingPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */; };
 		354451A630DF81468815108F /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
 		36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
@@ -34,31 +40,52 @@
 		65D0683FA2A905693317C5AB /* CongratsActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0488057E2A6456204E582B15 /* CongratsActionTests.swift */; };
 		69728C9F2333D06DF2684375 /* UpcomingGiveawayBannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F23EC5D834733F19B23706 /* UpcomingGiveawayBannerModel.swift */; };
 		6D6D8F5B3570802E2D336F7C /* GiveawayOverlayModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16A5F5E27CF6BD0259ED1E5 /* GiveawayOverlayModelTests.swift */; };
+		6DB99ADC7A25C5E364543B5E /* YourLibraryPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05FDC46B20CB37D84A8197 /* YourLibraryPageModel.swift */; };
 		6E073224D257FDD579575841 /* UpcomingGiveawayBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73585D96F0A0EB79FFD39F8E /* UpcomingGiveawayBadge.swift */; };
 		725E8382CB9672F532FC2CDD /* GiveawayMyResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B82DD37711E160592E3842D /* GiveawayMyResult.swift */; };
+		7C3EB088AA47A09C775DB7DC /* RewardsExperienceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D6113F0F682A5AB22EC6C63 /* RewardsExperienceTests.swift */; };
 		81599AD0B41E4A2496EEF25A /* PresetTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6613FD7A13B448187CB8595 /* PresetTests.swift */; };
 		8CECE7D0544EBE95DA92A501 /* GiveawayMyResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2B82DD37711E160592E3842D /* GiveawayMyResult.swift */; };
 		922EDF2DC64B95D9A7E981EC /* UpcomingGiveawayInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36EB0D70D43F1CF6504F637E /* UpcomingGiveawayInfo.swift */; };
+		930065958AE65D1A65716F54 /* YourLibraryPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903A1DE2476388DF8FCC8874 /* YourLibraryPageView.swift */; };
 		99112E8696C5C7952F8EBE10 /* GiveawayWinnerSubmissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7886543EC93B0BA403388A8 /* GiveawayWinnerSubmissionRequest.swift */; };
+		9B14EE137DB923F77EBEFB37 /* RewardsExperience.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD876AFF9DD0588179EB37B /* RewardsExperience.swift */; };
 		9B6663109A6517E11DB2D64E /* GiveawayWinnerPushTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BA44EE33EB697E44CEC84351 /* GiveawayWinnerPushTests.swift */; };
 		A1750A0000000000000000F2 /* PlayolaTLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F1 /* PlayolaTLS.swift */; };
 		A1750A0000000000000000F3 /* PlayolaTLS.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F1 /* PlayolaTLS.swift */; };
 		A1750A0000000000000000F5 /* ConnectivityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F4 /* ConnectivityProbe.swift */; };
 		A1750A0000000000000000F6 /* ConnectivityProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F4 /* ConnectivityProbe.swift */; };
 		A1750A0000000000000000F8 /* ConnectivityProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1750A0000000000000000F7 /* ConnectivityProbeTests.swift */; };
+		A5EC7100000000000000F002 /* LikedSongsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7100000000000000F001 /* LikedSongsSection.swift */; };
+		A5EC7100000000000000F003 /* LikedSongsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7100000000000000F001 /* LikedSongsSection.swift */; };
 		A8034ECCAE01C4925AEA0BA4 /* GiveawayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */; };
 		AA01000000000001AAAAAAAA /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
-		C816D77FF9455BD1B83AF237 /* PresetsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED42817003307A164F85FE7 /* PresetsModel.swift */; };
 		AA01000000000002AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
 		AA01000000000003AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
 		AA01000000000004AAAAAAAA /* PresetStarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */; };
 		AA01000000000005AAAAAAAA /* PresetTile.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0E49DF7714364A04B11B3 /* PresetTile.swift */; };
 		AA01000000000006AAAAAAAA /* PresetsCarousel.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */; };
+		AAF1000000000000000000B1 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AAF1000000000000000000A1 /* PrivacyInfo.xcprivacy */; };
+		AAF1000000000000000000B2 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AAF1000000000000000000A1 /* PrivacyInfo.xcprivacy */; };
+		AB0A00000000000000000001 /* StationPlayerPlaybackAttemptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0A00000000000000000002 /* StationPlayerPlaybackAttemptTests.swift */; };
+		ABCDEF010000000000000002 /* TabBarPlatformChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */; };
+		ABCDEF010000000000000003 /* TabBarPlatformChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */; };
+		ABCDEF020000000000000002 /* StationListPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF020000000000000001 /* StationListPadView.swift */; };
+		ABCDEF020000000000000003 /* StationListPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF020000000000000001 /* StationListPadView.swift */; };
+		ABCDEF030000000000000002 /* HomePagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF030000000000000001 /* HomePagePadView.swift */; };
+		ABCDEF030000000000000003 /* HomePagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF030000000000000001 /* HomePagePadView.swift */; };
+		ABCDEF040000000000000002 /* SignInPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF040000000000000001 /* SignInPadView.swift */; };
+		ABCDEF040000000000000003 /* SignInPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF040000000000000001 /* SignInPadView.swift */; };
+		ABCDEF050000000000000002 /* ContactPagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF050000000000000001 /* ContactPagePadView.swift */; };
+		ABCDEF050000000000000003 /* ContactPagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF050000000000000001 /* ContactPagePadView.swift */; };
 		B12730D5ECA7018F074B54E6 /* GiveawayBannerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */; };
 		B196C20AFDE46B1A6FBA8194 /* GiveawayCongratsSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C95B740988B02A7A472F8C /* GiveawayCongratsSheetModel.swift */; };
 		B9D97B72F461E83FF652BDBD /* GiveawayPlayerOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */; };
+		BD3E0D31823FDD5950701308 /* YourLibraryPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05FDC46B20CB37D84A8197 /* YourLibraryPageModel.swift */; };
 		C2FCC44BB8C98C486BC343E6 /* GiveawayOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */; };
 		C344F2AC7008BF0C48803B71 /* GiveawayWinnerSubmissionRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7886543EC93B0BA403388A8 /* GiveawayWinnerSubmissionRequest.swift */; };
+		C40A6A2D4B9EF1448F77A68E /* PresetsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED42817003307A164F85FE7 /* PresetsModel.swift */; };
+		C816D77FF9455BD1B83AF237 /* PresetsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED42817003307A164F85FE7 /* PresetsModel.swift */; };
 		C8BA849E20B449EC91DBF5F2 /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
 		C8DC13568BBCD5F8E6845644 /* GiveawayCongratsSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1493664DBC23415D4EE04C91 /* GiveawayCongratsSheetView.swift */; };
 		D0CD5FE434D4950E16A7B1F9 /* GiveawayOverlayModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */; };
@@ -92,7 +119,6 @@
 		D30F004C2E8592F0007BCC73 /* MainSceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C52D3E91B900E4E926 /* MainSceneDelegate.swift */; };
 		D30F004D2E8592F0007BCC73 /* RadioStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673B12D3DC59100E4E926 /* RadioStation.swift */; };
 		D30F004E2E8592F0007BCC73 /* RewardsPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744C12E3131770042A427 /* RewardsPageView.swift */; };
-		0A6E6C233E85A650521A5331 /* YourLibraryPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903A1DE2476388DF8FCC8874 /* YourLibraryPageView.swift */; };
 		D30F004F2E8592F0007BCC73 /* HomePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257B12DF88BBD001BC6F9 /* HomePageModel.swift */; };
 		D30F00502E8592F0007BCC73 /* SongDrawerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302578F2E63C13400F4228B /* SongDrawerView.swift */; };
 		D30F00512E8592F0007BCC73 /* SongDrawerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302578E2E63C13400F4228B /* SongDrawerModel.swift */; };
@@ -111,9 +137,6 @@
 		D30F005E2E8592F0007BCC73 /* CPListItem+InitWithRemoteUrl.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35673C22D3E871800E4E926 /* CPListItem+InitWithRemoteUrl.swift */; };
 		D30F005F2E8592F0007BCC73 /* MainContainerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744AC2E2FCD8E0042A427 /* MainContainerModel.swift */; };
 		D30F00602E8592F0007BCC73 /* ContactPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D39591162E39932300720CF8 /* ContactPageModel.swift */; };
-		E1AB0000000000000000AB01 /* AppVersionGateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA01 /* AppVersionGateModel.swift */; };
-		E1AB0000000000000000AB02 /* AppVersionGateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA01 /* AppVersionGateModel.swift */; };
-		E1AB0000000000000000AB03 /* AppVersionGateModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */; };
 		D30F00612E8592F0007BCC73 /* Toast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576A2E63423B00F4228B /* Toast.swift */; };
 		D30F00622E8592F0007BCC73 /* MailService.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E57D2BFD750700B9E35B /* MailService.swift */; };
 		D30F00632E8592F0007BCC73 /* FRadioPlayerMetadata+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E56E2BFD306600B9E35B /* FRadioPlayerMetadata+Equatable.swift */; };
@@ -141,12 +164,9 @@
 		D30F007A2E8592F0007BCC73 /* circleBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C32DF8F87F001BC6F9 /* circleBackground.swift */; };
 		D30F007B2E8592F0007BCC73 /* ShareSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = D378CCCF2E57947800497A4A /* ShareSheet.swift */; };
 		D30F007C2E8592F0007BCC73 /* RewardsPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744BF2E31316D0042A427 /* RewardsPageModel.swift */; };
-		6DB99ADC7A25C5E364543B5E /* YourLibraryPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05FDC46B20CB37D84A8197 /* YourLibraryPageModel.swift */; };
 		D30F007D2E8592F0007BCC73 /* ToastClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D302576C2E63428700F4228B /* ToastClient.swift */; };
 		D30F007E2E8592F0007BCC73 /* RewardsProfile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744AF2E2FE6F80042A427 /* RewardsProfile.swift */; };
 		D30F007F2E8592F0007BCC73 /* LikedSongsPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257862E63B6B700F4228B /* LikedSongsPage.swift */; };
-		A5EC7100000000000000F002 /* LikedSongsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7100000000000000F001 /* LikedSongsSection.swift */; };
-		A5EC7100000000000000F003 /* LikedSongsSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5EC7100000000000000F001 /* LikedSongsSection.swift */; };
 		D30F00802E8592F0007BCC73 /* EnumTypeEquatableProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3137DD32D3AC9B40070033A /* EnumTypeEquatableProtocol.swift */; };
 		D30F00822E8592F0007BCC73 /* LikedSongsPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257882E63B6BE00F4228B /* LikedSongsPageModel.swift */; };
 		D30F00832E8592F0007BCC73 /* UIApplication+keyWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A276682D496282006055AF /* UIApplication+keyWindow.swift */; };
@@ -161,16 +181,7 @@
 		D30F008C2E8592F0007BCC73 /* AnalyticsEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A08A302E4E2E0F002468E0 /* AnalyticsEvent.swift */; };
 		D30F008D2E8592F0007BCC73 /* URLStreamPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E56C2BFD2FAB00B9E35B /* URLStreamPlayer.swift */; };
 		D30F008E2E8592F0007BCC73 /* StationListPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E5662BFD10AE00B9E35B /* StationListPage.swift */; };
-		ABCDEF020000000000000002 /* StationListPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF020000000000000001 /* StationListPadView.swift */; };
-		ABCDEF020000000000000003 /* StationListPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF020000000000000001 /* StationListPadView.swift */; };
-		ABCDEF030000000000000002 /* HomePagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF030000000000000001 /* HomePagePadView.swift */; };
-		ABCDEF030000000000000003 /* HomePagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF030000000000000001 /* HomePagePadView.swift */; };
-		ABCDEF040000000000000002 /* SignInPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF040000000000000001 /* SignInPadView.swift */; };
-		ABCDEF040000000000000003 /* SignInPadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF040000000000000001 /* SignInPadView.swift */; };
-		ABCDEF050000000000000002 /* ContactPagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF050000000000000001 /* ContactPagePadView.swift */; };
-		ABCDEF050000000000000003 /* ContactPagePadView.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF050000000000000001 /* ContactPagePadView.swift */; };
 		D30F008F2E8592F0007BCC73 /* MainContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C82DFA247A001BC6F9 /* MainContainer.swift */; };
-		ABCDEF010000000000000002 /* TabBarPlatformChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */; };
 		D30F00902E8592F0007BCC73 /* ToastView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30257752E6342C600F4228B /* ToastView.swift */; };
 		D30F00912E8592F0007BCC73 /* APIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D339E5682BFD1C0800B9E35B /* APIClient.swift */; };
 		D30F00922E8592F0007BCC73 /* SmallPlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D382671B2E00C13E0006BAC2 /* SmallPlayer.swift */; };
@@ -192,8 +203,6 @@
 		D30F00A72E8592F0007BCC73 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3536A0B2BFA4F4A006942D6 /* Preview Assets.xcassets */; };
 		D30F00A82E8592F0007BCC73 /* SpaceGrotesk.ttf in Resources */ = {isa = PBXBuildFile; fileRef = D37257BA2DF891D5001BC6F9 /* SpaceGrotesk.ttf */; };
 		D30F00AA2E8592F0007BCC73 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3536A082BFA4F4A006942D6 /* Assets.xcassets */; };
-		AAF1000000000000000000B1 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AAF1000000000000000000A1 /* PrivacyInfo.xcprivacy */; };
-		AAF1000000000000000000B2 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = AAF1000000000000000000A1 /* PrivacyInfo.xcprivacy */; };
 		D30F00AC2E8592F0007BCC73 /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = D37257AA2DF87C72001BC6F9 /* LaunchScreen.storyboard */; };
 		D30F00B72E871945007BCC73 /* StationListStationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30F00B62E871940007BCC73 /* StationListStationRowView.swift */; };
 		D30F00B82E871945007BCC73 /* StationListStationRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D30F00B62E871940007BCC73 /* StationListStationRowView.swift */; };
@@ -261,7 +270,6 @@
 		D35905EC2DFCDA140064A9C1 /* StationListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35905EB2DFCDA110064A9C1 /* StationListModel.swift */; };
 		D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */; };
 		D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */; };
-		AB0A00000000000000000001 /* StationPlayerPlaybackAttemptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB0A00000000000000000002 /* StationPlayerPlaybackAttemptTests.swift */; };
 		D35EFBEE2F1092A7000F64A4 /* RRuleFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */; };
 		D35EFBF02F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
 		D35EFBF12F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
@@ -325,7 +333,6 @@
 		D37257C42DF8F885001BC6F9 /* circleBackground.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C32DF8F87F001BC6F9 /* circleBackground.swift */; };
 		D37257C62DF9F064001BC6F9 /* HomePageStationList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C52DF9EF8D001BC6F9 /* HomePageStationList.swift */; };
 		D37257C92DFA247D001BC6F9 /* MainContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257C82DFA247A001BC6F9 /* MainContainer.swift */; };
-		ABCDEF010000000000000003 /* TabBarPlatformChrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */; };
 		D37257CC2DFA3F83001BC6F9 /* FontNames.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */; };
 		D37257D02DFB4368001BC6F9 /* PlayerPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */; };
 		D37769F92F22B38700200ADF /* ChooseStationPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37769F62F22B38700200ADF /* ChooseStationPageModel.swift */; };
@@ -437,9 +444,6 @@
 		D3B744C02E3131730042A427 /* RewardsPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744BF2E31316D0042A427 /* RewardsPageModel.swift */; };
 		D3B744C22E31317B0042A427 /* RewardsPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744C12E3131770042A427 /* RewardsPageView.swift */; };
 		D3B744C52E31318A0042A427 /* RewardsPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744C32E31317F0042A427 /* RewardsPageTests.swift */; };
-		BD3E0D31823FDD5950701308 /* YourLibraryPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05FDC46B20CB37D84A8197 /* YourLibraryPageModel.swift */; };
-		930065958AE65D1A65716F54 /* YourLibraryPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903A1DE2476388DF8FCC8874 /* YourLibraryPageView.swift */; };
-		2891A2D21D67E32129F5F2ED /* YourLibraryPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5384ED9FE3A984F23C18BA /* YourLibraryPageTests.swift */; };
 		D3B744C82E31399E0042A427 /* ListeningTimeTileModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744C72E3139960042A427 /* ListeningTimeTileModel.swift */; };
 		D3B744CB2E313B230042A427 /* ListeningTimeTileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744C92E313B170042A427 /* ListeningTimeTileTests.swift */; };
 		D3B744CD2E368DB50042A427 /* Prize.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3B744CC2E368D790042A427 /* Prize.swift */; };
@@ -503,6 +507,9 @@
 		DA5BD241BADE11FCACB9AEA0 /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
 		DBD70D257638FF5934CA78DA /* CongratsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */; };
 		DDB617A9AA22B4D37A3E3808 /* GiveawayWinnerPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */; };
+		E1AB0000000000000000AB01 /* AppVersionGateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA01 /* AppVersionGateModel.swift */; };
+		E1AB0000000000000000AB02 /* AppVersionGateModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA01 /* AppVersionGateModel.swift */; };
+		E1AB0000000000000000AB03 /* AppVersionGateModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */; };
 		E1CA0000000000000000A002 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
 		E1CA0000000000000000A003 /* CarPlayPlaybackTransition.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */; };
 		E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */; };
@@ -523,8 +530,6 @@
 		FAF000000000000000000002 /* AudioRecorderClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FAF000000000000000000001 /* AudioRecorderClientTests.swift */; };
 		FE01A0C72DFCB368002BAC30 /* SharedStateTestTrait.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */; };
 		FE110A0000000000000000B2 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
-		C40A6A2D4B9EF1448F77A68E /* PresetsModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4ED42817003307A164F85FE7 /* PresetsModel.swift */; };
-		1DFA251ED9768A3CF235AF92 /* PresetsModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4951B01E879591B4AC3CDA52 /* PresetsModelTests.swift */; };
 		FE110A0000000000000000B3 /* WelcomeMessagePageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */; };
 		FE110A0000000000000000B4 /* WelcomeMessagePageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */; };
 		FE110A0000000000000000B5 /* WelcomeMessagePageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */; };
@@ -558,21 +563,35 @@
 		3809555E7296131D612667B9 /* GiveawayWinnerPendingPushTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPendingPushTests.swift; sourceTree = "<group>"; };
 		3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayOverlayModel.swift; sourceTree = "<group>"; };
 		3B83C3893A771EB211B3AF8F /* StationListLiveSortTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StationListLiveSortTests.swift; sourceTree = "<group>"; };
+		4951B01E879591B4AC3CDA52 /* PresetsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsModelTests.swift; sourceTree = "<group>"; };
 		49F23EC5D834733F19B23706 /* UpcomingGiveawayBannerModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UpcomingGiveawayBannerModel.swift; sourceTree = "<group>"; };
 		4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayPlayerOverlayView.swift; sourceTree = "<group>"; };
+		4D6113F0F682A5AB22EC6C63 /* RewardsExperienceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RewardsExperienceTests.swift; sourceTree = "<group>"; };
+		4ED42817003307A164F85FE7 /* PresetsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsModel.swift; sourceTree = "<group>"; };
 		51C95B740988B02A7A472F8C /* GiveawayCongratsSheetModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCongratsSheetModel.swift; sourceTree = "<group>"; };
 		5B3C275E61DA6CA4C482EC79 /* UpcomingGiveawayBannerModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UpcomingGiveawayBannerModelTests.swift; sourceTree = "<group>"; };
+		6B5384ED9FE3A984F23C18BA /* YourLibraryPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YourLibraryPageTests.swift; sourceTree = "<group>"; };
+		6C05FDC46B20CB37D84A8197 /* YourLibraryPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YourLibraryPageModel.swift; sourceTree = "<group>"; };
 		6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayParticipation.swift; sourceTree = "<group>"; };
 		70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPendingPush.swift; sourceTree = "<group>"; };
 		73585D96F0A0EB79FFD39F8E /* UpcomingGiveawayBadge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UpcomingGiveawayBadge.swift; sourceTree = "<group>"; };
+		903A1DE2476388DF8FCC8874 /* YourLibraryPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YourLibraryPageView.swift; sourceTree = "<group>"; };
 		917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayBannerState.swift; sourceTree = "<group>"; };
 		9553B35A6FBA27239EF49033 /* GiveawayModelsTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayModelsTests.swift; sourceTree = "<group>"; };
 		9E8719F70AFA4992B9037775 /* Preset.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Preset.swift; sourceTree = "<group>"; };
+		9EC624A968B0E0DA09E64702 /* KoozieShippingAddress.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KoozieShippingAddress.swift; sourceTree = "<group>"; };
 		A1750A0000000000000000F1 /* PlayolaTLS.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayolaTLS.swift; sourceTree = "<group>"; };
 		A1750A0000000000000000F4 /* ConnectivityProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityProbe.swift; sourceTree = "<group>"; };
 		A1750A0000000000000000F7 /* ConnectivityProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConnectivityProbeTests.swift; sourceTree = "<group>"; };
+		A5EC7100000000000000F001 /* LikedSongsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedSongsSection.swift; sourceTree = "<group>"; };
 		A6613FD7A13B448187CB8595 /* PresetTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTests.swift; sourceTree = "<group>"; };
-		4ED42817003307A164F85FE7 /* PresetsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsModel.swift; sourceTree = "<group>"; };
+		AAF1000000000000000000A1 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
+		AB0A00000000000000000002 /* StationPlayerPlaybackAttemptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerPlaybackAttemptTests.swift; sourceTree = "<group>"; };
+		ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPlatformChrome.swift; sourceTree = "<group>"; };
+		ABCDEF020000000000000001 /* StationListPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPadView.swift; sourceTree = "<group>"; };
+		ABCDEF030000000000000001 /* HomePagePadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePagePadView.swift; sourceTree = "<group>"; };
+		ABCDEF040000000000000001 /* SignInPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPadView.swift; sourceTree = "<group>"; };
+		ABCDEF050000000000000001 /* ContactPagePadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPagePadView.swift; sourceTree = "<group>"; };
 		AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetView.swift; sourceTree = "<group>"; };
 		BA44EE33EB697E44CEC84351 /* GiveawayWinnerPushTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPushTests.swift; sourceTree = "<group>"; };
 		BC138D8C4809A3F89A5B4985 /* GiveawayWinnerSheetModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetModelTests.swift; sourceTree = "<group>"; };
@@ -589,7 +608,6 @@
 		D302577F2E639FDD00F4228B /* LikesManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikesManagerTests.swift; sourceTree = "<group>"; };
 		D30257822E63A36A00F4228B /* LikeOperationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikeOperationTests.swift; sourceTree = "<group>"; };
 		D30257862E63B6B700F4228B /* LikedSongsPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedSongsPage.swift; sourceTree = "<group>"; };
-		A5EC7100000000000000F001 /* LikedSongsSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedSongsSection.swift; sourceTree = "<group>"; };
 		D30257882E63B6BE00F4228B /* LikedSongsPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedSongsPageModel.swift; sourceTree = "<group>"; };
 		D302578A2E63B6C800F4228B /* LikedSongsPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LikedSongsPageTests.swift; sourceTree = "<group>"; };
 		D302578E2E63C13400F4228B /* SongDrawerModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SongDrawerModel.swift; sourceTree = "<group>"; };
@@ -633,10 +651,6 @@
 		D3367BF72F08B7DC00AF87FA /* NotificationsSettingsPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NotificationsSettingsPageView.swift; sourceTree = "<group>"; };
 		D3367C002F097D0D00AF87FA /* PushNotificationSubscription.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PushNotificationSubscription.swift; sourceTree = "<group>"; };
 		D339E5662BFD10AE00B9E35B /* StationListPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPage.swift; sourceTree = "<group>"; };
-		ABCDEF020000000000000001 /* StationListPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListPadView.swift; sourceTree = "<group>"; };
-		ABCDEF030000000000000001 /* HomePagePadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePagePadView.swift; sourceTree = "<group>"; };
-		ABCDEF040000000000000001 /* SignInPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPadView.swift; sourceTree = "<group>"; };
-		ABCDEF050000000000000001 /* ContactPagePadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPagePadView.swift; sourceTree = "<group>"; };
 		D339E5682BFD1C0800B9E35B /* APIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClient.swift; sourceTree = "<group>"; };
 		D339E56C2BFD2FAB00B9E35B /* URLStreamPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLStreamPlayer.swift; sourceTree = "<group>"; };
 		D339E56E2BFD306600B9E35B /* FRadioPlayerMetadata+Equatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FRadioPlayerMetadata+Equatable.swift"; sourceTree = "<group>"; };
@@ -659,7 +673,6 @@
 		D35673BD2D3DCA1E00E4E926 /* Secrets.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Secrets.xcconfig; sourceTree = "<group>"; };
 		D35673BF2D3DCA3600E4E926 /* Secrets-Example.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Secrets-Example.xcconfig"; sourceTree = "<group>"; };
 		D35673C12D3DCF6000E4E926 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
-		AAF1000000000000000000A1 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		D35673C22D3E871800E4E926 /* CPListItem+InitWithRemoteUrl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CPListItem+InitWithRemoteUrl.swift"; sourceTree = "<group>"; };
 		D35673C42D3E8E1E00E4E926 /* PlayolaRadio.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = PlayolaRadio.entitlements; sourceTree = "<group>"; };
 		D35673C52D3E91B900E4E926 /* MainSceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainSceneDelegate.swift; sourceTree = "<group>"; };
@@ -668,7 +681,6 @@
 		D35905EB2DFCDA110064A9C1 /* StationListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListModel.swift; sourceTree = "<group>"; };
 		D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerTests.swift; sourceTree = "<group>"; };
-		AB0A00000000000000000002 /* StationPlayerPlaybackAttemptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerPlaybackAttemptTests.swift; sourceTree = "<group>"; };
 		D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatterTests.swift; sourceTree = "<group>"; };
 		D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatter.swift; sourceTree = "<group>"; };
 		D35EFBF22F1576EF000F64A4 /* NewFeatureTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFeatureTile.swift; sourceTree = "<group>"; };
@@ -712,7 +724,6 @@
 		D37257C32DF8F87F001BC6F9 /* circleBackground.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = circleBackground.swift; sourceTree = "<group>"; };
 		D37257C52DF9EF8D001BC6F9 /* HomePageStationList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomePageStationList.swift; sourceTree = "<group>"; };
 		D37257C82DFA247A001BC6F9 /* MainContainer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MainContainer.swift; sourceTree = "<group>"; };
-		ABCDEF010000000000000001 /* TabBarPlatformChrome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarPlatformChrome.swift; sourceTree = "<group>"; };
 		D37257CB2DFA3F7F001BC6F9 /* FontNames.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontNames.swift; sourceTree = "<group>"; };
 		D37257CF2DFB4364001BC6F9 /* PlayerPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerPage.swift; sourceTree = "<group>"; };
 		D37769F62F22B38700200ADF /* ChooseStationPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseStationPageModel.swift; sourceTree = "<group>"; };
@@ -744,8 +755,6 @@
 		D382671B2E00C13E0006BAC2 /* SmallPlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmallPlayer.swift; sourceTree = "<group>"; };
 		D39591142E39931D00720CF8 /* ContactPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPageView.swift; sourceTree = "<group>"; };
 		D39591162E39932300720CF8 /* ContactPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPageModel.swift; sourceTree = "<group>"; };
-		E1AB0000000000000000AA01 /* AppVersionGateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionGateModel.swift; sourceTree = "<group>"; };
-		E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionGateModelTests.swift; sourceTree = "<group>"; };
 		D39591182E39932800720CF8 /* ContactPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPageTests.swift; sourceTree = "<group>"; };
 		D39591252E3BB6FC00720CF8 /* EditProfilePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfilePageView.swift; sourceTree = "<group>"; };
 		D39591272E3BB70500720CF8 /* EditProfilePageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditProfilePageModel.swift; sourceTree = "<group>"; };
@@ -786,9 +795,6 @@
 		D3B744BF2E31316D0042A427 /* RewardsPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardsPageModel.swift; sourceTree = "<group>"; };
 		D3B744C12E3131770042A427 /* RewardsPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardsPageView.swift; sourceTree = "<group>"; };
 		D3B744C32E31317F0042A427 /* RewardsPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RewardsPageTests.swift; sourceTree = "<group>"; };
-		6C05FDC46B20CB37D84A8197 /* YourLibraryPageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YourLibraryPageModel.swift; sourceTree = "<group>"; };
-		903A1DE2476388DF8FCC8874 /* YourLibraryPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YourLibraryPageView.swift; sourceTree = "<group>"; };
-		6B5384ED9FE3A984F23C18BA /* YourLibraryPageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YourLibraryPageTests.swift; sourceTree = "<group>"; };
 		D3B744C72E3139960042A427 /* ListeningTimeTileModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTimeTileModel.swift; sourceTree = "<group>"; };
 		D3B744C92E313B170042A427 /* ListeningTimeTileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ListeningTimeTileTests.swift; sourceTree = "<group>"; };
 		D3B744CC2E368D790042A427 /* Prize.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Prize.swift; sourceTree = "<group>"; };
@@ -832,6 +838,8 @@
 		D7886543EC93B0BA403388A8 /* GiveawayWinnerSubmissionRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSubmissionRequest.swift; sourceTree = "<group>"; };
 		DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsAction.swift; sourceTree = "<group>"; };
 		E16A5F5E27CF6BD0259ED1E5 /* GiveawayOverlayModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayOverlayModelTests.swift; sourceTree = "<group>"; };
+		E1AB0000000000000000AA01 /* AppVersionGateModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionGateModel.swift; sourceTree = "<group>"; };
+		E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppVersionGateModelTests.swift; sourceTree = "<group>"; };
 		E1CA0000000000000000A001 /* CarPlayPlaybackTransition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransition.swift; sourceTree = "<group>"; };
 		E1CA0000000000000000A004 /* CarPlayPlaybackTransitionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CarPlayPlaybackTransitionTests.swift; sourceTree = "<group>"; };
 		F43C99E3FBFDF4522AA71C3C /* UpcomingGiveawayBanner.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UpcomingGiveawayBanner.swift; sourceTree = "<group>"; };
@@ -841,9 +849,9 @@
 		FAE000000000000000000004 /* AudioSessionCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioSessionCoordinatorTests.swift; sourceTree = "<group>"; };
 		FAE000000000000000000010 /* SingleNowPlayingWriterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SingleNowPlayingWriterTests.swift; sourceTree = "<group>"; };
 		FAF000000000000000000001 /* AudioRecorderClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AudioRecorderClientTests.swift; sourceTree = "<group>"; };
+		FBD876AFF9DD0588179EB37B /* RewardsExperience.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RewardsExperience.swift; sourceTree = "<group>"; };
 		FE02B3B32DF88BD9001BC6F9 /* SharedStateTestTrait.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedStateTestTrait.swift; sourceTree = "<group>"; };
 		FE110A0000000000000000F2 /* WelcomeMessagePageModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageModel.swift; sourceTree = "<group>"; };
-		4951B01E879591B4AC3CDA52 /* PresetsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsModelTests.swift; sourceTree = "<group>"; };
 		FE110A0000000000000000F3 /* WelcomeMessagePageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageView.swift; sourceTree = "<group>"; };
 		FE110A0000000000000000F4 /* WelcomeMessagePageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessagePageTests.swift; sourceTree = "<group>"; };
 		FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WelcomeMessageEligibilityTests.swift; sourceTree = "<group>"; };
@@ -933,6 +941,16 @@
 				A6613FD7A13B448187CB8595 /* PresetTests.swift */,
 			);
 			path = Preset;
+			sourceTree = "<group>";
+		};
+		A54D4D5A8EFD52CF2764EF6B /* YourLibraryPage */ = {
+			isa = PBXGroup;
+			children = (
+				6B5384ED9FE3A984F23C18BA /* YourLibraryPageTests.swift */,
+				903A1DE2476388DF8FCC8874 /* YourLibraryPageView.swift */,
+				6C05FDC46B20CB37D84A8197 /* YourLibraryPageModel.swift */,
+			);
+			path = YourLibraryPage;
 			sourceTree = "<group>";
 		};
 		BFF0E48DF7714364A04B11B2 /* Presets */ = {
@@ -1074,6 +1092,9 @@
 				70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */,
 				3809555E7296131D612667B9 /* GiveawayWinnerPendingPushTests.swift */,
 				36EB0D70D43F1CF6504F637E /* UpcomingGiveawayInfo.swift */,
+				FBD876AFF9DD0588179EB37B /* RewardsExperience.swift */,
+				4D6113F0F682A5AB22EC6C63 /* RewardsExperienceTests.swift */,
+				9EC624A968B0E0DA09E64702 /* KoozieShippingAddress.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -1600,15 +1621,6 @@
 			path = PushNotifications;
 			sourceTree = "<group>";
 		};
-		E1AB0000000000000000AC01 /* AppVersionGate */ = {
-			isa = PBXGroup;
-			children = (
-				E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */,
-				E1AB0000000000000000AA01 /* AppVersionGateModel.swift */,
-			);
-			path = AppVersionGate;
-			sourceTree = "<group>";
-		};
 		D39591132E39930500720CF8 /* ContactPage */ = {
 			isa = PBXGroup;
 			children = (
@@ -1717,16 +1729,6 @@
 			path = RewardsPage;
 			sourceTree = "<group>";
 		};
-		A54D4D5A8EFD52CF2764EF6B /* YourLibraryPage */ = {
-			isa = PBXGroup;
-			children = (
-				6B5384ED9FE3A984F23C18BA /* YourLibraryPageTests.swift */,
-				903A1DE2476388DF8FCC8874 /* YourLibraryPageView.swift */,
-				6C05FDC46B20CB37D84A8197 /* YourLibraryPageModel.swift */,
-			);
-			path = YourLibraryPage;
-			sourceTree = "<group>";
-		};
 		D3B744C62E3139860042A427 /* ListeningTimeTile */ = {
 			isa = PBXGroup;
 			children = (
@@ -1817,6 +1819,15 @@
 				D3FEC8042EDF644B00A33AE8 /* ChooseStationToBroadcastPageTests.swift */,
 			);
 			path = ChooseStationToBroadcastPage;
+			sourceTree = "<group>";
+		};
+		E1AB0000000000000000AC01 /* AppVersionGate */ = {
+			isa = PBXGroup;
+			children = (
+				E1AB0000000000000000AA02 /* AppVersionGateModelTests.swift */,
+				E1AB0000000000000000AA01 /* AppVersionGateModel.swift */,
+			);
+			path = AppVersionGate;
 			sourceTree = "<group>";
 		};
 		F1F99B497491A284FFAF08B6 /* Giveaways */ = {
@@ -2240,6 +2251,8 @@
 				69728C9F2333D06DF2684375 /* UpcomingGiveawayBannerModel.swift in Sources */,
 				EFAE322408433F245D07A620 /* UpcomingGiveawayBanner.swift in Sources */,
 				2613B751F316B4688367E6D7 /* UpcomingGiveawayBadge.swift in Sources */,
+				24801FB664BFA5B73E518BC3 /* RewardsExperience.swift in Sources */,
+				1E1FEF5BE44432473298C8CB /* KoozieShippingAddress.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2446,6 +2459,8 @@
 				D43D3440F8D39E737DAB1D24 /* UpcomingGiveawayBannerModel.swift in Sources */,
 				373573B1AD8886BC8570DD8F /* UpcomingGiveawayBanner.swift in Sources */,
 				6E073224D257FDD579575841 /* UpcomingGiveawayBadge.swift in Sources */,
+				9B14EE137DB923F77EBEFB37 /* RewardsExperience.swift in Sources */,
+				23D5CA2938294DB58EB23395 /* KoozieShippingAddress.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2536,6 +2551,7 @@
 				37BCC67C3543B124A9EDB4C8 /* GiveawayWinnerPendingPushTests.swift in Sources */,
 				45C15A64DBFAC157AF8EBA65 /* GiveawayCongratsSheetModelTests.swift in Sources */,
 				086EF07946AAF32C92DE834A /* UpcomingGiveawayBannerModelTests.swift in Sources */,
+				7C3EB088AA47A09C775DB7DC /* RewardsExperienceTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -37,12 +37,14 @@
 		4F0799748F9B6F6C03B34E06 /* FRadioPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 8A2626DA6E1408E57A38509F /* FRadioPlayer */; };
 		51CBBA46B5E06C646C37BD3A /* GiveawayWinnerPendingPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */; };
 		54419FC022E2F30E137BEDD6 /* GiveawayWinnerSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */; };
+		5C0327C159D6D3268DBB9EB7 /* KoozieTileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEE39FF8556B795049C7D10 /* KoozieTileSection.swift */; };
 		5F67160E76C1454189765E5D /* GiveawayWinnerSubmission.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */; };
 		5F721A0797795B3B529757CD /* GiveawayTapResponse.swift in Sources */ = {isa = PBXBuildFile; fileRef = D67B3CE3BA4BEB883A33FB94 /* GiveawayTapResponse.swift */; };
 		5FBBC84B39A22DF69240A54E /* GiveawayWinnerSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */; };
 		659E9B124BCB08D5F3D216D7 /* GiveawayEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EDCED098E801AAB2E9DC82 /* GiveawayEvent.swift */; };
 		65D0683FA2A905693317C5AB /* CongratsActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0488057E2A6456204E582B15 /* CongratsActionTests.swift */; };
 		69728C9F2333D06DF2684375 /* UpcomingGiveawayBannerModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F23EC5D834733F19B23706 /* UpcomingGiveawayBannerModel.swift */; };
+		6A6D03832896B38A5CBE843A /* KoozieTileSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AEE39FF8556B795049C7D10 /* KoozieTileSection.swift */; };
 		6D6D8F5B3570802E2D336F7C /* GiveawayOverlayModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E16A5F5E27CF6BD0259ED1E5 /* GiveawayOverlayModelTests.swift */; };
 		6DB99ADC7A25C5E364543B5E /* YourLibraryPageModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C05FDC46B20CB37D84A8197 /* YourLibraryPageModel.swift */; };
 		6E073224D257FDD579575841 /* UpcomingGiveawayBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73585D96F0A0EB79FFD39F8E /* UpcomingGiveawayBadge.swift */; };
@@ -573,6 +575,7 @@
 		3B83C3893A771EB211B3AF8F /* StationListLiveSortTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StationListLiveSortTests.swift; sourceTree = "<group>"; };
 		4951B01E879591B4AC3CDA52 /* PresetsModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsModelTests.swift; sourceTree = "<group>"; };
 		49F23EC5D834733F19B23706 /* UpcomingGiveawayBannerModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UpcomingGiveawayBannerModel.swift; sourceTree = "<group>"; };
+		4AEE39FF8556B795049C7D10 /* KoozieTileSection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KoozieTileSection.swift; sourceTree = "<group>"; };
 		4D3D10F16230F15FFF80C665 /* GiveawayPlayerOverlayView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayPlayerOverlayView.swift; sourceTree = "<group>"; };
 		4D6113F0F682A5AB22EC6C63 /* RewardsExperienceTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RewardsExperienceTests.swift; sourceTree = "<group>"; };
 		4ED42817003307A164F85FE7 /* PresetsModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsModel.swift; sourceTree = "<group>"; };
@@ -1749,6 +1752,7 @@
 				C5D7B33C7D72A6E770CF667F /* KoozieAddressFormModelTests.swift */,
 				3712613B63E92D656D1A78E7 /* KoozieTileModel.swift */,
 				B63FB46A7FE838F3A8A4C8A6 /* KoozieTileModelTests.swift */,
+				4AEE39FF8556B795049C7D10 /* KoozieTileSection.swift */,
 			);
 			path = ListeningTimeTile;
 			sourceTree = "<group>";
@@ -2269,6 +2273,7 @@
 				1E1FEF5BE44432473298C8CB /* KoozieShippingAddress.swift in Sources */,
 				FFE2EA430C2866C7B05C9B12 /* KoozieAddressFormModel.swift in Sources */,
 				EAFEAD89072009BB8142CF3A /* KoozieTileModel.swift in Sources */,
+				6A6D03832896B38A5CBE843A /* KoozieTileSection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2479,6 +2484,7 @@
 				23D5CA2938294DB58EB23395 /* KoozieShippingAddress.swift in Sources */,
 				24B6384BAEEAB70B98AF2B36 /* KoozieAddressFormModel.swift in Sources */,
 				35CB87DC50E3ED61D6FEA027 /* KoozieTileModel.swift in Sources */,
+				5C0327C159D6D3268DBB9EB7 /* KoozieTileSection.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		0574C4A160288D8AE401D4C9 /* UpcomingGiveawayInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 36EB0D70D43F1CF6504F637E /* UpcomingGiveawayInfo.swift */; };
 		086EF07946AAF32C92DE834A /* UpcomingGiveawayBannerModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B3C275E61DA6CA4C482EC79 /* UpcomingGiveawayBannerModelTests.swift */; };
 		0A6E6C233E85A650521A5331 /* YourLibraryPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 903A1DE2476388DF8FCC8874 /* YourLibraryPageView.swift */; };
+		0A70B3257BA0A86D3F1AA9E5 /* KoozieTileModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B63FB46A7FE838F3A8A4C8A6 /* KoozieTileModelTests.swift */; };
 		0F528AC0AC6E8A8043556CEC /* GiveawayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */; };
 		100DEE4C2F7441167117CC58 /* GiveawayCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCD2F408E712B42EAED9BE68 /* GiveawayCoordinatorTests.swift */; };
 		1D674687C98A493790039AA2 /* GiveawayCongratsSheetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1493664DBC23415D4EE04C91 /* GiveawayCongratsSheetView.swift */; };
@@ -21,14 +22,17 @@
 		1F6F57E01E254F5483BD939B /* Preset.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E8719F70AFA4992B9037775 /* Preset.swift */; };
 		23D5CA2938294DB58EB23395 /* KoozieShippingAddress.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC624A968B0E0DA09E64702 /* KoozieShippingAddress.swift */; };
 		24801FB664BFA5B73E518BC3 /* RewardsExperience.swift in Sources */ = {isa = PBXBuildFile; fileRef = FBD876AFF9DD0588179EB37B /* RewardsExperience.swift */; };
+		24B6384BAEEAB70B98AF2B36 /* KoozieAddressFormModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AAD05D9D43997B4956B822 /* KoozieAddressFormModel.swift */; };
 		2613B751F316B4688367E6D7 /* UpcomingGiveawayBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73585D96F0A0EB79FFD39F8E /* UpcomingGiveawayBadge.swift */; };
 		2891A2D21D67E32129F5F2ED /* YourLibraryPageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6B5384ED9FE3A984F23C18BA /* YourLibraryPageTests.swift */; };
 		2ADE71F9A72B59B6B6C727B5 /* GiveawayWinnerPendingPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */; };
 		354451A630DF81468815108F /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
+		35CB87DC50E3ED61D6FEA027 /* KoozieTileModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3712613B63E92D656D1A78E7 /* KoozieTileModel.swift */; };
 		36BE0070A8ED1A8626D2D52D /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
 		373573B1AD8886BC8570DD8F /* UpcomingGiveawayBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43C99E3FBFDF4522AA71C3C /* UpcomingGiveawayBanner.swift */; };
 		37BCC67C3543B124A9EDB4C8 /* GiveawayWinnerPendingPushTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3809555E7296131D612667B9 /* GiveawayWinnerPendingPushTests.swift */; };
 		3E9CF257B133D2AD4734F378 /* GiveawayWinnerSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */; };
+		438B06FF18E95D6D698E7678 /* KoozieAddressFormModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C5D7B33C7D72A6E770CF667F /* KoozieAddressFormModelTests.swift */; };
 		45C15A64DBFAC157AF8EBA65 /* GiveawayCongratsSheetModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2261DEC52F41A8CC973B73FF /* GiveawayCongratsSheetModelTests.swift */; };
 		4F0799748F9B6F6C03B34E06 /* FRadioPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 8A2626DA6E1408E57A38509F /* FRadioPlayer */; };
 		51CBBA46B5E06C646C37BD3A /* GiveawayWinnerPendingPush.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C547ECE1FDB131CE832D3D /* GiveawayWinnerPendingPush.swift */; };
@@ -516,6 +520,7 @@
 		E6A2E13F3905B715C7E6FA15 /* GiveawayEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02EDCED098E801AAB2E9DC82 /* GiveawayEvent.swift */; };
 		E6FA723C089B9E0115951DD1 /* GiveawayBannerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 917BAF1376F852871F0F3159 /* GiveawayBannerState.swift */; };
 		E96C77B08E039DD3EC6916BF /* GiveawayParticipation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CB3EF3C094D149DDC849813 /* GiveawayParticipation.swift */; };
+		EAFEAD89072009BB8142CF3A /* KoozieTileModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3712613B63E92D656D1A78E7 /* KoozieTileModel.swift */; };
 		EDC6A1FF8A6499631C7E1C1A /* GiveawayCongratsSheetModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C95B740988B02A7A472F8C /* GiveawayCongratsSheetModel.swift */; };
 		EDE2B63A1AB34C74CC65C898 /* CongratsAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACFAE7FE27DBB3341C0CE77 /* CongratsAction.swift */; };
 		EFAE322408433F245D07A620 /* UpcomingGiveawayBanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = F43C99E3FBFDF4522AA71C3C /* UpcomingGiveawayBanner.swift */; };
@@ -537,6 +542,7 @@
 		FE110AC0DE0000000000B1B1 /* WelcomeMessageEligibilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE110AC0DE0000000000F1F1 /* WelcomeMessageEligibilityTests.swift */; };
 		FE654232793406CA6A2FA1FE /* GiveawayWinnerSheetModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BC138D8C4809A3F89A5B4985 /* GiveawayWinnerSheetModelTests.swift */; };
 		FFC4AC782A480E2C45DFBA9C /* FRadioPlayer in Frameworks */ = {isa = PBXBuildFile; productRef = 33C7DB3D3801D1C1C337B26D /* FRadioPlayer */; };
+		FFE2EA430C2866C7B05C9B12 /* KoozieAddressFormModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07AAD05D9D43997B4956B822 /* KoozieAddressFormModel.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -553,6 +559,7 @@
 		02EDCED098E801AAB2E9DC82 /* GiveawayEvent.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayEvent.swift; sourceTree = "<group>"; };
 		0463608FA7279EBB205BF80E /* GiveawayWinnerPush.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPush.swift; sourceTree = "<group>"; };
 		0488057E2A6456204E582B15 /* CongratsActionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CongratsActionTests.swift; sourceTree = "<group>"; };
+		07AAD05D9D43997B4956B822 /* KoozieAddressFormModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KoozieAddressFormModel.swift; sourceTree = "<group>"; };
 		0C8084127A5D5C1680EE2ECA /* GiveawayWinnerSheetModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetModel.swift; sourceTree = "<group>"; };
 		1493664DBC23415D4EE04C91 /* GiveawayCongratsSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCongratsSheetView.swift; sourceTree = "<group>"; };
 		1DBB4FE7E4F57517A32804E0 /* GiveawayCoordinator.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCoordinator.swift; sourceTree = "<group>"; };
@@ -560,6 +567,7 @@
 		2B82DD37711E160592E3842D /* GiveawayMyResult.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayMyResult.swift; sourceTree = "<group>"; };
 		36AE0F6CC37C4970321497CF /* GiveawayWinnerSubmission.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSubmission.swift; sourceTree = "<group>"; };
 		36EB0D70D43F1CF6504F637E /* UpcomingGiveawayInfo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UpcomingGiveawayInfo.swift; sourceTree = "<group>"; };
+		3712613B63E92D656D1A78E7 /* KoozieTileModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KoozieTileModel.swift; sourceTree = "<group>"; };
 		3809555E7296131D612667B9 /* GiveawayWinnerPendingPushTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPendingPushTests.swift; sourceTree = "<group>"; };
 		3A4D634B4C9B84C1C25F6458 /* GiveawayOverlayModel.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayOverlayModel.swift; sourceTree = "<group>"; };
 		3B83C3893A771EB211B3AF8F /* StationListLiveSortTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = StationListLiveSortTests.swift; sourceTree = "<group>"; };
@@ -593,11 +601,13 @@
 		ABCDEF040000000000000001 /* SignInPadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignInPadView.swift; sourceTree = "<group>"; };
 		ABCDEF050000000000000001 /* ContactPagePadView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactPagePadView.swift; sourceTree = "<group>"; };
 		AC860B8DF872B25EFF727088 /* GiveawayWinnerSheetView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetView.swift; sourceTree = "<group>"; };
+		B63FB46A7FE838F3A8A4C8A6 /* KoozieTileModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KoozieTileModelTests.swift; sourceTree = "<group>"; };
 		BA44EE33EB697E44CEC84351 /* GiveawayWinnerPushTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerPushTests.swift; sourceTree = "<group>"; };
 		BC138D8C4809A3F89A5B4985 /* GiveawayWinnerSheetModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayWinnerSheetModelTests.swift; sourceTree = "<group>"; };
 		BFF0E48AF7714364A04B11B2 /* PresetStarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetStarButton.swift; sourceTree = "<group>"; };
 		BFF0E49DF7714364A04B11B3 /* PresetTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetTile.swift; sourceTree = "<group>"; };
 		BFF0EA0DF7714364A04B11B7 /* PresetsCarousel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PresetsCarousel.swift; sourceTree = "<group>"; };
+		C5D7B33C7D72A6E770CF667F /* KoozieAddressFormModelTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = KoozieAddressFormModelTests.swift; sourceTree = "<group>"; };
 		CCD2F408E712B42EAED9BE68 /* GiveawayCoordinatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = GiveawayCoordinatorTests.swift; sourceTree = "<group>"; };
 		D302576A2E63423B00F4228B /* Toast.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Toast.swift; sourceTree = "<group>"; };
 		D302576C2E63428700F4228B /* ToastClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToastClient.swift; sourceTree = "<group>"; };
@@ -1735,6 +1745,10 @@
 				D3B744C92E313B170042A427 /* ListeningTimeTileTests.swift */,
 				D3B744C72E3139960042A427 /* ListeningTimeTileModel.swift */,
 				D3B744B82E2FF1600042A427 /* ListeningTimeTile.swift */,
+				07AAD05D9D43997B4956B822 /* KoozieAddressFormModel.swift */,
+				C5D7B33C7D72A6E770CF667F /* KoozieAddressFormModelTests.swift */,
+				3712613B63E92D656D1A78E7 /* KoozieTileModel.swift */,
+				B63FB46A7FE838F3A8A4C8A6 /* KoozieTileModelTests.swift */,
 			);
 			path = ListeningTimeTile;
 			sourceTree = "<group>";
@@ -2253,6 +2267,8 @@
 				2613B751F316B4688367E6D7 /* UpcomingGiveawayBadge.swift in Sources */,
 				24801FB664BFA5B73E518BC3 /* RewardsExperience.swift in Sources */,
 				1E1FEF5BE44432473298C8CB /* KoozieShippingAddress.swift in Sources */,
+				FFE2EA430C2866C7B05C9B12 /* KoozieAddressFormModel.swift in Sources */,
+				EAFEAD89072009BB8142CF3A /* KoozieTileModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2461,6 +2477,8 @@
 				6E073224D257FDD579575841 /* UpcomingGiveawayBadge.swift in Sources */,
 				9B14EE137DB923F77EBEFB37 /* RewardsExperience.swift in Sources */,
 				23D5CA2938294DB58EB23395 /* KoozieShippingAddress.swift in Sources */,
+				24B6384BAEEAB70B98AF2B36 /* KoozieAddressFormModel.swift in Sources */,
+				35CB87DC50E3ED61D6FEA027 /* KoozieTileModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2552,6 +2570,8 @@
 				45C15A64DBFAC157AF8EBA65 /* GiveawayCongratsSheetModelTests.swift in Sources */,
 				086EF07946AAF32C92DE834A /* UpcomingGiveawayBannerModelTests.swift in Sources */,
 				7C3EB088AA47A09C775DB7DC /* RewardsExperienceTests.swift in Sources */,
+				438B06FF18E95D6D698E7678 /* KoozieAddressFormModelTests.swift in Sources */,
+				0A70B3257BA0A86D3F1AA9E5 /* KoozieTileModelTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -288,6 +288,46 @@ extension APIClient: DependencyKey {
           parameters: params
         )
       },
+      redeemKooziePrize: { jwtToken, prizeId, address in
+        let url =
+          "\(Config.shared.baseUrl.absoluteString)/v1/rewards/users/me/prizes/\(prizeId)/redeem"
+        let headers: HTTPHeaders = ["Authorization": "Bearer \(jwtToken)"]
+        let body = RedeemKooziePrizeRequest(shippingAddress: address)
+
+        let dataResponse = await apiSession.request(
+          url, method: .post, parameters: body, encoder: JSONParameterEncoder.default,
+          headers: headers
+        )
+        .serializingData()
+        .response
+
+        guard let statusCode = dataResponse.response?.statusCode else {
+          throw transportFailure(dataResponse.error)
+        }
+        // 409 "already redeemed" is idempotent success (e.g. a concurrent double-tap).
+        if (200..<300).contains(statusCode) || statusCode == 409 { return }
+        let message =
+          dataResponse.value.flatMap { parsePlayolaErrorMessage(from: $0) }
+          ?? "Could not claim your koozie. Please try again."
+        throw APIError.validationError(message)
+      },
+      markKoozieCongratsSeen: { jwtToken in
+        let url = "\(Config.shared.baseUrl.absoluteString)/v1/rewards/users/me/koozie-congrats-seen"
+        let headers: HTTPHeaders = ["Authorization": "Bearer \(jwtToken)"]
+
+        let dataResponse = await apiSession.request(url, method: .post, headers: headers)
+          .serializingData()
+          .response
+
+        guard let statusCode = dataResponse.response?.statusCode else {
+          throw transportFailure(dataResponse.error)
+        }
+        if (200..<300).contains(statusCode) || statusCode == 409 { return }
+        let message =
+          dataResponse.value.flatMap { parsePlayolaErrorMessage(from: $0) }
+          ?? "Could not dismiss the koozie message."
+        throw APIError.validationError(message)
+      },
       updateUser: { jwtToken, firstName, lastName, verifiedEmail in
         let url = "\(Config.shared.baseUrl.absoluteString)/v1/users/me"
 

--- a/PlayolaRadio/Core/API/APIClient.swift
+++ b/PlayolaRadio/Core/API/APIClient.swift
@@ -96,6 +96,18 @@ struct APIClient: Sendable {
           redeemedAt: Date(), createdAt: Date(), updatedAt: Date(), prize: nil)
       }
 
+  /// Claims the koozie prize with a US shipping address.
+  /// 201 → claimed (server sends the congrats email). 409 ("already redeemed", incl. a
+  /// concurrent double-tap) is treated as success (idempotent). 400 → throws
+  /// `APIError.validationError(serverMessage)` for inline display on the form.
+  var redeemKooziePrize:
+    @Sendable (_ jwtToken: String, _ prizeId: String, _ address: KoozieShippingAddress)
+      async throws -> Void = { _, _, _ in }
+
+  /// Marks the in-app koozie congrats dismissed (write-once). 204 → recorded;
+  /// 409 (not earned) tolerated as success.
+  var markKoozieCongratsSeen: @Sendable (_ jwtToken: String) async throws -> Void = { _ in }
+
   ///   - jwtToken: Current JWT
   ///   - firstName: New first name
   ///   - lastName: New last name (optional, "" treated as nil)

--- a/PlayolaRadio/Core/ListeningTracker/ListeningTracker.swift
+++ b/PlayolaRadio/Core/ListeningTracker/ListeningTracker.swift
@@ -63,4 +63,12 @@ final class ListeningTracker {
     let serverListeningTimeMS = rewardsProfile.totalTimeListenedMS
     return localListeningMS + serverListeningTimeMS
   }
+
+  /// Returns a new tracker with a refreshed `rewardsProfile` but the SAME
+  /// `localListeningSessions`, so a mid-session profile refetch (e.g. after a koozie
+  /// redeem/dismiss) doesn't reset the live counter. Snapshot sessions at call time —
+  /// call this after any network await, not before.
+  func replacingRewardsProfile(_ profile: RewardsProfile) -> ListeningTracker {
+    ListeningTracker(rewardsProfile: profile, localListeningSessions: localListeningSessions)
+  }
 }

--- a/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
+++ b/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
@@ -389,6 +389,7 @@ struct ListeningTrackerTests {
   // MARK: - replacingRewardsProfile
 
   @Test func replacingRewardsProfilePreservesLocalSessions() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     let original = ListeningTracker(
       rewardsProfile: createMockRewardsProfile(totalTimeListenedMS: 1_000),
       localListeningSessions: [

--- a/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
+++ b/PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift
@@ -385,6 +385,28 @@ struct ListeningTrackerTests {
       #expect(duration >= 0)  // Should be non-negative
     }
   }
+
+  // MARK: - replacingRewardsProfile
+
+  @Test func replacingRewardsProfilePreservesLocalSessions() {
+    let original = ListeningTracker(
+      rewardsProfile: createMockRewardsProfile(totalTimeListenedMS: 1_000),
+      localListeningSessions: [
+        LocalListeningSession(
+          startTime: Date(timeIntervalSince1970: 0),
+          endTime: Date(timeIntervalSince1970: 60))  // 60s = 60_000ms
+      ])
+    let newProfile = RewardsProfile(
+      totalTimeListenedMS: 5_000, totalMSAvailableForRewards: 5_000, accurateAsOfTime: Date(),
+      koozieEarned: true)
+
+    let replaced = original.replacingRewardsProfile(newProfile)
+
+    #expect(replaced.rewardsProfile.totalTimeListenedMS == 5_000)
+    #expect(replaced.rewardsProfile.koozieEarned == true)
+    // Local sessions carried over: 5_000 server + 60_000 local
+    #expect(replaced.totalListenTimeMS == 65_000)
+  }
 }
 
 // swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinator.swift
+++ b/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinator.swift
@@ -34,9 +34,14 @@ final class MainContainerNavigationCoordinator {
   var appMode: AppMode = .listening
 
   @ObservationIgnored @Shared(.activeTab) var activeTab
+  @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
   @ObservationIgnored @Dependency(\.continuousClock) var clock
 
   nonisolated init() {}
+
+  private var isKoozieOnly: Bool {
+    listeningTracker?.rewardsProfile.rewardsExperienceType == .koozieOnly
+  }
 
   /// Returns a binding-compatible path for the current active tab
   var path: [Path] {
@@ -113,6 +118,33 @@ final class MainContainerNavigationCoordinator {
 
   func push(_ path: Path) {
     self.path.append(path)
+  }
+
+  /// Pushes the Rewards page unless the user is koozie-only (the route is inert for them —
+  /// they have no multi-tier rewards page).
+  func pushRewards(_ model: RewardsPageModel) {
+    guard !isKoozieOnly else { return }
+    push(.rewardsPage(model))
+  }
+
+  /// Drops any `.rewardsPage` entries from every tab path. Called when a koozie-only profile
+  /// loads so restored nav state / deep links can't surface the legacy Rewards page.
+  func sanitizeRewardsRouteForKoozie() {
+    guard isKoozieOnly else { return }
+    let strip: ([Path]) -> [Path] = { paths in
+      paths.filter { path in
+        if case .rewardsPage = path { return false }
+        return true
+      }
+    }
+    homePath = strip(homePath)
+    stationsPath = strip(stationsPath)
+    yourLibraryPath = strip(yourLibraryPath)
+    profilePath = strip(profilePath)
+    broadcastPath = strip(broadcastPath)
+    libraryPath = strip(libraryPath)
+    listenersPath = strip(listenersPath)
+    settingsPath = strip(settingsPath)
   }
 
   func pop() {

--- a/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinatorTests.swift
+++ b/PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinatorTests.swift
@@ -335,4 +335,51 @@ struct MainContainerNavigationCoordinatorTests {
       }
     }
   }
+
+  // MARK: - Koozie route guard
+
+  private func koozieTracker(koozieOnly: Bool) -> ListeningTracker {
+    ListeningTracker(
+      rewardsProfile: RewardsProfile(
+        totalTimeListenedMS: 0, totalMSAvailableForRewards: 0, accurateAsOfTime: Date(),
+        rewardsExperience: koozieOnly ? "koozie_only" : nil))
+  }
+
+  @Test func pushRewardsNoOpsForKoozieUser() {
+    @Shared(.activeTab) var activeTab: MainContainerModel.ActiveTab = .profile
+    @Shared(.listeningTracker) var lt = koozieTracker(koozieOnly: true)
+    let coordinator = MainContainerNavigationCoordinator()
+    coordinator.pushRewards(RewardsPageModel())
+    #expect(coordinator.profilePath.isEmpty)
+  }
+
+  @Test func pushRewardsPushesForFullTiersUser() {
+    @Shared(.activeTab) var activeTab: MainContainerModel.ActiveTab = .profile
+    @Shared(.listeningTracker) var lt = koozieTracker(koozieOnly: false)
+    let coordinator = MainContainerNavigationCoordinator()
+    coordinator.pushRewards(RewardsPageModel())
+    #expect(coordinator.profilePath.count == 1)
+  }
+
+  @Test func sanitizeStripsRewardsFromProfilePathForKoozie() {
+    @Shared(.listeningTracker) var lt = koozieTracker(koozieOnly: true)
+    let coordinator = MainContainerNavigationCoordinator()
+    coordinator.profilePath = [
+      .rewardsPage(RewardsPageModel()),
+      .notificationsSettingsPage(NotificationsSettingsPageModel()),
+    ]
+    coordinator.sanitizeRewardsRouteForKoozie()
+    #expect(coordinator.profilePath.count == 1)
+    if case .rewardsPage = coordinator.profilePath.first {
+      Issue.record("rewardsPage should have been stripped for koozie user")
+    }
+  }
+
+  @Test func sanitizeLeavesRewardsForFullTiersUser() {
+    @Shared(.listeningTracker) var lt = koozieTracker(koozieOnly: false)
+    let coordinator = MainContainerNavigationCoordinator()
+    coordinator.profilePath = [.rewardsPage(RewardsPageModel())]
+    coordinator.sanitizeRewardsRouteForKoozie()
+    #expect(coordinator.profilePath.count == 1)
+  }
 }

--- a/PlayolaRadio/Models/KoozieShippingAddress.swift
+++ b/PlayolaRadio/Models/KoozieShippingAddress.swift
@@ -1,0 +1,25 @@
+//
+//  KoozieShippingAddress.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/10/26.
+//
+
+import Foundation
+
+/// US shipping address captured when a koozie is claimed. `country` is intentionally omitted
+/// from the wire body — the server defaults it to "US". `state` is sent as a 2-letter code
+/// (server uppercases regardless).
+struct KoozieShippingAddress: Encodable, Equatable, Sendable {
+  var fullName: String
+  var addressLine1: String
+  var addressLine2: String?
+  var city: String
+  var state: String
+  var postalCode: String
+}
+
+/// Redeem request body. `stationId` is omitted for the koozie.
+struct RedeemKooziePrizeRequest: Encodable, Sendable {
+  let shippingAddress: KoozieShippingAddress
+}

--- a/PlayolaRadio/Models/Prize.swift
+++ b/PlayolaRadio/Models/Prize.swift
@@ -12,6 +12,7 @@ struct Prize: Decodable, Sendable, Identifiable, Equatable {
   let name: String
   let prizeTierId: String
   let imageUrl: URL?
+  let slug: String?
   let createdAt: Date
   let updatedAt: Date
 
@@ -20,6 +21,7 @@ struct Prize: Decodable, Sendable, Identifiable, Equatable {
     case name
     case prizeTierId
     case imageUrl
+    case slug
     case createdAt
     case updatedAt
   }
@@ -37,6 +39,8 @@ struct Prize: Decodable, Sendable, Identifiable, Equatable {
       imageUrl = nil
     }
 
+    slug = try container.decodeIfPresent(String.self, forKey: .slug)
+
     createdAt = try container.decode(Date.self, forKey: .createdAt)
     updatedAt = try container.decode(Date.self, forKey: .updatedAt)
   }
@@ -46,6 +50,7 @@ struct Prize: Decodable, Sendable, Identifiable, Equatable {
     name: String,
     prizeTierId: String,
     imageUrl: URL?,
+    slug: String? = nil,
     createdAt: Date = Date(),
     updatedAt: Date = Date()
   ) {
@@ -53,6 +58,7 @@ struct Prize: Decodable, Sendable, Identifiable, Equatable {
     self.name = name
     self.prizeTierId = prizeTierId
     self.imageUrl = imageUrl
+    self.slug = slug
     self.createdAt = createdAt
     self.updatedAt = updatedAt
   }

--- a/PlayolaRadio/Models/PrizeTier.swift
+++ b/PlayolaRadio/Models/PrizeTier.swift
@@ -86,7 +86,8 @@ extension PrizeTier {
             id: "7d03685d-1872-4bcd-a4b3-8d77f6999fd8",
             name: "Bri Bagwell's Banned Radio Koozie",
             prizeTierId: "8e43d874-d63f-4479-8759-8258a0b63fc3",
-            imageUrl: nil
+            imageUrl: nil,
+            slug: "koozie"
           ),
           Prize(
             id: "koozie-2",

--- a/PlayolaRadio/Models/RewardsExperience.swift
+++ b/PlayolaRadio/Models/RewardsExperience.swift
@@ -1,0 +1,45 @@
+//
+//  RewardsExperience.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/10/26.
+//
+
+import Foundation
+
+/// Which rewards experience the server has assigned this user. Absent/null/unrecognized
+/// server values fall back to `.fullTiers` (never koozie-only) per the project's
+/// "server enums need a safe unknown fallback" rule.
+enum RewardsExperience: Equatable, Sendable {
+  case fullTiers
+  case koozieOnly
+
+  init(rawServerValue: String?) {
+    switch rawServerValue {
+    case "koozie_only": self = .koozieOnly
+    default: self = .fullTiers
+    }
+  }
+}
+
+/// The koozie prize's identity + threshold, located in the public `/tiers` response by
+/// `slug == "koozie"`. Nil when no koozie prize exists (older server / non-koozie data).
+struct KooziePrizeInfo: Equatable, Sendable {
+  let prizeId: String
+  let prizeName: String
+  let requiredHours: Int
+}
+
+extension Array where Element == PrizeTier {
+  /// Locates the koozie prize by `slug == "koozie"` and returns its id, name, and its
+  /// tier's `requiredListeningHours`. Keys off the slug, never a hardcoded UUID.
+  var kooziePrizeInfo: KooziePrizeInfo? {
+    for tier in self {
+      if let prize = tier.prizes.first(where: { $0.slug == "koozie" }) {
+        return KooziePrizeInfo(
+          prizeId: prize.id, prizeName: prize.name, requiredHours: tier.requiredListeningHours)
+      }
+    }
+    return nil
+  }
+}

--- a/PlayolaRadio/Models/RewardsExperienceTests.swift
+++ b/PlayolaRadio/Models/RewardsExperienceTests.swift
@@ -13,6 +13,7 @@ import Testing
 // swiftlint:disable line_length
 
 @Suite(.freshSharedState)
+@MainActor
 struct RewardsExperienceTests {
   private func decodeProfile(_ json: String) throws -> RewardsProfile {
     let decoder = JSONDecoder()

--- a/PlayolaRadio/Models/RewardsExperienceTests.swift
+++ b/PlayolaRadio/Models/RewardsExperienceTests.swift
@@ -1,0 +1,103 @@
+//
+//  RewardsExperienceTests.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/10/26.
+//
+
+import Foundation
+import Testing
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+struct RewardsExperienceTests {
+  private func decodeProfile(_ json: String) throws -> RewardsProfile {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try decoder.decode(RewardsProfile.self, from: Data(json.utf8))
+  }
+
+  @Test func absentRewardsExperienceIsFullTiers() throws {
+    let profile = try decodeProfile(
+      #"""
+      {"totalTimeListenedMS":1000,"totalMSAvailableForRewards":1000,"accurateAsOfTime":"2026-09-20T14:00:00Z"}
+      """#)
+    #expect(profile.rewardsExperienceType == .fullTiers)
+    #expect(profile.koozieEarned == nil)
+    #expect(profile.shouldShowKoozieCongrats == nil)
+  }
+
+  @Test func koozieOnlyStringIsKoozieOnly() throws {
+    let profile = try decodeProfile(
+      #"""
+      {"totalTimeListenedMS":1000,"totalMSAvailableForRewards":1000,"accurateAsOfTime":"2026-09-20T14:00:00Z","rewardsExperience":"koozie_only","koozieEarned":true,"shouldShowKoozieCongrats":true}
+      """#)
+    #expect(profile.rewardsExperienceType == .koozieOnly)
+    #expect(profile.koozieEarned == true)
+    #expect(profile.shouldShowKoozieCongrats == true)
+  }
+
+  @Test func unknownRewardsExperienceFallsBackToFullTiers() throws {
+    let profile = try decodeProfile(
+      #"""
+      {"totalTimeListenedMS":1000,"totalMSAvailableForRewards":1000,"accurateAsOfTime":"2026-09-20T14:00:00Z","rewardsExperience":"some_future_tier_v3"}
+      """#)
+    #expect(profile.rewardsExperienceType == .fullTiers)
+  }
+
+  @Test func prizeSlugDecodes() throws {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    let withSlug = try decoder.decode(
+      Prize.self,
+      from: Data(
+        #"""
+        {"id":"p1","name":"Playola Koozie","prizeTierId":"t1","slug":"koozie","createdAt":"2026-09-20T14:00:00Z","updatedAt":"2026-09-20T14:00:00Z"}
+        """#.utf8))
+    #expect(withSlug.slug == "koozie")
+    let withoutSlug = try decoder.decode(
+      Prize.self,
+      from: Data(
+        #"""
+        {"id":"p2","name":"Tee","prizeTierId":"t2","createdAt":"2026-09-20T14:00:00Z","updatedAt":"2026-09-20T14:00:00Z"}
+        """#.utf8))
+    #expect(withoutSlug.slug == nil)
+  }
+
+  @Test func kooziePrizeInfoLocatesBySlug() {
+    let tiers = [
+      PrizeTier(
+        id: "tier-koozie", name: "Koozie", requiredListeningHours: 50, imageIconUrl: nil,
+        prizes: [
+          Prize(
+            id: "prize-koozie", name: "Playola Koozie", prizeTierId: "tier-koozie", imageUrl: nil,
+            slug: "koozie")
+        ]),
+      PrizeTier(
+        id: "tier-tshirt", name: "T-Shirt", requiredListeningHours: 100, imageIconUrl: nil,
+        prizes: [
+          Prize(
+            id: "prize-tshirt", name: "Tee", prizeTierId: "tier-tshirt", imageUrl: nil,
+            slug: "tshirt")
+        ]),
+    ]
+    let info = tiers.kooziePrizeInfo
+    #expect(info?.prizeId == "prize-koozie")
+    #expect(info?.requiredHours == 50)
+    #expect(info?.prizeName == "Playola Koozie")
+  }
+
+  @Test func kooziePrizeInfoIsNilWhenNoKoozieSlug() {
+    let tiers = [
+      PrizeTier(
+        id: "tier-tshirt", name: "T-Shirt", requiredListeningHours: 100, imageIconUrl: nil,
+        prizes: [
+          Prize(
+            id: "prize-tshirt", name: "Tee", prizeTierId: "tier-tshirt", imageUrl: nil,
+            slug: "tshirt")
+        ])
+    ]
+    #expect(tiers.kooziePrizeInfo == nil)
+  }
+}

--- a/PlayolaRadio/Models/RewardsExperienceTests.swift
+++ b/PlayolaRadio/Models/RewardsExperienceTests.swift
@@ -10,6 +10,8 @@ import Testing
 
 @testable import PlayolaRadio
 
+// swiftlint:disable line_length
+
 @Suite(.freshSharedState)
 struct RewardsExperienceTests {
   private func decodeProfile(_ json: String) throws -> RewardsProfile {
@@ -101,3 +103,5 @@ struct RewardsExperienceTests {
     #expect(tiers.kooziePrizeInfo == nil)
   }
 }
+
+// swiftlint:enable line_length

--- a/PlayolaRadio/Models/RewardsProfile.swift
+++ b/PlayolaRadio/Models/RewardsProfile.swift
@@ -15,4 +15,16 @@ struct RewardsProfile: Codable, Sendable {
   // memberwise init stays source-compatible with existing call sites while the optional
   // is still decoded (decodeIfPresent → nil when the server omits it).
   var shouldShowWelcomeMessage: Bool?
+
+  // Koozie-only cohort fields (self-only, all optional). Absent ⇒ today's full-tiers
+  // behavior. Same `var` + default rationale as `shouldShowWelcomeMessage`: synthesized
+  // Decodable uses decodeIfPresent for optionals, and the memberwise init stays
+  // source-compatible with existing positional call sites.
+  var rewardsExperience: String?
+  var koozieEarned: Bool?
+  var shouldShowKoozieCongrats: Bool?
+
+  var rewardsExperienceType: RewardsExperience {
+    RewardsExperience(rawServerValue: rewardsExperience)
+  }
 }

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift
@@ -24,6 +24,7 @@ class ContactPageModel: ViewModel {
 
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.stationLists) var stationLists
+  @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
   @ObservationIgnored @Shared(.mainContainerNavigationCoordinator)
   var mainContainerNavigationCoordinator
 
@@ -97,9 +98,15 @@ class ContactPageModel: ViewModel {
     print(mainContainerNavigationCoordinator.path)
   }
 
+  /// Koozie-only users have no multi-tier rewards page, so the button is hidden for them.
+  var showRewardsButton: Bool {
+    listeningTracker?.rewardsProfile.rewardsExperienceType != .koozieOnly
+  }
+
   @MainActor
   func onRewardsTapped() {
-    mainContainerNavigationCoordinator.path.append(.rewardsPage(self.rewardsPageModel))
+    // Guarded at the coordinator: a no-op for koozie-only users even if this is reached.
+    mainContainerNavigationCoordinator.pushRewards(self.rewardsPageModel)
   }
 
   @MainActor

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPagePadView.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPagePadView.swift
@@ -137,10 +137,12 @@ struct ContactPagePadView: View {
 
   private var actionGrid: some View {
     LazyVGrid(columns: columns, spacing: 16) {
-      ProfilePadActionButton(
-        icon: "gift.fill", label: model.rewardsLabel, background: .playolaRed
-      ) {
-        model.onRewardsTapped()
+      if model.showRewardsButton {
+        ProfilePadActionButton(
+          icon: "gift.fill", label: model.rewardsLabel, background: .playolaRed
+        ) {
+          model.onRewardsTapped()
+        }
       }
 
       ProfilePadActionButton(

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -554,4 +554,25 @@ struct ContactPageTests {
       #expect(!model.myStationButtonVisible)
     }
   }
+
+  // MARK: - Rewards button visibility (koozie cohort)
+
+  @Test func showRewardsButtonFalseForKoozieUser() {
+    @Shared(.listeningTracker) var lt = ListeningTracker(
+      rewardsProfile: RewardsProfile(
+        totalTimeListenedMS: 0, totalMSAvailableForRewards: 0, accurateAsOfTime: Date(),
+        rewardsExperience: "koozie_only"))
+    #expect(ContactPageModel().showRewardsButton == false)
+  }
+
+  @Test func showRewardsButtonTrueForFullTiersUser() {
+    @Shared(.listeningTracker) var lt = ListeningTracker(
+      rewardsProfile: RewardsProfile(
+        totalTimeListenedMS: 0, totalMSAvailableForRewards: 0, accurateAsOfTime: Date()))
+    #expect(ContactPageModel().showRewardsButton == true)
+  }
+
+  @Test func showRewardsButtonTrueWhenNoTracker() {
+    #expect(ContactPageModel().showRewardsButton == true)
+  }
 }

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift
@@ -169,32 +169,34 @@ struct ContactPageView: View {
           }
 
           // Rewards Button
-          Button(
-            action: {
-              model.onRewardsTapped()
-            },
-            label: {
-              HStack(spacing: 12) {
-                Image(systemName: "gift.fill")
-                  .foregroundColor(.white)
-                  .font(.system(size: 16))
+          if model.showRewardsButton {
+            Button(
+              action: {
+                model.onRewardsTapped()
+              },
+              label: {
+                HStack(spacing: 12) {
+                  Image(systemName: "gift.fill")
+                    .foregroundColor(.white)
+                    .font(.system(size: 16))
 
-                Text(model.rewardsLabel)
-                  .font(.custom(FontNames.Inter_500_Medium, size: 16))
-                  .foregroundColor(.white)
+                  Text(model.rewardsLabel)
+                    .font(.custom(FontNames.Inter_500_Medium, size: 16))
+                    .foregroundColor(.white)
 
-                Image(systemName: "chevron.right")
-                  .foregroundColor(.white)
-                  .font(.system(size: 14))
+                  Image(systemName: "chevron.right")
+                    .foregroundColor(.white)
+                    .font(.system(size: 14))
+                }
+                .frame(maxWidth: .infinity)
+                .frame(height: 50)
+                .padding(.horizontal, 16)
+                .background(Color.playolaRed)
+                .cornerRadius(6)
               }
-              .frame(maxWidth: .infinity)
-              .frame(height: 50)
-              .padding(.horizontal, 16)
-              .background(Color.playolaRed)
-              .cornerRadius(6)
-            }
-          )
-          .padding(.horizontal, 20)
+            )
+            .padding(.horizontal, 20)
+          }
 
           // Notifications Button
           Button(

--- a/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift
@@ -90,7 +90,8 @@ class HomePageModel: ViewModel {
         if case .rewardsPage = await self.mainContainerNavigationCoordinator.profilePath.last {
           return
         }
-        await self.mainContainerNavigationCoordinator.push(.rewardsPage(RewardsPageModel()))
+        // Guarded for koozie-only users (no-op) even though the koozie tile hides this button.
+        await self.mainContainerNavigationCoordinator.pushRewards(RewardsPageModel())
       }
     )
 

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -252,7 +252,11 @@ class MainContainerModel: ViewModel {
     }
     do {
       let rewards = try await api.getRewardsProfile(authJWT)
-      self.$listeningTracker.withLock { $0 = ListeningTracker(rewardsProfile: rewards) }
+      self.$listeningTracker.withLock { tracker in
+        // Preserve any local sessions accrued this run instead of resetting the live counter.
+        tracker =
+          tracker?.replacingRewardsProfile(rewards) ?? ListeningTracker(rewardsProfile: rewards)
+      }
       self.$welcomeMessageEligible.withLock { $0 = rewards.shouldShowWelcomeMessage ?? false }
     } catch let err {
       // TODO: Show inline error state on the listening hours tile (instead of

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -258,6 +258,8 @@ class MainContainerModel: ViewModel {
           tracker?.replacingRewardsProfile(rewards) ?? ListeningTracker(rewardsProfile: rewards)
       }
       self.$welcomeMessageEligible.withLock { $0 = rewards.shouldShowWelcomeMessage ?? false }
+      // Koozie-only users must never reach the legacy Rewards page, even via restored nav state.
+      mainContainerNavigationCoordinator.sanitizeRewardsRouteForKoozie()
     } catch let err {
       // TODO: Show inline error state on the listening hours tile (instead of
       // a modal alert) — see PR #272 review. Background tile loads shouldn't

--- a/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
+++ b/PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift
@@ -252,11 +252,7 @@ class MainContainerModel: ViewModel {
     }
     do {
       let rewards = try await api.getRewardsProfile(authJWT)
-      self.$listeningTracker.withLock { tracker in
-        // Preserve any local sessions accrued this run instead of resetting the live counter.
-        tracker =
-          tracker?.replacingRewardsProfile(rewards) ?? ListeningTracker(rewardsProfile: rewards)
-      }
+      self.$listeningTracker.withLock { $0 = ListeningTracker(rewardsProfile: rewards) }
       self.$welcomeMessageEligible.withLock { $0 = rewards.shouldShowWelcomeMessage ?? false }
       // Koozie-only users must never reach the legacy Rewards page, even via restored nav state.
       mainContainerNavigationCoordinator.sanitizeRewardsRouteForKoozie()

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModel.swift
@@ -10,7 +10,9 @@ import Observation
 
 @MainActor
 @Observable
-final class KoozieAddressFormModel {
+final class KoozieAddressFormModel: ViewModel {
+  override init() { super.init() }
+
   var fullName: String = ""
   var addressLine1: String = ""
   var addressLine2: String = ""

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModel.swift
@@ -44,10 +44,14 @@ final class KoozieAddressFormModel {
     trimmed(postalCode).range(of: #"^\d{5}(-\d{4})?$"#, options: .regularExpression) != nil
   }
 
+  private var isStateValid: Bool {
+    trimmed(state).range(of: #"^[A-Za-z]{2}$"#, options: .regularExpression) != nil
+  }
+
   var canSubmit: Bool {
     guard !isSubmitting else { return false }
     return !trimmed(fullName).isEmpty && !trimmed(addressLine1).isEmpty && !trimmed(city).isEmpty
-      && !trimmed(state).isEmpty && isZipValid
+      && isStateValid && isZipValid
   }
 
   /// Trimmed, wire-ready address. `state` is uppercased; empty line 2 becomes nil.

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModel.swift
@@ -1,0 +1,64 @@
+//
+//  KoozieAddressFormModel.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/10/26.
+//
+
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class KoozieAddressFormModel {
+  var fullName: String = ""
+  var addressLine1: String = ""
+  var addressLine2: String = ""
+  var city: String = ""
+  var state: String = ""
+  var postalCode: String = ""
+
+  var serverError: String?
+  var isSubmitting: Bool = false
+
+  // MARK: - Copy
+
+  var title: String { "Where should we send it?" }
+  var subtitle: String { "US addresses only. We'll only use this to ship your koozie." }
+  var fullNamePlaceholder: String { "Full name" }
+  var addressLine1Placeholder: String { "Street address" }
+  var addressLine2Placeholder: String { "Apt, suite (optional)" }
+  var cityPlaceholder: String { "City" }
+  var statePlaceholder: String { "State" }
+  var zipPlaceholder: String { "ZIP" }
+  var backButtonText: String { "Back" }
+  var submitButtonText: String { "Send my koozie" }
+
+  // MARK: - Validation
+
+  private func trimmed(_ value: String) -> String {
+    value.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+
+  private var isZipValid: Bool {
+    trimmed(postalCode).range(of: #"^\d{5}(-\d{4})?$"#, options: .regularExpression) != nil
+  }
+
+  var canSubmit: Bool {
+    guard !isSubmitting else { return false }
+    return !trimmed(fullName).isEmpty && !trimmed(addressLine1).isEmpty && !trimmed(city).isEmpty
+      && !trimmed(state).isEmpty && isZipValid
+  }
+
+  /// Trimmed, wire-ready address. `state` is uppercased; empty line 2 becomes nil.
+  func trimmedAddress() -> KoozieShippingAddress {
+    let line2 = trimmed(addressLine2)
+    return KoozieShippingAddress(
+      fullName: trimmed(fullName),
+      addressLine1: trimmed(addressLine1),
+      addressLine2: line2.isEmpty ? nil : line2,
+      city: trimmed(city),
+      state: trimmed(state).uppercased(),
+      postalCode: trimmed(postalCode))
+  }
+}

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModelTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModelTests.swift
@@ -1,0 +1,79 @@
+//
+//  KoozieAddressFormModelTests.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/10/26.
+//
+
+import Testing
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+@MainActor
+struct KoozieAddressFormModelTests {
+  private func filledModel() -> KoozieAddressFormModel {
+    let model = KoozieAddressFormModel()
+    model.fullName = "Jane Doe"
+    model.addressLine1 = "123 Main St"
+    model.city = "Austin"
+    model.state = "TX"
+    model.postalCode = "78704"
+    return model
+  }
+
+  @Test func canSubmitFalseWhenRequiredFieldsBlank() {
+    let model = KoozieAddressFormModel()
+    #expect(model.canSubmit == false)
+    model.fullName = "Jane"
+    model.addressLine1 = "123 Main"
+    model.city = "Austin"
+    model.state = "TX"
+    #expect(model.canSubmit == false)  // still missing ZIP
+  }
+
+  @Test func canSubmitTrueWhenRequiredFilledAndZipValid() {
+    #expect(filledModel().canSubmit == true)
+  }
+
+  @Test func zipMustMatchFiveOrNinePattern() {
+    let model = filledModel()
+    model.postalCode = "7870"
+    #expect(model.canSubmit == false)
+    model.postalCode = "78704-1234"
+    #expect(model.canSubmit == true)
+    model.postalCode = "abcde"
+    #expect(model.canSubmit == false)
+  }
+
+  @Test func whitespaceOnlyFieldsDoNotCount() {
+    let model = filledModel()
+    model.fullName = "   "
+    #expect(model.canSubmit == false)
+  }
+
+  @Test func cannotSubmitWhileSubmitting() {
+    let model = filledModel()
+    model.isSubmitting = true
+    #expect(model.canSubmit == false)
+  }
+
+  @Test func trimmedAddressTrimsAndOmitsEmptyLine2() {
+    let model = filledModel()
+    model.fullName = "  Jane Doe  "
+    model.addressLine2 = "   "
+    let address = model.trimmedAddress()
+    #expect(address.fullName == "Jane Doe")
+    #expect(address.addressLine2 == nil)
+    #expect(address.postalCode == "78704")
+  }
+
+  @Test func trimmedAddressKeepsNonEmptyLine2AndUppercasesState() {
+    let model = filledModel()
+    model.addressLine2 = " Apt 4 "
+    model.state = "tx"
+    let address = model.trimmedAddress()
+    #expect(address.addressLine2 == "Apt 4")
+    #expect(address.state == "TX")
+  }
+}

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModelTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModelTests.swift
@@ -46,6 +46,16 @@ struct KoozieAddressFormModelTests {
     #expect(model.canSubmit == false)
   }
 
+  @Test func stateMustBeTwoLetters() {
+    let model = filledModel()
+    model.state = "Texas"
+    #expect(model.canSubmit == false)
+    model.state = "T"
+    #expect(model.canSubmit == false)
+    model.state = "tx"
+    #expect(model.canSubmit == true)  // case-insensitive; uppercased in trimmedAddress
+  }
+
   @Test func whitespaceOnlyFieldsDoNotCount() {
     let model = filledModel()
     model.fullName = "   "

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
@@ -1,0 +1,131 @@
+//
+//  KoozieTileModel.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/10/26.
+//
+
+import Dependencies
+import Foundation
+import Observation
+import Sharing
+
+/// The koozie-only listening-tile states. Legacy (full-tiers) users never reach these —
+/// `ListeningTimeTileModel` only builds a `KoozieTileModel` for the koozie cohort.
+enum KoozieTileMode: Equatable {
+  case inProgress
+  case claimable
+  case addressForm
+  case congrats
+  case earned
+}
+
+@MainActor
+@Observable
+final class KoozieTileModel {
+  @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Shared(.auth) var auth
+  @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+
+  /// Koozie prize id + threshold, loaded once from `/tiers`. Nil until loaded.
+  var kooziePrizeInfo: KooziePrizeInfo?
+  /// Live listening total (ms), fed each second by the parent tile model's refresh loop.
+  var liveTotalMS: Int = 0
+  var addressForm = KoozieAddressFormModel()
+
+  private var isShowingAddressForm = false
+  private var congratsDismissedLocally = false
+
+  // MARK: - Copy
+
+  var progressTitle: String { "Playola Koozie" }
+  var claimableTitle: String { "You earned a koozie!" }
+  var claimableSubtitle: String { "Claim it and we'll get one out to you." }
+  var redeemButtonText: String { "Redeem your koozie" }
+  var earnedText: String { "Koozie redeemed — check your email" }
+  var congratsMessage: String {
+    "You've earned a \(kooziePrizeInfo?.prizeName ?? "koozie")! Thanks for listening!"
+  }
+
+  // MARK: - Derived state
+
+  private var profile: RewardsProfile? { listeningTracker?.rewardsProfile }
+
+  var mode: KoozieTileMode {
+    if profile?.koozieEarned == true {
+      if profile?.shouldShowKoozieCongrats == true, !congratsDismissedLocally {
+        return .congrats
+      }
+      return .earned
+    }
+    if isShowingAddressForm { return .addressForm }
+    if let info = kooziePrizeInfo, liveTotalMS >= info.requiredHours * 3_600_000 {
+      return .claimable
+    }
+    return .inProgress
+  }
+
+  var progressFraction: Double {
+    guard let info = kooziePrizeInfo, info.requiredHours > 0 else { return 0 }
+    return min(1.0, Double(liveTotalMS) / Double(info.requiredHours * 3_600_000))
+  }
+
+  var progressPercentLabel: String { "\(Int(progressFraction * 100))%" }
+
+  var hoursToGoLabel: String {
+    guard let info = kooziePrizeInfo else { return "" }
+    let remainingMS = max(0, info.requiredHours * 3_600_000 - liveTotalMS)
+    let totalMinutes = remainingMS / 60_000
+    return "\(totalMinutes / 60)h \(totalMinutes % 60)m of listening to go"
+  }
+
+  // MARK: - Actions
+
+  /// One-shot tiers fetch to resolve the koozie prize id + threshold.
+  func viewAppeared() async {
+    guard kooziePrizeInfo == nil else { return }
+    if let tiers = try? await api.getPrizeTiers() {
+      kooziePrizeInfo = tiers.kooziePrizeInfo
+    }
+  }
+
+  func redeemTapped() {
+    addressForm.serverError = nil
+    isShowingAddressForm = true
+  }
+
+  func backTapped() {
+    isShowingAddressForm = false
+  }
+
+  func sendMyKoozieTapped() async {
+    guard addressForm.canSubmit, let jwt = auth.jwt, let info = kooziePrizeInfo else { return }
+    addressForm.serverError = nil
+    addressForm.isSubmitting = true
+    defer { addressForm.isSubmitting = false }
+    do {
+      try await api.redeemKooziePrize(jwt, info.prizeId, addressForm.trimmedAddress())
+      isShowingAddressForm = false
+      await refreshProfile()
+    } catch {
+      addressForm.serverError =
+        (error as? APIError)?.errorDescription ?? "Could not claim your koozie. Please try again."
+    }
+  }
+
+  func dismissCongratsTapped() async {
+    congratsDismissedLocally = true  // optimistic → .earned
+    guard let jwt = auth.jwt else { return }
+    try? await api.markKoozieCongratsSeen(jwt)
+    await refreshProfile()
+  }
+
+  private func refreshProfile() async {
+    guard let jwt = auth.jwt else { return }
+    guard let refreshed = try? await api.getRewardsProfile(jwt) else { return }
+    $listeningTracker.withLock { tracker in
+      tracker =
+        tracker?.replacingRewardsProfile(refreshed) ?? ListeningTracker(rewardsProfile: refreshed)
+    }
+  }
+}

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
@@ -24,6 +24,7 @@ enum KoozieTileMode: Equatable {
 @Observable
 final class KoozieTileModel {
   @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
 
@@ -35,7 +36,9 @@ final class KoozieTileModel {
 
   private var isShowingAddressForm = false
   private var congratsDismissedLocally = false
-  private var hasAttemptedTiersLoad = false
+  /// The single in-flight/completed tiers-load task. Kept non-nil once started so the tile's
+  /// 1s loop can call `startTiersLoadIfNeeded()` every tick without launching duplicates.
+  private(set) var tiersLoadTask: Task<Void, Never>?
 
   // MARK: - Copy
 
@@ -82,14 +85,32 @@ final class KoozieTileModel {
 
   // MARK: - Actions
 
-  /// One-shot tiers fetch to resolve the koozie prize id + threshold. Attempts exactly once
-  /// per model lifetime — the flag is set regardless of outcome so a failed `/tiers` (or one
-  /// with no `slug == "koozie"`) does NOT get refetched every second by the tile's 1s loop.
-  func viewAppeared() async {
-    guard !hasAttemptedTiersLoad else { return }
-    hasAttemptedTiersLoad = true
-    if let tiers = try? await api.getPrizeTiers() {
+  /// Launches the tiers load once, decoupled from the tile's 1s counter loop (so a slow
+  /// `/tiers` never stalls the live counter) and retrying with capped backoff on network
+  /// failure (so one transient failure doesn't permanently strand a claimable user in
+  /// `.inProgress`). Safe to call every tick — guarded to a single task.
+  func startTiersLoadIfNeeded() {
+    guard tiersLoadTask == nil, kooziePrizeInfo == nil else { return }
+    tiersLoadTask = Task { [weak self] in
+      guard let self else { return }
+      var delay: Duration = .seconds(2)
+      while !Task.isCancelled {
+        if await self.loadTiersOnce() { return }  // stop on any successful fetch
+        try? await self.clock.sleep(for: delay)
+        delay = min(delay * 2, .seconds(30))
+      }
+    }
+  }
+
+  /// A single tiers fetch attempt. Returns true when the fetch succeeded (whether or not a
+  /// koozie prize was present); false only on a thrown/transport error.
+  func loadTiersOnce() async -> Bool {
+    do {
+      let tiers = try await api.getPrizeTiers()
       kooziePrizeInfo = tiers.kooziePrizeInfo
+      return true
+    } catch {
+      return false
     }
   }
 
@@ -128,8 +149,18 @@ final class KoozieTileModel {
     guard let jwt = auth.jwt else { return }
     guard let refreshed = try? await api.getRewardsProfile(jwt) else { return }
     $listeningTracker.withLock { tracker in
-      tracker =
-        tracker?.replacingRewardsProfile(refreshed) ?? ListeningTracker(rewardsProfile: refreshed)
+      guard let current = tracker else {
+        tracker = ListeningTracker(rewardsProfile: refreshed)
+        return
+      }
+      // Adopt ONLY the koozie/earned flags. Keep the existing time totals + local sessions so
+      // the live counter neither jumps backward nor double-counts local listening the refreshed
+      // server total may already include. The full total re-syncs on the next app launch.
+      var merged = current.rewardsProfile
+      merged.rewardsExperience = refreshed.rewardsExperience
+      merged.koozieEarned = refreshed.koozieEarned
+      merged.shouldShowKoozieCongrats = refreshed.shouldShowKoozieCongrats
+      tracker = current.replacingRewardsProfile(merged)
     }
   }
 }

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
@@ -22,11 +22,13 @@ enum KoozieTileMode: Equatable {
 
 @MainActor
 @Observable
-final class KoozieTileModel {
+final class KoozieTileModel: ViewModel {
   @ObservationIgnored @Dependency(\.api) var api
   @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Shared(.auth) var auth
   @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+
+  override init() { super.init() }
 
   /// Koozie prize id + threshold, loaded once from `/tiers`. Nil until loaded.
   var kooziePrizeInfo: KooziePrizeInfo?
@@ -36,6 +38,10 @@ final class KoozieTileModel {
 
   private var isShowingAddressForm = false
   private var congratsDismissedLocally = false
+  /// Set once a redeem returns 201/409 (claim persisted server-side). Keeps the tile out of
+  /// `.claimable` even if the follow-up profile refresh fails, so the koozie can't be
+  /// re-submitted while the server flags catch up.
+  private var hasClaimedLocally = false
   /// The single in-flight/completed tiers-load task. Kept non-nil once started so the tile's
   /// 1s loop can call `startTiersLoadIfNeeded()` every tick without launching duplicates.
   private(set) var tiersLoadTask: Task<Void, Never>?
@@ -61,6 +67,12 @@ final class KoozieTileModel {
         return .congrats
       }
       return .earned
+    }
+    // A claim that succeeded this session but isn't yet reflected in the profile (e.g. the
+    // post-redeem refresh failed): show the claimed state so it can't be re-submitted, and
+    // still honor an optimistic dismiss.
+    if hasClaimedLocally {
+      return congratsDismissedLocally ? .earned : .congrats
     }
     if isShowingAddressForm { return .addressForm }
     if let info = kooziePrizeInfo, liveTotalMS >= info.requiredHours * 3_600_000 {
@@ -132,12 +144,15 @@ final class KoozieTileModel {
   }
 
   func sendMyKoozieTapped() async {
+    guard !addressForm.isSubmitting else { return }  // no concurrent redemptions
+    guard !hasClaimedLocally else { return }  // already claimed this session — no re-submit
     guard addressForm.canSubmit, let jwt = auth.jwt, let info = kooziePrizeInfo else { return }
     addressForm.serverError = nil
     addressForm.isSubmitting = true
     defer { addressForm.isSubmitting = false }
     do {
       try await api.redeemKooziePrize(jwt, info.prizeId, addressForm.trimmedAddress())
+      hasClaimedLocally = true  // 201/409 → claimed server-side; lock out re-submission
       isShowingAddressForm = false
       await refreshProfile()
     } catch {

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
@@ -35,6 +35,7 @@ final class KoozieTileModel {
 
   private var isShowingAddressForm = false
   private var congratsDismissedLocally = false
+  private var hasAttemptedTiersLoad = false
 
   // MARK: - Copy
 
@@ -81,9 +82,12 @@ final class KoozieTileModel {
 
   // MARK: - Actions
 
-  /// One-shot tiers fetch to resolve the koozie prize id + threshold.
+  /// One-shot tiers fetch to resolve the koozie prize id + threshold. Attempts exactly once
+  /// per model lifetime — the flag is set regardless of outcome so a failed `/tiers` (or one
+  /// with no `slug == "koozie"`) does NOT get refetched every second by the tile's 1s loop.
   func viewAppeared() async {
-    guard kooziePrizeInfo == nil else { return }
+    guard !hasAttemptedTiersLoad else { return }
+    hasAttemptedTiersLoad = true
     if let tiers = try? await api.getPrizeTiers() {
       kooziePrizeInfo = tiers.kooziePrizeInfo
     }

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift
@@ -102,6 +102,14 @@ final class KoozieTileModel {
     }
   }
 
+  /// Cancels the tiers backoff task (breaking the strong self-retain it holds while looping)
+  /// and clears it so the load can restart if the tile reappears. Called on tile disappear
+  /// and when the koozie model is torn down.
+  func cancelTiersLoad() {
+    tiersLoadTask?.cancel()
+    tiersLoadTask = nil
+  }
+
   /// A single tiers fetch attempt. Returns true when the fetch succeeded (whether or not a
   /// koozie prize was present); false only on a thrown/transport error.
   func loadTiersOnce() async -> Bool {

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
@@ -19,7 +19,10 @@ struct KoozieTileModelTests {
   private func tracker(totalMS: Int, koozieEarned: Bool? = nil, congrats: Bool? = nil)
     -> ListeningTracker
   {
-    ListeningTracker(
+    // ListeningTracker subscribes to @Shared(.nowPlaying) in init; seed it locally (in the
+    // test's fresh scope) so no leaked playback state can start a session and skew totals.
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
+    return ListeningTracker(
       rewardsProfile: RewardsProfile(
         totalTimeListenedMS: totalMS, totalMSAvailableForRewards: totalMS, accurateAsOfTime: Date(),
         rewardsExperience: "koozie_only", koozieEarned: koozieEarned,
@@ -105,6 +108,34 @@ struct KoozieTileModelTests {
 
     #expect(captured.value?.state == "TX")  // uppercased
     #expect(model.mode == .congrats)
+  }
+
+  @Test func redeemSuccessKeepsClaimedEvenWhenRefreshFailsAndBlocksResubmit() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 50 * 3_600_000)
+    let redeemCount = LockIsolated(0)
+    let model = withDependencies {
+      $0.api.redeemKooziePrize = { _, _, _ in redeemCount.withValue { $0 += 1 } }
+      $0.api.getRewardsProfile = { _ in throw APIError.dataNotValid }  // post-redeem refresh fails
+    } operation: {
+      KoozieTileModel()
+    }
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 50 * 3_600_000
+    model.redeemTapped()
+    model.addressForm.fullName = "Jane Doe"
+    model.addressForm.addressLine1 = "123 Main St"
+    model.addressForm.city = "Austin"
+    model.addressForm.state = "TX"
+    model.addressForm.postalCode = "78704"
+
+    await model.sendMyKoozieTapped()
+
+    #expect(model.mode == .congrats)  // NOT .claimable despite the failed refresh
+    #expect(redeemCount.value == 1)
+
+    await model.sendMyKoozieTapped()  // a second attempt must not re-redeem
+    #expect(redeemCount.value == 1)
   }
 
   @Test func sendMyKoozieValidationErrorSurfacesInlineAndStaysOnForm() async {

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
@@ -21,6 +21,7 @@ struct KoozieTileModelTests {
   {
     // ListeningTracker subscribes to @Shared(.nowPlaying) in init; seed it locally (in the
     // test's fresh scope) so no leaked playback state can start a session and skew totals.
+    // swiftlint:disable:next redundant_optional_initialization
     @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     return ListeningTracker(
       rewardsProfile: RewardsProfile(

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
@@ -1,0 +1,157 @@
+//
+//  KoozieTileModelTests.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/10/26.
+//
+
+import ConcurrencyExtras
+import Dependencies
+import Foundation
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+@MainActor
+struct KoozieTileModelTests {
+  private func tracker(totalMS: Int, koozieEarned: Bool? = nil, congrats: Bool? = nil)
+    -> ListeningTracker
+  {
+    ListeningTracker(
+      rewardsProfile: RewardsProfile(
+        totalTimeListenedMS: totalMS, totalMSAvailableForRewards: totalMS, accurateAsOfTime: Date(),
+        rewardsExperience: "koozie_only", koozieEarned: koozieEarned,
+        shouldShowKoozieCongrats: congrats))
+  }
+
+  private let info = KooziePrizeInfo(prizeId: "p1", prizeName: "Playola Koozie", requiredHours: 50)
+
+  @Test func belowThresholdIsInProgress() {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 10 * 3_600_000)  // 10h of 50h
+    let model = KoozieTileModel()
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 10 * 3_600_000
+    #expect(model.mode == .inProgress)
+    #expect(model.progressPercentLabel == "20%")
+    #expect(model.hoursToGoLabel == "40h 0m of listening to go")
+  }
+
+  @Test func atThresholdNotEarnedIsClaimable() {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 50 * 3_600_000)
+    let model = KoozieTileModel()
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 50 * 3_600_000
+    #expect(model.mode == .claimable)
+  }
+
+  @Test func redeemTappedShowsAddressFormAndBackReturns() {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 50 * 3_600_000)
+    let model = KoozieTileModel()
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 50 * 3_600_000
+    model.redeemTapped()
+    #expect(model.mode == .addressForm)
+    model.backTapped()
+    #expect(model.mode == .claimable)
+  }
+
+  @Test func earnedWithCongratsIsCongrats() {
+    @Shared(.listeningTracker) var lt = tracker(
+      totalMS: 60 * 3_600_000, koozieEarned: true, congrats: true)
+    let model = KoozieTileModel()
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 60 * 3_600_000
+    #expect(model.mode == .congrats)
+    #expect(model.congratsMessage == "You've earned a Playola Koozie! Thanks for listening!")
+  }
+
+  @Test func earnedWithoutCongratsIsEarned() {
+    @Shared(.listeningTracker) var lt = tracker(
+      totalMS: 60 * 3_600_000, koozieEarned: true, congrats: false)
+    let model = KoozieTileModel()
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 60 * 3_600_000
+    #expect(model.mode == .earned)
+  }
+
+  @Test func sendMyKoozieSuccessRefreshesToCongrats() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 50 * 3_600_000)
+    let captured = LockIsolated<KoozieShippingAddress?>(nil)
+    let model = withDependencies {
+      $0.api.getPrizeTiers = { [] }
+      $0.api.redeemKooziePrize = { _, _, address in captured.setValue(address) }
+      $0.api.getRewardsProfile = { _ in
+        RewardsProfile(
+          totalTimeListenedMS: 50 * 3_600_000, totalMSAvailableForRewards: 0,
+          accurateAsOfTime: Date(), rewardsExperience: "koozie_only", koozieEarned: true,
+          shouldShowKoozieCongrats: true)
+      }
+    } operation: {
+      KoozieTileModel()
+    }
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 50 * 3_600_000
+    model.redeemTapped()
+    model.addressForm.fullName = "Jane Doe"
+    model.addressForm.addressLine1 = "123 Main St"
+    model.addressForm.city = "Austin"
+    model.addressForm.state = "tx"
+    model.addressForm.postalCode = "78704"
+
+    await model.sendMyKoozieTapped()
+
+    #expect(captured.value?.state == "TX")  // uppercased
+    #expect(model.mode == .congrats)
+  }
+
+  @Test func sendMyKoozieValidationErrorSurfacesInlineAndStaysOnForm() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 50 * 3_600_000)
+    let model = withDependencies {
+      $0.api.redeemKooziePrize = { _, _, _ in
+        throw APIError.validationError("Invalid US shipping address")
+      }
+    } operation: {
+      KoozieTileModel()
+    }
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 50 * 3_600_000
+    model.redeemTapped()
+    model.addressForm.fullName = "Jane"
+    model.addressForm.addressLine1 = "1 St"
+    model.addressForm.city = "Austin"
+    model.addressForm.state = "TX"
+    model.addressForm.postalCode = "78704"
+
+    await model.sendMyKoozieTapped()
+
+    #expect(model.addressForm.serverError == "Invalid US shipping address")
+    #expect(model.mode == .addressForm)
+  }
+
+  @Test func dismissCongratsOptimisticallyShowsEarned() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.listeningTracker) var lt = tracker(
+      totalMS: 60 * 3_600_000, koozieEarned: true, congrats: true)
+    let model = withDependencies {
+      $0.api.markKoozieCongratsSeen = { _ in }
+      $0.api.getRewardsProfile = { _ in
+        RewardsProfile(
+          totalTimeListenedMS: 60 * 3_600_000, totalMSAvailableForRewards: 0,
+          accurateAsOfTime: Date(), rewardsExperience: "koozie_only", koozieEarned: true,
+          shouldShowKoozieCongrats: false)
+      }
+    } operation: {
+      KoozieTileModel()
+    }
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 60 * 3_600_000
+
+    await model.dismissCongratsTapped()
+
+    #expect(model.mode == .earned)
+  }
+}

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
@@ -190,6 +190,23 @@ struct KoozieTileModelTests {
     #expect(model.kooziePrizeInfo?.requiredHours == 50)
   }
 
+  @Test func cancelTiersLoadStopsRetryingAndClearsTask() async {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 0)
+    let model = withDependencies {
+      $0.continuousClock = ImmediateClock()
+      $0.api.getPrizeTiers = { throw APIError.dataNotValid }  // always fails → would retry forever
+    } operation: {
+      KoozieTileModel()
+    }
+
+    model.startTiersLoadIfNeeded()
+    let task = model.tiersLoadTask
+    model.cancelTiersLoad()
+
+    #expect(model.tiersLoadTask == nil)
+    await task?.value  // terminates via cancellation; would hang forever if not cancelled
+  }
+
   @Test func refreshOnlyUpdatesFlagsAndKeepsTimeTotal() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.listeningTracker) var lt = tracker(

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
@@ -132,11 +132,12 @@ struct KoozieTileModelTests {
     #expect(model.mode == .addressForm)
   }
 
-  @Test func viewAppearedFetchesTiersOnlyOnceEvenWhenNoKoozie() async {
+  @Test func startTiersLoadLaunchesSingleFetchEvenWhenCalledEveryTick() async {
     @Shared(.listeningTracker) var lt = tracker(totalMS: 0)
     let callCount = LockIsolated(0)
     let model = withDependencies {
-      // Returns tiers with NO koozie slug → kooziePrizeInfo stays nil.
+      $0.continuousClock = ImmediateClock()
+      // Returns tiers with NO koozie slug → kooziePrizeInfo stays nil, but still a success.
       $0.api.getPrizeTiers = {
         callCount.withValue { $0 += 1 }
         return [
@@ -149,12 +150,70 @@ struct KoozieTileModelTests {
       KoozieTileModel()
     }
 
-    await model.viewAppeared()
-    await model.viewAppeared()
-    await model.viewAppeared()
+    model.startTiersLoadIfNeeded()
+    model.startTiersLoadIfNeeded()
+    model.startTiersLoadIfNeeded()
+    await model.tiersLoadTask?.value
 
-    #expect(callCount.value == 1)  // no per-tick refetch storm
+    #expect(callCount.value == 1)  // single task, no per-tick refetch storm
     #expect(model.kooziePrizeInfo == nil)
+  }
+
+  @Test func startTiersLoadRetriesOnFailureThenSucceeds() async {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 0)
+    let callCount = LockIsolated(0)
+    let model = withDependencies {
+      $0.continuousClock = ImmediateClock()
+      $0.api.getPrizeTiers = {
+        let attempt = callCount.withValue {
+          $0 += 1
+          return $0
+        }
+        if attempt < 3 { throw APIError.dataNotValid }
+        return [
+          PrizeTier(
+            id: "tk", name: "Koozie", requiredListeningHours: 50, imageIconUrl: nil,
+            prizes: [
+              Prize(
+                id: "pk", name: "Playola Koozie", prizeTierId: "tk", imageUrl: nil, slug: "koozie")
+            ])
+        ]
+      }
+    } operation: {
+      KoozieTileModel()
+    }
+
+    model.startTiersLoadIfNeeded()
+    await model.tiersLoadTask?.value
+
+    #expect(callCount.value == 3)  // retried past two transient failures
+    #expect(model.kooziePrizeInfo?.requiredHours == 50)
+  }
+
+  @Test func refreshOnlyUpdatesFlagsAndKeepsTimeTotal() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.listeningTracker) var lt = tracker(
+      totalMS: 60 * 3_600_000, koozieEarned: true, congrats: true)
+    let model = withDependencies {
+      $0.api.markKoozieCongratsSeen = { _ in }
+      // Server reports a DIFFERENT (much higher) total; the client must NOT adopt it mid-session,
+      // or it would double-count local listening already reflected in the fresh server total.
+      $0.api.getRewardsProfile = { _ in
+        RewardsProfile(
+          totalTimeListenedMS: 999 * 3_600_000, totalMSAvailableForRewards: 0,
+          accurateAsOfTime: Date(), rewardsExperience: "koozie_only", koozieEarned: true,
+          shouldShowKoozieCongrats: false)
+      }
+    } operation: {
+      KoozieTileModel()
+    }
+    model.kooziePrizeInfo = info
+    model.liveTotalMS = 60 * 3_600_000
+
+    await model.dismissCongratsTapped()
+
+    #expect(model.mode == .earned)  // flag adopted
+    #expect(lt?.rewardsProfile.totalTimeListenedMS == 60 * 3_600_000)  // total NOT jumped
   }
 
   @Test func dismissCongratsOptimisticallyShowsEarned() async {

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift
@@ -132,6 +132,31 @@ struct KoozieTileModelTests {
     #expect(model.mode == .addressForm)
   }
 
+  @Test func viewAppearedFetchesTiersOnlyOnceEvenWhenNoKoozie() async {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 0)
+    let callCount = LockIsolated(0)
+    let model = withDependencies {
+      // Returns tiers with NO koozie slug → kooziePrizeInfo stays nil.
+      $0.api.getPrizeTiers = {
+        callCount.withValue { $0 += 1 }
+        return [
+          PrizeTier(
+            id: "t", name: "Tee", requiredListeningHours: 100, imageIconUrl: nil,
+            prizes: [Prize(id: "p", name: "Tee", prizeTierId: "t", imageUrl: nil, slug: "tshirt")])
+        ]
+      }
+    } operation: {
+      KoozieTileModel()
+    }
+
+    await model.viewAppeared()
+    await model.viewAppeared()
+    await model.viewAppeared()
+
+    #expect(callCount.value == 1)  // no per-tick refetch storm
+    #expect(model.kooziePrizeInfo == nil)
+  }
+
   @Test func dismissCongratsOptimisticallyShowsEarned() async {
     @Shared(.auth) var auth = Auth(jwt: "jwt")
     @Shared(.listeningTracker) var lt = tracker(

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileSection.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileSection.swift
@@ -73,15 +73,17 @@ struct KoozieTileSection: View {
         }
         Spacer()
       }
-      Button(action: { model.redeemTapped() }) {
-        Text(model.redeemButtonText)
-          .font(.custom(FontNames.Inter_500_Medium, size: 16))
-          .foregroundColor(.white)
-          .frame(maxWidth: .infinity)
-          .padding(.vertical, 14)
-          .background(Color.playolaRed)
-          .cornerRadius(8)
-      }
+      Button(
+        action: { model.redeemTapped() },
+        label: {
+          Text(model.redeemButtonText)
+            .font(.custom(FontNames.Inter_500_Medium, size: 16))
+            .foregroundColor(.white)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background(Color.playolaRed)
+            .cornerRadius(8)
+        })
     }
     .padding(16)
     .background(Color.elevatedSurface)
@@ -98,11 +100,13 @@ struct KoozieTileSection: View {
         .foregroundColor(.white)
         .fixedSize(horizontal: false, vertical: true)
       Spacer(minLength: 8)
-      Button(action: { Task { await model.dismissCongratsTapped() } }) {
-        Image(systemName: "xmark.circle.fill")
-          .font(.system(size: 20))
-          .foregroundColor(Color.textSecondary)
-      }
+      Button(
+        action: { Task { await model.dismissCongratsTapped() } },
+        label: {
+          Image(systemName: "xmark.circle.fill")
+            .font(.system(size: 20))
+            .foregroundColor(Color.textSecondary)
+        })
     }
     .padding(16)
     .background(Color.elevatedSurface)
@@ -190,14 +194,17 @@ struct KoozieAddressFormView: View {
             .cornerRadius(8)
         }
         Spacer()
-        Button(action: { Task { await onSend() } }) {
-          Text(form.submitButtonText)
-            .font(.custom(FontNames.Inter_700_Bold, size: 16))
-            .foregroundColor(.white)
-            .padding(.vertical, 12)
-            .padding(.horizontal, 20)
-            .opacity(form.canSubmit ? 1.0 : 0.5)
-        }
+        Button(
+          action: { Task { await onSend() } },
+          label: {
+            Text(form.submitButtonText)
+              .font(.custom(FontNames.Inter_700_Bold, size: 16))
+              .foregroundColor(.white)
+              .padding(.vertical, 12)
+              .padding(.horizontal, 20)
+              .opacity(form.canSubmit ? 1.0 : 0.5)
+          }
+        )
         .disabled(!form.canSubmit)
       }
     }

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileSection.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileSection.swift
@@ -1,0 +1,217 @@
+//
+//  KoozieTileSection.swift
+//  PlayolaRadio
+//
+//  Created by Brian D Keane on 8/10/26.
+//
+
+import SwiftUI
+
+/// The koozie bottom-section of the Listening Time tile. Renders one of the five koozie
+/// states off `model.mode`; all copy/behavior lives on the model. A reusable component
+/// (not a page view), so the `switch` on `model.mode` is allowed.
+struct KoozieTileSection: View {
+  @Bindable var model: KoozieTileModel
+
+  var body: some View {
+    switch model.mode {
+    case .inProgress: progressView
+    case .claimable: claimableView
+    case .addressForm:
+      KoozieAddressFormView(
+        form: model.addressForm,
+        onBack: { model.backTapped() },
+        onSend: { await model.sendMyKoozieTapped() })
+    case .congrats: congratsView
+    case .earned: earnedView
+    }
+  }
+
+  // MARK: - In progress
+
+  private var progressView: some View {
+    VStack(spacing: 12) {
+      HStack(spacing: 12) {
+        koozieIcon(background: Color.gray900)
+        VStack(alignment: .leading, spacing: 4) {
+          Text(model.progressTitle)
+            .font(.custom(FontNames.Inter_600_SemiBold, size: 15))
+            .foregroundColor(Color.textPrimary)
+          Text(model.hoursToGoLabel)
+            .font(.custom(FontNames.Inter_400_Regular, size: 13))
+            .foregroundColor(Color.textSecondary)
+        }
+        Spacer()
+        Text(model.progressPercentLabel)
+          .font(.custom(FontNames.Inter_500_Medium, size: 13))
+          .foregroundColor(Color.textSecondary)
+      }
+      GeometryReader { geo in
+        ZStack(alignment: .leading) {
+          Capsule().fill(Color.gray900)
+          Capsule().fill(Color.playolaRed)
+            .frame(width: geo.size.width * model.progressFraction)
+        }
+      }
+      .frame(height: 6)
+    }
+  }
+
+  // MARK: - Claimable
+
+  private var claimableView: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack(spacing: 12) {
+        koozieIcon(background: Color.playolaRed)
+        VStack(alignment: .leading, spacing: 4) {
+          Text(model.claimableTitle)
+            .font(.custom(FontNames.Inter_700_Bold, size: 16))
+            .foregroundColor(.white)
+          Text(model.claimableSubtitle)
+            .font(.custom(FontNames.Inter_400_Regular, size: 13))
+            .foregroundColor(Color.textSecondary)
+        }
+        Spacer()
+      }
+      Button(action: { model.redeemTapped() }) {
+        Text(model.redeemButtonText)
+          .font(.custom(FontNames.Inter_500_Medium, size: 16))
+          .foregroundColor(.white)
+          .frame(maxWidth: .infinity)
+          .padding(.vertical, 14)
+          .background(Color.playolaRed)
+          .cornerRadius(8)
+      }
+    }
+    .padding(16)
+    .background(Color.elevatedSurface)
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+  }
+
+  // MARK: - Congrats
+
+  private var congratsView: some View {
+    HStack(alignment: .top, spacing: 12) {
+      koozieIcon(background: Color.playolaRed)
+      Text(model.congratsMessage)
+        .font(.custom(FontNames.Inter_500_Medium, size: 15))
+        .foregroundColor(.white)
+        .fixedSize(horizontal: false, vertical: true)
+      Spacer(minLength: 8)
+      Button(action: { Task { await model.dismissCongratsTapped() } }) {
+        Image(systemName: "xmark.circle.fill")
+          .font(.system(size: 20))
+          .foregroundColor(Color.textSecondary)
+      }
+    }
+    .padding(16)
+    .background(Color.elevatedSurface)
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+  }
+
+  // MARK: - Earned
+
+  private var earnedView: some View {
+    HStack(spacing: 12) {
+      koozieIcon(background: Color.playolaRed, size: 28)
+      Text(model.earnedText)
+        .font(.custom(FontNames.Inter_500_Medium, size: 14))
+        .foregroundColor(Color.textSecondary)
+      Spacer()
+    }
+    .padding(12)
+    .background(Color.cardSurface)
+    .clipShape(RoundedRectangle(cornerRadius: 10))
+  }
+
+  // MARK: - Shared icon
+
+  private func koozieIcon(background: Color, size: CGFloat = 40) -> some View {
+    Image("koozie-icon")
+      .renderingMode(.template)
+      .resizable()
+      .scaledToFit()
+      .foregroundColor(.white)
+      .frame(width: size * 0.5, height: size * 0.5)
+      .frame(width: size, height: size)
+      .background(background)
+      .clipShape(RoundedRectangle(cornerRadius: 8))
+  }
+}
+
+/// Inline "Where should we send it?" address form. Fields bind straight to the form model;
+/// Back/Send are provided by the tile model. Reusable component, so the `if let` for the
+/// inline error is acceptable.
+struct KoozieAddressFormView: View {
+  @Bindable var form: KoozieAddressFormModel
+  let onBack: () -> Void
+  let onSend: () async -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 10) {
+      Text(form.title)
+        .font(.custom(FontNames.Inter_700_Bold, size: 16))
+        .foregroundColor(.white)
+      Text(form.subtitle)
+        .font(.custom(FontNames.Inter_400_Regular, size: 13))
+        .foregroundColor(Color.textSecondary)
+        .fixedSize(horizontal: false, vertical: true)
+
+      field(form.fullNamePlaceholder, text: $form.fullName)
+        .textContentType(.name)
+      field(form.addressLine1Placeholder, text: $form.addressLine1)
+        .textContentType(.fullStreetAddress)
+      field(form.addressLine2Placeholder, text: $form.addressLine2)
+
+      HStack(spacing: 8) {
+        field(form.cityPlaceholder, text: $form.city)
+        field(form.statePlaceholder, text: $form.state)
+          .frame(width: 64)
+          .textInputAutocapitalization(.characters)
+        field(form.zipPlaceholder, text: $form.postalCode)
+          .frame(width: 90)
+          .keyboardType(.numbersAndPunctuation)
+      }
+
+      if let error = form.serverError {
+        Text(error)
+          .font(.custom(FontNames.Inter_400_Regular, size: 13))
+          .foregroundColor(Color.error)
+      }
+
+      HStack {
+        Button(action: onBack) {
+          Text(form.backButtonText)
+            .font(.custom(FontNames.Inter_500_Medium, size: 15))
+            .foregroundColor(.white)
+            .padding(.vertical, 12)
+            .padding(.horizontal, 24)
+            .background(Color.black.opacity(0.35))
+            .cornerRadius(8)
+        }
+        Spacer()
+        Button(action: { Task { await onSend() } }) {
+          Text(form.submitButtonText)
+            .font(.custom(FontNames.Inter_700_Bold, size: 16))
+            .foregroundColor(.white)
+            .padding(.vertical, 12)
+            .padding(.horizontal, 20)
+            .opacity(form.canSubmit ? 1.0 : 0.5)
+        }
+        .disabled(!form.canSubmit)
+      }
+    }
+    .padding(16)
+    .background(Color.elevatedSurface)
+    .clipShape(RoundedRectangle(cornerRadius: 12))
+  }
+
+  private func field(_ placeholder: String, text: Binding<String>) -> some View {
+    TextField("", text: text, prompt: Text(placeholder).foregroundColor(Color.textSecondary))
+      .font(.custom(FontNames.Inter_400_Regular, size: 15))
+      .foregroundColor(.white)
+      .padding(10)
+      .background(Color.cardSurface)
+      .clipShape(RoundedRectangle(cornerRadius: 8))
+  }
+}

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTile.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTile.swift
@@ -30,7 +30,9 @@ struct ListeningTimeTile: View {
         .font(.custom(FontNames.Inter_700_Bold, size: 32))
         .foregroundColor(.white)
 
-      if let buttonText = model.buttonText {
+      if let koozie = model.koozieTileModel {
+        KoozieTileSection(model: koozie)
+      } else if let buttonText = model.buttonText {
         Button(
           action: { Task { await model.onButtonTapped() } },
           label: {

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
@@ -82,7 +82,7 @@ class ListeningTimeTileModel: ViewModel {
         self.refreshFromTracker()
         if let koozie = self.koozieTileModel {
           koozie.liveTotalMS = ms
-          await koozie.viewAppeared()  // idempotent: fetches /tiers once
+          koozie.startTiersLoadIfNeeded()  // one-shot, decoupled — never stalls this counter
         }
         try? await self.clock.sleep(for: .seconds(1))
       }

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
@@ -51,21 +51,40 @@ class ListeningTimeTileModel: ViewModel {
 
   var titleText: String { "Listening Time" }
 
+  /// Non-nil only for the koozie-only cohort. When present, the tile renders the koozie
+  /// sections instead of the legacy "Redeem Your Rewards!" button.
+  private(set) var koozieTileModel: KoozieTileModel?
+
+  /// Legacy button shows only when there is no koozie tile and a button was configured.
+  var showsLegacyButton: Bool { koozieTileModel == nil && buttonText != nil }
+
+  /// Creates or tears down the koozie sub-model to match the current cohort. Cheap and
+  /// idempotent — safe to call on appear and each refresh tick.
+  func refreshFromTracker() {
+    let isKoozie = listeningTracker?.rewardsProfile.rewardsExperienceType == .koozieOnly
+    if isKoozie, koozieTileModel == nil {
+      koozieTileModel = KoozieTileModel()
+    } else if !isKoozie, koozieTileModel != nil {
+      koozieTileModel = nil
+    }
+  }
+
   private var refreshTask: Task<Void, Never>?
 
   func viewAppeared() {
+    refreshFromTracker()
     refreshTask?.cancel()
     refreshTask = Task { [weak self] in
       while !Task.isCancelled {
         guard let self else { return }
-        if let ms = listeningTracker?.totalListenTimeMS {
-          totalListeningTime = ms
-        } else {
-          print("Tracker missing or zero")
-          totalListeningTime = 0
+        let ms = self.listeningTracker?.totalListenTimeMS ?? 0
+        self.totalListeningTime = ms
+        self.refreshFromTracker()
+        if let koozie = self.koozieTileModel {
+          koozie.liveTotalMS = ms
+          await koozie.viewAppeared()  // idempotent: fetches /tiers once
         }
-
-        try? await clock.sleep(for: .seconds(1))
+        try? await self.clock.sleep(for: .seconds(1))
       }
     }
   }

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift
@@ -65,6 +65,7 @@ class ListeningTimeTileModel: ViewModel {
     if isKoozie, koozieTileModel == nil {
       koozieTileModel = KoozieTileModel()
     } else if !isKoozie, koozieTileModel != nil {
+      koozieTileModel?.cancelTiersLoad()
       koozieTileModel = nil
     }
   }
@@ -96,5 +97,6 @@ class ListeningTimeTileModel: ViewModel {
   func viewDisappeared() {
     refreshTask?.cancel()
     refreshTask = nil
+    koozieTileModel?.cancelTiersLoad()
   }
 }

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
@@ -319,5 +319,27 @@ struct ListeningTimeTileModelTests {
 
     model.viewDisappeared()
   }
+
+  // MARK: - Koozie cohort selection
+
+  @Test func legacyUserHasNoKoozieModel() {
+    @Shared(.listeningTracker) var lt = createMockListeningTracker(totalTimeMS: 1_000)
+    let model = ListeningTimeTileModel(buttonText: "Redeem Your Rewards!", buttonAction: {})
+    model.refreshFromTracker()
+    #expect(model.koozieTileModel == nil)
+    #expect(model.showsLegacyButton == true)
+    #expect(model.buttonText == "Redeem Your Rewards!")
+  }
+
+  @Test func koozieUserGetsKoozieModelAndSuppressesLegacyButton() {
+    @Shared(.listeningTracker) var lt = ListeningTracker(
+      rewardsProfile: RewardsProfile(
+        totalTimeListenedMS: 1_000, totalMSAvailableForRewards: 1_000, accurateAsOfTime: Date(),
+        rewardsExperience: "koozie_only"))
+    let model = ListeningTimeTileModel(buttonText: "Redeem Your Rewards!", buttonAction: {})
+    model.refreshFromTracker()
+    #expect(model.koozieTileModel != nil)
+    #expect(model.showsLegacyButton == false)
+  }
 }
 // swiftlint:enable redundant_optional_initialization

--- a/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
+++ b/PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift
@@ -323,6 +323,7 @@ struct ListeningTimeTileModelTests {
   // MARK: - Koozie cohort selection
 
   @Test func legacyUserHasNoKoozieModel() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     @Shared(.listeningTracker) var lt = createMockListeningTracker(totalTimeMS: 1_000)
     let model = ListeningTimeTileModel(buttonText: "Redeem Your Rewards!", buttonAction: {})
     model.refreshFromTracker()
@@ -332,6 +333,7 @@ struct ListeningTimeTileModelTests {
   }
 
   @Test func koozieUserGetsKoozieModelAndSuppressesLegacyButton() {
+    @Shared(.nowPlaying) var nowPlaying: NowPlaying? = nil
     @Shared(.listeningTracker) var lt = ListeningTracker(
       rewardsProfile: RewardsProfile(
         totalTimeListenedMS: 1_000, totalMSAvailableForRewards: 1_000, accurateAsOfTime: Date(),

--- a/docs/superpowers/plans/2026-08-10-koozie-only-rewards.md
+++ b/docs/superpowers/plans/2026-08-10-koozie-only-rewards.md
@@ -1,0 +1,1124 @@
+# Koozie-Only Rewards Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** New ("koozie_only") users earn a single Koozie inline on the Home Listening Time tile — progress → claim (with a US shipping address) → congrats → quiet earned state — while the multi-tier Rewards page/button/route disappear for them; existing users are byte-for-byte unchanged.
+
+**Architecture:** Server-owns / client-reads. Cohort + earned/congrats flags ride on the already-fetched `RewardsProfile` (no new durable `@Shared`). The reusable `ListeningTimeTileModel` stays thin and only selects `.legacy` vs a new `.koozie(KoozieTileModel)`; `KoozieTileModel` owns all koozie mode-derivation/copy/actions, and a nested `KoozieAddressFormModel` owns the form. New typed API closures handle redeem-with-address (409-as-success, 400-inline-error) and congrats-dismiss.
+
+**Tech Stack:** SwiftUI, `@Observable` MV models, swift-dependencies (`@Dependency`/`@DependencyClient`), swift-sharing (`@Shared`), Alamofire, swift-testing (`@Test`/`@Suite`/`#expect`), swift-custom-dump.
+
+## Global Constraints
+
+- **Design source of truth:** `docs/superpowers/specs/2026-08-10-koozie-only-rewards-design.md`. Read it before starting.
+- **Never gate on environment.** No `Config.shared.environment != .production` anywhere. Feature is gated solely on `rewardsExperience == .koozieOnly`.
+- **Backward compatible:** every new server field is optional; absent ⇒ today's behavior. `develop` stays deployable at each commit.
+- **Threshold + koozie identity come from the server.** Find the prize with `slug == "koozie"` in `/tiers`; use its `id` (redeem `prizeId`) and its tier's `requiredListeningHours`. **No hardcoded UUID or hour count.**
+- **Server enums need a safe fallback:** unknown/absent `rewardsExperience` ⇒ `.fullTiers` (never koozie-only).
+- **Congrats copy (verbatim):** `"You've earned a \(prizeName)! Thanks for listening!"` where `prizeName` is the koozie prize's `name`.
+- **New `.swift` files MUST be hand-registered in `PlayolaRadio.xcodeproj/project.pbxproj`** (explicit `PBXBuildFile` + `PBXFileReference` + group membership + `PBXSourcesBuildPhase` entry for the correct target — app target for source files, `PlayolaRadioTests` for test files). The project uses explicit refs, NOT synced folders. Forgetting this = "file not found" or "symbol not in scope" at build. Register a new file in the SAME commit that creates it.
+- **Tests:** swift-testing only (no XCTest). Every suite carries `@Suite(.freshSharedState)` and `@MainActor`. Mock dependencies with `withDependencies { $0.api.x = ... }` (there is NO `.dependencies` test trait / DependenciesTestSupport). Use `@Shared(.key) var x = value` locally inside each test. Prefer `expectNoDifference` (swift-custom-dump) over `#expect(a == b)` for value comparisons. Tests colocated with code. Never use `Task.sleep` in tests — inject `continuousClock` or assert synchronously.
+- **Build/test locally to match CI:** `DEVELOPER_DIR` must point at the CI Xcode (26.5.0), not the local 27.0 beta. App + Staging targets have `SWIFT_TREAT_WARNINGS_AS_ERRORS=YES` (tests excluded) — no new warnings. Run `make lint` (SwiftLint) before pushing; the pre-commit hook only runs swift-format.
+- **Run tests yourself** via `xcodebuild test` (foreground, `timeout 600000`; ~9 min) with `-skipPackagePluginValidation` and a concrete simulator id. `build-for-testing` alone does not run them.
+
+---
+
+## File Map
+
+**Create:**
+- `PlayolaRadio/Models/RewardsExperience.swift` — cohort enum + `[PrizeTier]` koozie lookup.
+- `PlayolaRadio/Models/KoozieShippingAddress.swift` — `Encodable` address + redeem request body.
+- `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModel.swift` (+ Tests) — form fields/validation.
+- `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift` (+ Tests) — koozie mode + actions.
+- `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileSection.swift` — the koozie bottom-section view.
+- `PlayolaRadio/Models/RewardsExperienceTests.swift`, `PlayolaRadio/Models/PrizeTests.swift` (if absent) — decode tests.
+
+**Modify:**
+- `PlayolaRadio/Models/RewardsProfile.swift` — add optional cohort/earned/congrats fields + computed enum.
+- `PlayolaRadio/Models/Prize.swift` — add `slug: String?`.
+- `PlayolaRadio/Core/API/APIClient.swift` — add `redeemKooziePrize`, `markKoozieCongratsSeen` closures.
+- `PlayolaRadio/Core/API/APIClient+Live.swift` — live impls.
+- `PlayolaRadio/Core/ListeningTracker/ListeningTracker.swift` — `replacingRewardsProfile(_:)`.
+- `PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift` — use `replacingRewardsProfile` in `loadListeningTracker`.
+- `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift` + `ListeningTimeTile.swift` — legacy/koozie selection + render.
+- `PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift` — construct koozie-aware tile model.
+- `PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift` + `ContactPageView.swift` (+ `ContactPagePadView.swift`) — `showRewardsButton`, guarded `onRewardsTapped`.
+- `PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinator.swift` — route guard + path sanitize.
+
+---
+
+## Task 1: Model fields — cohort enum, profile flags, Prize.slug, koozie lookup
+
+**Files:**
+- Create: `PlayolaRadio/Models/RewardsExperience.swift`
+- Modify: `PlayolaRadio/Models/RewardsProfile.swift`
+- Modify: `PlayolaRadio/Models/Prize.swift:10-58`
+- Test: `PlayolaRadio/Models/RewardsExperienceTests.swift` (create), `PlayolaRadio/Models/PrizeTests.swift` (create if absent)
+
+**Interfaces:**
+- Produces: `enum RewardsExperience { case fullTiers, koozieOnly }`; `RewardsProfile.rewardsExperience: String?`, `.koozieEarned: Bool?`, `.shouldShowKoozieCongrats: Bool?`, computed `.rewardsExperienceType: RewardsExperience`; `Prize.slug: String?`; `[PrizeTier].kooziePrizeInfo -> KooziePrizeInfo?` where `struct KooziePrizeInfo { let prizeId: String; let prizeName: String; let requiredHours: Int }`.
+
+- [ ] **Step 1: Write failing decode tests**
+
+Create `PlayolaRadio/Models/RewardsExperienceTests.swift`:
+
+```swift
+import Foundation
+import Testing
+import CustomDump
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+struct RewardsExperienceTests {
+  private func decodeProfile(_ json: String) throws -> RewardsProfile {
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    return try decoder.decode(RewardsProfile.self, from: Data(json.utf8))
+  }
+
+  @Test func absentRewardsExperienceIsFullTiers() throws {
+    let profile = try decodeProfile(#"""
+    {"totalTimeListenedMS":1000,"totalMSAvailableForRewards":1000,"accurateAsOfTime":"2026-09-20T14:00:00Z"}
+    """#)
+    #expect(profile.rewardsExperienceType == .fullTiers)
+    #expect(profile.koozieEarned == nil)
+    #expect(profile.shouldShowKoozieCongrats == nil)
+  }
+
+  @Test func koozieOnlyStringIsKoozieOnly() throws {
+    let profile = try decodeProfile(#"""
+    {"totalTimeListenedMS":1000,"totalMSAvailableForRewards":1000,"accurateAsOfTime":"2026-09-20T14:00:00Z","rewardsExperience":"koozie_only","koozieEarned":true,"shouldShowKoozieCongrats":true}
+    """#)
+    #expect(profile.rewardsExperienceType == .koozieOnly)
+    #expect(profile.koozieEarned == true)
+    #expect(profile.shouldShowKoozieCongrats == true)
+  }
+
+  @Test func unknownRewardsExperienceFallsBackToFullTiers() throws {
+    let profile = try decodeProfile(#"""
+    {"totalTimeListenedMS":1000,"totalMSAvailableForRewards":1000,"accurateAsOfTime":"2026-09-20T14:00:00Z","rewardsExperience":"some_future_tier_v3"}
+    """#)
+    #expect(profile.rewardsExperienceType == .fullTiers)
+  }
+
+  @Test func kooziePrizeInfoLocatesBySlug() {
+    let tiers = [
+      PrizeTier(
+        id: "tier-koozie", name: "Koozie", requiredListeningHours: 50, imageIconUrl: nil,
+        prizes: [Prize(id: "prize-koozie", name: "Playola Koozie", prizeTierId: "tier-koozie", imageUrl: nil, slug: "koozie")]
+      ),
+      PrizeTier(
+        id: "tier-tshirt", name: "T-Shirt", requiredListeningHours: 100, imageIconUrl: nil,
+        prizes: [Prize(id: "prize-tshirt", name: "Tee", prizeTierId: "tier-tshirt", imageUrl: nil, slug: "tshirt")]
+      ),
+    ]
+    let info = tiers.kooziePrizeInfo
+    #expect(info?.prizeId == "prize-koozie")
+    #expect(info?.requiredHours == 50)
+    #expect(info?.prizeName == "Playola Koozie")
+  }
+
+  @Test func kooziePrizeInfoIsNilWhenNoKoozieSlug() {
+    let tiers = [
+      PrizeTier(
+        id: "tier-tshirt", name: "T-Shirt", requiredListeningHours: 100, imageIconUrl: nil,
+        prizes: [Prize(id: "prize-tshirt", name: "Tee", prizeTierId: "tier-tshirt", imageUrl: nil, slug: "tshirt")]
+      )
+    ]
+    #expect(tiers.kooziePrizeInfo == nil)
+  }
+}
+```
+
+Register `RewardsExperienceTests.swift` in `project.pbxproj` under the `PlayolaRadioTests` target.
+
+- [ ] **Step 2: Run tests — verify they fail to compile**
+
+Run the suite (see Task 8 for the full command). Expected: FAIL — `RewardsExperience`, `rewardsExperienceType`, `Prize.slug`, `kooziePrizeInfo` undefined.
+
+- [ ] **Step 3: Add `Prize.slug`**
+
+In `PlayolaRadio/Models/Prize.swift`: add `let slug: String?` after `imageUrl`, a `case slug` to `CodingKeys`, `slug = try container.decodeIfPresent(String.self, forKey: .slug)` in `init(from:)`, and `slug: String? = nil` to the memberwise `init` (assign `self.slug = slug`). Update the `mocks` in `PrizeTier.swift` koozie prize to pass `slug: "koozie"` (leave others `nil` or their slug).
+
+- [ ] **Step 4: Add profile fields + enum + lookup**
+
+In `PlayolaRadio/Models/RewardsProfile.swift`, add after `shouldShowWelcomeMessage`:
+
+```swift
+  var rewardsExperience: String?
+  var koozieEarned: Bool?
+  var shouldShowKoozieCongrats: Bool?
+
+  var rewardsExperienceType: RewardsExperience {
+    RewardsExperience(rawServerValue: rewardsExperience)
+  }
+```
+
+Create `PlayolaRadio/Models/RewardsExperience.swift`:
+
+```swift
+import Foundation
+
+enum RewardsExperience: Equatable, Sendable {
+  case fullTiers   // absent / null / any unrecognized value
+  case koozieOnly
+
+  init(rawServerValue: String?) {
+    switch rawServerValue {
+    case "koozie_only": self = .koozieOnly
+    default: self = .fullTiers
+    }
+  }
+}
+
+struct KooziePrizeInfo: Equatable, Sendable {
+  let prizeId: String
+  let prizeName: String
+  let requiredHours: Int
+}
+
+extension Array where Element == PrizeTier {
+  /// Locates the koozie prize by `slug == "koozie"` and returns its id, name, and its
+  /// tier's required hours. Nil when no koozie prize exists (older server / non-koozie data).
+  var kooziePrizeInfo: KooziePrizeInfo? {
+    for tier in self {
+      if let prize = tier.prizes.first(where: { $0.slug == "koozie" }) {
+        return KooziePrizeInfo(
+          prizeId: prize.id, prizeName: prize.name, requiredHours: tier.requiredListeningHours)
+      }
+    }
+    return nil
+  }
+}
+```
+
+Register `RewardsExperience.swift` in `project.pbxproj` (app target). Create `PrizeTests.swift` only if you added slug-specific tests beyond the above (optional — the koozie test already exercises slug decode via mocks; add a raw-JSON slug decode test if you want belt-and-suspenders).
+
+- [ ] **Step 5: Run tests — verify pass**
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add PlayolaRadio/Models/RewardsExperience.swift PlayolaRadio/Models/RewardsProfile.swift PlayolaRadio/Models/Prize.swift PlayolaRadio/Models/PrizeTier.swift PlayolaRadio/Models/RewardsExperienceTests.swift PlayolaRadio.xcodeproj/project.pbxproj
+git commit -m "feat(rewards): koozie cohort model fields, Prize.slug, tiers koozie lookup"
+```
+
+---
+
+## Task 2: `ListeningTracker.replacingRewardsProfile` (preserve local sessions)
+
+**Files:**
+- Modify: `PlayolaRadio/Core/ListeningTracker/ListeningTracker.swift`
+- Modify: `PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift:248-268`
+- Test: `PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift`
+
+**Interfaces:**
+- Produces: `ListeningTracker.replacingRewardsProfile(_ profile: RewardsProfile) -> ListeningTracker` (carries over `localListeningSessions`).
+
+- [ ] **Step 1: Write failing test**
+
+Add to `ListeningTrackerTests.swift`:
+
+```swift
+@Test func replacingRewardsProfilePreservesLocalSessions() {
+  let original = ListeningTracker(
+    rewardsProfile: RewardsProfile(
+      totalTimeListenedMS: 1_000, totalMSAvailableForRewards: 1_000, accurateAsOfTime: Date()),
+    localListeningSessions: [
+      LocalListeningSession(startTime: Date(timeIntervalSince1970: 0),
+                            endTime: Date(timeIntervalSince1970: 60))  // 60s = 60_000ms
+    ])
+  let newProfile = RewardsProfile(
+    totalTimeListenedMS: 5_000, totalMSAvailableForRewards: 5_000, accurateAsOfTime: Date(),
+    koozieEarned: true)
+
+  let replaced = original.replacingRewardsProfile(newProfile)
+
+  #expect(replaced.rewardsProfile.totalTimeListenedMS == 5_000)
+  #expect(replaced.rewardsProfile.koozieEarned == true)
+  // Local sessions carried over: 5_000 server + 60_000 local
+  #expect(replaced.totalListenTimeMS == 65_000)
+}
+```
+
+(Confirm `LocalListeningSession`'s initializer signature in `ListeningTracker.swift`; adjust the mock session to produce a known `totalTimeMS`.)
+
+- [ ] **Step 2: Run — verify fail** (`replacingRewardsProfile` undefined).
+
+- [ ] **Step 3: Implement**
+
+In `ListeningTracker.swift`:
+
+```swift
+  /// Returns a new tracker with a refreshed `rewardsProfile` but the SAME
+  /// `localListeningSessions`, so a mid-session profile refetch doesn't reset the
+  /// live counter. Snapshot sessions at call time (after any network await).
+  func replacingRewardsProfile(_ profile: RewardsProfile) -> ListeningTracker {
+    ListeningTracker(rewardsProfile: profile, localListeningSessions: localListeningSessions)
+  }
+```
+
+- [ ] **Step 4: Use it in `MainContainerModel.loadListeningTracker`**
+
+Replace the write at `MainContainerModel.swift:255`:
+
+```swift
+      let rewards = try await api.getRewardsProfile(authJWT)
+      self.$listeningTracker.withLock { tracker in
+        if let existing = tracker {
+          tracker = existing.replacingRewardsProfile(rewards)
+        } else {
+          tracker = ListeningTracker(rewardsProfile: rewards)
+        }
+      }
+      self.$welcomeMessageEligible.withLock { $0 = rewards.shouldShowWelcomeMessage ?? false }
+```
+
+- [ ] **Step 5: Run — verify pass.** Also confirm existing `ListeningTrackerTests` + `MainContainerTests` still pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add "PlayolaRadio/Core/ListeningTracker/ListeningTracker.swift" "PlayolaRadio/Core/ListeningTracker/ListeningTrackerTests.swift" "PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift"
+git commit -m "feat(tracker): replacingRewardsProfile preserves local sessions on refresh"
+```
+
+---
+
+## Task 3: API — `redeemKooziePrize` + `markKoozieCongratsSeen`
+
+**Files:**
+- Create: `PlayolaRadio/Models/KoozieShippingAddress.swift`
+- Modify: `PlayolaRadio/Core/API/APIClient.swift:75-99` (add closures near `redeemPrize`)
+- Modify: `PlayolaRadio/Core/API/APIClient+Live.swift:282-290` (add impls near `redeemPrize`)
+
+**Interfaces:**
+- Produces: `struct KoozieShippingAddress: Encodable, Equatable, Sendable { var fullName, addressLine1: String; var addressLine2: String?; var city, state, postalCode: String }`; `api.redeemKooziePrize(jwt, prizeId, KoozieShippingAddress) async throws -> Void` (409 → success, 400 → `APIError.validationError(message)`); `api.markKoozieCongratsSeen(jwt) async throws -> Void` (204/409 → success).
+
+> **Testing note:** `APIClientTests` has no URL-mock harness (only URL-encoding tests), and adding one is out of scope for this PR. The live 201/409/400 branches are verified by the Codex adversarial pass + manual QA (Task 8). Model-level tests (Tasks 4–5) mock these closures, so their *contract* (called with the right args, success/failure propagation) is fully covered.
+
+- [ ] **Step 1: Create the address model**
+
+`PlayolaRadio/Models/KoozieShippingAddress.swift`:
+
+```swift
+import Foundation
+
+/// US shipping address captured when a koozie is claimed. `country` is intentionally omitted
+/// from the wire body — the server defaults it to "US".
+struct KoozieShippingAddress: Encodable, Equatable, Sendable {
+  var fullName: String
+  var addressLine1: String
+  var addressLine2: String?
+  var city: String
+  var state: String
+  var postalCode: String
+}
+
+/// Redeem request body. `stationId` is omitted for the koozie.
+struct RedeemKooziePrizeRequest: Encodable, Sendable {
+  let shippingAddress: KoozieShippingAddress
+}
+```
+
+Register in `project.pbxproj` (app target).
+
+- [ ] **Step 2: Declare the `@DependencyClient` closures**
+
+In `APIClient.swift`, after `redeemPrize` (~line 92), add:
+
+```swift
+  /// Claims the koozie prize with a US shipping address.
+  /// 201 → claimed. 409 ("already redeemed") is treated as success (idempotent).
+  /// 400 → throws `APIError.validationError(serverMessage)` for inline display.
+  var redeemKooziePrize:
+    @Sendable (_ jwtToken: String, _ prizeId: String, _ address: KoozieShippingAddress)
+      async throws -> Void = { _, _, _ in }
+
+  /// Marks the in-app koozie congrats dismissed (write-once). 204 → recorded;
+  /// 409 (not earned) tolerated as success.
+  var markKoozieCongratsSeen: @Sendable (_ jwtToken: String) async throws -> Void = { _ in }
+```
+
+- [ ] **Step 3: Implement in `APIClient+Live.swift`**
+
+After the `redeemPrize` closure (~line 290), add (mirrors the `moveSpin`/`deleteSpin` manual `serializingData().response` pattern):
+
+```swift
+      redeemKooziePrize: { jwtToken, prizeId, address in
+        let url =
+          "\(Config.shared.baseUrl.absoluteString)/v1/rewards/users/me/prizes/\(prizeId)/redeem"
+        let headers: HTTPHeaders = ["Authorization": "Bearer \(jwtToken)"]
+        let body = RedeemKooziePrizeRequest(shippingAddress: address)
+
+        let dataResponse = await apiSession.request(
+          url, method: .post, parameters: body, encoder: JSONParameterEncoder.default,
+          headers: headers
+        )
+        .serializingData()
+        .response
+
+        guard let statusCode = dataResponse.response?.statusCode else {
+          throw transportFailure(dataResponse.error)
+        }
+        // 409 "already redeemed" is idempotent success (concurrent double-tap).
+        if (200..<300).contains(statusCode) || statusCode == 409 { return }
+        let message =
+          dataResponse.value.flatMap { parsePlayolaErrorMessage(from: $0) }
+          ?? "Could not claim your koozie. Please try again."
+        throw APIError.validationError(message)
+      },
+      markKoozieCongratsSeen: { jwtToken in
+        let url = "\(Config.shared.baseUrl.absoluteString)/v1/rewards/users/me/koozie-congrats-seen"
+        let headers: HTTPHeaders = ["Authorization": "Bearer \(jwtToken)"]
+
+        let dataResponse = await apiSession.request(url, method: .post, headers: headers)
+          .serializingData()
+          .response
+
+        guard let statusCode = dataResponse.response?.statusCode else {
+          throw transportFailure(dataResponse.error)
+        }
+        if (200..<300).contains(statusCode) || statusCode == 409 { return }
+        let message =
+          dataResponse.value.flatMap { parsePlayolaErrorMessage(from: $0) }
+          ?? "Could not dismiss the koozie message."
+        throw APIError.validationError(message)
+      },
+```
+
+- [ ] **Step 4: Build** (no unit test here — see testing note). Confirm the app + test targets compile.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add PlayolaRadio/Models/KoozieShippingAddress.swift PlayolaRadio/Core/API/APIClient.swift PlayolaRadio/Core/API/APIClient+Live.swift PlayolaRadio.xcodeproj/project.pbxproj
+git commit -m "feat(api): redeemKooziePrize (409-idempotent, 400-inline) + markKoozieCongratsSeen"
+```
+
+---
+
+## Task 4: `KoozieAddressFormModel`
+
+**Files:**
+- Create: `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModel.swift`
+- Test: `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModelTests.swift`
+
+**Interfaces:**
+- Produces: `@Observable @MainActor final class KoozieAddressFormModel` with bindable `var fullName, addressLine1, addressLine2, city, state, postalCode: String`; `var serverError: String?`; `var isSubmitting: Bool`; computed `var canSubmit: Bool`; `func trimmedAddress() -> KoozieShippingAddress`; static copy (`title`, `subtitle`, field placeholders, `backButtonText`, `submitButtonText`).
+
+- [ ] **Step 1: Write failing tests**
+
+`KoozieAddressFormModelTests.swift`:
+
+```swift
+import Testing
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+@MainActor
+struct KoozieAddressFormModelTests {
+  private func filledModel() -> KoozieAddressFormModel {
+    let m = KoozieAddressFormModel()
+    m.fullName = "Jane Doe"
+    m.addressLine1 = "123 Main St"
+    m.city = "Austin"
+    m.state = "TX"
+    m.postalCode = "78704"
+    return m
+  }
+
+  @Test func canSubmitFalseWhenRequiredFieldsBlank() {
+    let m = KoozieAddressFormModel()
+    #expect(m.canSubmit == false)
+    m.fullName = "Jane"; m.addressLine1 = "123 Main"; m.city = "Austin"; m.state = "TX"
+    #expect(m.canSubmit == false)  // still missing ZIP
+  }
+
+  @Test func canSubmitTrueWhenRequiredFilledAndZipValid() {
+    #expect(filledModel().canSubmit == true)
+  }
+
+  @Test func zipMustMatchFiveOrNinePattern() {
+    let m = filledModel()
+    m.postalCode = "7870"
+    #expect(m.canSubmit == false)
+    m.postalCode = "78704-1234"
+    #expect(m.canSubmit == true)
+    m.postalCode = "abcde"
+    #expect(m.canSubmit == false)
+  }
+
+  @Test func whitespaceOnlyFieldsDoNotCount() {
+    let m = filledModel()
+    m.fullName = "   "
+    #expect(m.canSubmit == false)
+  }
+
+  @Test func trimmedAddressTrimsAndOmitsEmptyLine2() {
+    let m = filledModel()
+    m.fullName = "  Jane Doe  "
+    m.addressLine2 = "   "
+    let addr = m.trimmedAddress()
+    #expect(addr.fullName == "Jane Doe")
+    #expect(addr.addressLine2 == nil)
+    #expect(addr.postalCode == "78704")
+  }
+
+  @Test func trimmedAddressKeepsNonEmptyLine2() {
+    let m = filledModel()
+    m.addressLine2 = " Apt 4 "
+    #expect(m.trimmedAddress().addressLine2 == "Apt 4")
+  }
+}
+```
+
+Register the test file in `project.pbxproj` (test target).
+
+- [ ] **Step 2: Run — verify fail.**
+
+- [ ] **Step 3: Implement**
+
+```swift
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+final class KoozieAddressFormModel {
+  var fullName: String = ""
+  var addressLine1: String = ""
+  var addressLine2: String = ""
+  var city: String = ""
+  var state: String = ""
+  var postalCode: String = ""
+
+  var serverError: String?
+  var isSubmitting: Bool = false
+
+  // MARK: - Copy
+  var title: String { "Where should we send it?" }
+  var subtitle: String { "US addresses only. We'll only use this to ship your koozie." }
+  var fullNamePlaceholder: String { "Full name" }
+  var addressLine1Placeholder: String { "Street address" }
+  var addressLine2Placeholder: String { "Apt, suite (optional)" }
+  var cityPlaceholder: String { "City" }
+  var statePlaceholder: String { "State" }
+  var zipPlaceholder: String { "ZIP" }
+  var backButtonText: String { "Back" }
+  var submitButtonText: String { "Send my koozie" }
+
+  // MARK: - Validation
+  private func t(_ s: String) -> String {
+    s.trimmingCharacters(in: .whitespacesAndNewlines)
+  }
+  private var isZipValid: Bool {
+    t(postalCode).range(of: #"^\d{5}(-\d{4})?$"#, options: .regularExpression) != nil
+  }
+  var canSubmit: Bool {
+    guard !isSubmitting else { return false }
+    return !t(fullName).isEmpty && !t(addressLine1).isEmpty && !t(city).isEmpty
+      && !t(state).isEmpty && isZipValid
+  }
+
+  func trimmedAddress() -> KoozieShippingAddress {
+    let line2 = t(addressLine2)
+    return KoozieShippingAddress(
+      fullName: t(fullName), addressLine1: t(addressLine1),
+      addressLine2: line2.isEmpty ? nil : line2,
+      city: t(city), state: t(state).uppercased(), postalCode: t(postalCode))
+  }
+}
+```
+
+Register `KoozieAddressFormModel.swift` in `project.pbxproj` (app target).
+
+- [ ] **Step 4: Run — verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModel.swift" "PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieAddressFormModelTests.swift" PlayolaRadio.xcodeproj/project.pbxproj
+git commit -m "feat(koozie): KoozieAddressFormModel with trimming + ZIP validation"
+```
+
+---
+
+## Task 5: `KoozieTileModel` — mode derivation + actions
+
+**Files:**
+- Create: `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift`
+- Test: `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift`
+
+**Interfaces:**
+- Consumes: `api.getPrizeTiers`, `api.redeemKooziePrize`, `api.markKoozieCongratsSeen`, `api.getRewardsProfile`; `@Shared(.auth)`, `@Shared(.listeningTracker)`; `[PrizeTier].kooziePrizeInfo`; `ListeningTracker.replacingRewardsProfile`; `KoozieAddressFormModel`.
+- Produces: `enum KoozieTileMode { case inProgress, claimable, addressForm, congrats, earned }`; `KoozieTileModel` with `var mode`, display strings, `var liveTotalMS`, `var addressForm`, and actions `viewAppeared()`, `redeemTapped()`, `backTapped()`, `sendMyKoozieTapped()`, `dismissCongratsTapped()`.
+
+- [ ] **Step 1: Write failing tests**
+
+`KoozieTileModelTests.swift`:
+
+```swift
+import Foundation
+import Sharing
+import Dependencies
+import Testing
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+@MainActor
+struct KoozieTileModelTests {
+  private func tracker(totalMS: Int, koozieEarned: Bool? = nil, congrats: Bool? = nil)
+    -> ListeningTracker
+  {
+    ListeningTracker(rewardsProfile: RewardsProfile(
+      totalTimeListenedMS: totalMS, totalMSAvailableForRewards: totalMS, accurateAsOfTime: Date(),
+      rewardsExperience: "koozie_only", koozieEarned: koozieEarned,
+      shouldShowKoozieCongrats: congrats))
+  }
+  private let info = KooziePrizeInfo(prizeId: "p1", prizeName: "Playola Koozie", requiredHours: 50)
+
+  @Test func belowThresholdIsInProgress() {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 10 * 3_600_000)  // 10h of 50h
+    let m = KoozieTileModel()
+    m.kooziePrizeInfo = info
+    m.liveTotalMS = 10 * 3_600_000
+    #expect(m.mode == .inProgress)
+    #expect(m.progressPercentLabel == "20%")
+    #expect(m.hoursToGoLabel == "40h 0m of listening to go")
+  }
+
+  @Test func atThresholdNotEarnedIsClaimable() {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 50 * 3_600_000)
+    let m = KoozieTileModel(); m.kooziePrizeInfo = info; m.liveTotalMS = 50 * 3_600_000
+    #expect(m.mode == .claimable)
+  }
+
+  @Test func redeemTappedShowsAddressForm() {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 50 * 3_600_000)
+    let m = KoozieTileModel(); m.kooziePrizeInfo = info; m.liveTotalMS = 50 * 3_600_000
+    m.redeemTapped()
+    #expect(m.mode == .addressForm)
+    m.backTapped()
+    #expect(m.mode == .claimable)
+  }
+
+  @Test func earnedWithCongratsIsCongrats() {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 60 * 3_600_000, koozieEarned: true, congrats: true)
+    let m = KoozieTileModel(); m.kooziePrizeInfo = info; m.liveTotalMS = 60 * 3_600_000
+    #expect(m.mode == .congrats)
+    #expect(m.congratsMessage == "You've earned a Playola Koozie! Thanks for listening!")
+  }
+
+  @Test func earnedWithoutCongratsIsEarned() {
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 60 * 3_600_000, koozieEarned: true, congrats: false)
+    let m = KoozieTileModel(); m.kooziePrizeInfo = info; m.liveTotalMS = 60 * 3_600_000
+    #expect(m.mode == .earned)
+  }
+
+  @Test func sendMyKoozieSuccessRefreshesToCongrats() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 50 * 3_600_000)
+    let captured = LockIsolated<KoozieShippingAddress?>(nil)
+    let m = withDependencies {
+      $0.api.getPrizeTiers = { [] }
+      $0.api.redeemKooziePrize = { _, _, addr in captured.setValue(addr) }
+      $0.api.getRewardsProfile = { _ in
+        RewardsProfile(totalTimeListenedMS: 50 * 3_600_000, totalMSAvailableForRewards: 0,
+          accurateAsOfTime: Date(), rewardsExperience: "koozie_only",
+          koozieEarned: true, shouldShowKoozieCongrats: true)
+      }
+    } operation: { KoozieTileModel() }
+    m.kooziePrizeInfo = info; m.liveTotalMS = 50 * 3_600_000
+    m.redeemTapped()
+    m.addressForm.fullName = "Jane Doe"; m.addressForm.addressLine1 = "123 Main St"
+    m.addressForm.city = "Austin"; m.addressForm.state = "tx"; m.addressForm.postalCode = "78704"
+
+    await m.sendMyKoozieTapped()
+
+    #expect(captured.value?.state == "TX")  // uppercased
+    #expect(m.mode == .congrats)
+  }
+
+  @Test func sendMyKoozieValidationErrorSurfacesInlineAndStaysOnForm() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 50 * 3_600_000)
+    let m = withDependencies {
+      $0.api.redeemKooziePrize = { _, _, _ in throw APIError.validationError("Invalid US shipping address") }
+    } operation: { KoozieTileModel() }
+    m.kooziePrizeInfo = info; m.liveTotalMS = 50 * 3_600_000
+    m.redeemTapped()
+    m.addressForm.fullName = "Jane"; m.addressForm.addressLine1 = "1 St"
+    m.addressForm.city = "Austin"; m.addressForm.state = "TX"; m.addressForm.postalCode = "78704"
+
+    await m.sendMyKoozieTapped()
+
+    #expect(m.addressForm.serverError == "Invalid US shipping address")
+    #expect(m.mode == .addressForm)
+  }
+
+  @Test func dismissCongratsOptimisticallyShowsEarned() async {
+    @Shared(.auth) var auth = Auth(jwt: "jwt")
+    @Shared(.listeningTracker) var lt = tracker(totalMS: 60 * 3_600_000, koozieEarned: true, congrats: true)
+    let m = withDependencies {
+      $0.api.markKoozieCongratsSeen = { _ in }
+      $0.api.getRewardsProfile = { _ in
+        RewardsProfile(totalTimeListenedMS: 60 * 3_600_000, totalMSAvailableForRewards: 0,
+          accurateAsOfTime: Date(), rewardsExperience: "koozie_only",
+          koozieEarned: true, shouldShowKoozieCongrats: false)
+      }
+    } operation: { KoozieTileModel() }
+    m.kooziePrizeInfo = info; m.liveTotalMS = 60 * 3_600_000
+
+    await m.dismissCongratsTapped()
+
+    #expect(m.mode == .earned)
+  }
+}
+```
+
+Register the test file in `project.pbxproj` (test target).
+
+- [ ] **Step 2: Run — verify fail.**
+
+- [ ] **Step 3: Implement**
+
+```swift
+import Foundation
+import Dependencies
+import Observation
+import Sharing
+
+enum KoozieTileMode: Equatable {
+  case inProgress
+  case claimable
+  case addressForm
+  case congrats
+  case earned
+}
+
+@MainActor
+@Observable
+final class KoozieTileModel {
+  @ObservationIgnored @Dependency(\.api) var api
+  @ObservationIgnored @Shared(.auth) var auth
+  @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+
+  var kooziePrizeInfo: KooziePrizeInfo?
+  var liveTotalMS: Int = 0
+  var addressForm = KoozieAddressFormModel()
+
+  private var isShowingAddressForm = false
+  private var congratsDismissedLocally = false
+
+  // MARK: - Static copy
+  var progressTitle: String { "Playola Koozie" }
+  var claimableTitle: String { "You earned a koozie!" }
+  var claimableSubtitle: String { "Claim it and we'll get one out to you." }
+  var redeemButtonText: String { "Redeem your koozie" }
+  var earnedText: String { "Koozie redeemed — check your email" }
+  var congratsMessage: String {
+    "You've earned a \(kooziePrizeInfo?.prizeName ?? "koozie")! Thanks for listening!"
+  }
+
+  // MARK: - Derived
+  private var profile: RewardsProfile? { listeningTracker?.rewardsProfile }
+
+  var mode: KoozieTileMode {
+    if profile?.koozieEarned == true {
+      if profile?.shouldShowKoozieCongrats == true && !congratsDismissedLocally {
+        return .congrats
+      }
+      return .earned
+    }
+    if isShowingAddressForm { return .addressForm }
+    if let info = kooziePrizeInfo, liveTotalMS >= info.requiredHours * 3_600_000 {
+      return .claimable
+    }
+    return .inProgress
+  }
+
+  var progressFraction: Double {
+    guard let info = kooziePrizeInfo, info.requiredHours > 0 else { return 0 }
+    return min(1.0, Double(liveTotalMS) / Double(info.requiredHours * 3_600_000))
+  }
+  var progressPercentLabel: String { "\(Int(progressFraction * 100))%" }
+  var hoursToGoLabel: String {
+    guard let info = kooziePrizeInfo else { return "" }
+    let remainingMS = max(0, info.requiredHours * 3_600_000 - liveTotalMS)
+    let totalMinutes = remainingMS / 60_000
+    return "\(totalMinutes / 60)h \(totalMinutes % 60)m of listening to go"
+  }
+
+  // MARK: - Actions
+  func viewAppeared() async {
+    guard kooziePrizeInfo == nil else { return }
+    if let tiers = try? await api.getPrizeTiers() {
+      kooziePrizeInfo = tiers.kooziePrizeInfo
+    }
+  }
+
+  func redeemTapped() {
+    addressForm.serverError = nil
+    isShowingAddressForm = true
+  }
+
+  func backTapped() { isShowingAddressForm = false }
+
+  func sendMyKoozieTapped() async {
+    guard addressForm.canSubmit, let jwt = auth.jwt, let info = kooziePrizeInfo else { return }
+    addressForm.serverError = nil
+    addressForm.isSubmitting = true
+    defer { addressForm.isSubmitting = false }
+    do {
+      try await api.redeemKooziePrize(jwt, info.prizeId, addressForm.trimmedAddress())
+      isShowingAddressForm = false
+      await refreshProfile()
+    } catch {
+      addressForm.serverError =
+        (error as? APIError)?.errorDescription ?? "Could not claim your koozie. Please try again."
+    }
+  }
+
+  func dismissCongratsTapped() async {
+    congratsDismissedLocally = true  // optimistic → .earned
+    guard let jwt = auth.jwt else { return }
+    try? await api.markKoozieCongratsSeen(jwt)
+    await refreshProfile()
+  }
+
+  private func refreshProfile() async {
+    guard let jwt = auth.jwt else { return }
+    guard let refreshed = try? await api.getRewardsProfile(jwt) else { return }
+    $listeningTracker.withLock { tracker in
+      tracker = tracker?.replacingRewardsProfile(refreshed) ?? ListeningTracker(rewardsProfile: refreshed)
+    }
+  }
+}
+```
+
+Register `KoozieTileModel.swift` in `project.pbxproj` (app target).
+
+- [ ] **Step 4: Run — verify pass.**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add "PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModel.swift" "PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileModelTests.swift" PlayolaRadio.xcodeproj/project.pbxproj
+git commit -m "feat(koozie): KoozieTileModel mode derivation + redeem/dismiss/refresh actions"
+```
+
+---
+
+## Task 6: Wire the tile — `ListeningTimeTileModel` selection + views (legacy unchanged)
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileModel.swift`
+- Modify: `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTile.swift`
+- Create: `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/KoozieTileSection.swift`
+- Modify: `PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift:82-95`
+- Test: `PlayolaRadio/Views/Reusable Components/ListeningTimeTile/ListeningTimeTileTests.swift`
+
+**Interfaces:**
+- Consumes: `KoozieTileModel`, `KoozieTileSection`.
+- Produces: `ListeningTimeTileModel.koozieTileModel: KoozieTileModel?` (non-nil only for koozie cohort), driven by its existing 1s loop which now also feeds `koozieTileModel?.liveTotalMS`.
+
+- [ ] **Step 1: Write failing tests** (legacy-unchanged guard + koozie activation)
+
+Add to `ListeningTimeTileModelTests.swift`:
+
+```swift
+@Test func legacyUserHasNoKoozieModel() {
+  @Shared(.listeningTracker) var lt = createMockListeningTracker(totalTimeMS: 1_000)  // no rewardsExperience
+  let model = ListeningTimeTileModel(buttonText: "Redeem Your Rewards!", buttonAction: {})
+  model.refreshFromTracker()
+  #expect(model.koozieTileModel == nil)
+  #expect(model.buttonText == "Redeem Your Rewards!")
+}
+
+@Test func koozieUserGetsKoozieModelAndSuppressesLegacyButton() {
+  @Shared(.listeningTracker) var lt = ListeningTracker(rewardsProfile: RewardsProfile(
+    totalTimeListenedMS: 1_000, totalMSAvailableForRewards: 1_000, accurateAsOfTime: Date(),
+    rewardsExperience: "koozie_only"))
+  let model = ListeningTimeTileModel(buttonText: "Redeem Your Rewards!", buttonAction: {})
+  model.refreshFromTracker()
+  #expect(model.koozieTileModel != nil)
+  #expect(model.showsLegacyButton == false)
+}
+```
+
+- [ ] **Step 2: Run — verify fail.**
+
+- [ ] **Step 3: Implement the selection in `ListeningTimeTileModel`**
+
+Add:
+
+```swift
+  private(set) var koozieTileModel: KoozieTileModel?
+
+  var showsLegacyButton: Bool { koozieTileModel == nil && buttonText != nil }
+
+  /// Sets up koozie mode iff the cohort is koozie-only; called on appear and each tick.
+  func refreshFromTracker() {
+    let isKoozie = listeningTracker?.rewardsProfile.rewardsExperienceType == .koozieOnly
+    if isKoozie, koozieTileModel == nil {
+      koozieTileModel = KoozieTileModel()
+    } else if !isKoozie, koozieTileModel != nil {
+      koozieTileModel = nil
+    }
+  }
+```
+
+Update `viewAppeared()` so the loop keeps koozie state fresh and feeds the live counter:
+
+```swift
+  func viewAppeared() {
+    refreshTask?.cancel()
+    refreshTask = Task { [weak self] in
+      guard let self else { return }
+      self.refreshFromTracker()
+      await self.koozieTileModel?.viewAppeared()  // one-shot tiers fetch (guards internally)
+      while !Task.isCancelled {
+        let ms = self.listeningTracker?.totalListenTimeMS ?? 0
+        self.totalListeningTime = ms
+        self.refreshFromTracker()
+        self.koozieTileModel?.liveTotalMS = ms
+        try? await self.clock.sleep(for: .seconds(1))
+      }
+    }
+  }
+```
+
+- [ ] **Step 4: Implement `KoozieTileSection.swift`** (dumb view; koozie-model bindings only)
+
+```swift
+import SwiftUI
+
+struct KoozieTileSection: View {
+  @Bindable var model: KoozieTileModel
+
+  var body: some View {
+    Group {
+      switch model.mode {
+      case .inProgress: progressView
+      case .claimable: claimableView
+      case .addressForm: KoozieAddressFormView(model: model)
+      case .congrats: congratsView
+      case .earned: earnedView
+      }
+    }
+  }
+  // progressView / claimableView / congratsView / earnedView: render model strings + koozie-icon,
+  // progress bar (model.progressFraction), and buttons calling model.redeemTapped() /
+  // model.dismissCongratsTapped(). See spec state table for layout.
+  // ... (implement each subview per the mockup; no logic beyond reading model)
+}
+```
+
+> Implementer: build the four inline subviews and a `KoozieAddressFormView` (fields bound to `model.addressForm.*`, `Back` → `model.backTapped()`, `Send my koozie` → `await model.sendMyKoozieTapped()`, disabled when `!model.addressForm.canSubmit`, inline `model.addressForm.serverError`). Use `Image("koozie-icon")`. Keep it control-flow-limited to the `switch` on `model.mode` (a reusable component, not a page view). Register `KoozieTileSection.swift` in `project.pbxproj`.
+
+- [ ] **Step 5: Render the section in `ListeningTimeTile.swift`**
+
+Replace the legacy `if let buttonText` block with:
+
+```swift
+      if let koozie = model.koozieTileModel {
+        Divider().overlay(Color.white.opacity(0.15))
+        KoozieTileSection(model: koozie)
+      } else if let buttonText = model.buttonText {
+        // ...existing legacy button, unchanged...
+      }
+```
+
+- [ ] **Step 6: HomePage stays as-is** — `HomePageModel.listeningTimeTileModel` still constructs with the legacy `buttonText`/`buttonAction`; koozie users simply get `koozieTileModel` populated from the tracker, and `showsLegacyButton`/the view suppress the legacy button. No change needed unless a test requires it; confirm `HomePageTests` still pass.
+
+- [ ] **Step 7: Run all tests — verify pass, and legacy tile behavior unchanged.**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add "PlayolaRadio/Views/Reusable Components/ListeningTimeTile/" PlayolaRadio.xcodeproj/project.pbxproj
+git commit -m "feat(koozie): render koozie tile sections; legacy tile path unchanged"
+```
+
+---
+
+## Task 7: Remove Rewards for koozie users — button + coordinator route guard
+
+**Files:**
+- Modify: `PlayolaRadio/Views/Pages/ContactPage/ContactPageModel.swift`
+- Modify: `PlayolaRadio/Views/Pages/ContactPage/ContactPageView.swift:171-197` (+ `ContactPagePadView.swift`)
+- Modify: `PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinator.swift`
+- Modify: `PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift` (sanitize on load)
+- Test: `PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift`, `PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinatorTests.swift`
+
+**Interfaces:**
+- Produces: `ContactPageModel.showRewardsButton: Bool`; guarded `onRewardsTapped()`; `MainContainerNavigationCoordinator.pushRewards(_:)` (no-ops for koozie) + `sanitizeRewardsRouteForKoozie()`.
+
+- [ ] **Step 1: Write failing tests**
+
+`ContactPageTests.swift`:
+
+```swift
+@Test func showRewardsButtonFalseForKoozieUser() {
+  @Shared(.listeningTracker) var lt = ListeningTracker(rewardsProfile: RewardsProfile(
+    totalTimeListenedMS: 0, totalMSAvailableForRewards: 0, accurateAsOfTime: Date(),
+    rewardsExperience: "koozie_only"))
+  #expect(ContactPageModel().showRewardsButton == false)
+}
+
+@Test func showRewardsButtonTrueForFullTiersUser() {
+  @Shared(.listeningTracker) var lt = ListeningTracker(rewardsProfile: RewardsProfile(
+    totalTimeListenedMS: 0, totalMSAvailableForRewards: 0, accurateAsOfTime: Date()))
+  #expect(ContactPageModel().showRewardsButton == true)
+}
+
+@Test func onRewardsTappedNoOpsForKoozieUser() {
+  @Shared(.listeningTracker) var lt = ListeningTracker(rewardsProfile: RewardsProfile(
+    totalTimeListenedMS: 0, totalMSAvailableForRewards: 0, accurateAsOfTime: Date(),
+    rewardsExperience: "koozie_only"))
+  @Shared(.mainContainerNavigationCoordinator) var coord = MainContainerNavigationCoordinator()
+  let model = ContactPageModel()
+  model.onRewardsTapped()
+  #expect(coord.profilePath.isEmpty)
+}
+```
+
+`MainContainerNavigationCoordinatorTests.swift`:
+
+```swift
+@Test func sanitizeStripsRewardsFromProfilePath() {
+  @Shared(.activeTab) var tab = MainContainerModel.ActiveTab.profile
+  let coord = MainContainerNavigationCoordinator()
+  coord.profilePath = [.rewardsPage(RewardsPageModel()), .notificationsSettingsPage(NotificationsSettingsPageModel())]
+  coord.sanitizeRewardsRouteForKoozie()
+  #expect(coord.profilePath.count == 1)
+  if case .rewardsPage = coord.profilePath.first { Issue.record("rewardsPage should be stripped") }
+}
+```
+
+(Confirm the `activeTab` shared-key type / default so `profilePath` is the active tab's path in the test.)
+
+- [ ] **Step 2: Run — verify fail.**
+
+- [ ] **Step 3: Implement coordinator guard + sanitize**
+
+In `MainContainerNavigationCoordinator.swift`:
+
+```swift
+  @ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?
+
+  private var isKoozieOnly: Bool {
+    listeningTracker?.rewardsProfile.rewardsExperienceType == .koozieOnly
+  }
+
+  /// Push the Rewards page unless the user is koozie-only (route is inert for them).
+  func pushRewards(_ model: RewardsPageModel) {
+    guard !isKoozieOnly else { return }
+    push(.rewardsPage(model))
+  }
+
+  /// Drop any `.rewardsPage` entries from every tab path (call when a koozie profile loads,
+  /// so restored nav state can't surface the legacy page).
+  func sanitizeRewardsRouteForKoozie() {
+    guard isKoozieOnly else { return }
+    let strip: ([Path]) -> [Path] = { $0.filter { if case .rewardsPage = $0 { return false }; return true } }
+    homePath = strip(homePath); stationsPath = strip(stationsPath)
+    yourLibraryPath = strip(yourLibraryPath); profilePath = strip(profilePath)
+    broadcastPath = strip(broadcastPath); libraryPath = strip(libraryPath)
+    listenersPath = strip(listenersPath); settingsPath = strip(settingsPath)
+  }
+```
+
+Add `@ObservationIgnored @Shared(.listeningTracker)` requires importing nothing new. Note `nonisolated init()` — `@Shared` property wrappers are fine here.
+
+- [ ] **Step 4: Route callers through the guard**
+
+- `ContactPageModel.onRewardsTapped()`:
+
+```swift
+  var showRewardsButton: Bool {
+    listeningTracker?.rewardsProfile.rewardsExperienceType != .koozieOnly
+  }
+
+  @MainActor
+  func onRewardsTapped() {
+    mainContainerNavigationCoordinator.pushRewards(self.rewardsPageModel)
+  }
+```
+
+Add `@ObservationIgnored @Shared(.listeningTracker) var listeningTracker: ListeningTracker?` to `ContactPageModel`.
+
+- `HomePageModel.listeningTimeTileModel` legacy button action already checks `if case .rewardsPage`; change its push to `pushRewards(RewardsPageModel())`. (For koozie users the legacy button isn't shown anyway; this is defense in depth.)
+
+- [ ] **Step 5: Hide the button in the views**
+
+In `ContactPageView.swift`, wrap the Rewards button block (lines 171-197) in `if model.showRewardsButton { ... }` (matches the file's existing `if model.myStationButtonVisible` pattern). Do the same in `ContactPagePadView.swift` if it renders a Rewards button.
+
+- [ ] **Step 6: Sanitize on profile load**
+
+In `MainContainerModel.loadListeningTracker`, after writing the tracker, call:
+
+```swift
+      mainContainerNavigationCoordinator.sanitizeRewardsRouteForKoozie()
+```
+
+- [ ] **Step 7: Run all tests — verify pass.**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add "PlayolaRadio/Views/Pages/ContactPage/" "PlayolaRadio/Core/Navigation/MainContainerNavigationCoordinator.swift" "PlayolaRadio/Views/Pages/MainContainer/MainContainerModel.swift" "PlayolaRadio/Views/Pages/HomePage/HomePageModel.swift"
+git commit -m "feat(koozie): hide Rewards button + guard/sanitize .rewardsPage route for koozie users"
+```
+
+---
+
+## Task 8: Integration verification, lint, and QA
+
+**Files:** none (verification + polish only).
+
+- [ ] **Step 1: Full test run (foreground, ~9 min)**
+
+Run (substitute a concrete booted simulator UDID from `xcrun simctl list devices booted`):
+
+```bash
+DEVELOPER_DIR="/Applications/Xcode-26.5.0.app/Contents/Developer" \
+xcodebuild test \
+  -project PlayolaRadio.xcodeproj -scheme PlayolaRadio \
+  -destination 'platform=iOS Simulator,id=<SIM_UDID>' \
+  -skipPackagePluginValidation 2>&1 | tail -40
+```
+
+Expected: all suites pass, including the new koozie suites and the unchanged `ListeningTimeTileModelTests`, `MainContainerTests`, `HomePageTests`, `ContactPageTests`.
+
+- [ ] **Step 2: Lint + format**
+
+```bash
+make format && make lint
+```
+
+Fix any SwiftLint violations (CI fails on them; the pre-commit hook only formats).
+
+- [ ] **Step 3: Manual/simulator QA of the live path**
+
+Verify the full flow against staging with a koozie-cohort account (or a mocked profile): in-progress bar → claimable → address form (Back works, validation gates Send) → Send my koozie → congrats → ✕ dismiss → quiet earned row. Confirm double-tapping Send (409) still lands on congrats (idempotent), and a bad ZIP shows the inline server/client message. Confirm a full-tiers account sees ZERO change (Rewards button present, tile button present).
+
+- [ ] **Step 4: Codex adversarial review** (per Architect-with-Codex pipeline)
+
+`/codex review` then `/codex challenge` on the branch diff (resume session `019fec5b-2ec9-7093-99d7-308cf83d9b36` for continuity). Fix everything surfaced; re-run if fixes are non-trivial.
+
+- [ ] **Step 5: PR** — open against `develop` (not `main`), then run `/fix-review` once.
+
+---
+
+## Self-Review (author checklist — completed)
+
+- **Spec coverage:** cohort decode (T1), profile refresh preserving sessions (T2), redeem/dismiss API incl. 409/400 (T3), address form + validation (T4), 5-state derivation + actions incl. congrats copy (T5), tile wiring + legacy-unchanged (T6), button hide + coordinator route guard + path sanitize (T7), backward-compat + QA (T8). All spec sections map to a task.
+- **Placeholder scan:** the only intentionally-summarized code is the four `KoozieTileSection` subviews + `KoozieAddressFormView` (pure layout, no logic, driven entirely by already-defined model strings/actions) — flagged explicitly for the implementer, not left as vague logic.
+- **Type consistency:** `KooziePrizeInfo(prizeId/prizeName/requiredHours)`, `KoozieShippingAddress`, `KoozieTileMode`, `rewardsExperienceType`, `replacingRewardsProfile`, `redeemKooziePrize`, `markKoozieCongratsSeen`, `koozieTileModel`, `showRewardsButton`, `pushRewards`, `sanitizeRewardsRouteForKoozie` used consistently across tasks.
+- **Not tracked in `LONG_RUNNING.md`** (per spec: single-PR iOS change, no soak).
+</content>

--- a/docs/superpowers/specs/2026-08-10-koozie-only-rewards-design.md
+++ b/docs/superpowers/specs/2026-08-10-koozie-only-rewards-design.md
@@ -1,0 +1,219 @@
+# Koozie-Only Rewards Experience for New Users — Design (v2)
+
+**Date:** 2026-08-10
+**Branch:** `briankeane/koozie-only-rewards`
+**Status:** Design approved by user. Server endpoints shipped. Ready for architecture + plan.
+**Supersedes:** `2026-08-08-koozie-only-rewards-design.md` (that version assumed a server
+auto-award + `koozieRequiredHours` on the profile; the server actually shipped a
+**user-initiated redeem with an inline shipping-address capture**, threshold from `/tiers`,
+koozie identified by `slug`).
+
+## Overview
+
+New users (server-designated cohort) get a stripped-down rewards experience: instead of
+the full multi-tier "Listener Rewards" page, they can only earn a **Koozie**. Progress
+toward it, claiming it (with a US shipping address), a one-time congrats, and a quiet
+earned state all live **inline on the Home screen's existing Listening Time tile**. For
+these users the Rewards page and the Profile "Rewards" button are removed.
+
+Existing ("full-tiers") users are **completely unchanged**.
+
+This is a **client-reads / server-owns** design: the server owns cohort assignment, the
+koozie threshold, earning/claim, fulfillment, and the congrats email. The client reads
+that state and renders it; it never invents or locally persists reward state. Every new
+server field is optional — **absent ⇒ exactly today's behavior**, so `develop` stays
+deployable even if the client ships before (or without) the server.
+
+## Cohort & data sources
+
+- **Cohort flag:** `RewardsProfile.rewardsExperience: String?` (new, self-only). Parsed to
+  an enum with a conservative fallback:
+
+  ```swift
+  enum RewardsExperience: Equatable {
+    case fullTiers   // absent / null / ANY unrecognized value
+    case koozieOnly  // "koozie_only"
+  }
+  ```
+
+  Unknown string ⇒ `.fullTiers` (never koozie-only), per the repo's "server enums need a
+  safe unknown fallback" rule.
+
+- **Threshold + koozie identity:** from the existing public `GET /v1/rewards/tiers`. Each
+  `Prize` now carries `slug: String?`. Find the prize with `slug == "koozie"`; take its
+  `id` (the `prizeId` for redeem) and its tier's `requiredListeningHours` (the threshold —
+  50 today; **read it, don't hardcode**). No hardcoded UUID.
+
+- **Earned / congrats:** `RewardsProfile.koozieEarned: Bool?` and
+  `RewardsProfile.shouldShowKoozieCongrats: Bool?` (new, self-only, koozie-cohort only).
+  `koozieEarned` is true once claimed and stays true after congrats is dismissed;
+  `shouldShowKoozieCongrats` is true only while earned AND the in-app congrats has not been
+  dismissed.
+
+- **Prize name (congrats copy):** the koozie `Prize.name` from `/tiers`.
+
+All koozie state rides on the already-fetched `listeningTracker.rewardsProfile`
+(`MainContainerModel.loadListeningTracker`). **No new durable `@Shared` koozie flag** — the
+profile is the single source of truth (survives reinstall / second device).
+
+## Live counter (unchanged calculation)
+
+Progress and the redeem-enable threshold reuse the tile's **existing live counter**,
+`listeningTracker.totalListenTimeMS` (= local sessions + server `totalTimeListenedMS`),
+already computed and ticking every second in `ListeningTimeTileModel`. No new calculation.
+
+## State machine
+
+One derived `ListeningTimeTileMode`, owned by the tile **model** (the SwiftUI view stays
+logic-free and just renders the header counter + a mode-driven bottom section):
+
+| Mode | Condition | Bottom section |
+|---|---|---|
+| `.legacyRewards` | not `.koozieOnly` | **unchanged** — live counter + "Redeem Your Rewards!" button |
+| `.koozieInProgress(hoursRemaining, progress)` | koozie, `!koozieEarned`, live hrs `<` threshold | koozie icon · "Playola Koozie" · "Xh Ym of listening to go" · "NN%" + progress bar |
+| `.koozieClaimable` | koozie, `!koozieEarned`, live hrs `≥` threshold | "You earned a koozie!" + **Redeem your koozie** button (no ✕) |
+| `.koozieAddressForm` | *(client-only sub-state of Claimable)* | "Where should we send it? · US addresses only. We'll only use this to ship your koozie." + address fields + **Back** / **Send my koozie** |
+| `.koozieCongrats` | koozie, `koozieEarned`, `shouldShowKoozieCongrats` | "Congrats on winning your {prizeName}!" + **✕ dismiss** |
+| `.koozieEarned` | koozie, `koozieEarned`, `!shouldShowKoozieCongrats` | quiet row: "Koozie redeemed — check your email" |
+
+Notes:
+- **Distance/percent are live** off the local counter (smooth countdown); the **earned
+  flip is server-authoritative** (only changes after a successful claim + profile refetch).
+- **Claimable → Congrats are two separate states**, not one card. The ✕ (dismiss) calls
+  `koozie-congrats-seen`, which the server rejects with **409 KOOZIE_NOT_EARNED** before a
+  claim — so a dismiss is only offered post-claim. Redeem (button) and dismiss (✕) act on
+  different server states.
+- **Address form is client-only UI state** entered by tapping "Redeem your koozie" and
+  left via "Back" (→ Claimable) or "Send my koozie" (→ submit). Backgrounding without
+  submitting returns to Claimable on next launch (`koozieEarned` still false).
+- There is **no "pending verification" state** (the old spec's server-auto-award lag): the
+  earned flip is caused by the user's own claim, so the only transient is the in-flight
+  submit, shown as a busy state on "Send my koozie".
+
+## Actions
+
+### Redeem (Send my koozie)
+`POST /v1/rewards/users/me/prizes/{kooziePrizeId}/redeem`
+
+Body:
+```json
+{
+  "shippingAddress": {
+    "fullName": "…",       // required
+    "addressLine1": "…",   // required
+    "addressLine2": "…",   // optional (omit when empty)
+    "city": "…",           // required
+    "state": "TX",         // required, 2-letter US code (server uppercases)
+    "postalCode": "78704"  // required, ##### or #####-####
+                           // country omitted (server defaults to "US")
+  }
+  // stationId omitted for the koozie
+}
+```
+- **201** → claimed; server sends the congrats email. Response is the `UserPrize` (with the
+  address snapshot); the client does not need to read it — it re-fetches the profile.
+- **409** ("Prize already redeemed", incl. concurrent double-tap) → **treat as success**
+  (idempotent). Re-fetch profile.
+- **400** (missing/invalid address or bad UUID) → surface an inline error on the form using
+  the server's `error.message`; keep the form open so the user can fix it. (Client also
+  validates ZIP `#####`/`#####-####` first for a nicer message.)
+- On success (201 or 409) → **re-fetch profile** → `koozieEarned: true`,
+  `shouldShowKoozieCongrats: true` → drives `.koozieCongrats`.
+
+Field mapping (form → body): Full name → `fullName`, Street address → `addressLine1`
+(+ optional line 2 → `addressLine2`), City → `city`, State → `state`, ZIP → `postalCode`.
+
+### Dismiss congrats (✕)
+`POST /v1/rewards/users/me/koozie-congrats-seen` (no body; mirrors `welcome-message-seen`).
+- **204** → recorded (write-once + idempotent).
+- 409 KOOZIE_NOT_EARNED / other → tolerated (we only offer ✕ in `.koozieCongrats`, so this
+  is defensive).
+- Optimistically drop to `.koozieEarned`; reconcile on the next profile fetch
+  (`shouldShowKoozieCongrats: false`).
+
+### Profile refresh preserving local sessions
+After redeem/dismiss the client must refresh the rewards profile to pick up the new flags.
+Today's `loadListeningTracker` rebuilds `ListeningTracker(rewardsProfile:)` with an **empty**
+`localListeningSessions`, which would reset the live local delta mid-session. The refresh
+used here must **preserve the current tracker's `localListeningSessions`** (build the new
+tracker with the existing sessions). This is a shared concern with `MainContainerModel`.
+
+## Removals for koozie users
+
+- **Home tile:** no "Redeem Your Rewards!" button (the koozie sections replace it).
+- **Profile (Contact) page:** hide the "Rewards" button — model exposes
+  `showRewardsButton: Bool` (false for koozie-only); the view stays control-flow-free.
+- **Guard the route, not just the button:** the `.rewardsPage` destination is inert
+  (no-op / not pushed) for koozie users so nav-state restoration / deep links can't surface
+  the legacy page. The route + model stay in code, just unused for this cohort.
+
+Full-tiers users: **zero change** to Home, Profile, Rewards page, or the tile.
+
+## Address form (inline in the tile)
+
+Per the mockup the form is **inline in the Listening Time tile** (not a sheet), rendered
+below the live counter in `.koozieAddressForm`.
+
+- Fields (all trimmed): Full name, Street address, (optional) address line 2, City, State
+  (2-letter), ZIP. US-only helper copy.
+- **Model owns validation & enablement:** "Send my koozie" enabled only when required
+  fields are non-empty and ZIP matches `^\d{5}(-\d{4})?$`. Field values are model state
+  exposed as bindings; the view has no logic.
+- "Back" returns to `.koozieClaimable` (fields retained in-session is fine).
+- Keyboard/scroll: the tile lives on the Home scroll view; ensure the form is reachable
+  above the keyboard (implementation detail; no design impact).
+
+## Model ownership
+
+`ListeningTimeTileModel` (the model layer) owns: the koozie `mode` derivation, **all**
+display copy, progress values, the address-form field state + validation, and the redeem /
+dismiss / profile-refresh actions. It gains `@Dependency(\.api)` and `@Shared(.auth)` (for
+the authenticated calls) in addition to its existing `listeningTracker` + clock. The
+`ListeningTimeTile` **view** renders header + mode-driven bottom section and address-form
+bindings only — no logic. (Whether the address-form state is a small nested value/model is
+an architecture-phase decision.)
+
+`ContactPageModel` gains read access to `rewardsExperience` (via
+`listeningTracker.rewardsProfile`) to drive `showRewardsButton` and the route guard.
+
+## Backward compatibility & sequencing
+
+- **Client before/without server fields:** `rewardsExperience` absent ⇒ `.fullTiers` ⇒
+  today's behavior exactly; missing `koozieEarned` / `shouldShowKoozieCongrats` / `slug`
+  tolerated as nil. `develop` stays deployable at every step.
+- **Client after server:** all new behavior gated solely on `rewardsExperience ==
+  .koozieOnly`. Server endpoints are already live.
+
+## Testing
+
+swift-testing, `@MainActor`, `@Suite(.freshSharedState)`; mock via `withDependencies`;
+`expectNoDifference` for value comparisons. (See CLAUDE.md testing rules + pfw-testing /
+pfw-custom-dump.)
+
+- Cohort decode: absent ⇒ `.fullTiers`; `"koozie_only"` ⇒ `.koozieOnly`; unknown ⇒
+  `.fullTiers`.
+- `Prize.slug` decodes (present / absent → nil). Koozie lookup by slug picks the right
+  `prizeId` + tier `requiredListeningHours`.
+- Tile mode derivation: each mode from representative inputs, including the
+  claimable boundary (live hrs crossing threshold with `koozieEarned == false`).
+- Address form: "Send my koozie" enablement (required fields, ZIP regex); Back returns to
+  Claimable.
+- Redeem: builds the correct body from form fields; 201 → refetch → `.koozieCongrats`;
+  **409 treated as success** → refetch; 400 surfaces the server message inline and keeps
+  the form open.
+- Dismiss: optimistic hide + calls `koozie-congrats-seen`; reconciles when the profile
+  returns `shouldShowKoozieCongrats == false`.
+- Profile refresh preserves `localListeningSessions` (live counter not reset).
+- `ContactPageModel.showRewardsButton` false for koozie-only, true otherwise; `.rewardsPage`
+  route inert for koozie-only.
+- Backward compat: all new fields absent ⇒ Home / Contact / Rewards behave exactly as today.
+
+## Out of scope
+
+- Any change to the three-tier experience for existing users.
+- Server implementation (already shipped: redeem-with-address, `koozie-congrats-seen`,
+  profile cohort fields, `slug` on prizes).
+- `LONG_RUNNING.md` soak tracking (not tracked there; single-PR iOS change).
+- Collecting anything beyond the US shipping address; non-US addresses.
+</content>
+</invoke>

--- a/docs/superpowers/specs/2026-08-10-koozie-only-rewards-design.md
+++ b/docs/superpowers/specs/2026-08-10-koozie-only-rewards-design.md
@@ -50,7 +50,8 @@ deployable even if the client ships before (or without) the server.
   `shouldShowKoozieCongrats` is true only while earned AND the in-app congrats has not been
   dismissed.
 
-- **Prize name (congrats copy):** the koozie `Prize.name` from `/tiers`.
+- **Prize name (congrats copy):** the koozie `Prize.name` from `/tiers`. Congrats reads
+  "You've earned a {prizeName}! Thanks for listening!".
 
 All koozie state rides on the already-fetched `listeningTracker.rewardsProfile`
 (`MainContainerModel.loadListeningTracker`). **No new durable `@Shared` koozie flag** — the
@@ -73,7 +74,7 @@ logic-free and just renders the header counter + a mode-driven bottom section):
 | `.koozieInProgress(hoursRemaining, progress)` | koozie, `!koozieEarned`, live hrs `<` threshold | koozie icon · "Playola Koozie" · "Xh Ym of listening to go" · "NN%" + progress bar |
 | `.koozieClaimable` | koozie, `!koozieEarned`, live hrs `≥` threshold | "You earned a koozie!" + **Redeem your koozie** button (no ✕) |
 | `.koozieAddressForm` | *(client-only sub-state of Claimable)* | "Where should we send it? · US addresses only. We'll only use this to ship your koozie." + address fields + **Back** / **Send my koozie** |
-| `.koozieCongrats` | koozie, `koozieEarned`, `shouldShowKoozieCongrats` | "Congrats on winning your {prizeName}!" + **✕ dismiss** |
+| `.koozieCongrats` | koozie, `koozieEarned`, `shouldShowKoozieCongrats` | "You've earned a {prizeName}! Thanks for listening!" + **✕ dismiss** |
 | `.koozieEarned` | koozie, `koozieEarned`, `!shouldShowKoozieCongrats` | quiet row: "Koozie redeemed — check your email" |
 
 Notes:

--- a/docs/superpowers/specs/2026-08-10-koozie-only-rewards-design.md
+++ b/docs/superpowers/specs/2026-08-10-koozie-only-rewards-design.md
@@ -111,13 +111,20 @@ Body:
   // stationId omitted for the koozie
 }
 ```
+**API design (locked):** a **new** `redeemKooziePrize(jwt, prizeId, address)` client
+method (do **not** overload the station-shaped `redeemPrize`), with a typed
+`KoozieShippingAddress: Encodable` body built via a manual `serializingData().response`
+path (the generic `[String:String]` helpers can't express the nested JSON and discard the
+error body). HTTP handling lives **inside the live dependency closure** — models never
+inspect `AFError`:
 - **201** → claimed; server sends the congrats email. Response is the `UserPrize` (with the
-  address snapshot); the client does not need to read it — it re-fetches the profile.
-- **409** ("Prize already redeemed", incl. concurrent double-tap) → **treat as success**
-  (idempotent). Re-fetch profile.
-- **400** (missing/invalid address or bad UUID) → surface an inline error on the form using
-  the server's `error.message`; keep the form open so the user can fix it. (Client also
-  validates ZIP `#####`/`#####-####` first for a nicer message.)
+  address snapshot); the client does not read it — it re-fetches the profile.
+- **409** ("Prize already redeemed", incl. concurrent double-tap) → **caught in the
+  dependency and returned as success** (idempotent). Re-fetch profile.
+- **400** (missing/invalid address or bad UUID) → dependency throws
+  `APIError.validationError(serverMessage)` (parsed from `error.message`); the model shows
+  it inline on the form and keeps the form open. (Client validates ZIP `#####`/`#####-####`
+  first for a nicer message.)
 - On success (201 or 409) → **re-fetch profile** → `koozieEarned: true`,
   `shouldShowKoozieCongrats: true` → drives `.koozieCongrats`.
 
@@ -125,28 +132,40 @@ Field mapping (form → body): Full name → `fullName`, Street address → `add
 (+ optional line 2 → `addressLine2`), City → `city`, State → `state`, ZIP → `postalCode`.
 
 ### Dismiss congrats (✕)
+New `markKoozieCongratsSeen(jwt)` void POST →
 `POST /v1/rewards/users/me/koozie-congrats-seen` (no body; mirrors `welcome-message-seen`).
 - **204** → recorded (write-once + idempotent).
-- 409 KOOZIE_NOT_EARNED / other → tolerated (we only offer ✕ in `.koozieCongrats`, so this
-  is defensive).
+- 409 KOOZIE_NOT_EARNED / other → **tolerated as success inside the dependency** (we only
+  offer ✕ in `.koozieCongrats`, so this is defensive).
 - Optimistically drop to `.koozieEarned`; reconcile on the next profile fetch
   (`shouldShowKoozieCongrats: false`).
 
 ### Profile refresh preserving local sessions
 After redeem/dismiss the client must refresh the rewards profile to pick up the new flags.
 Today's `loadListeningTracker` rebuilds `ListeningTracker(rewardsProfile:)` with an **empty**
-`localListeningSessions`, which would reset the live local delta mid-session. The refresh
-used here must **preserve the current tracker's `localListeningSessions`** (build the new
-tracker with the existing sessions). This is a shared concern with `MainContainerModel`.
+`localListeningSessions`, which would visibly jump the live timer backward mid-session.
+
+**Mechanism (locked):** add a preservation primitive on `ListeningTracker`, e.g.
+`replacingRewardsProfile(_ profile:) -> ListeningTracker`, that carries over the current
+`localListeningSessions`. Use it from **both** `MainContainerModel.loadListeningTracker`
+(fixing the existing reset at `MainContainerModel.swift:255`) and the koozie redeem/dismiss
+refresh. **Snapshot the sessions at assignment time — after the network await, not before**
+— so a slow profile fetch can't overwrite sessions accrued while it was in flight. All
+writes are on the main actor; the 1s loop only reads `totalListenTimeMS`, so main-actor
+replacement of the shared tracker is safe.
 
 ## Removals for koozie users
 
 - **Home tile:** no "Redeem Your Rewards!" button (the koozie sections replace it).
 - **Profile (Contact) page:** hide the "Rewards" button — model exposes
   `showRewardsButton: Bool` (false for koozie-only); the view stays control-flow-free.
-- **Guard the route, not just the button:** the `.rewardsPage` destination is inert
-  (no-op / not pushed) for koozie users so nav-state restoration / deep links can't surface
-  the legacy page. The route + model stay in code, just unused for this cohort.
+- **Guard the route at the coordinator, not just the button** (locked): hiding buttons +
+  no-op `onRewardsTapped` is cosmetic — restored nav state or a stray push can still land on
+  `.rewardsPage`, which renders unconditionally today
+  (`MainContainerNavigationCoordinator.swift:90`). Guard the push/append entry points for
+  `.rewardsPage` and **sanitize the existing profile path** (drop any `.rewardsPage`
+  entries) when a koozie-only profile loads. The route + model stay in code, just
+  unreachable for this cohort.
 
 Full-tiers users: **zero change** to Home, Profile, Rewards page, or the tile.
 
@@ -164,18 +183,26 @@ below the live counter in `.koozieAddressForm`.
 - Keyboard/scroll: the tile lives on the Home scroll view; ensure the form is reachable
   above the keyboard (implementation detail; no design impact).
 
-## Model ownership
+## Model ownership (locked in architecture pass — Codex consult 2026-08-10)
 
-`ListeningTimeTileModel` (the model layer) owns: the koozie `mode` derivation, **all**
-display copy, progress values, the address-form field state + validation, and the redeem /
-dismiss / profile-refresh actions. It gains `@Dependency(\.api)` and `@Shared(.auth)` (for
-the authenticated calls) in addition to its existing `listeningTracker` + clock. The
-`ListeningTimeTile` **view** renders header + mode-driven bottom section and address-form
-bindings only — no logic. (Whether the address-form state is a small nested value/model is
-an architecture-phase decision.)
-
-`ContactPageModel` gains read access to `rewardsExperience` (via
-`listeningTracker.rewardsProfile`) to drive `showRewardsButton` and the route guard.
+- **`ListeningTimeTileModel` stays thin.** It keeps its existing 1s live-counter loop and
+  legacy button behavior **byte-for-byte unchanged**, and only gains a selector between
+  `.legacy` and `.koozie(KoozieTileModel)`. Do **not** fatten it into a rewards workflow
+  object, and do **not** have a parent (Home) inject the mode (that would move reward
+  derivation + timing into the page). This keeps the reusable tile reusable.
+- **`KoozieTileModel` (new, `@Observable`)** owns the koozie concerns: mode derivation
+  (from `rewardsExperience` / `koozieEarned` / `shouldShowKoozieCongrats` / live hrs vs
+  threshold), **all** koozie copy + progress values, the redeem / dismiss / profile-refresh
+  actions, and the tiers lookup (`slug == "koozie"` → `prizeId` + `requiredListeningHours`).
+  It holds `@Dependency(\.api)`, `@Shared(.auth)`, `@Shared(.listeningTracker)`.
+- **`KoozieAddressFormModel` (new, nested `@Observable`)** owns the form: bindable fields
+  (fullName / addressLine1 / addressLine2 / city / state / postalCode), trimming, ZIP
+  validation, `canSubmit`, the trimmed `KoozieShippingAddress` payload, and the inline
+  server-error string. Keeps the tile model out of "junk-drawer" territory.
+- The `ListeningTimeTile` **view** renders header + a mode-driven bottom section and binds
+  to the form fields only — no logic.
+- **`ContactPageModel`** gains read access to `rewardsExperience` (via
+  `listeningTracker.rewardsProfile`) to drive `showRewardsButton`.
 
 ## Backward compatibility & sequencing
 


### PR DESCRIPTION
## Koozie-only rewards for new users

Server-designated **new users** (`rewardsExperience == "koozie_only"`) get a stripped-down rewards experience inline on the Home **Listening Time** tile: progress toward a single Koozie → claim it with a US shipping address → congrats → quiet earned state. The multi-tier Rewards page + Profile "Rewards" button are removed for them. **Existing users are byte-for-byte unchanged** (every new server field is optional; absent ⇒ today's behavior).

Server-owns / client-reads: the client never invents or persists earned/dismissed state — it re-derives everything from the profile.

### Tile states (koozie cohort)
| Mode | Condition | UI |
|---|---|---|
| In progress | `!koozieEarned`, live hrs < threshold | "Playola Koozie · Xh Ym of listening to go · NN%" + bar |
| Claimable | `!koozieEarned`, live hrs ≥ threshold | "You earned a koozie!" + **Redeem your koozie** |
| Address form | (client-only) | "Where should we send it?" + fields + Back / **Send my koozie** |
| Congrats | `koozieEarned` + `shouldShowKoozieCongrats` | "You've earned a {prizeName}! Thanks for listening!" + ✕ |
| Earned | `koozieEarned`, dismissed | "Koozie redeemed — check your email" |

### Contract
- Threshold + koozie identity from `GET /v1/rewards/tiers` — prize with `slug == "koozie"` → `prizeId` + tier `requiredListeningHours` (no hardcoding).
- `POST …/prizes/{id}/redeem` with `{shippingAddress:{fullName,addressLine1,addressLine2?,city,state,postalCode}}`; **201 or 409 → claimed** (idempotent); **400 → inline error** from `error.message`.
- Dismiss: `POST …/koozie-congrats-seen` (204; 409 tolerated).

### Architecture notes
- Thin `ListeningTimeTileModel` selects `.legacy` vs a new `KoozieTileModel`; nested `KoozieAddressFormModel`; `KoozieTileSection` view (all copy/logic in the models).
- Koozie flags ride on `listeningTracker.rewardsProfile` (no new durable `@Shared`). Mid-session refresh **merges only the koozie flags**, keeping time totals so the live counter never jumps or double-counts.
- Tiers load is decoupled from the 1s counter loop into a **backoff-retry task** (retries transient `/tiers` failures; cancelled on teardown).
- Rewards removed via `ContactPageModel.showRewardsButton` + coordinator `pushRewards` guard + `sanitizeRewardsRouteForKoozie` (strips restored `.rewardsPage` state).

### Testing
- New suites: `RewardsExperienceTests`, `KoozieAddressFormModelTests`, `KoozieTileModelTests`; extended `ListeningTimeTileModelTests`, `ContactPageTests`, `MainContainerNavigationCoordinatorTests`, `ListeningTrackerTests`.
- Covers: cohort/slug decode, 5-state derivation, redeem success→congrats + 400 inline + state uppercased, optimistic dismiss→earned, merge-keeps-total, tiers single-launch + retry-on-failure + cancellation, legacy path unchanged, route guard/sanitize.
- **Full suite: 1277 tests / 81 suites green** (Xcode 26.5.0). `make lint` clean.
- Reviewed via Codex (architect consult + 2 adversarial rounds); all P1/P2 findings fixed (double-count, tiers-brick, counter-stall, task leak).

### Known residuals (low risk, flagged not fixed)
- Pre-load window: before the first profile fetch completes, a koozie user could briefly reach Rewards; self-heals when `sanitizeRewardsRouteForKoozie` runs on profile load.
- `Path.destinationView` still renders `.rewardsPage` unconditionally — all current push sites are guarded + state is sanitized, so it's only a concern for a hypothetical future raw `push(.rewardsPage)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a koozie-only rewards experience with live listening progress and claimable reward states.
  * Added US shipping address collection, validation, and koozie prize redemption.
  * Added congratulations messaging with dismissal support.
  * Preserved the existing full-tier rewards experience for eligible customers.
  * Hid and protected legacy Rewards navigation for koozie-only customers.
* **Bug Fixes**
  * Preserved local listening history when rewards information refreshes.
  * Added handling for duplicate redemption requests and server validation errors.
* **Documentation**
  * Added design and implementation documentation for the koozie rewards experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->