### PR TITLE
docs: MAINTENANCE.md with due dates + whats-due skill

### DIFF
--- a/.claude/skills/whats-due/SKILL.md
+++ b/.claude/skills/whats-due/SKILL.md
@@ -16,10 +16,11 @@ trackers at the repo root.
    checklist under Dependency updates for unchecked groups.
 3. Read `LONG_RUNNING.md`. In the **Active** table, compare each row's
    "Next check" date to today. `—` means opportunistic — skip it.
-4. Report three buckets, most urgent first:
+4. Report three mutually exclusive buckets, most urgent first:
    - **Overdue** (due date < today) — include how many days overdue.
-   - **Due today / this week** (within 7 days).
-   - **Coming up** (within 30 days) — one line each, no detail.
+   - **Due today / this week** (today through today + 7 days).
+   - **Coming up** (today + 8 through today + 30 days) — one line each, no
+     detail.
 5. For each due item, say what the *next concrete action* is (pull it from the
    item's section in the file — e.g. which dependency group is next, or which
    soak gate to verify), not just that it's due.

--- a/.claude/skills/whats-due/SKILL.md
+++ b/.claude/skills/whats-due/SKILL.md
@@ -1,0 +1,35 @@
+---
+name: whats-due
+description: Use when the user asks what maintenance needs to be done, what long-running tasks need attention, what's due/overdue, or invokes /whats-due. Reads MAINTENANCE.md and LONG_RUNNING.md and reports items whose due date has arrived.
+---
+
+# What's Due
+
+Report which maintenance items and long-running tasks are due, from the two
+trackers at the repo root.
+
+## Steps
+
+1. Get today's date (from context, or `date +%F`).
+2. Read `MAINTENANCE.md`. In the **Schedule** table, compare each row's
+   "Next due" (ISO `YYYY-MM-DD`) to today. Also check the "Current sweep"
+   checklist under Dependency updates for unchecked groups.
+3. Read `LONG_RUNNING.md`. In the **Active** table, compare each row's
+   "Next check" date to today. `—` means opportunistic — skip it.
+4. Report three buckets, most urgent first:
+   - **Overdue** (due date < today) — include how many days overdue.
+   - **Due today / this week** (within 7 days).
+   - **Coming up** (within 30 days) — one line each, no detail.
+5. For each due item, say what the *next concrete action* is (pull it from the
+   item's section in the file — e.g. which dependency group is next, or which
+   soak gate to verify), not just that it's due.
+6. If nothing is due, say so and state the nearest upcoming date.
+
+## Rules
+
+- Dates in both files are ISO (`YYYY-MM-DD`); an item is due when
+  today ≥ the date.
+- Do NOT start doing the work — this skill only reports. Offer to tackle a
+  specific item as a follow-up.
+- If you *do* subsequently complete an item, update its dates in the tracker
+  in the same PR as the work (both files require this).

--- a/LONG_RUNNING.md
+++ b/LONG_RUNNING.md
@@ -19,21 +19,27 @@ not ✅ done until its soak clears.
 > Entries marked `⟨owner: …⟩` are placeholders the task owner should fill in —
 > I scaffolded them from open PRs/branches but don't know the internal plan.
 
-_Last updated: 2026-08-26_
+_Last updated: 2026-08-27_
 
 ---
 
 ## Active
 
