### PR TITLE
style: migrate aspectRatio(contentMode:) to scaledToFit/scaledToFill

### DIFF
--- a/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
+++ b/PlayolaRadio/Views/Pages/BroadcastPage/BroadcastPageView.swift
@@ -195,7 +195,7 @@ struct StagingRowView: View {
             CGSize(width: 40, height: 40), scale: displayScale)
         )
         .resizable()
-        .aspectRatio(contentMode: .fill)
+        .scaledToFill()
         .frame(width: 40, height: 40)
         .clipShape(Circle())
       } else if let icon = item.icon {
@@ -561,7 +561,7 @@ struct ScheduleItemImage: View {
             CGSize(width: 45, height: 45), scale: displayScale)
         )
         .resizable()
-        .aspectRatio(contentMode: .fill)
+        .scaledToFill()
         .frame(width: 45, height: 45)
         .clipped()
       } else {

--- a/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageView.swift
+++ b/PlayolaRadio/Views/Pages/ChooseStationPage/ChooseStationPageView.swift
@@ -43,7 +43,7 @@ private struct StationRow: View {
       ) { image in
         image
           .resizable()
-          .aspectRatio(contentMode: .fill)
+          .scaledToFill()
       } placeholder: {
         Color(white: 0.2)
       }

--- a/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
+++ b/PlayolaRadio/Views/Pages/HomePage/UI Components/HomePageStationList.swift
@@ -31,7 +31,7 @@ struct StationCardView: View {
             ) { image in
               image
                 .resizable()
-                .aspectRatio(contentMode: .fill)
+                .scaledToFill()
             } placeholder: {
               Color(white: 0.3)
             }

--- a/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
+++ b/PlayolaRadio/Views/Pages/LibraryPage/LibraryPageView.swift
@@ -282,7 +282,7 @@ struct LibrarySongRow: View {
             CGSize(width: 45, height: 45), scale: displayScale)
         )
         .resizable()
-        .aspectRatio(contentMode: .fill)
+        .scaledToFill()
         .frame(width: 45, height: 45)
         .clipped()
       } else {
@@ -388,7 +388,7 @@ struct LibraryRequestRow: View {
               CGSize(width: 45, height: 45), scale: displayScale)
           )
           .resizable()
-          .aspectRatio(contentMode: .fill)
+          .scaledToFill()
           .frame(width: 45, height: 45)
           .clipped()
         } else {

--- a/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsSection.swift
+++ b/PlayolaRadio/Views/Pages/LikedSongsPage/LikedSongsSection.swift
@@ -62,7 +62,7 @@ struct LikedSongRow: View {
       ) { image in
         image
           .resizable()
-          .aspectRatio(contentMode: .fill)
+          .scaledToFill()
       } placeholder: {
         RoundedRectangle(cornerRadius: 6)
           .fill(Color(hex: "#666666"))

--- a/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
+++ b/PlayolaRadio/Views/Pages/ListenerQuestionDetailPage/ListenerQuestionDetailPageView.swift
@@ -84,7 +84,7 @@ struct ListenerQuestionDetailPageView: View {
             CGSize(width: 48, height: 48), scale: displayScale)
         )
         .resizable()
-        .aspectRatio(contentMode: .fill)
+        .scaledToFill()
         .frame(width: 48, height: 48)
         .clipShape(Circle())
       } else {

--- a/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
+++ b/PlayolaRadio/Views/Pages/NotificationsSettingsPage/NotificationsSettingsPageView.swift
@@ -148,7 +148,7 @@ struct NotificationsSettingsPageView: View {
       ) { image in
         image
           .resizable()
-          .aspectRatio(contentMode: .fill)
+          .scaledToFill()
       } placeholder: {
         Color(white: 0.2)
       }

--- a/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
+++ b/PlayolaRadio/Views/Pages/PlayerPage/PlayerPage.swift
@@ -190,7 +190,7 @@ private struct HeroArtwork: View {
         ) { image in
           image
             .resizable()
-            .aspectRatio(contentMode: .fill)
+            .scaledToFill()
         } placeholder: {
           Color.clear
         }

--- a/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
+++ b/PlayolaRadio/Views/Pages/RecordIntroPage/RecordIntroPageView.swift
@@ -96,7 +96,7 @@ struct RecordIntroPageView: View {
             CGSize(width: 56, height: 56), scale: displayScale)
         )
         .resizable()
-        .aspectRatio(contentMode: .fill)
+        .scaledToFill()
         .frame(width: 56, height: 56)
         .cornerRadius(6)
         .clipped()

