### PR TITLE
Keep lock-screen button live after Stop and resume last Playola station

### DIFF
--- a/PlayolaRadio.xcodeproj/project.pbxproj
+++ b/PlayolaRadio.xcodeproj/project.pbxproj
@@ -279,6 +279,7 @@
 		D35905EC2DFCDA140064A9C1 /* StationListModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35905EB2DFCDA110064A9C1 /* StationListModel.swift */; };
 		D35EFBD72F0EC6F7000F64A4 /* APIClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */; };
 		D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */; };
+		D3A1B2C52F101A76000F64A4 /* StationPlayerLastPlayedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3A1B2C42F101A76000F64A4 /* StationPlayerLastPlayedTests.swift */; };
 		D35EFBEE2F1092A7000F64A4 /* RRuleFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */; };
 		D35EFBF02F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
 		D35EFBF12F1092D7000F64A4 /* RRuleFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */; };
@@ -705,6 +706,7 @@
 		D35905EB2DFCDA110064A9C1 /* StationListModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationListModel.swift; sourceTree = "<group>"; };
 		D35EFBD62F0EC6F7000F64A4 /* APIClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = APIClientTests.swift; sourceTree = "<group>"; };
 		D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerTests.swift; sourceTree = "<group>"; };
+		D3A1B2C42F101A76000F64A4 /* StationPlayerLastPlayedTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StationPlayerLastPlayedTests.swift; sourceTree = "<group>"; };
 		D35EFBEC2F1092A7000F64A4 /* RRuleFormatterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatterTests.swift; sourceTree = "<group>"; };
 		D35EFBEF2F1092D7000F64A4 /* RRuleFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RRuleFormatter.swift; sourceTree = "<group>"; };
 		D35EFBF22F1576EF000F64A4 /* NewFeatureTile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NewFeatureTile.swift; sourceTree = "<group>"; };
@@ -1609,6 +1611,7 @@
 				AB0A00000000000000000004 /* StationPlayerRenderBackendTests.swift */,
 				AB0A00000000000000000006 /* StationPlayerTestDoubles.swift */,
 				D35EFBD82F101A76000F64A4 /* StationPlayerTests.swift */,
+				D3A1B2C42F101A76000F64A4 /* StationPlayerLastPlayedTests.swift */,
 				FAE000000000000000000001 /* AudioSessionCoordinator.swift */,
 				FAE000000000000000000004 /* AudioSessionCoordinatorTests.swift */,
 				FAE000000000000000000010 /* SingleNowPlayingWriterTests.swift */,
@@ -2597,6 +2600,7 @@
 				AB0A00000000000000000003 /* StationPlayerRenderBackendTests.swift in Sources */,
 				AB0A00000000000000000005 /* StationPlayerTestDoubles.swift in Sources */,
 				D35EFBD92F101A76000F64A4 /* StationPlayerTests.swift in Sources */,
+				D3A1B2C52F101A76000F64A4 /* StationPlayerLastPlayedTests.swift in Sources */,
 				E1CA0000000000000000A005 /* CarPlayPlaybackTransitionTests.swift in Sources */,
 				D395911A2E39933800720CF8 /* ContactPageTests.swift in Sources */,
 				E1AB0000000000000000AB03 /* AppVersionGateModelTests.swift in Sources */,

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift
@@ -9,6 +9,7 @@ import Dependencies
 import Foundation
 import MediaPlayer
 import PlayolaPlayer
+import Sharing
 
 // MARK: - Now Playing Data Structure
 
