### PR TITLE
hotfix(7.5.1): prefer HTTP/3 on Playola API — fix sign-in/stations on TCP-hostile networks

### DIFF
--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -19,7 +19,7 @@ not ✅ done until its soak clears.
 > Entries marked `⟨owner: …⟩` are placeholders the task owner should fill in —
 > I scaffolded them from open PRs/branches but don't know the internal plan.
 
-_Last updated: 2026-08-08_
+_Last updated: 2026-08-19_
 
 ---
 
@@ -27,7 +27,7 @@ _Last updated: 2026-08-08_
 
 | Task | Status | Current step | Soak | Links |
 |------|--------|--------------|------|-------|
-| Host-owned audio → Sonos | 🟡 soaking | Phase 1 in prod (phased, from 2026-08-08); Phase 2+3 merged to develop, soaking on staging | Phase 1: prod phased rollout · Phase 2+3: staging soak from 2026-08-08 | PR #345 · #384 · plan |
+| Host-owned audio → Sonos | 🟡 soaking | Phase 1 done (7.4.2 at 100% since ~2026-08-09, canary clean); Phase 2+3 shipping to prod in 7.5.1 (this PR) | Phase 2+3: prod phased rollout via 7.5.1 (submission held on device matrix) | PR #345 · #384 · #402 · plan |
 | Clip share | 🔵 in progress | ⟨owner: current step⟩ | none (standard release) | PR #219 |
 | Rewards → Your Library | 🔵 in progress | Rewards→Profile, Library tab, Presets move | none | PR #372 · `fix-library-requests-ui` |
 | Siri "Play on Playola" (App Intents media schema) | 🟢 planning | Approach B decided (2026-06-14); not started | n/a | — |
@@ -84,21 +84,29 @@ CarPlay teardown, speaker-stuck-after-recording) along the way.
 ### Phases
 
 - [x] **Phase 0 — SDK host-only** (shipped as PlayolaPlayer 0.20.0 → 0.20.2)
