### PR TITLE
build(deps): monthly sweep group 1 — Point-Free package floors

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -3264,7 +3264,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.12.0;
+				minimumVersion = 1.17.0;
 			};
 		};
 		D30F00462E8592F0007BCC73 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
@@ -3312,7 +3312,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-sharing";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 2.8.0;
+				minimumVersion = 2.9.1;
 			};
 		};
 		D395910D2E38069200720CF8 /* XCRemoteSwiftPackageReference "SDWebImageSwiftUI" */ = {
@@ -3352,7 +3352,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-dependencies";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.12.0;
+				minimumVersion = 1.17.0;
 			};
 		};
 		D3CE19012D3C825C0091B888 /* XCRemoteSwiftPackageReference "playola-player-swift" */ = {
@@ -3368,7 +3368,7 @@
 			repositoryURL = "https://github.com/pointfreeco/swift-custom-dump";
 			requirement = {
 				kind = upToNextMajorVersion;
-				minimumVersion = 1.5.0;
+				minimumVersion = 1.7.0;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */


### PR DESCRIPTION
First group of the monthly dependency sweep (tracked in `MAINTENANCE.md`, added in #410).

## Changes

| Package | Floor before | Floor after |
|---------|-------------|-------------|
| swift-dependencies (×2 refs) | 1.12.0 | 1.17.0 |
| swift-sharing | 2.8.0 | 2.9.1 |
| swift-custom-dump | 1.5.0 | 1.7.0 |
| swift-identified-collections | 1.1.1 | (already current) |

## Notes

- `Package.resolved` is gitignored, so CI already resolves to the latest allowed versions on every build — this PR raises the declared `minimumVersion` floors to match reality and verifies the current resolution locally.
- **swift-custom-dump is deliberately capped at 1.7.0, not 1.7.1**: 1.7.1 declares its dependency via the renamed `swift-issue-reporting` URL while the rest of the graph (swift-dependencies 1.17.0 et al.) still resolves the same repo as `xctest-dynamic-overlay`, and SPM rejects the mixed package identities. Revisit when the sibling packages migrate.
- Both `swift-dependencies` package refs (PlayolaRadio + Staging targets) bumped.

## Verification

- `xcodebuild -resolvePackageDependencies` clean (Xcode 26.5, matching CI-adjacent toolchain)
- Full test suite: **1301 tests in 83 suites passed** (iPhone 17 Pro sim, iOS 26.5)
- `make lint`: 0 violations

🤖 Generated with [Claude Code](https://claude.com/claude-code)