@@ -76,13 +77,16 @@ struct NowPlaying: Equatable, Codable {
 class NowPlayingUpdater {
   var stationPlayer: StationPlayer
 
-  @ObservationIgnored @Dependency(\.continuousClock) var clock
   @ObservationIgnored @Dependency(\.analytics) var analytics
   @ObservationIgnored @Dependency(\.date.now) var now
 
+  /// Durable snapshot of the last Playola station the user chose to play (written
+  /// by `StationPlayer` on accepted play intent). Survives Stop and relaunch, and
+  /// is the resume source for the lock-screen / car play command. The in-memory
+  /// `lastPlayedStation` below is only an analytics cache for the current session.
+  @ObservationIgnored @Shared(.lastPlayedStation) var persistedLastStation: LastPlayedStation?
+
   private var disposeBag = Set<AnyCancellable>()
-  private var inactivityTask: Task<Void, Never>?
-  private let inactivityTimeout: Duration = .seconds(15 * 60)  // 15 minutes
   var lastPlayedStation: AnyStation?
   private var currentArtworkURL: String?
 
@@ -97,21 +101,20 @@ class NowPlayingUpdater {
   private var sessionStartTime: Date?
   private var lastPlaybackStatus: StationPlayer.PlaybackStatus = .stopped
   private func updateNowPlaying(with stationPlayerState: StationPlayer.State) {
-    print(
-      "🎵 NowPlayingUpdater: updateNowPlaying called with status: \(stationPlayerState.playbackStatus)"
-    )
-    print("🎵 Current station: \(stationPlayer.currentStation?.name ?? "nil")")
-
-    guard let currentStation = stationPlayer.currentStation else {
-      print("🎵 No current station - clearing now playing info")
+    guard let displayStation = stationForDisplay(stationPlayerState) else {
       clearNowPlayingInfo()
       return
     }
 
-    lastPlayedStation = currentStation
+    // Only refresh the analytics cache while a station is genuinely current; a
+    // stopped-with-snapshot render must not resurrect it as "playing".
+    if let currentStation = stationPlayer.currentStation {
+      lastPlayedStation = currentStation
+    }
+
     var nowPlayingInfo = buildNowPlayingInfo(
       for: stationPlayerState,
-      station: currentStation
+      station: displayStation
     )
     updatePlaybackState(for: stationPlayerState.playbackStatus)
     setPlaybackRate(for: stationPlayerState.playbackStatus, in: &nowPlayingInfo)
@@ -122,9 +125,9 @@ class NowPlayingUpdater {
       // For loading/stopped states, preserve existing artwork if available, otherwise load new
       if currentNowPlayingInfo[MPMediaItemPropertyArtwork] != nil {
         nowPlayingInfo = preservingExistingArtwork(in: nowPlayingInfo)
-      } else if currentArtworkURL != currentStation.imageUrl?.absoluteString {
+      } else if currentArtworkURL != displayStation.imageUrl?.absoluteString {
         // Only load if we don't already have this station's artwork
-        loadStationArtwork(from: stationPlayerState, station: currentStation)
+        loadStationArtwork(from: stationPlayerState, station: displayStation)
       }
     case .playing, .paused:
       // Preserve existing artwork
@@ -134,6 +137,28 @@ class NowPlayingUpdater {
     }
 
     setNowPlayingInfo(nowPlayingInfo)
+  }
+
+  /// The station whose metadata the lock-screen / Now Playing entry should show.
+  /// While a station is current, that station. Once stopped, the durably persisted
+  /// last Playola station, so the entry — and its live play command — survive Stop
+  /// and a cold-but-alive relaunch, which is what lets the car resume it. Any other
+  /// stationless status (e.g. `.error` after a failed cold start) clears the entry.
+  private func stationForDisplay(_ state: StationPlayer.State) -> AnyStation? {
+    if let currentStation = stationPlayer.currentStation {
+      return currentStation
+    }
+    if case .stopped = state.playbackStatus,
+      let snapshotStation = persistedLastStation?.station,
+      case .playola = snapshotStation
+    {
+      // Only ever surface a `.playola` snapshot after Stop. The persisted store is
+      // written solely for `.playola` stations today, so this is defense-in-depth
+      // (matching the guard in `stationToResume()`): the retired URL backend must
+      // never drive a stopped Now Playing entry / live play button.
+      return snapshotStation
+    }
+    return nil
   }
 
   private func clearNowPlayingInfo() {
@@ -179,7 +204,7 @@ class NowPlayingUpdater {
     case .loading(_, let progress):
       populateLoadingInfo(&nowPlayingInfo, station: station, progress: progress)
     case .stopped:
-      populateStoppedInfo(&nowPlayingInfo, state: state)
+      populateStoppedInfo(&nowPlayingInfo, state: state, station: station)
     case .startingNewStation:
       populateConnectingInfo(&nowPlayingInfo, station: station)
     case .error:
@@ -201,18 +226,18 @@ class NowPlayingUpdater {
 
     switch status {
     case .playing, .loading, .startingNewStation:
-      cancelInactivityTimer()
       setupRemoteControlCenter()
       MPNowPlayingInfoCenter.default().playbackState = .playing
-    case .paused:
-      // Interruption pause: keep the Now Playing entry and remote controls alive
-      // so the lock-screen play button can resume. NOT `.stopped` (which tears
-      // the entry down) and no inactivity timer (which would eventually clear it).
-      cancelInactivityTimer()
+    case .paused, .stopped:
+      // Interruption pause OR a user Stop: keep the Now Playing entry and remote
+      // controls alive so the lock-screen / car play button stays live and can
+      // resume. Presented as `.paused` (never `.stopped`, which greys the button
+      // out). No teardown — the audio session is already released on Stop, and
+      // keeping the metadata + command handlers registered costs nothing. The
+      // command center is (re)registered so a cold-but-alive launch is resumable.
       setupRemoteControlCenter()
       MPNowPlayingInfoCenter.default().playbackState = .paused
-    case .stopped, .error:
-      if case .stopped = status { startInactivityTimer() }
+    case .error:
       MPNowPlayingInfoCenter.default().playbackState = .stopped
     }
   }
@@ -284,14 +309,14 @@ class NowPlayingUpdater {
 
   private func populateStoppedInfo(
     _ info: inout [String: Any],
-    state: StationPlayer.State
+    state: StationPlayer.State,
+    station: AnyStation
   ) {
-    if let artistPlaying = state.artistPlaying {
-      info[MPMediaItemPropertyArtist] = artistPlaying
-    }
-    if let titlePlaying = state.titlePlaying {
-      info[MPMediaItemPropertyTitle] = titlePlaying
-    }
+    // Fall back to the station's own name/curator so a cold-launch stopped entry
+    // (persisted snapshot, no in-session track metadata) still shows the station
+    // instead of a blank lock-screen control.
+    info[MPMediaItemPropertyTitle] = state.titlePlaying ?? station.stationName
+    info[MPMediaItemPropertyArtist] = state.artistPlaying ?? station.name
   }
 
   private func populateConnectingInfo(
@@ -315,9 +340,13 @@ class NowPlayingUpdater {
     in info: inout [String: Any]
   ) {
     guard !status.isLoading else { return }
-    if case .paused = status {
+    // iOS infers the lock-screen play-vs-pause button from the audio session
+    // state + this rate, NOT from `playbackState`. A stopped entry must report
+    // rate 0.0 (like paused) or iOS shows a Pause button over stopped audio.
+    switch status {
+    case .paused, .stopped:
       info[MPNowPlayingInfoPropertyPlaybackRate] = 0.0
-    } else {
+    default:
       info[MPNowPlayingInfoPropertyPlaybackRate] = 1.0
     }
   }
@@ -346,7 +375,7 @@ class NowPlayingUpdater {
   /// Whether `station` is still the one being played. Used to drop artwork that
   /// finished loading after a fast station switch superseded the request.
   func isStillCurrent(_ station: AnyStation) -> Bool {
-    stationPlayer.currentStation?.id == station.id
+    (stationPlayer.currentStation ?? persistedLastStation?.station)?.id == station.id
   }
 
   private func updateNowPlayingImage(_ image: UIImage) {
@@ -418,26 +447,52 @@ class NowPlayingUpdater {
     }
 
     // Play command - resume a station paused by an interruption, or restart the
-    // last played station when stopped.
+    // durably persisted last station when stopped.
     commandCenter.playCommand.isEnabled = true
     commandCenter.playCommand.addTarget { [weak self] _ in
-      guard let self else { return .commandFailed }
-      // Paused by an interruption/route loss: resume the active backend. This is
-      // the recovery path for an interruption that ended without `.shouldResume`
-      // (e.g. the user started another audio app).
-      if case .paused = self.stationPlayer.state.playbackStatus {
-        Task { @MainActor in await self.stationPlayer.resume() }
-        return .success
-      }
-      // Stopped: restart the last played station.
-      guard let lastStation = self.lastPlayedStation,
-        self.stationPlayer.currentStation == nil
-      else { return .commandFailed }
-      Task { @MainActor in
-        await self.stationPlayer.play(station: lastStation)
-      }
+      self?.handlePlayCommand() ?? .commandFailed
+    }
+  }
+
+  // internal for testability
+  /// The single resume path for the lock-screen / car play command. Paused (by an
+  /// interruption/route loss) → resume the live backend; this is the recovery path
+  /// for an interruption that ended without `.shouldResume` (e.g. the user started
+  /// another audio app). Stopped → restart the durably persisted last Playola
+  /// station, which survives relaunch so the car's play command can resume it even
+  /// after a cold-but-alive launch. `.commandFailed` only when there is genuinely
+  /// nothing to resume.
+  func handlePlayCommand() -> MPRemoteCommandHandlerStatus {
+    if case .paused = stationPlayer.state.playbackStatus {
+      Task { @MainActor in await stationPlayer.resume() }
       return .success
     }
+    guard stationPlayer.currentStation == nil,
+      let resumeStation = stationToResume()
+    else { return .commandFailed }
+    Task { @MainActor in
+      await stationPlayer.play(station: resumeStation)
+    }
+    return .success
+  }
+
+  /// The station a stopped play command should resume: the durably persisted last
+  /// Playola station, re-resolved against the loaded station lists for fresher
+  /// metadata / an active check when it appears there, and otherwise the raw
+  /// snapshot so a cold launch with no lists still resumes with zero network.
+  /// Refuses (nil) only when the station IS present in the lists and provably
+  /// inactive — never merely because lists haven't loaded.
+  private func stationToResume() -> AnyStation? {
+    guard let snapshotStation = persistedLastStation?.station,
+      case .playola = snapshotStation
+    else { return nil }
+    if let resolved = stationPlayer.stationLists
+      .flatMap({ $0.stations })
+      .first(where: { $0.id == snapshotStation.id })
+    {
+      return resolved.active ? resolved : nil
+    }
+    return snapshotStation
   }
 
   func releaseRemoteControlCenter() {
@@ -456,32 +511,6 @@ class NowPlayingUpdater {
 
     // Stop receiving remote control events
     UIApplication.shared.endReceivingRemoteControlEvents()
-  }
-
-  // MARK: - Inactivity Timer
-
-  func startInactivityTimer() {
-    cancelInactivityTimer()
-
-    inactivityTask = Task { [weak self] in
-      guard let self else { return }
-
-      do {
-        try await self.clock.sleep(for: self.inactivityTimeout)
-
-        // Clear Now Playing info after inactivity timeout
-        await MainActor.run {
-          self.releaseRemoteControlCenter()
-        }
-      } catch {
-        // Task was cancelled
-      }
-    }
-  }
-
-  private func cancelInactivityTimer() {
-    inactivityTask?.cancel()
-    inactivityTask = nil
   }
 }
 

--- a/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdaterTests.swift
@@ -104,6 +104,125 @@ struct NowPlayingUpdaterTests {
     #expect(!updater.isStillCurrent(makeTestStation2()))
   }
 
+  // MARK: - Resume Last Station Tests
+
+  @Test
+  func stoppedWithPersistedStationRendersNowPlayingEntry() {
+    let station = AnyStation.mockPlayola(name: "Bri's Show", curatorName: "Bri")
+    @Shared(.lastPlayedStation) var persisted: LastPlayedStation? =
+      LastPlayedStation(station: station)
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer(
+        playolaStationPlayer: SpyPlayolaStationPlayer(),
+        audioSessionCoordinator: AudioSessionCoordinator(session: NoOpAudioSession()))
+      // Default state is `.stopped` (currentStation nil): the init `$state` sink
+      // fires synchronously and must render the persisted snapshot, not clear.
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    // A Stop with a persisted snapshot keeps the Now Playing entry populated (so
+    // the lock-screen button stays live) instead of clearing it, and reports rate
+    // 0.0 so iOS shows a functional Play button rather than a Pause.
+    #expect(!updater.currentNowPlayingInfo.isEmpty)
+    #expect(updater.currentNowPlayingInfo[MPMediaItemPropertyTitle] as? String == "Bri's Show")
+    #expect(updater.currentNowPlayingInfo[MPNowPlayingInfoPropertyPlaybackRate] as? Double == 0.0)
+  }
+
+  @Test
+  func stoppedWithNonPlayolaSnapshotClearsNowPlayingEntry() {
+    // Mirror of the resume-boundary guard on the display side: only `.playola`
+    // snapshots drive a stopped Now Playing entry, so a stale/corrupt `.url`
+    // snapshot must not surface a live lock-screen button for the retiring URL
+    // backend. (`.url` is never persisted today; this enforces the invariant.)
+    @Shared(.lastPlayedStation) var persisted: LastPlayedStation? =
+      LastPlayedStation(station: .mockUrl())
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer(
+        playolaStationPlayer: SpyPlayolaStationPlayer(),
+        audioSessionCoordinator: AudioSessionCoordinator(session: NoOpAudioSession()))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    #expect(updater.currentNowPlayingInfo.isEmpty)
+  }
+
+  @Test
+  func handlePlayCommandResumesPersistedStationWhenStopped() {
+    @Shared(.lastPlayedStation) var persisted: LastPlayedStation? =
+      LastPlayedStation(station: .mockPlayola())
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer(
+        playolaStationPlayer: SpyPlayolaStationPlayer(),
+        audioSessionCoordinator: AudioSessionCoordinator(session: NoOpAudioSession()))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    // Stopped with a durable snapshot: the play command accepts and restarts it.
+    #expect(updater.handlePlayCommand() == .success)
+  }
+
+  @Test
+  func handlePlayCommandReturnsCommandFailedWhenNoPersistedStation() {
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer(
+        playolaStationPlayer: SpyPlayolaStationPlayer(),
+        audioSessionCoordinator: AudioSessionCoordinator(session: NoOpAudioSession()))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    // Nothing was ever played: there is genuinely nothing to resume.
+    #expect(updater.handlePlayCommand() == .commandFailed)
+  }
+
+  @Test
+  func handlePlayCommandRefusesNonPlayolaSnapshot() {
+    // Only `.playola` is ever persisted, but enforce the invariant at the resume
+    // boundary: a stale/corrupt `.url` snapshot must never reach the retiring URL
+    // backend via the play command.
+    @Shared(.lastPlayedStation) var persisted: LastPlayedStation? =
+      LastPlayedStation(station: .mockUrl())
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer(
+        playolaStationPlayer: SpyPlayolaStationPlayer(),
+        audioSessionCoordinator: AudioSessionCoordinator(session: NoOpAudioSession()))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    #expect(updater.handlePlayCommand() == .commandFailed)
+  }
+
+  @Test
+  func handlePlayCommandResumesPausedStation() {
+    let updater = withDependencies {
+      $0.analytics.track = { _ in }
+      $0.date = .constant(Date())
+    } operation: {
+      let stationPlayer = StationPlayer(
+        playolaStationPlayer: SpyPlayolaStationPlayer(),
+        audioSessionCoordinator: AudioSessionCoordinator(session: NoOpAudioSession()))
+      stationPlayer.state = StationPlayer.State(playbackStatus: .paused(.mockPlayola()))
+      return NowPlayingUpdater(stationPlayer: stationPlayer)
+    }
+
+    // Interruption pause: the play command resumes the live backend directly.
+    #expect(updater.handlePlayCommand() == .success)
+  }
+
   // MARK: - Analytics Tests
 
   // MARK: - render_backend plumbing

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayer.swift
@@ -27,6 +27,7 @@ class StationPlayer: ObservableObject {
   var sampleBufferRendererAllowed: Bool = true
   @ObservationIgnored @Shared(.sampleBufferRendererLocalOverride)
   var sampleBufferRendererLocalOverride: Bool = false
+  @ObservationIgnored @Shared(.lastPlayedStation) var lastPlayedStation: LastPlayedStation?
 
   enum PlaybackStatus: Codable, Equatable {
     case startingNewStation(AnyStation)
@@ -186,6 +187,16 @@ class StationPlayer: ObservableObject {
       activePlaybackAttempt.station == station
     {
       return await activePlaybackAttempt.waitForResult()
+    }
+
+    // Persist the last-played Playola station on accepted user intent — before
+    // stopping the previous one — so the lock-screen / car play command can
+    // resume it after Stop and across a cold-but-alive relaunch. Written here,
+    // not on `.playing`: if the user selects a station and then hits a dead zone
+    // mid-buffer, we still remember their choice. Only `.playola` stations are
+    // persisted; the legacy URL backend is being retired and never overwrites it.
+    if case .playola = station {
+      $lastPlayedStation.withLock { $0 = LastPlayedStation(station: station) }
     }
 
     stop()

--- a/PlayolaRadio/Core/AudioPlayback/StationPlayerLastPlayedTests.swift
+++ b/PlayolaRadio/Core/AudioPlayback/StationPlayerLastPlayedTests.swift
@@ -1,0 +1,119 @@
+//
+//  StationPlayerLastPlayedTests.swift
+//  PlayolaRadio
+//
+//  Created by Claude on 1/8/26.
+//
+
+import CustomDump
+import Dependencies
+import Sharing
+import Testing
+
+@testable import PlayolaRadio
+
+@Suite(.freshSharedState)
+@MainActor
+struct StationPlayerLastPlayedTests {
+
+  @Test
+  func playolaPlayPersistsLastPlayedStation() async {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    @Shared(.lastPlayedStation) var lastPlayedStation: LastPlayedStation?
+    let coordinator = AudioSessionCoordinator(session: SpyAudioSession())
+    let player = StationPlayer(
+      playolaStationPlayer: SpyPlayolaStationPlayer(), audioSessionCoordinator: coordinator)
+    let station = AnyStation.mockPlayola()
+
+    await player.play(station: station)
+
+    // Persisted on accepted user intent so the lock-screen / car play command can
+    // resume it after Stop and across a cold-but-alive relaunch.
+    expectNoDifference(lastPlayedStation, LastPlayedStation(station: station))
+  }
+
+  @Test
+  func urlPlayDoesNotOverwriteLastPlayedPlayolaStation() async {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    let playolaStation = AnyStation.mockPlayola()
+    @Shared(.lastPlayedStation) var lastPlayedStation: LastPlayedStation? =
+      LastPlayedStation(station: playolaStation)
+    let coordinator = AudioSessionCoordinator(session: SpyAudioSession())
+    let player = StationPlayer(
+      playolaStationPlayer: SpyPlayolaStationPlayer(), audioSessionCoordinator: coordinator)
+
+    await withDependencies {
+      $0.continuousClock = ImmediateClock()
+    } operation: {
+      await player.play(station: .mockUrl())
+    }
+
+    // Only `.playola` stations are persisted; the legacy URL backend never
+    // overwrites the durable snapshot.
+    expectNoDifference(lastPlayedStation, LastPlayedStation(station: playolaStation))
+  }
+
+  @Test
+  func stopDoesNotClearPersistedLastPlayedStation() async {
+    @Shared(.nowPlaying) var nowPlaying = NowPlaying(playbackStatus: .stopped)
+    @Shared(.lastPlayedStation) var lastPlayedStation: LastPlayedStation?
+    let coordinator = AudioSessionCoordinator(session: SpyAudioSession())
+    let player = StationPlayer(
+      playolaStationPlayer: SpyPlayolaStationPlayer(), audioSessionCoordinator: coordinator)
+    let station = AnyStation.mockPlayola()
+    await player.play(station: station)
+
+    player.stop()
+
+    // Stop must not erase the snapshot — it is precisely what a later play command
+    // resumes.
+    expectNoDifference(lastPlayedStation, LastPlayedStation(station: station))
+  }
+
+  @Test
+  func signOutClearsPersistedLastPlayedStation() async {
+    @Shared(.auth) var auth = Auth()
+    @Shared(.lastPlayedStation) var lastPlayedStation: LastPlayedStation? =
+      LastPlayedStation(station: .mockPlayola())
+    let player = StationPlayer(
+      playolaStationPlayer: SpyPlayolaStationPlayer(),
+      audioSessionCoordinator: AudioSessionCoordinator(session: SpyAudioSession()))
+
+    await withDependencies {
+      $0.analytics.reset = {}
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+      $0.nowPlayingUpdater = NowPlayingUpdater(stationPlayer: player)
+    } operation: {
+      await AuthService.shared.signOut()
+    }
+
+    // Station content is account-scoped: one account must never resume into
+    // another's last station.
+    #expect(lastPlayedStation == nil)
+  }
+
+  @Test
+  func signOutStopsActivePlayback() async {
+    @Shared(.auth) var auth = Auth()
+    @Shared(.lastPlayedStation) var lastPlayedStation: LastPlayedStation?
+    let player = StationPlayer(
+      playolaStationPlayer: SpyPlayolaStationPlayer(),
+      audioSessionCoordinator: AudioSessionCoordinator(session: SpyAudioSession()))
+
+    await withDependencies {
+      $0.continuousClock = ImmediateClock()
+      $0.analytics.reset = {}
+      $0.analytics.track = { _ in }
+      $0.stationPlayer = player
+      $0.nowPlayingUpdater = NowPlayingUpdater(stationPlayer: player)
+    } operation: {
+      await player.play(station: .mockPlayola())
+      await AuthService.shared.signOut()
+    }
+
+    // Playback must not survive sign-out; otherwise a later state emission could
+    // resurrect the Now Playing entry from the still-current station.
+    #expect(player.currentStation == nil)
+  }
+}

--- a/PlayolaRadio/Models/LoggedInUser.swift
+++ b/PlayolaRadio/Models/LoggedInUser.swift
@@ -190,7 +190,10 @@ class AuthService: @unchecked Sendable {
   func signOut() async {
     @Dependency(\.api) var api
     @Dependency(\.analytics) var analytics
+    @Dependency(\.nowPlayingUpdater) var nowPlayingUpdater
+    @Dependency(\.stationPlayer) var stationPlayer
     @Shared(.auth) var auth
+    @Shared(.lastPlayedStation) var lastPlayedStation
     @Shared(.registeredDeviceId) var registeredDeviceId
     @Shared(.userLikes) var userLikes
     @Shared(.pendingLikeOperations) var pendingLikeOperations
@@ -217,6 +220,7 @@ class AuthService: @unchecked Sendable {
     await analytics.reset()
 
     $auth.withLock { $0 = Auth() }
+    $lastPlayedStation.withLock { $0 = nil }
     $registeredDeviceId.withLock { $0 = nil }
     $userLikes.withLock { $0 = [:] }
     $pendingLikeOperations.withLock { $0 = [] }
@@ -232,6 +236,16 @@ class AuthService: @unchecked Sendable {
     $giveawayParticipations.withLock { $0 = [:] }
     $dismissedGiveawayBannerIds.withLock { $0 = [] }
     $pendingCongratsActions.withLock { $0 = [:] }
+
+    // Sign-out is the one real teardown event for the remote command center.
+    // Stop any active playback first (the snapshot is already cleared above, so
+    // the resulting stopped state can't repopulate Now Playing from a persisted
+    // station), then clear the lock-screen entry and unregister the play/stop
+    // handlers now that there is no account-scoped station to resume.
+    await MainActor.run {
+      stationPlayer.stop()
+      nowPlayingUpdater.releaseRemoteControlCenter()
+    }
 
     UserDefaults.standard.removeObject(forKey: "analytics_session_paused_at")
   }

--- a/PlayolaRadio/State/SharedUserDefaults.swift
+++ b/PlayolaRadio/State/SharedUserDefaults.swift
@@ -101,6 +101,26 @@ extension SharedKey where Self == InMemoryKey<ListeningTracker?>.Default {
   }
 }
 
+// MARK: - Last Played Station
+
+/// Durable snapshot of the last Playola station the user chose to play. Keeps the
+/// lock-screen Now Playing entry alive after Stop and lets the car / lock-screen
+/// play command resume the last station — including after a cold-but-alive
+/// relaunch, before station lists have been fetched. Only `.playola` stations are
+/// persisted (the legacy URL backend is being retired). A wrapper struct (rather
+/// than a bare `AnyStation?`) leaves room to grow without a storage migration.
+struct LastPlayedStation: Codable, Equatable, Sendable {
+  var station: AnyStation
+}
+
+extension SharedKey where Self == FileStorageKey<LastPlayedStation?>.Default {
+  static var lastPlayedStation: Self {
+    Self[
+      .fileStorage(.documentsDirectory.appending(component: "last-played-station.json")),
+      default: nil]
+  }
+}
+
 extension SharedKey where Self == InMemoryKey<MainContainerModel.ActiveTab>.Default {
   static var activeTab: Self {
     Self[.inMemory("activeTab"), default: .home]

--- a/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
+++ b/PlayolaRadio/Views/Pages/ContactPage/ContactPageTests.swift
@@ -48,7 +48,10 @@ struct ContactPageTests {
       await ContactPageModel().onLogOutTapped()
     }
 
-    #expect(stationPlayerMock.stopCalledCount == 1)
+    // Stopped twice: once by the page for an immediate audio cut on tap, once by
+    // `signOut()` as the account-teardown backstop covering non-UI sign-out paths
+    // (e.g. the credential-revoked observer). `stop()` is idempotent.
+    #expect(stationPlayerMock.stopCalledCount == 2)
     #expect(unregisterCalls.value.count == 1)
     #expect(unregisterCalls.value.first?.0 == "test-jwt")
     #expect(unregisterCalls.value.first?.1 == "device-xyz")

--- a/docs/superpowers/specs/2026-08-27-resume-last-station-design.md
+++ b/docs/superpowers/specs/2026-08-27-resume-last-station-design.md
@@ -1,0 +1,205 @@
+# Resume Last Station (Lock Screen + Car) — Design
+
+**Date:** 2026-08-27
+**Branch:** `briankeane/lock-screen-resume-last-station`
+**Status:** Approved, ready for implementation
+
+## Problem
+
+Two linked issues, one root cause and one shared foundation.
+
+1. **Bug — lock-screen play button dies after Stop.** When the user hits Stop,
+   `StationPlayer.stop()` sets state to `.stopped` and drops `currentStation` to
+   `nil`. That triggers `NowPlayingUpdater.clearNowPlayingInfo()`, which nils
+   `MPNowPlayingInfoCenter.nowPlayingInfo`. iOS then greys out / disables the
+   lock-screen play button because there is no current item behind it. Separately,
+   a 15-minute inactivity timer calls `releaseRemoteControlCenter()`, which removes
+   all command targets and calls `endReceivingRemoteControlEvents()`. The play
+   command already has a fallback to restart `lastPlayedStation`, but that value is
+   held only in memory (lost on relaunch) and the button looks dead because the info
+   was cleared.
+
+2. **Feature — resume last station in the car, like Apple Music.** Apple Music is
+   not doing proprietary car detection. It stays the system's Now Playing app (valid
+   `nowPlayingInfo` + live play command) while stopped/paused; when the car connects
+   it emits a play command over CarPlay / Bluetooth AVRCP, and Apple Music resumes
+   via `MPRemoteCommandCenter`. The correct third-party approach is the same: keep a
+   valid Now Playing entry + live play command + a durably persisted last station, so
+   the car's play command restarts it. No route-sniffing, no CarPlay auto-play.
+
+## Scope
+
+- Targets the **Playola / AirPlay-2 (`playolaStationPlayer`) path only.** The legacy
+  `urlStreamPlayer` backend is being abandoned and is not touched. We persist and
+  resume **only `.playola` stations**.
+
+## Accepted limitation
+
+If iOS has fully terminated the app (user force-quit, or memory jettison), the car
+cannot relaunch a third-party app, so resume will not fire. Suspended / backgrounded
+/ alive / foreground-launched cases all work. This is the same boundary every
+non-system audio app hits; Apple Music beats it only because it is a system app.
+
+## Research finding that shapes the fix (iOS behavior)
+
+`MPNowPlayingInfoCenter.playbackState` is effectively **macOS-only**. On iOS the
+system infers the lock-screen play-vs-pause button from **`AVAudioSession`
+active/inactive** state plus **`MPNowPlayingInfoPropertyPlaybackRate`**, not from the
+`playbackState` enum. Therefore the button renders as a functional **Play** (resume)
+after Stop only when all three hold:
+
+1. `nowPlayingInfo` stays populated (non-nil).
+2. `AVAudioSession` is inactive (already true — we release the session on Stop).
+3. `MPNowPlayingInfoPropertyPlaybackRate = 0.0`.
+
+Consequence: setting the playback rate to **0.0 on stop is mandatory**, not cosmetic.
+The current code sets rate `1.0` for `.stopped`, which can make iOS show the wrong
+(pause) button even with info populated. We still set `playbackState = .paused`
+because CarPlay's `CPNowPlayingTemplate` and macOS do honor it (belt-and-suspenders),
+but the enum choice is low-risk either way.
+
+Sources:
+- https://developer.apple.com/documentation/mediaplayer/mpnowplayingplaybackstate
+- https://developer.apple.com/forums/thread/773870
+- https://developer.apple.com/forums/thread/779533
+- https://developer.apple.com/documentation/mediaplayer/mpnowplayinginfocenter
+
+**Device-verify:** after a cold-but-alive launch (app alive, never played this
+session), confirm on the truck that the car/lock-screen button shows Play and tapping
+it resumes. One unresolved Apple thread reports a stale Pause icon on fresh restore
+until the app backgrounds once; if we hit that, add a background-transition refresh.
+
+## Design
+
+### 1. Durable last-played station (new)
+
+```swift
+struct LastPlayedStation: Codable, Equatable, Sendable {
+  var station: AnyStation
+  var persistedAt: Date
+}
+```
+
+- Persisted via **`.fileStorage`** (JSON file in the documents directory), NOT
+  `.appStorage`. `appStorage` is for scalar prefs; structured Codable models belong
+  in file storage, matching existing repo patterns.
+- Store the **full station snapshot**, not just an id. When the car's play command
+  arrives at launch, `@Shared(.stationLists)` may not be fetched yet; the snapshot
+  lets us resume with zero network.
+- On resume: prefer re-resolving the snapshot's id against `@Shared(.stationLists)`
+  if it is loaded (fresher metadata / active check); fall back to the snapshot if the
+  list is not available. Only refuse resume when lists are loaded AND the station is
+  provably inactive/removed.
+
+New shared key in `SharedUserDefaults.swift`:
+
+```swift
+extension SharedKey where Self == FileStorageKey<LastPlayedStation?>.Default {
+  static var lastPlayedStation: Self {
+    Self[.fileStorage(.documentsDirectory.appending(component: "last-played-station.json")), default: nil]
+  }
+}
+```
+
+### 2. When to persist
+
+- Written on **accepted user intent** inside `StationPlayer.play(station:)`, before it
+  stops the previous station — NOT on `.playing`. Writing on `.playing` is too late:
+  a user could select a station, buffering starts, then they hit a dead zone, and the
+  snapshot would be lost.
+- **Only for `.playola` stations.** URL/legacy stations never overwrite the snapshot.
+
+### 3. Keep the Now Playing entry alive after Stop
+
+- Stop nilling `nowPlayingInfo` on stop. After Stop, keep the entry populated from
+  the last station's title / artist / artwork, presented as **`.paused`** with
+  **`MPNowPlayingInfoPropertyPlaybackRate = 0.0`**.
+- The app's own `StationPlayer` state stays honestly `.stopped`. Resumability lives in
+  the separate durable snapshot, NOT by forcing `currentStation` to stay non-nil
+  (that would poison UI, analytics, CarPlay transitions, and seek logic).
+- `setPlaybackRate`: use `0.0` for both `.paused` and `.stopped`.
+- **Drop the 15-minute inactivity teardown** for ordinary stop. It is the thing that
+  kills resumability and is not load-bearing for correctness (the expensive resource
+  is the audio session, which we already release on Stop; keeping metadata + command
+  handlers registered costs nothing meaningful). Reserve `releaseRemoteControlCenter()`
+  for a real teardown event only — **sign-out**.
+
+### 4. Play command is the single resume path
+
+- Extract `handlePlayCommand() -> MPRemoteCommandHandlerStatus` for testability; the
+  registered `playCommand` target just calls it.
+- Logic: if `.paused` → resume; else restart the durably persisted Playola station
+  (resolved via list, fallback to snapshot). Return `.commandFailed` only when there
+  is genuinely no persisted station.
+- On `NowPlayingUpdater` init (app launch), repopulate the Now Playing entry from the
+  persisted snapshot so a cold-but-alive app is car-resumable before the user touches
+  anything.
+- Resume MUST go through `StationPlayer.play(station:)`, because that path activates
+  `AVAudioSession` first and selects `.longFormAudio`. Do NOT activate the audio
+  session merely to remain resumable while stopped.
+- **No** CarPlay `didConnect` auto-play and **no** positive route-change detection.
+  The car's own play command is the trigger.
+
+### 5. Sign-out clears the snapshot
+
+Clear `@Shared(.lastPlayedStation)` on sign-out (station content is account-scoped).
+Also run `releaseRemoteControlCenter()` at sign-out as the real teardown event.
+
+## Background execution requirements (reality check)
+
+- `UIBackgroundModes` includes `audio` — already present in `Info.plist`.
+- Registered `MPRemoteCommandCenter` handlers — kept alive after Stop by this design.
+- Populated `MPNowPlayingInfoCenter.nowPlayingInfo` — kept alive by this design.
+- `playCommand.isEnabled = true`.
+- App still alive/suspended (not force-quit/jettisoned).
+
+Returning `.success` from the command handler before async playback completes is
+normal; failures must surface through `.error` and update Now Playing metadata.
+
+## File-by-file plan (dependency order)
+
+1. **`PlayolaRadio/State/SharedUserDefaults.swift`** — add `LastPlayedStation` model
+   and the `.lastPlayedStation` `FileStorageKey` shared key.
+2. **`PlayolaRadio/Core/AudioPlayback/StationPlayer.swift`** — add
+   `@Shared(.lastPlayedStation)`; in `play(station:)`, persist the snapshot before
+   stopping the previous station, only when `case .playola`. Leave `.stopped`
+   stationless. Clear the snapshot on sign-out.
+3. **`PlayolaRadio/Core/AudioPlayback/NowPlayingUpdater/NowPlayingUpdater.swift`** —
+   back the resume source with `@Shared(.lastPlayedStation)` (memory var becomes a
+   cache at most); on init, if stopped and a snapshot exists, populate
+   `currentNowPlayingInfo`; in `updateNowPlaying(with:)`, when
+   `currentStation == nil && state == .stopped`, render the persisted station instead
+   of clearing; `setPlaybackRate` → `0.0` for `.stopped` too; stop calling
+   `startInactivityTimer()` for `.stopped`; reserve `releaseRemoteControlCenter()` for
+   sign-out; extract `handlePlayCommand()`.
+4. **`PlayolaRadio/PlayolaRadioApp.swift`** — likely no change if `NowPlayingUpdater`
+   init repopulates metadata; avoid double-registration churn.
+5. **`PlayolaRadio/CarPlay/CarPlaySceneDelegate.swift`** — no auto-play; no
+   route/connect resume logic. (Metadata refresh on connect is already handled.)
+
+## Tests (swift-testing, `@Suite(.freshSharedState)`, `expectNoDifference`, `withDependencies`)
+
+`StationPlayerTests.swift`:
+- `playolaPlayPersistsLastPlayedStationBeforeBackendStarts`
+- `urlPlayDoesNotOverwriteLastPlayedPlayolaStation`
+- `stopDoesNotClearPersistedLastPlayedStation`
+- `signOutClearsPersistedLastPlayedStation`
+
+`NowPlayingUpdaterTests.swift`:
+- stopped state with a persisted last station builds non-empty `currentNowPlayingInfo`
+- stopped state sets playback rate `0.0`
+- inactivity timer is not started / release is not called for ordinary `.stopped`
+- `handlePlayCommand()` resumes the persisted station when current station is nil
+- `handlePlayCommand()` returns `.commandFailed` when no persisted station exists
+- paused state resumes via `handlePlayCommand()`
+
+## swift-sharing / Codable footguns
+
+- `@Shared(.key) var x = value` is a default, not a write — tests seed with `= value`
+  under `.freshSharedState`, and use `$shared.withLock` only to drive mid-test changes.
+- Persisting raw `AnyStation` couples the file format to the SDK's `Station` Codable
+  shape; acceptable as the pragmatic first implementation since `play(station:)`
+  already requires `AnyStation`. If the shape ever changes, decode must fail soft to
+  `nil` (no crash, just no resume).
+- File-storage writes can fail quietly; never make resume depend on station lists when
+  the durable snapshot exists.


### PR DESCRIPTION
## Summary

One unified mechanism — scoped **only** to the Playola/AirPlay-2 backend (`.playola`) — that fixes two linked lock-screen issues. The legacy URL backend is being retired and is **not touched**: only `.playola` stations are persisted or resumed.

**Bug — dead play button after Stop.** After hitting Stop, the lock-screen play button went disabled/greyed shortly after. The old `NowPlayingUpdater` ran a 15-min inactivity timer that tore down the Now Playing entry. That timer is removed; a Stop is now presented as `.paused` with playback rate `0.0` and the remote command center still registered, so iOS keeps a **functional Play button** (iOS infers play-vs-pause from the audio-session state + rate, not `playbackState`).

**Feature — resume last station (Apple-Music-style).** A durable `@Shared(.lastPlayedStation)` FileStorage snapshot is written on **accepted `.playola` play intent** in `StationPlayer.play(station:)`. It survives Stop and a cold-but-alive relaunch and drives a stopped Now Playing entry whose **play command restarts that station** — so connecting to a car (or the lock-screen play button) resumes the last-played Playola station.

## Scope / safety

- **Only `.playola` is persisted.** URL playback never overwrites the snapshot.
- **`.playola`-guarded at both boundaries:** the resume path (`stationToResume`) and the display path (`stationForDisplay`) both refuse a non-`.playola` snapshot, so the retiring URL backend can never drive a stopped entry or its play button.
- **Account-scoped teardown on sign-out:** `signOut()` stops active playback, clears the snapshot, and releases the command center — one account can never resume into another's last station.
- `stationToResume` re-resolves the snapshot against loaded station lists (fresher metadata + `active` check) and refuses only when the station is present-and-inactive — never merely because lists haven't loaded (that would break cold-launch car resume).

## Tests

- `StationPlayerLastPlayedTests` — persists on `.playola` play; URL play doesn't overwrite; Stop doesn't clear; sign-out clears + stops active playback.
- `NowPlayingUpdaterTests` — stopped-with-snapshot renders a live entry at rate 0.0; play command resumes when stopped / returns `.commandFailed` with nothing to resume; **refuses a non-`.playola` snapshot at both the resume and display boundaries**.
- Full suite: 1312 tests pass; lint clean.

## Design note / deviation

The approved design doc listed a `persistedAt` field on `LastPlayedStation`. It was **dropped**: recording it would force a `date` dependency into the otherwise date-free `StationPlayer.play()` path, and nothing consumes a timestamp (resume is unconditional for the last `.playola` station). `LastPlayedStation` is just `{ station: AnyStation }`. Easy to add later if a freshness/TTL policy is ever wanted.

## Verification pipeline

Codex review pass (2 findings — sign-out now stops playback; `.playola` resume guard — both fixed) and Codex adversarial challenge pass both run; challenge findings were either non-issues against the actual shared-state flow or closed by the display-boundary guard added here.