-| Task | Status | Current step | Soak | Links |
-|------|--------|--------------|------|-------|
-| Host-owned audio → Sonos | 🟡 soaking | Phase 1 done (7.4.2 at 100% since ~2026-08-09, canary clean); Phase 2+3 shipping to prod in 7.5.1 | Phase 2+3: prod phased rollout via 7.5.1 (submission held on device matrix) | PR #345 · #384 · #402 · plan |
-| AirPlay-2 sample-buffer renderer (Phase 5) | 🟡 soaking | App on SDK **0.21.0 (stable)**; **shipping to 100% of users in 7.6.0** (PR #408) — the server flag is now a **rollback lever**, not a rollout gate | prod at **100%**: the sample-buffer renderer is served to everyone via the server flag. Kill lever (rollback): flip `SAMPLE_BUFFER_RENDERER_ALLOWED=false` (or clear the enabled env) to revert the whole population to the legacy renderer at each user's next app launch (backend locks per process). Watch Mixpanel `render_backend` on Listening Session Started + Sentry `render_backend` tag; hold ✅ until metrics clean across a full release cycle | PR #404 · #408 |
-| Clip share | 🔵 in progress | ⟨owner: current step⟩ | none (standard release) | PR #219 |
-| Rewards → Your Library | 🔵 in progress | Rewards→Profile, Library tab, Presets move | none | PR #372 · `fix-library-requests-ui` |
-| Siri "Play on Playola" (App Intents media schema) | 🟢 planning | Approach B decided (2026-06-14); not started | n/a | — |
-| View/Model pattern cleanup | 🔵 in progress (opportunistic) | ongoing, fix-on-touch | none | `TODO_VIEW_MODEL_VIOLATIONS.md` |
-| Prettify iPad screens | 🔵 in progress | Profile (screen 4 of N) | none (standard release) | specs in `docs/superpowers/specs/2026-08-0*-ipad-*-design.md` |
+**"Next check"** is the ISO date by which someone should look at the task again
+(advance it, verify a soak gate, or ping the owner) — not a delivery deadline.
+An item is **due** when today ≥ that date. Update it whenever you touch the
+task. `—` = opportunistic, no scheduled check. Ask "What long-running tasks do
+we need to tackle?" (or run the `whats-due` skill) to see what's due.
+
+| Task | Status | Current step | Soak | Next check | Links |
+|------|--------|--------------|------|------------|-------|
+| Host-owned audio → Sonos | 🟡 soaking | Phase 1 done (7.4.2 at 100% since ~2026-08-09, canary clean); Phase 2+3 shipping to prod in 7.5.1 | Phase 2+3: prod phased rollout via 7.5.1 (submission held on device matrix) | 2026-09-03 | PR #345 · #384 · #402 · plan |
+| AirPlay-2 sample-buffer renderer (Phase 5) | 🟡 soaking | App on SDK **0.21.0 (stable)**; **shipping to 100% of users in 7.6.0** (PR #408) — the server flag is now a **rollback lever**, not a rollout gate | prod at **100%**: the sample-buffer renderer is served to everyone via the server flag. Kill lever (rollback): flip `SAMPLE_BUFFER_RENDERER_ALLOWED=false` (or clear the enabled env) to revert the whole population to the legacy renderer at each user's next app launch (backend locks per process). Watch Mixpanel `render_backend` on Listening Session Started + Sentry `render_backend` tag; hold ✅ until metrics clean across a full release cycle | 2026-09-10 | PR #404 · #408 |
+| Clip share | 🔵 in progress | ⟨owner: current step⟩ | none (standard release) | 2026-09-10 | PR #219 |
+| Rewards → Your Library | 🔵 in progress | Rewards→Profile, Library tab, Presets move | none | 2026-09-10 | PR #372 · `fix-library-requests-ui` |
+| Siri "Play on Playola" (App Intents media schema) | 🟢 planning | Approach B decided (2026-06-14); not started | n/a | 2026-10-01 | — |
+| View/Model pattern cleanup | 🔵 in progress (opportunistic) | ongoing, fix-on-touch | none | — | `TODO_VIEW_MODEL_VIOLATIONS.md` |
+| Prettify iPad screens | 🔵 in progress | Profile (screen 4 of N) | none (standard release) | 2026-09-10 | specs in `docs/superpowers/specs/2026-08-0*-ipad-*-design.md` |
 
 ---
 

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -1,0 +1,146 @@
+# Maintenance
+
+Recurring upkeep tasks for this repo. Ask "What maintenance needs to be done?"
+(or run the `whats-due` skill) to see what's due.
+
+**Rules:**
+- Dates are ISO (`YYYY-MM-DD`). "Next due" is the date the *next action* should
+  happen by — an item is **due** when today ≥ that date.
+- When you complete an item, update its "Last completed" and "Next due" dates
+  **in the same PR** (same philosophy as `LONG_RUNNING.md`: a stale tracker is
+  worse than none).
+
+## Schedule
+
+| Item | Cadence | Last completed | Next due |
+|------|---------|----------------|----------|
+| [Dependency updates](#dependency-updates) | Monthly | In progress (sweep started 2026-08-27) | 2026-09-03 (finish current sweep) |
+| [CI Xcode version check](#ci-xcode-version-check) | Quarterly | Never | 2026-11-27 |
+| [Certificates & provisioning check](#certificates--provisioning-check) | Quarterly | Never | 2026-09-10 (first audit) |
+| [LONG_RUNNING.md review](#long_runningmd-review) | Monthly | 2026-08-26 | 2026-09-26 |
+
+---
+
+## Dependency updates
+
+Update third-party dependencies once a month. Don't update strictly one
+package at a time — update by **group**, one PR per group, so related packages
+move together but an unrelated regression is still easy to bisect and revert.
+
+**How updates actually work here (load-bearing):** `Package.resolved` is
+**gitignored**, so CI resolves fresh on every build and already floats to the
+latest version each `upToNextMajor` range allows. The monthly sweep therefore
+means: check upstream for new releases, **raise the `minimumVersion` floors in
+`project.pbxproj`** to current, resolve + build + test locally, and catch any
+**major** versions (which the ranges block until we opt in).
+
+**Two-refs gotcha:** most packages have TWO `XCRemoteSwiftPackageReference`
+entries in `project.pbxproj` (PlayolaRadio + Staging targets). Bump **both** or
+the targets drift: Alamofire, GoogleSignIn-iOS, mixpanel-swift,
+SDWebImageSwiftUI, SDWebImageSVGCoder, swift-dependencies,
+playola-player-swift. (sentry-cocoa, swift-sharing,
+swift-identified-collections, swift-custom-dump, SwiftLintPlugins have one.)
+
+### Groups (one PR each)
+
+1. **Point-Free family** — `swift-dependencies`, `swift-sharing`,
+   `swift-identified-collections`, `swift-custom-dump`. These are designed to
+   move together and share types; updating them independently can cause
+   resolution conflicts.
+2. **SDWebImage pair** — `SDWebImageSwiftUI`, `SDWebImageSVGCoder`. Same
+   ecosystem, shared core.
+3. **Sentry** (`sentry-cocoa`) — releases frequently; majors change the SDK
+   surface, so read the changelog before a major bump.
+4. **Mixpanel** (`mixpanel-swift`)
+5. **Alamofire**
+6. **GoogleSignIn-iOS** — test the real sign-in flow after updating, not just
+   the unit tests.
+7. **SwiftLint (plugin + CI, in lockstep)** — two pins that MUST move together
+   in the same PR:
+   - the `SwiftLintPlugins` exact pin in `project.pbxproj` (build-tool plugin;
+     fails the local/CI build on violations), and
+   - **`.swiftlint-version`** at the repo root — CI's `swiftlint_check` job
+     downloads exactly that SwiftLint release (see `.circleci/config.yml`).
+
+   Use the same version number in both. After bumping, run `make lint` locally:
+   new SwiftLint releases add rules that can fail builds nobody touched
+   (warnings-as-errors is on). Fix or explicitly disable new rules in
+   `.swiftlint.yml` as part of the bump PR.
+8. **fastlane** — `bundle update fastlane` (Gemfile/Gemfile.lock only).
+
+### Excluded from routine updates
+
+- **playola-player-swift** — exact-pinned in-house SDK; bumped deliberately
+  with feature work, not on a maintenance cadence. (Two-refs gotcha applies.)
+- **FRadioPlayer** — vendored local package in `LocalPackages/`; no upstream
+  updates.
+
+### Process per PR
+
+- Minor/patch bumps within a group can share one PR. A **major** version bump
+  gets its own PR with the changelog reviewed.
+- Every PR must build, pass the full test suite, and pass `make lint` before
+  merge (same bar as any other PR into `develop`).
+- When the sweep finishes, set "Last completed" to that date and "Next due" to
+  one month later.
+
+### Current sweep — started 2026-08-27
+
+- [x] Group 1: Point-Free family (swift-dependencies 1.12.0→1.17.0,
+      swift-sharing 2.8.0→2.9.1, swift-custom-dump 1.5.0→1.7.1,
+      swift-identified-collections already current at 1.1.1)
+- [ ] Group 2: SDWebImage pair
+- [ ] Group 3: Sentry
+- [ ] Group 4: Mixpanel
+- [ ] Group 5: Alamofire
+- [ ] Group 6: GoogleSignIn-iOS
+- [ ] Group 7: SwiftLint (plugin + `.swiftlint-version`)
+- [ ] Group 8: fastlane
+
+---
+
+## CI Xcode version check
+
+CircleCI jobs pin a macOS Xcode image (`xcode: 26.2`, five places in
+`.circleci/config.yml`). Quarterly:
+
+1. Check what Xcode versions CircleCI offers and what the App Store currently
+   requires for submission (Apple periodically raises the minimum SDK).
+2. If moving: bump all `xcode:` entries in `.circleci/config.yml` together, and
+   keep the local build instruction in sync (we build via
+   `DEVELOPER_DIR=/Applications/Xcode-<version>.app` to match CI — see
+   memory/docs about local Xcode beta mismatch).
+3. A new Xcode = new Swift compiler = possible new warnings, and
+   warnings-as-errors is on for App+Staging. Expect to fix warnings in the same
+   PR.
+
+---
+
+## Certificates & provisioning check
+
+Signing is fastlane **match**-managed (`fastlane/Matchfile`); staging TestFlight
+uses manual + match signing. Apple distribution certificates and provisioning
+profiles expire yearly and fail the release lane with confusing errors when
+they do. Quarterly:
+
+1. Check expiry dates: `bundle exec fastlane match appstore --readonly` (or
+   the Certificates page in the Apple Developer portal).
+2. Record the earliest expiry date below, and set this item's "Next due" to at
+   least 30 days **before** that date.
+3. To renew: use match's normal renew flow. Watch for the known gotcha:
+   duplicate distribution certs in the local keychain break the staging build.
+
+**Earliest known expiry:** _not yet audited_
+
+---
+
+## LONG_RUNNING.md review
+
+Monthly, sweep `LONG_RUNNING.md`:
+
+- Is every active task's "Current step" still true?
+- Have any soak windows ("Advance when" criteria) been met or breached?
+- Are any tasks stale (no movement since last review) — ping the owner or mark
+  ⏸️ paused?
+- Does every active task have a "Next check" date, and are overdue ones acted
+  on?

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -86,9 +86,13 @@ swift-identified-collections, swift-custom-dump, SwiftLintPlugins have one.)
 
 ### Current sweep — started 2026-08-27
 
-- [x] Group 1: Point-Free family (swift-dependencies 1.12.0→1.17.0,
-      swift-sharing 2.8.0→2.9.1, swift-custom-dump 1.5.0→1.7.1,
-      swift-identified-collections already current at 1.1.1)
+- [x] Group 1: Point-Free family — PR #411 (swift-dependencies 1.12.0→1.17.0,
+      swift-sharing 2.8.0→2.9.1, swift-custom-dump 1.5.0→1.7.0,
+      swift-identified-collections already current at 1.1.1).
+      swift-custom-dump capped at 1.7.0: 1.7.1 depends on the renamed
+      `swift-issue-reporting` repo while the rest of the graph still resolves
+      it as `xctest-dynamic-overlay`, and SPM rejects the mixed identities —
+      revisit when the sibling packages migrate.
 - [ ] Group 2: SDWebImage pair
 - [ ] Group 3: Sentry
 - [ ] Group 4: Mixpanel

--- a/MAINTENANCE.md
+++ b/MAINTENANCE.md
@@ -86,7 +86,8 @@ swift-identified-collections, swift-custom-dump, SwiftLintPlugins have one.)
 
 ### Current sweep — started 2026-08-27
 
-- [x] Group 1: Point-Free family — PR #411 (swift-dependencies 1.12.0→1.17.0,
+- [ ] Group 1: Point-Free family — PR #411 open; check off when it merges
+      (swift-dependencies 1.12.0→1.17.0,
       swift-sharing 2.8.0→2.9.1, swift-custom-dump 1.5.0→1.7.0,
       swift-identified-collections already current at 1.1.1).
       swift-custom-dump capped at 1.7.0: 1.7.1 depends on the renamed


### PR DESCRIPTION
## Summary

- Adds **MAINTENANCE.md**: a maintenance schedule with ISO due dates — monthly dependency sweep (grouped into 8 one-PR groups, with the SwiftLintPlugins pin and CI's `.swiftlint-version` bumped in lockstep), quarterly CI Xcode-image check, quarterly certificate/provisioning audit, and a monthly LONG_RUNNING.md review.
- Adds a **Next check** date column to `LONG_RUNNING.md`'s Active table (check-in dates, not delivery deadlines) so due tasks are queryable.
- Adds a project skill **`whats-due`** (`.claude/skills/whats-due/SKILL.md`): ask "What maintenance needs to be done?" / "What long-running tasks do we need to tackle?" in any workspace and it reports overdue/upcoming items from both trackers.

Key facts encoded in the doc: `Package.resolved` is gitignored so CI already floats within `upToNextMajor` ranges (the sweep raises `minimumVersion` floors deliberately), and most packages have two `XCRemoteSwiftPackageReference` entries (PlayolaRadio + Staging) that must be bumped together.

The first sweep (group 1, Point-Free family) is being opened as a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “What’s Due” report that identifies overdue, current-week, and upcoming maintenance items with recommended next actions.
  * Reports the nearest upcoming date when no tasks are currently due.
* **Documentation**
  * Added recurring maintenance procedures and schedules.
  * Enhanced long-running task tracking with next-review dates and support for opportunistic work.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->