--- a/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
+++ b/PlayolaRadio/Views/Pages/RewardsPage/PrizeTierRow.swift
@@ -40,7 +40,7 @@ struct PrizeTierRow: View {
         )
         .renderingMode(.template)
         .resizable()
-        .aspectRatio(contentMode: .fit)
+        .scaledToFit()
         .frame(width: 28, height: 28)
         .foregroundColor(
           isRedeemed ? Color(red: 153 / 255, green: 153 / 255, blue: 153 / 255) : .white)

--- a/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
+++ b/PlayolaRadio/Views/Pages/SeriesListPage/SeriesCard/SeriesCard.swift
@@ -94,7 +94,7 @@ struct SeriesCard: View {
         ) { image in
           image
             .resizable()
-            .aspectRatio(contentMode: .fill)
+            .scaledToFill()
         } placeholder: {
           Circle()
             .fill(Color.gray.opacity(0.3))

--- a/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
+++ b/PlayolaRadio/Views/Pages/SongSearchPage/SongSearchPageView.swift
@@ -154,7 +154,7 @@ struct SongSearchResultRow: View {
             CGSize(width: 45, height: 45), scale: displayScale)
         )
         .resizable()
-        .aspectRatio(contentMode: .fill)
+        .scaledToFill()
         .frame(width: 45, height: 45)
         .clipped()
       } else {
@@ -213,7 +213,7 @@ struct SongRequestResultRow: View {
             CGSize(width: 45, height: 45), scale: displayScale)
         )
         .resizable()
-        .aspectRatio(contentMode: .fill)
+        .scaledToFill()
         .frame(width: 45, height: 45)
         .clipped()
       } else {

--- a/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/Presets/PresetTile.swift
@@ -23,7 +23,7 @@ struct PresetTile: View {
         url: display.imageUrl,
         context: RemoteArtwork.downsampleContext(CGSize(width: 92, height: 92), scale: displayScale)
       ) { image in
-        image.resizable().aspectRatio(contentMode: .fill)
+        image.resizable().scaledToFill()
       } placeholder: {
         Color(hex: "#333333")
       }

--- a/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
+++ b/PlayolaRadio/Views/Pages/StationListPage/StationListStationRowView/StationListStationRowView.swift
@@ -27,7 +27,7 @@ struct StationListStationRowView: View {
           ) { image in
             image
               .resizable()
-              .aspectRatio(contentMode: .fill)
+              .scaledToFill()
           } placeholder: {
             Color(hex: "#333333")
           }

--- a/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
+++ b/PlayolaRadio/Views/Pages/WelcomeMessage/WelcomeMessagePageView.swift
@@ -30,7 +30,7 @@ struct WelcomeMessagePageView: View {
           } placeholder: {
             WelcomePalette.cardSurface
           }
-          .aspectRatio(contentMode: .fill)
+          .scaledToFill()
           .frame(width: geo.size.width, height: geo.size.height * 0.44)
           .clipped()
 

--- a/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
+++ b/PlayolaRadio/Views/Reusable Components/Song Drawer/SongDrawerView.swift
@@ -25,7 +25,7 @@ struct SongDrawerView: View {
         ) { image in
           image
             .resizable()
-            .aspectRatio(contentMode: .fill)
+            .scaledToFill()
         } placeholder: {
           RoundedRectangle(cornerRadius: 6)
             .fill(Color(hex: "#666666"))


### PR DESCRIPTION
## Why

CI's `swiftlint_check` job installs the latest SwiftLint via Homebrew (unpinned). SwiftLint 0.65 added the `legacy_swiftui_aspect_ratio` rule, which fails `--strict` on 19 pre-existing call sites — so **every branch's next CI run fails**, with no code change on our side. First observed on PR #404's CI.

## What

Cherry-pick of `db11472b` from PR #404 (already verified green there): migrates all 19 ratio-less `.aspectRatio(contentMode: .fit/.fill)` calls to `.scaledToFit()` / `.scaledToFill()`.

- **Behavior-identical**: SwiftUI documents `scaledToFit()`/`scaledToFill()` as exact equivalents of the ratio-less `aspectRatio(contentMode:)` form.
- The two-arg `aspectRatio(_:contentMode:)` form (explicit ratio, used by the WebImage sizing pattern) is not flagged by the rule and is untouched.
- Verified locally with SwiftLint 0.65.1 `--strict`: 0 violations. Full suite passed on the source branch (1292 tests / 83 suites); CI runs it again here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated artwork and avatar image scaling across the app to use consistent fill and fit presentation.
  * Preserved existing image proportions and framing across stations, songs, albums, playlists, and rewards.
  * No functional or visual behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->