-- [x] **Phase 1 — app owns session + interruptions** (PR #345) — released to production 2026-08-08 (🟡 phased-rollout soak)
-- [x] **Phase 2 — single Now Playing writer** (low risk, PR #384) — 🟡 merged to develop, soaking on staging (removes URLStreamPlayer's MPNowPlayingInfoCenter writes; NowPlayingUpdater sole writer)
+- [x] **Phase 1 — app owns session + interruptions** (PR #345) — ✅ done. Shipped in 7.4.2 (build 103); went to **100% immediately** (no phased rollout, despite the plan). Field adoption from ~2026-08-09. Canary verified clean 2026-08-19: listening minutes/session *up* post-rollout, zero new audio clusters in Sentry, and the one real CoreAudio issue (APPLE-IOS-1P "player did not see an IO cycle") has zero events on 7.4.2.
+- [x] **Phase 2 — single Now Playing writer** (low risk, PR #384) — 🟡 shipping to prod in **7.5.1** (PR #402); staging-soaked since 2026-08-08 (removes URLStreamPlayer's MPNowPlayingInfoCenter writes; NowPlayingUpdater sole writer)
 - [ ] **Verify URL stations → Sonos** (quick AirPlay-2 check; possible early win)
-- [x] **Phase 3 — single state-derivation source** (PR #384) — 🟡 merged to develop, soaking on staging (StationPlayer is the sole `@Shared(.nowPlaying)` writer + single derivation authority; NowPlayingUpdater is now a pure renderer of `stationPlayer.$state`; structural + behavioral tests guard it)
+- [x] **Phase 3 — single state-derivation source** (PR #384) — 🟡 shipping to prod in **7.5.1** (PR #402); staging-soaked since 2026-08-08 (StationPlayer is the sole `@Shared(.nowPlaying)` writer + single derivation authority; NowPlayingUpdater is now a pure renderer of `stationPlayer.$state`; structural + behavioral tests guard it)
 - [ ] **Owned URLStreamBackend** (retire the vendored FRadioPlayer fork; optional)
 - [ ] **Phase 5 — Sonos renderer** (AVSampleBuffer render path; big; own plan + server-flag rollout)
 
 ### Current step
 
-Phase 1 **released to production 2026-08-08** (phased rollout under way). That lifted the
-hold on PR #384 — the hold existed so the Phase 1 *staging* soak canary stayed attributable
-to Phase 1 alone; Phase 1 is now off staging, so Phase 2+3 can soak there without
-contaminating it (different metric stream from Phase 1's prod rollout).
+**Shipping Phase 2+3 to production via 7.5.1 (PR #402, this PR).** What happened between
+the last update and now, discovered 2026-08-19:
 
-**Phase 2 + Phase 3 merged to develop together (PR #384) and are now soaking on staging.**
+- 7.4.2 (Phase 1) shipped to **100% immediately** — it was never a phased rollout. It's been
+  in the field at scale since ~2026-08-09 with clean metrics (see Phase 1 checklist entry).
+- **7.5.0 was tagged (`v7.5.0-b103`) and its build uploaded to TestFlight (build 104) but
+  never submitted to the App Store** — no 7.5.0 version record exists in ASC. The release
+  process ends at TestFlight; the ASC submission step is manual and silently didn't happen.
+  Its payload (Phase 2+3 + iPad layouts) therefore ships in 7.5.1 instead.
+- Phase 2+3's gates were re-verified 2026-08-19: staging soak 11 days (> the ~1-week bar),
+  Mixpanel canary flat-to-up, Sentry clean. **Remaining gate: the device matrix below —
+  the 7.5.1 ASC submission is held until it passes.**
+
+**Phase 2 + Phase 3 (merged to develop 2026-08-08, PR #384).**
 Phase 2 (single MPNowPlayingInfoCenter writer): URLStreamPlayer no longer writes the lock
 screen, NowPlayingUpdater is the sole writer. Phase 3 (single state-derivation source):
 StationPlayer is the sole writer of `@Shared(.nowPlaying)` and the single derivation
@@ -106,11 +114,10 @@ authority — its backend processors publish `nowPlaying` as a projection of `st
 two can't drift); NowPlayingUpdater is a pure renderer of `stationPlayer.$state`. Both
 guarded by structural + behavioral tests.
 
-**Next:** cut a staging TestFlight build (`fastlane release_staging` from develop), soak ~1
-week (see "Soak — Phase 2+3"). **Do NOT cut the Phase 2+3 production release while Phase 1's
-phased prod rollout is still in flight** — stacking two audio changes on real listeners
-re-muddies prod attribution. Gate the prod cut on: staging soak clean AND Phase 1 prod
-rollout completed cleanly.
+**Next:** device matrix on the 7.5.1 build → create ASC version 7.5.1, attach the build,
+**phased release ON** (7.4.2 skipped it; for an audio change we want the pause lever), submit.
+Watch the canary across the 7-day rollout. Koozie/develop content waits for the next release
+(7.6.x) so this rollout's audio attribution stays clean.
 
 Behavior change to note: URL stations now surface their ICY track artwork in the in-app
 now-playing UI (SmallPlayer / PlayerPage), consistent with Playola stations. Phase 3 makes
@@ -121,23 +128,21 @@ write is guarded to the URL backend so the stale `artworkDidChange(nil)` that ev
 play triggers via `reset()` can't blank the active Playola spin's artwork. Lock-screen
 artwork (station image) is unchanged.
 
-### Soak — Phase 1
+### Soak — Phase 1 (✅ cleared 2026-08-19)
 
-- **Environment:** staging TestFlight (cleared) → App Store phased rollout, **live from 2026-08-08**.
-- **Now:** in production phased rollout. Watch the go/no-go metrics below across the
-  rollout; hold Phase 2+3's *production* cut until this rollout completes cleanly.
-- **Watch (go/no-go metrics):** Mixpanel `listeningSessionStarted` count + session
-  length (the canary — a dip means audio broke in the field without a crash);
-  Sentry for new `AVAudioSession` / `engine.start` error clusters.
-- **Rollback lever:** known-good prior version is PlayolaPlayer **0.19.0**. Now that
-  Phase 1 is live, roll back by shipping a build repinned to 0.19.0 (phased release
-  again) — reverting source does *not* change binaries already installed.
+- Shipped in 7.4.2 (build 103), live at **100% from ~2026-08-09** (released all-at-once,
+  not phased). ~11 days of field exposure at 87% adoption of the active listening base.
+- **Canary results (verified 2026-08-19):** weekly `listeningSessionStarted` flat through
+  the rollout (the 7.4.2-crossover week was the highest of the four-week window); per-user
+  session counts on 7.4.2 ≥ same-window 7.3.1; server-side listening minutes hit the
+  window's high the week 7.4.2 owned the base, with avg session length up 28.5 → 32.7 min.
+  Sentry: zero new audio clusters; APPLE-IOS-1P (CoreAudio IO-cycle) has no 7.4.2 events.
+- **Rollback lever (unchanged, now historical):** repin PlayolaPlayer 0.19.0 and ship.
 
 ### Soak — Phase 2+3
 
-- **Environment:** staging TestFlight (from develop) → later a production phased rollout.
-- **Soaking since:** 2026-08-08 (merged to develop). Cut the staging build with
-  `fastlane release_staging` from develop; the "~1 week clean" clock runs from that build.
+- **Environment:** staging TestFlight (from develop) → production phased rollout via 7.5.1.
+- **Staging soak:** 2026-08-08 → 2026-08-19 (11 days, clean) — the ~1-week bar is met.
 - **Device matrix (must pass before the production cut) — focused on the now-playing
   surface these phases change:** lock screen shows the correct track/title/artist ·
   **CarPlay Now Playing is NOT dismissed when a Playola station starts** (the `.urlNotSet`
@@ -148,11 +153,11 @@ artwork (station image) is unchanged.
 - **Watch (go/no-go metrics):** same canary — Mixpanel `listeningSessionStarted` count +
   session length; Sentry for `AVAudioSession` / `engine.start` clusters and any new
   MediaPlayer/now-playing errors.
-- **Advance when:** device matrix passes AND ~1 week clean staging dogfooding AND Mixpanel
-  session metrics flat **AND Phase 1's production rollout has completed cleanly**. Then cut
-  the Phase 2+3 production release.
-- **Rollback lever:** revert the PR #384 merge on develop; nothing shipped to production
-  until the gate above is met, so pre-prod rollback is just not cutting the release.
+- **Advance when:** device matrix passes (**the only gate still open** — staging soak,
+  Mixpanel, Sentry, and Phase 1 all verified clean 2026-08-19). Then submit 7.5.1 in ASC
+  with phased release ON.
+- **Rollback lever:** before ASC submission — just don't submit. During the phased rollout —
+  pause it in ASC; if a fix is needed, revert PR #384 on a hotfix branch from main and ship.
 
 ### Notes
 

--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -2572,7 +2572,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2592,7 +2592,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.5.0;
+				MARKETING_VERSION = 7.5.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2617,7 +2617,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2637,7 +2637,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.5.0;
+				MARKETING_VERSION = 7.5.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2662,7 +2662,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
 				ENABLE_PREVIEWS = YES;
@@ -2682,7 +2682,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.5.0;
+				MARKETING_VERSION = 7.5.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio.staging;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2828,7 +2828,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = CTFSB7Y8TD;
@@ -2850,7 +2850,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.5.0;
+				MARKETING_VERSION = 7.5.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2875,7 +2875,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Distribution";
 				CODE_SIGN_STYLE = Manual;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = FSRSPV9N9Q;
@@ -2897,7 +2897,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.5.0;
+				MARKETING_VERSION = 7.5.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -2917,7 +2917,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -2938,7 +2938,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -3028,7 +3028,7 @@
 				CODE_SIGN_ENTITLEMENTS = PlayolaRadio/PlayolaRadio.entitlements;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_ASSET_PATHS = "\"PlayolaRadio/Preview Content\"";
 				DEVELOPMENT_TEAM = CTFSB7Y8TD;
@@ -3050,7 +3050,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 7.5.0;
+				MARKETING_VERSION = 7.5.1;
 				OTHER_SWIFT_FLAGS = "$(inherited) -enable-upcoming-feature InferSendableFromCaptures";
 				PRODUCT_BUNDLE_IDENTIFIER = fm.playola.playolaradio;
 				PRODUCT_NAME = "$(TARGET_NAME)";
@@ -3070,7 +3070,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 103;
+				CURRENT_PROJECT_VERSION = 104;
 				DEVELOPMENT_TEAM = 896JR349G2;
 				GENERATE_INFOPLIST_FILE = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 18.1;
@@ -3152,7 +3152,7 @@
 			repositoryURL = "https://github.com/playola-radio/playola-player-swift";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.20.2;
+				minimumVersion = 0.20.3;
 			};
 		};
 		D30F003A2E8592F0007BCC73 /* XCRemoteSwiftPackageReference "mixpanel-swift" */ = {
@@ -3280,7 +3280,7 @@
 			repositoryURL = "https://github.com/playola-radio/playola-player-swift";
 			requirement = {
 				kind = upToNextMinorVersion;
-				minimumVersion = 0.20.2;
+				minimumVersion = 0.20.3;
 			};
 		};
 		D3FF74D32FA7CA760052D500 /* XCRemoteSwiftPackageReference "swift-custom-dump" */ = {

--- a/PlayolaRadio/Core/API/APIClient+Live.swift
+++ b/PlayolaRadio/Core/API/APIClient+Live.swift
@@ -27,12 +27,15 @@ private struct CreateVoicetrackParameters: Encodable, Sendable {
 
 private let sharedIsoDecoder = JSONDecoderWithIsoFull()
 
-// TEMPORARY: Global TLS 1.2 cap. Every Alamofire request in this file is routed through
-// `apiSession`, which caps the URLSession to TLS 1.2 so the iOS 26 post-quantum ClientHello
-// stays small enough for broken middleboxes to pass through. The policy itself lives in
-// `PlayolaTLS` (single source of truth); the aggregated `tls13_probe` Sentry trend
-// (see `ConnectivityProbe`) tells us when it is safe to revert. Full background there.
-private let apiSession = Alamofire.Session(configuration: PlayolaTLS.mitigated(.af.default))
+// Playola API requests prefer HTTP/3 (QUIC). Some listeners sit behind networks that
+// interfere with TCP to *.playola.fm specifically (host/SNI-targeted resets) while leaving
+// UDP/QUIC alone — the old TLS 1.2 cap was still TCP and never helped them (Sentry
+// `tls13_probe` diagnosis `http3Rescues`). The interceptor sets `assumesHTTP3Capable` on
+// Playola API hosts; QUIC races on the first request and falls back to HTTP/2 over TCP
+// automatically. Policy lives in `PlayolaTLS`. Pairs with the matching PlayolaPlayer SDK fix
+// (0.20.3+), which does the same for schedule fetch + audio.
+private let apiSession = Alamofire.Session(
+  configuration: .af.default, interceptor: PlayolaTLS.http3Interceptor)
 
 private func signInPost(
   authMethod: AuthMethod,

--- a/PlayolaRadio/Core/API/PlayolaTLS.swift
+++ b/PlayolaRadio/Core/API/PlayolaTLS.swift
@@ -21,10 +21,15 @@ import Foundation
 /// unavailable. Only first-party Playola API hosts (which advertise `alt-svc: h3`) get the
 /// hint; third-party hosts (e.g. S3 artwork) are untouched.
 enum PlayolaTLS {
-  /// First-party API hosts we own that advertise HTTP/3. Only these get the QUIC hint.
+  /// First-party API hosts we own. All Playola API subdomains (`admin-api`,
+  /// `admin-api-staging`, `production-api`, …) are on Cloudflare and advertise `alt-svc: h3`,
+  /// so match the whole `*.playola.fm` zone — this keeps staging/TestFlight able to exercise
+  /// the mitigation, and future subdomains work automatically. Non-Playola hosts (e.g. S3
+  /// artwork on `amazonaws.com`) are excluded; `assumesHTTP3Capable` falls back gracefully
+  /// anyway, so an over-match would be harmless.
   static func isPlayolaAPIHost(_ host: String?) -> Bool {
     guard let host else { return false }
-    return host == "admin-api.playola.fm" || host == "production-api.playola.fm"
+    return host == "playola.fm" || host.hasSuffix(".playola.fm")
   }
 
   /// Marks a request to a Playola API host as HTTP/3-preferring. No-op for other hosts.

--- a/PlayolaRadio/Core/API/PlayolaTLS.swift
+++ b/PlayolaRadio/Core/API/PlayolaTLS.swift
@@ -5,35 +5,52 @@
 //  Created by Brian D Keane on 7/10/26.
 //
 
+import Alamofire
 import Foundation
 
-/// Single source of truth for the TEMPORARY iOS 26 TLS mitigation.
+/// Single source of truth for the app's first-party network transport policy.
 ///
-/// On iOS 26, URLSession sends a TLS 1.3 ClientHello that includes the X25519MLKEM768
-/// post-quantum hybrid key share (~1.1 KB). It spans two TCP segments, and some middleboxes
-/// (antivirus SSL inspection, parental-control routers, captive portals, etc.) drop the
-/// oversized ClientHello and surface it as NSURLErrorSecureConnectionFailed (-1200) — every
-/// request fails on those networks. Capping the session to TLS 1.2 keeps the ClientHello small
-/// enough to pass.
+/// Some listeners sit behind networks that interfere with TCP connections to `*.playola.fm`
+/// specifically (host/SNI-targeted resets, SSL-inspection middleboxes) while leaving UDP/QUIC
+/// alone. The earlier mitigation capped URLSession to TLS 1.2 to shrink the iOS 26 post-quantum
+/// ClientHello — but that is still TCP, so it never helped these users (Sentry `tls13_probe`
+/// diagnosis `http3Rescues`: both TLS 1.2 and TLS 1.3 over TCP fail while HTTP/3 succeeds).
 ///
-/// Every first-party URLSession / Alamofire session in the app routes through here so the
-/// policy lives in exactly one place. When we later make this adaptive (try 1.3, fall back to
-/// 1.2) or add HTTP/3, this is the seam to change.
-///
-/// REVERT WHEN: Apple ships an iOS 26 fix (watch the `tls13_probe` Sentry trend) OR exposes a
-/// supported opt-out for the post-quantum hybrid key share so we can keep TLS 1.3.
+/// We now prefer HTTP/3 (QUIC) on Playola API requests via `assumesHTTP3Capable`, which races
+/// QUIC on the very first request and falls back to HTTP/2 over TCP automatically when QUIC is
+/// unavailable. Only first-party Playola API hosts (which advertise `alt-svc: h3`) get the
+/// hint; third-party hosts (e.g. S3 artwork) are untouched.
 enum PlayolaTLS {
-  /// Applies the TLS 1.2 cap to a configuration and returns it. Callers pass whatever base
-  /// configuration they need (default, Alamofire's default, or one with custom caching).
+  /// First-party API hosts we own that advertise HTTP/3. Only these get the QUIC hint.
+  static func isPlayolaAPIHost(_ host: String?) -> Bool {
+    guard let host else { return false }
+    return host == "admin-api.playola.fm" || host == "production-api.playola.fm"
+  }
+
+  /// Marks a request to a Playola API host as HTTP/3-preferring. No-op for other hosts.
+  static func preferHTTP3IfPlayolaHost(_ request: inout URLRequest) {
+    if isPlayolaAPIHost(request.url?.host) {
+      request.assumesHTTP3Capable = true
+    }
+  }
+
+  /// Alamofire interceptor that applies the HTTP/3 hint to every Playola API request issued on
+  /// a `Session`. Attach to the shared `apiSession`.
+  static let http3Interceptor = Adapter { urlRequest, _, completion in
+    var request = urlRequest
+    preferHTTP3IfPlayolaHost(&request)
+    completion(.success(request))
+  }
+
+  /// Shared uncapped `URLSession` for FIRST-PARTY requests that do NOT go through Alamofire
+  /// (e.g. the URL-stream listening-session reporter). Callers set the HTTP/3 hint per request
+  /// via `preferHTTP3IfPlayolaHost`.
+  static let sharedSession = URLSession(configuration: .default)
+
+  /// Caps a configuration to TLS 1.2. Retained ONLY for `ConnectivityProbe`'s diagnostic
+  /// TLS-1.2 measurement leg — production no longer caps TLS. Do NOT use for real requests.
   static func mitigated(_ configuration: URLSessionConfiguration) -> URLSessionConfiguration {
     configuration.tlsMaximumSupportedProtocolVersion = .TLSv12
     return configuration
   }
-
-  /// Shared TLS-mitigated `URLSession` for FIRST-PARTY requests that do NOT go through
-  /// Alamofire (e.g. the listening-session reporter). Deliberately not used for remote artwork
-  /// loaders: those can hit third-party / TLS-1.3-only image hosts, where capping to 1.2 would
-  /// break loads on the healthy majority of networks for no real gain (artwork is cosmetic and
-  /// the main artwork path is SDWebImage, which is uncapped anyway).
-  static let sharedSession = URLSession(configuration: mitigated(.default))
 }

--- a/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
+++ b/PlayolaRadio/Core/AudioPlayback/UrlStreamListeningSessionReporter.swift
@@ -144,6 +144,7 @@ public class UrlStreamListeningSessionReporter {
     request.httpBody = jsonData
     request.addValue("Bearer \(jwtToken)", forHTTPHeaderField: "Authorization")
     request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+    PlayolaTLS.preferHTTP3IfPlayolaHost(&request)
     return request
   }
 }


### PR DESCRIPTION
Emergency hotfix off `main` (7.5.0 → 7.5.1). See `RELEASE.md` → "Emergency hotfix off `main`".

## Why
Some listeners on iOS 26 can't sign in (Apple/Google) or load stations after reinstall. Sentry proves it's a TLS/transport failure, not auth logic: `-1200` handshake errors to `admin-api.playola.fm` (issue **APPLE-IOS-T**), and the shipped `tls13_probe` diagnostic shows the dominant failure is **`http3Rescues` (17 users)** — both TLS 1.2 **and** TLS 1.3 over TCP fail while **HTTP/3 (QUIC/UDP) succeeds**. One affected user's probe fired 10s before his sign-in failed: `apiTLS13=fail, apiTLS12=fail, apiHTTP3=success, control(cloudflare.com/TCP)=success` → host/SNI-targeted TCP interference against `*.playola.fm` that QUIC evades.

The shipped TLS 1.2 cap is **still TCP**, so it never helped these users — and the probe shows it actively broke 5 others (`cappedPathBroken`) while helping only 1 (`clientHelloDrop`).

## What
- `PlayolaTLS` now prefers **HTTP/3** (`assumesHTTP3Capable`) on Playola API hosts instead of capping TLS 1.2. QUIC races on the first request and falls back to HTTP/2 over TCP automatically.
  - Applied via an Alamofire `RequestInterceptor` on the shared `apiSession` (auth + station-list + everything in `APIClient+Live`).
  - Applied per-request in `UrlStreamListeningSessionReporter` (uses `PlayolaTLS.sharedSession`, now uncapped).
- Host match is the whole `*.playola.fm` zone (admin-api, **admin-api-staging**, production-api) — all Cloudflare, all advertise `alt-svc: h3` (verified). S3 artwork/audio (`amazonaws.com`) untouched.
- `PlayolaTLS.mitigated` retained **only** for `ConnectivityProbe`'s TLS-1.2 diagnostic leg.
- Bumps PlayolaPlayer SDK **0.20.2 → 0.20.3** (matching SDK fix: schedule fetch + listening-session reports prefer HTTP/3; playola-player-swift#104). Version **7.5.0 → 7.5.1 (build 104)**.

## Verification
- `xcodebuild build-for-testing` clean; **all 1242 tests / 78 suites pass**.
- SPM resolves PlayolaPlayer to `0.20.3`.
- Codex adversarial review run; both findings triaged (see below).
- `make lint` on changed files clean.

## Codex review triage
- **[P2] staging host** — fixed (matched `*.playola.fm`).
- **[P3] `ConnectivityProbe` still emits `cappedPathBroken`** — **deferred as a follow-up.** Post-fix that label is stale (production no longer caps TLS), but the probe's raw legs (`apiTLS13/apiTLS12/apiHTTP3/control`) are still collected correctly. Reworking the diagnosis taxonomy is a separate change I don't want to cram into an urgent transport hotfix. During soak, read the raw legs (h3 success + APPLE-IOS-T trend), not the `cappedPathBroken` label.

## Soak / watch after release
- Sentry **APPLE-IOS-T** (`-1200` sign-in TLS failures) should fall toward zero.
- `tls13_probe`: `http3Rescues` (17) + `cappedPathBroken` (5) resolve; the 1 `clientHelloDrop` user may regress (accepted — cap helped 1, harmed 22).
- Rollback lever: additive change (removes a cap, adds a QUIC hint). If HTTP/3 misbehaves, repin to `0.20.2` and revert `PlayolaTLS`, reship phased.

Note: the `LONG_RUNNING.md` tracker entry + the `RELEASE.md` emergency-hotfix runbook for this effort live on `develop` (this main-based hotfix is intentionally code-only).